### PR TITLE
Default NODE_ENV to development for usage of env.ts

### DIFF
--- a/packages/devtools/src/config/env.ts
+++ b/packages/devtools/src/config/env.ts
@@ -46,23 +46,24 @@ export function configureEnvVariables(): void {
     return;
   }
 
-  const NODE_ENV = process.env.NODE_ENV;
-
-  if (!NODE_ENV) {
-    throw new Error('The NODE_ENV environment variable is required but was not specified.');
+  if (!process.env.NODE_ENV) {
+    console.warn('[@statechannels/devtools] NODE_ENV is undefined — setting to "development"');
+    process.env.NODE_ENV = 'development';
   }
+
+  const NODE_ENV = process.env.NODE_ENV;
 
   // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
   // NOTE: dotenv joins paths with cwd https://www.npmjs.com/package/dotenv#path
-  let dotenvFiles = [
-    `.env.${NODE_ENV}.local`,
+  let dotenvFiles = ['.env'];
+
+  if (NODE_ENV) dotenvFiles = dotenvFiles.concat([`.env.${NODE_ENV}.local`, `.env.${NODE_ENV}`]);
+
+  if (NODE_ENV && NODE_ENV !== 'test')
     // Don't include `.env.local` for `test` environment
     // since normally you expect tests to produce the same
     // results for everyone
-    NODE_ENV !== 'test' && `.env.local`,
-    `.env.${NODE_ENV}`,
-    '.env'
-  ].filter((x): x is string => !!x);
+    dotenvFiles.push('.env.local');
 
   const monorepoDotenvFiles = dotenvFiles.slice(0);
 


### PR DESCRIPTION
Our software presently depends on `NODE_ENV` to exist in order to read from the environment for certain things. One of those things is the `server-wallet`, which threw an error if `NODE_ENV` was undefined. This fixes that.

Importing is still ugly though this these warnings. But manageable for now.

```node
> require('@statechannels/server-wallet')
HUB_DESTINATION environment variable should be defined, you might see issues
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
{ Wallet: [Function: Wallet], getOrThrow: [Function: getOrThrow] }
```

