### PR TITLE
Consolidate UpdateChannel and SignState actions into a single, explicit action

### DIFF
--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -7,10 +7,9 @@ import {Bytes32} from '../type-aliases';
 Actions that protocols can declare.
 */
 
-type UpdateOpts = Partial<StateVariables>;
-type UpdateChannel = {type: 'UpdateChannel'; channelId: Bytes32} & UpdateOpts;
-export type SignState = {type: 'SignState'; channelId: Bytes32} & UpdateOpts;
+export type SignState = {type: 'SignState'; channelId: Bytes32} & StateVariables;
 type NotifyApp = {type: 'NotifyApp'; notice: Omit<Notification, 'jsonrpc'>};
+
 export type SubmitTransaction = {
   type: 'SubmitTransaction';
   transactionRequest: providers.TransactionRequest;
@@ -20,7 +19,6 @@ const guard = <T extends ProtocolAction>(type: ProtocolAction['type']) => (
   a: ProtocolAction
 ): a is T => a.type === type;
 
-export const isUpdateChannel = guard<UpdateChannel>('UpdateChannel');
 export const isSignState = guard<SignState>('SignState');
 export const isNotifyApp = guard<NotifyApp>('NotifyApp');
 export const isSubmitTransaction = guard<SubmitTransaction>('SubmitTransaction');
@@ -28,9 +26,5 @@ export const isSubmitTransaction = guard<SubmitTransaction>('SubmitTransaction')
 export const isOutgoing = isNotifyApp;
 
 export type Outgoing = NotifyApp;
-export type Internal = UpdateChannel | SignState;
 
-export const isInternal = (a: ProtocolAction): a is Internal =>
-  [isSignState, isUpdateChannel].some(g => g(a));
-
-export type ProtocolAction = UpdateChannel | SignState | NotifyApp | SubmitTransaction;
+export type ProtocolAction = SignState | NotifyApp | SubmitTransaction;

--- a/packages/server-wallet/src/protocols/direct-funding.ts
+++ b/packages/server-wallet/src/protocols/direct-funding.ts
@@ -5,9 +5,9 @@ import {
   BN,
   Outcome,
   Zero,
-  simpleEthAllocation,
   isSimpleAllocation,
   simpleTokenAllocation,
+  checkThat,
 } from '@statechannels/wallet-core';
 
 import {match} from '../match';
@@ -41,18 +41,17 @@ const minimalOutcome = (
 };
 
 const signState = (stage: 'PrefundSetup' | 'PostfundSetup') => (
-  state: ProtocolState
+  ps: ProtocolState
 ): ProtocolResult => {
-  const currentOutcome =
-    state.supported && isSimpleAllocation(state.supported.outcome)
-      ? state.supported.outcome
-      : simpleEthAllocation([]);
+  const {outcome, appData, isFinal} = ps.latest;
   return right(
     some({
       type: 'SignState',
-      channelId: state.channelId,
+      channelId: ps.channelId,
       turnNum: stage === 'PrefundSetup' ? 0 : 1,
-      outcome: minimalOutcome(currentOutcome, state.minimalOutcome),
+      outcome: minimalOutcome(checkThat(outcome, isSimpleAllocation), ps.minimalOutcome),
+      appData,
+      isFinal,
     })
   );
 };

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -13,7 +13,7 @@ export type ChannelState = {
   channelId: string;
   myIndex: 0 | 1;
   supported?: SignedStateWithHash;
-  latest?: SignedStateWithHash;
+  latest: SignedStateWithHash;
   latestSignedByMe?: SignedStateWithHash;
   funding: Record<Address, Uint256>;
 };


### PR DESCRIPTION
It is important for `UpdateChannel` to specify all state variables --
otherwise, who decides which state variables to use? Should it come
from the latest state? the supported state? My latest state?

It seems like it's the protocol's responsibility to answer that.

When all state variables must be given, UpdateChannel and SignState
both mean the same thing: "Sign this state".