### PR TITLE
Fix issue /2124

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/optional/multiple-leecher.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/optional/multiple-leecher.test.ts
@@ -93,7 +93,7 @@ describe('One file, six leechers, one seeder', () => {
 
     console.log('Waiting for channels to close');
     await forEachActor(
-      ({tab}, label) => label === Label.A && waitForFinishedOrCanceledDownload(tab)
+      ({tab}, label) => label !== Label.A && waitForFinishedOrCanceledDownload(tab)
     );
   });
 });


### PR DESCRIPTION
(hopefully?) Fixes https://github.com/statechannels/monorepo/issues/2124

I was able to reproduce #2124 locally
   - before 66a89bb, I was experiencing flickering tests due to nonce mismatches
   - The hub uses the 6th account from the devtools account list, so I limited the number of leechers to 5

However, it appeared as if the channels did in fact close:
```
magmo/investigations/2124 on ☁️  us-west-1 
❯ grep -c '"status":"closed"' $LOGS_DIR/multiple-leecher.*.pino.log
../../state-channels-monorepo/logs/multiple-leecher.A.5.pino.log:5
../../state-channels-monorepo/logs/multiple-leecher.B.0.pino.log:1
../../state-channels-monorepo/logs/multiple-leecher.C.1.pino.log:1
../../state-channels-monorepo/logs/multiple-leecher.D.2.pino.log:1
../../state-channels-monorepo/logs/multiple-leecher.E.3.pino.log:1
../../state-channels-monorepo/logs/multiple-leecher.F.4.pino.log:1
```

I have no explanation why the expectation suddenly started to fail. But, if `waitForFinishedOrCanceledDownload` works reliably, let's just use that.