### PR TITLE
Add `lockApp` method

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -1,0 +1,63 @@
+import _ from 'lodash';
+import {ChannelResult} from '@statechannels/client-api-schema';
+
+import {Channel} from '../../models/channel';
+import {withSupportedState} from '../../models/__test__/fixtures/channel';
+import {Store} from '../store';
+import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import knex from '../../db/connection';
+
+import {stateVars} from './fixtures/state-vars';
+
+it('works', async () => {
+  await seedAlicesSigningWallet(knex);
+  const c = withSupportedState(stateVars({turnNum: 5}))();
+  await Channel.query().insert(c);
+
+  const {channelId, latest} = c;
+  await expect(
+    Store.lockApp(channelId, async tx =>
+      Store.signState(channelId, {...latest, turnNum: latest.turnNum + 1}, tx)
+    )
+  ).resolves.toMatchObject({channelResult: {turnNum: 6}});
+});
+
+it('works when run concurrently', async () => {
+  await seedAlicesSigningWallet(knex);
+  const c = withSupportedState(stateVars({turnNum: 5}))();
+  await Channel.query().insert(c);
+
+  const {channelId, latest} = c;
+  const next = {...latest, turnNum: latest.turnNum + 1};
+
+  const numAttempts = 10;
+  let numResolved = 0;
+  let numRejected = 0;
+  let numSettled = 0;
+  const countResolvedPromise = ({channelResult}: {channelResult: ChannelResult}): any => {
+    expect(channelResult).toMatchObject({turnNum: 6});
+    numResolved += 1;
+  };
+  const countRejectedPromise = (error: Error): any => {
+    expect(error).toMatchObject(new Error('Stale state'));
+    numRejected += 1;
+  };
+  const countSettledPromise = (): any => (numSettled += 1);
+
+  await Promise.all(
+    _.range(numAttempts).map(() =>
+      Store.lockApp(channelId, async tx => Store.signState(channelId, next, tx))
+        .then(countResolvedPromise)
+        .catch(countRejectedPromise)
+        .finally(countSettledPromise)
+    )
+  );
+
+  expect(numResolved).toEqual(1);
+  expect(numRejected).toEqual(numAttempts - 1);
+  expect(numSettled).toEqual(numAttempts);
+
+  await expect(Store.getChannel(channelId, undefined)).resolves.toMatchObject({
+    latest: {turnNum: 6},
+  });
+});

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import {ChannelResult} from '@statechannels/client-api-schema';
+import {StateVariables} from '@statechannels/wallet-core';
 
 import {Channel} from '../../models/channel';
 import {withSupportedState} from '../../models/__test__/fixtures/channel';
@@ -22,42 +23,77 @@ it('works', async () => {
   ).resolves.toMatchObject({channelResult: {turnNum: 6}});
 });
 
