### PR TITLE
[channel-provider] Tweaks

### DIFF
--- a/packages/docs-website/docs/app-devs/quick-start-dapp.md
+++ b/packages/docs-website/docs/app-devs/quick-start-dapp.md
@@ -27,7 +27,7 @@ require('@statechannels/iframe-channel-provider');
 The channel provider needs to be pointed at our hosted wallet:
 
 ```typescript
-window.channelProvider.mountWalletComponent('https://xstate-wallet.statechannels.org/');
+await window.channelProvider.mountWalletComponent('https://xstate-wallet.statechannels.org/');
 ```
 
 This step mounts the wallet iFrame in your Dapp, configures communication and performs an initial handshake with the wallet.
@@ -35,12 +35,14 @@ This step mounts the wallet iFrame in your Dapp, configures communication and pe
 At some point in your user flow, you will want to enable the wallet:
 
 ```typescript
-window.channelProvider.enable();
+await window.channelProvider.enable();
 ```
 
 If everything is setup correctly, you should see the statechannels wallet UI:
 
 ![](assets/wallet-ui.png)
+
+Because this popup will be triggered, to maintain a good UX you should only call `window.channelProvider.enable()` when the user clicks a button.
 
 ## App <-> Wallet security
 

--- a/packages/iframe-channel-provider/src/channel-provider.ts
+++ b/packages/iframe-channel-provider/src/channel-provider.ts
@@ -101,10 +101,11 @@ export class IFrameChannelProvider implements IFrameChannelProviderInterface {
     }
     this.iframe.setUrl(this.url);
     this.messaging.setUrl(this.url);
+    const walletReady = this.walletReady;
     await this.iframe.mount();
     logger.info('Application successfully mounted Wallet iFrame inside DOM.');
     logger.info('Waiting for wallet ping...');
-    await this.walletReady;
+    await walletReady;
     logger.info('Wallet ready to receive requests');
     const {signingAddress, destinationAddress, walletVersion} = await this.send(
       'GetWalletInformation',
@@ -123,6 +124,12 @@ export class IFrameChannelProvider implements IFrameChannelProviderInterface {
    * @returns Promise which resolves when the wallet has completed the Enable Ethereum workflow.
    */
   async enable() {
+    if (!this.mounted) {
+      throw new Error(
+        'ChannelProvider: You must call .mountWalletComponent() before calling .enable()'
+      );
+    }
+
     const {signingAddress, destinationAddress, walletVersion} = await this.send(
       'EnableEthereum',
       {}

--- a/packages/iframe-channel-provider/src/iframe-service.ts
+++ b/packages/iframe-channel-provider/src/iframe-service.ts
@@ -110,16 +110,10 @@ export class IFrameService {
   }
 
   async getTarget(): Promise<Window> {
-    /* The below Promise shouldn't be an async executor according to this: 
-       https://eslint.org/docs/rules/no-async-promise-executor */
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async resolve => {
-      if (!this.iframe) {
-        await this.mount();
-      }
-
-      const iframe = this.iframe as HTMLIFrameElement;
-      resolve(iframe.contentWindow as Window);
-    });
+    if (!this.iframe) {
+      await this.mount();
+    }
+    const iframe = this.iframe as HTMLIFrameElement;
+    return iframe.contentWindow as Window;
   }
 }

--- a/packages/iframe-channel-provider/src/postmessage-service.ts
+++ b/packages/iframe-channel-provider/src/postmessage-service.ts
@@ -77,7 +77,7 @@ export class PostMessageService {
 
       logger.info({message}, 'Requesting:');
 
-      this.send(target, message as JsonRpcRequest, this.url);
+      this.send(target, message, this.url);
     });
   }
 


### PR DESCRIPTION
I spent some time debugging this error:
```
Failed to execute 'postMessage' on 'DOMWindow': The target origin provided does not match the recipient window's origin.
```

which you can see if you try and communicate with the wallet before the iframe has properly mounted. We need to make it clear to app devs that they should await these async methods in the correct order. Have also added an error if they are called out of order. 

