### PR TITLE
Use lf for line endings for api-extractor generated files

### DIFF
--- a/packages/channel-client/api-extractor.json
+++ b/packages/channel-client/api-extractor.json
@@ -14,5 +14,7 @@
   },
   "dtsRollup": {
     "enabled": true
-  }
+  },
+
+  "newlineKind": "lf"
 }

--- a/packages/iframe-channel-provider/api-extractor.json
+++ b/packages/iframe-channel-provider/api-extractor.json
@@ -14,5 +14,6 @@
   },
   "dtsRollup": {
     "enabled": true
-  }
+  },
+  "newlineKind": "lf"
 }


### PR DESCRIPTION
Gets rid of this dreaded diff after every yarn run:
```
warning: CRLF will be replaced by LF in packages/channel-client/temp/channel-client.api.md.
The file will have its original line endings in your working directory
warning: CRLF will be replaced by LF in packages/docs-website/docs/generated-apis/channel-client.api.json.
The file will have its original line endings in your working directory
warning: CRLF will be replaced by LF in packages/docs-website/docs/generated-apis/iframe-channel-provider.api.json.
```