-it('works when run concurrently', async () => {
-  await seedAlicesSigningWallet(knex);
-  const c = withSupportedState(stateVars({turnNum: 5}))();
-  await Channel.query().insert(c);
+describe('concurrency', () => {
+  let channelId: string;
+  let numResolved: number;
+  let numRejected: number;
+  let numSettled: number;
+  let next: StateVariables;
 
-  const {channelId, latest} = c;
-  const next = {...latest, turnNum: latest.turnNum + 1};
-
+  let countResolvedPromise: any;
+  let countRejectedPromise: any;
+  let countSettledPromise: any;
   const numAttempts = 10;
-  let numResolved = 0;
-  let numRejected = 0;
-  let numSettled = 0;
-  const countResolvedPromise = ({channelResult}: {channelResult: ChannelResult}): any => {
-    expect(channelResult).toMatchObject({turnNum: 6});
-    numResolved += 1;
-  };
-  const countRejectedPromise = (error: Error): any => {
-    expect(error).toMatchObject(new Error('Stale state'));
-    numRejected += 1;
-  };
-  const countSettledPromise = (): any => (numSettled += 1);
 
-  await Promise.all(
-    _.range(numAttempts).map(() =>
-      Store.lockApp(channelId, async tx => Store.signState(channelId, next, tx))
-        .then(countResolvedPromise)
-        .catch(countRejectedPromise)
-        .finally(countSettledPromise)
-    )
-  );
+  beforeEach(async () => {
+    await seedAlicesSigningWallet(knex);
+    const c = withSupportedState(stateVars({turnNum: 5}))();
+    await Channel.query().insert(c);
+    channelId = c.channelId;
 
-  expect(numResolved).toEqual(1);
-  expect(numRejected).toEqual(numAttempts - 1);
-  expect(numSettled).toEqual(numAttempts);
+    next = {...c.latest, turnNum: c.latest.turnNum + 1};
 
-  await expect(Store.getChannel(channelId, undefined)).resolves.toMatchObject({
-    latest: {turnNum: 6},
+    numResolved = 0;
+    numRejected = 0;
+    numSettled = 0;
+    countResolvedPromise = ({channelResult}: {channelResult: ChannelResult}): any => {
+      expect(channelResult).toMatchObject({turnNum: 6});
+      numResolved += 1;
+    };
+    countRejectedPromise = (error: Error): any => {
+      expect(error).toMatchObject(new Error('Stale state'));
+      numRejected += 1;
+    };
+    countSettledPromise = (): any => (numSettled += 1);
+  });
+
+  it('works when run concurrently', async () => {
+    await Promise.all(
+      _.range(numAttempts).map(() =>
+        Store.lockApp(channelId, async tx => Store.signState(channelId, next, tx))
+          .then(countResolvedPromise)
+          .catch(countRejectedPromise)
+          .finally(countSettledPromise)
+      )
+    );
+
+    expect([numResolved, numRejected, numSettled]).toMatchObject([1, 9, 10]);
+
+    expect(numResolved).toEqual(1);
+    expect(numRejected).toEqual(numAttempts - 1);
+    expect(numSettled).toEqual(numAttempts);
+
+    await expect(Store.getChannel(channelId, undefined)).resolves.toMatchObject({
+      latest: {turnNum: 6},
+    });
+  });
+
+  test('sign state does not block concurrent updates', async () => {
+    await Promise.all(
+      _.range(numAttempts).map(() =>
+        Store.signState(channelId, next, undefined as any)
+          .then(countResolvedPromise)
+          .catch(countRejectedPromise)
+          .finally(countSettledPromise)
+      )
+    );
+
+    expect(numResolved).toEqual(10);
+    expect(numRejected).toEqual(0);
+    expect(numSettled).toEqual(numAttempts);
+
+    await expect(Store.getChannel(channelId, undefined)).resolves.toMatchObject({
+      latest: {turnNum: 6},
+    });
   });
 });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -91,7 +91,8 @@ export class Wallet implements WalletInterface {
   }
 
   async joinChannel({channelId}: JoinChannelParams): SingleChannelResult {
-    const {outbox, channelResult} = await knex.transaction(
+    const {outbox, channelResult} = await Store.lockApp(
+      channelId,
       async (tx): Promise<{outbox: any; channelResult: ChannelResult}> => {
         const channel = await Store.getChannel(channelId, tx);
 
@@ -117,7 +118,7 @@ export class Wallet implements WalletInterface {
   }
 
   async updateChannel({channelId, allocations, appData}: UpdateChannelParams): SingleChannelResult {
-    return knex.transaction(async tx => {
+    return Store.lockApp(channelId, async tx => {
       const channel = await Store.getChannel(channelId, tx);
 
       if (!channel)


### PR DESCRIPTION
Resolves https://github.com/statechannels/statechannels/issues/2371.

See https://www.notion.so/App-level-concurrency-870d2e8e5e49436696bbc303d9976e02 for discussion.

It seems a bit strange to test this kind of code with a unit test like included here. The real test will be the [stress test](https://github.com/statechannels/statechannels/issues/2391)