### PR TITLE
Store.signState returns Either

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -31,7 +31,7 @@ describe('signState', () => {
     expect(c.latestSignedByMe).toBeUndefined();
 
     const result = await Store.signState(c.channelId, c.vars[0], tx);
-    expect(result).toMatchObject({
+    expect(result).toEqualRight({
       outgoing: [
         {
           type: 'NotifyApp',

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -193,7 +193,10 @@ const takeActions = async (channels: Bytes32[]): Promise<ExecutionResult> => {
       const doAction = async (action: ProtocolAction): Promise<any> => {
         switch (action.type) {
           case 'SignState': {
-            const {outgoing, channelResult} = await Store.signState(action.channelId, action, tx);
+            const signStateResult = await Store.signState(action.channelId, action, tx);
+            if (Either.isLeft(signStateResult)) throw signStateResult;
+            const {outgoing, channelResult} = signStateResult.right;
+
             outgoing.map(n => outbox.push(n.notice));
             channelResults.push(channelResult);
             return;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -58,7 +58,7 @@ export const Store = {
 
     const {channelResult} = channel;
 
-    return {outgoing, channelResult};
+    return right({outgoing, channelResult});
   },
   getChannel: async function(
     channelId: Bytes32,
@@ -116,7 +116,7 @@ export const Store = {
   },
 };
 
-class StoreError extends Error {
+export class StoreError extends Error {
   readonly type = 'InvariantError';
   constructor(reason: StoreErrors, public readonly data: any = undefined) {
     super(reason);


### PR DESCRIPTION
Updates the `signState` api to return an `Either` instead of throwing errors. This work can be contrasted with https://github.com/statechannels/statechannels/pull/2386.

I must admit that working with typed error return values using imperative programming is tedious. We are repeatedly inspecting if a return value is an error or a valid return and making decisions based on that.

Perhaps the tedium is worth it to have explicit, typed error handling?