### PR TITLE
Update Wallet API return types

### DIFF
--- a/packages/server-wallet/e2e-test/ping/client.ts
+++ b/packages/server-wallet/e2e-test/ping/client.ts
@@ -40,9 +40,7 @@ export default class PingClient {
   }
 
   public async getChannel(channelId: string): Promise<ChannelResult> {
-    const {
-      channelResults: [channel],
-    } = await this.wallet.getState({channelId});
+    const {channelResult: channel} = await this.wallet.getState({channelId});
 
     return channel;
   }
@@ -55,7 +53,7 @@ export default class PingClient {
   public async createPingChannel(pong: Participant): Promise<ChannelResult> {
     const {
       outbox: [{params}],
-      channelResults: [channel],
+      channelResult: channel,
     } = await this.wallet.createChannel({
       appData: '0x',
       appDefinition: AddressZero,

--- a/packages/server-wallet/e2e-test/pong/controller.ts
+++ b/packages/server-wallet/e2e-test/pong/controller.ts
@@ -45,9 +45,7 @@ export default class PongController {
       };
     }
 
-    const {
-      channelResults: [channelResult],
-    } = await this.wallet.getState({
+    const {channelResult} = await this.wallet.getState({
       channelId: calculateChannelId({...convertedSignedStates[0]}),
     });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -35,7 +35,7 @@ describe('happy path', () => {
       ],
       channelResults: [{channelId: expect.any(String), turnNum: 0, appData}],
     });
-    const {channelId} = (await createPromise).channelResults[0];
+    const {channelId} = (await createPromise).channelResult;
     expect(await Channel.query().resultSize()).toEqual(1);
 
     const updated = await Channel.forId(channelId, undefined);

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -20,7 +20,7 @@ describe('happy path', () => {
     const appData = '0xaf00';
     const createPromise = w.createChannel(createChannelArgs({appData}));
     await expect(createPromise).resolves.toMatchObject({
-      channelResults: [{channelId: expect.any(String)}],
+      channelResult: {channelId: expect.any(String)},
     });
 
     await expect(createPromise).resolves.toMatchObject({
@@ -33,7 +33,7 @@ describe('happy path', () => {
           },
         },
       ],
-      channelResults: [{channelId: expect.any(String), turnNum: 0, appData}],
+      channelResult: {channelId: expect.any(String), turnNum: 0, appData},
     });
     const {channelId} = (await createPromise).channelResult;
     expect(await Channel.query().resultSize()).toEqual(1);

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -35,7 +35,7 @@ it('updates a channel', async () => {
         },
       },
     ],
-    channelResults: [{channelId, turnNum: 6, appData}],
+    channelResult: {channelId, turnNum: 6, appData},
   });
 
   const updated = await Channel.forId(channelId, undefined);


### PR DESCRIPTION
Adds two separate return types `SingleChannelResult` and `MultipleChannelResult`