### PR TITLE
[web3torrent] Reduce UI update events

### DIFF
--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -333,11 +333,11 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         } else if (this.paymentChannelClient.isPaymentToMe(channelState)) {
           // Accepting payment, refilling buffer and unblocking
           await this.paymentChannelClient.acceptChannelUpdate(channelState);
-          await this.refillBuffer(torrent.infoHash, channelState.channelId);
+          this.refillBuffer(torrent.infoHash, channelState.channelId);
           this.unblockPeer(torrent.infoHash, wire);
         }
+        this.emitTorrentUpdated(torrent.infoHash, 'onChannelUpdated');
       }
-      this.emitTorrentUpdated(torrent.infoHash, 'onChannelUpdated');
     });
 
     {


### PR DESCRIPTION
At the moment, `emitTorrentUpdated` (which tells the File component to rerender) is fired every time a `onChannelUpdated` wire listener is run. But every wire listens to every channel update.

With this PR, the `emitTorrentUpdated` is fired only if the update is relevant to the wire.