### PR TITLE
[docs] Pin tutorial to nitro-protocol v0.1.6.

### DIFF
--- a/packages/nitro-protocol/docs/protocol-docs/tutorial.md
+++ b/packages/nitro-protocol/docs/protocol-docs/tutorial.md
@@ -6,3 +6,7 @@ title: Tutorial
 The quickest way to get going with nitro protocol is to clone our [nitro-tutorial](https://github.com/statechannels/nitro-tutorial) github repository, where you are provided with a test environment and a prepared set of test scripts covering the content below.
 
 If you would prefer to start from scratch, follow the steps in the [quick start](./quick-start) and follow along below.
+
+:::tip
+This tutorial follows @statechannels/nitro-protocol at v0.1.6
+:::

--- a/packages/nitro-protocol/docs/protocol-tutorial/deposit-assets.md
+++ b/packages/nitro-protocol/docs/protocol-tutorial/deposit-assets.md
@@ -30,7 +30,7 @@ for (let i = 0; i < 3; i++) {
 
 const chainId = '0x1234'; // E.g. '0x1' for mainnnet. Using a mock here
 
-const channelNonce = bigNumberify(0).toHexString();
+const channelNonce = 0;
 const channel: Channel = {chainId, channelNonce, participants};
 const channelId = getChannelId(channel);
 ```

--- a/packages/nitro-protocol/docs/protocol-tutorial/deposit-assets.md
+++ b/packages/nitro-protocol/docs/protocol-tutorial/deposit-assets.md
@@ -52,17 +52,17 @@ Because we are depositing ETH, we must remember to send the right amount of ETH 
 
 ```typescript
 import {ethers} from 'ethers';
-import {randomChannelId} from '@statechannels/nitro-protocol';
+import {randomChannelId, randomChannelId} from '@statechannels/nitro-protocol';
 
 // In lesson5.test.ts
 
 /*
       Get an appropriate representation of 1 wei, and
-      use ethers.HashZero = 0x000...0 as a dummy channelId.
+      use randomChannelId() as a dummy channelId.
       WARNING: don't do this in the wild: you won't be able to recover these funds.
   */
 const amount = ethers.utils.parseUnits('1', 'wei');
-const destination = ethers.constants.HashZero;
+const destination = randomChannelId();
 
 /*
     Attempt to deposit 1 wei against the channel id we created.

--- a/packages/nitro-protocol/docs/protocol-tutorial/execute-state-transitions.md
+++ b/packages/nitro-protocol/docs/protocol-tutorial/execute-state-transitions.md
@@ -34,7 +34,7 @@ const chainId = '0x1234';
     :~ how many times have these participants
     already run a channel on this chain?
   */
-const channelNonce = bigNumberify(0).toHexString();
+const channelNonce = 0;
 
 /* 
     Define the challengeDuration 
@@ -280,7 +280,7 @@ import {signState} from '@statechannels/nitro-protocol';
 
 const wallet = Wallet.createRandom();
 const state: State = {
-  channel: {chainId: '0x1', channelNonce: '0x1', participants: [wallet.address]},
+  channel: {chainId: '0x1', channelNonce: 1, participants: [wallet.address]},
   outcome: [],
   turnNum: 1,
   isFinal: false,

--- a/packages/nitro-protocol/docs/protocol-tutorial/finalize-a-channel-sad.md
+++ b/packages/nitro-protocol/docs/protocol-tutorial/finalize-a-channel-sad.md
@@ -35,7 +35,7 @@ for (let i = 0; i < 3; i++) {
   participants[i] = wallets[i].address;
 }
 const chainId = '0x1234';
-const channelNonce = bigNumberify(0).toHexString();
+const channelNonce = 0;
 const channel: Channel = {chainId, channelNonce, participants};
 
 /* Choose a challenger */


### PR DESCRIPTION
These changes mirror those made in statechannels/nitro-tutorial repo, which now includes CI testing.