### PR TITLE
Improve lockApp error handling

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import {ChannelResult} from '@statechannels/client-api-schema';
+import {StateVariables} from '@statechannels/wallet-core';
 
 import {Channel} from '../../models/channel';
 import {withSupportedState} from '../../models/__test__/fixtures/channel';
@@ -22,42 +23,77 @@ it('works', async () => {
   ).resolves.toMatchObject({channelResult: {turnNum: 6}});
 });
 
-it('works when run concurrently', async () => {
-  await seedAlicesSigningWallet(knex);
-  const c = withSupportedState(stateVars({turnNum: 5}))();
-  await Channel.query().insert(c);
+describe('concurrency', () => {
+  let channelId: string;
+  let numResolved: number;
+  let numRejected: number;
+  let numSettled: number;
+  let next: StateVariables;
 
-  const {channelId, latest} = c;
-  const next = {...latest, turnNum: latest.turnNum + 1};
-
+  let countResolvedPromise: any;
+  let countRejectedPromise: any;
+  let countSettledPromise: any;
   const numAttempts = 10;
-  let numResolved = 0;
-  let numRejected = 0;
-  let numSettled = 0;
-  const countResolvedPromise = ({channelResult}: {channelResult: ChannelResult}): any => {
-    expect(channelResult).toMatchObject({turnNum: 6});
-    numResolved += 1;
-  };
-  const countRejectedPromise = (error: Error): any => {
-    expect(error).toMatchObject(new Error('Stale state'));
-    numRejected += 1;
-  };
-  const countSettledPromise = (): any => (numSettled += 1);
 
-  await Promise.all(
-    _.range(numAttempts).map(() =>
-      Store.lockApp(channelId, async tx => Store.signState(channelId, next, tx))
-        .then(countResolvedPromise)
-        .catch(countRejectedPromise)
-        .finally(countSettledPromise)
-    )
-  );
+  beforeEach(async () => {
+    await seedAlicesSigningWallet(knex);
+    const c = withSupportedState(stateVars({turnNum: 5}))();
+    await Channel.query().insert(c);
+    channelId = c.channelId;
 
-  expect(numResolved).toEqual(1);
-  expect(numRejected).toEqual(numAttempts - 1);
-  expect(numSettled).toEqual(numAttempts);
+    next = {...c.latest, turnNum: c.latest.turnNum + 1};
 
-  await expect(Store.getChannel(channelId, undefined)).resolves.toMatchObject({
-    latest: {turnNum: 6},
+    numResolved = 0;
+    numRejected = 0;
+    numSettled = 0;
+    countResolvedPromise = ({channelResult}: {channelResult: ChannelResult}): any => {
+      expect(channelResult).toMatchObject({turnNum: 6});
+      numResolved += 1;
+    };
+    countRejectedPromise = (error: Error): any => {
+      expect(error).toMatchObject(new Error('Stale state'));
+      numRejected += 1;
+    };
+    countSettledPromise = (): any => (numSettled += 1);
+  });
+
+  it('works when run concurrently', async () => {
+    await Promise.all(
+      _.range(numAttempts).map(() =>
+        Store.lockApp(channelId, async tx => Store.signState(channelId, next, tx))
+          .then(countResolvedPromise)
+          .catch(countRejectedPromise)
+          .finally(countSettledPromise)
+      )
+    );
+
+    expect([numResolved, numRejected, numSettled]).toMatchObject([1, 9, 10]);
+
+    expect(numResolved).toEqual(1);
+    expect(numRejected).toEqual(numAttempts - 1);
+    expect(numSettled).toEqual(numAttempts);
+
+    await expect(Store.getChannel(channelId, undefined)).resolves.toMatchObject({
+      latest: {turnNum: 6},
+    });
+  });
+
+  test('sign state does not block concurrent updates', async () => {
+    await Promise.all(
+      _.range(numAttempts).map(() =>
+        Store.signState(channelId, next, undefined as any)
+          .then(countResolvedPromise)
+          .catch(countRejectedPromise)
+          .finally(countSettledPromise)
+      )
+    );
+
+    expect(numResolved).toEqual(10);
+    expect(numRejected).toEqual(0);
+    expect(numSettled).toEqual(numAttempts);
+
+    await expect(Store.getChannel(channelId, undefined)).resolves.toMatchObject({
+      latest: {turnNum: 6},
+    });
   });
 });

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {ChannelResult} from '@statechannels/client-api-schema';
 import {StateVariables} from '@statechannels/wallet-core';
 
-import {Channel} from '../../models/channel';
+import {Channel, ChannelError} from '../../models/channel';
 import {withSupportedState} from '../../models/__test__/fixtures/channel';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
@@ -96,4 +96,17 @@ describe('concurrency', () => {
       latest: {turnNum: 6},
     });
   });
+});
+
+describe('Missing channels', () => {
+  it('throws a ChannelError by default', () =>
+    expect(Store.lockApp('foo', _.noop)).rejects.toThrow(
+      new ChannelError(ChannelError.reasons.channelMissing, {channelId: 'foo'})
+    ));
+
+  it('calls the onChannelMissing handler when given', () =>
+    expect(Store.lockApp('foo', _.noop, _.noop)).resolves.not.toThrow());
+
+  it('calls the onChannelMissing handler with the channel Id when given', () =>
+    expect(Store.lockApp('foo', _.noop, _.identity)).resolves.toEqual('foo'));
 });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -93,15 +93,11 @@ export class Wallet implements WalletInterface {
   async joinChannel({channelId}: JoinChannelParams): SingleChannelResult {
     const {outbox, channelResult} = await Store.lockApp(
       channelId,
-      async (tx): Promise<{outbox: any; channelResult: ChannelResult}> => {
-        const channel = await Store.getChannel(channelId, tx);
-
+      async (tx, channel): Promise<{outbox: any; channelResult: ChannelResult}> => {
         if (!channel)
           throw new JoinChannel.JoinChannelError(
             JoinChannel.JoinChannelError.reasons.channelNotFound,
-            {
-              channelId,
-            }
+            {channelId}
           );
 
         const nextState = getOrThrow(JoinChannel.joinChannel({channelId}, channel));
@@ -118,15 +114,11 @@ export class Wallet implements WalletInterface {
   }
 
   async updateChannel({channelId, allocations, appData}: UpdateChannelParams): SingleChannelResult {
-    return Store.lockApp(channelId, async tx => {
-      const channel = await Store.getChannel(channelId, tx);
-
+    return Store.lockApp(channelId, async (tx, channel) => {
       if (!channel)
         throw new UpdateChannel.UpdateChannelError(
           UpdateChannel.UpdateChannelError.reasons.channelNotFound,
-          {
-            channelId,
-          }
+          {channelId}
         );
 
       const outcome = deserializeAllocations(allocations);

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -91,7 +91,8 @@ export class Wallet implements WalletInterface {
   }
 
   async joinChannel({channelId}: JoinChannelParams): SingleChannelResult {
-    const {outbox, channelResult} = await knex.transaction(
+    const {outbox, channelResult} = await Store.lockApp(
+      channelId,
       async (tx): Promise<{outbox: any; channelResult: ChannelResult}> => {
         const channel = await Store.getChannel(channelId, tx);
 
@@ -117,7 +118,7 @@ export class Wallet implements WalletInterface {
   }
 
   async updateChannel({channelId, allocations, appData}: UpdateChannelParams): SingleChannelResult {
-    return knex.transaction(async tx => {
+    return Store.lockApp(channelId, async tx => {
       const channel = await Store.getChannel(channelId, tx);
 
       if (!channel)

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -32,13 +32,17 @@ export const Store = {
    * on a single row in the Channels table. This guarantees that at most one `cb` can be executing
    * concurrently across all wallets.
    */
-  lockApp: async function<T>(channelId: Bytes32, cb: (tx: Transaction) => Promise<T>): Promise<T> {
+  lockApp: async function<T>(
+    channelId: Bytes32,
+    cb: (tx: Transaction, channel: ChannelState | undefined) => Promise<T>
+  ): Promise<T> {
     return knex.transaction(async tx => {
-      await Channel.query(tx)
+      const channel = await Channel.query(tx)
         .where({channelId})
-        .forUpdate();
+        .forUpdate()
+        .first();
 
-      return cb(tx);
+      return cb(tx, channel?.protocolState);
     });
   },
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -23,6 +23,15 @@ import {WalletError, Values} from '../errors/wallet-error';
 import knex from '../db/connection';
 
 export const Store = {
+  /**
+   *
+   * @param channelId application channel Id
+   * @param cb critical code to be executed while holding a lock on channelId
+   *
+   * This excutes `cb` within the context of a SQL transaction, after first acquiring a row-level lock
+   * on a single row in the Channels table. This guarantees that at most one `cb` can be executing
+   * concurrently across all wallets.
+   */
   lockApp: async function<T>(channelId: Bytes32, cb: (tx: Transaction) => Promise<T>): Promise<T> {
     return knex.transaction(async tx => {
       await Channel.query(tx)


### PR DESCRIPTION
It seems like the default behaviour when a channel is missing should be
to throw a generic ChannelMissing error. This attempts to minimize the
chance that a missing channel goes unhandled.

This allows you to pass a custom missing channel handler, in case you
want to throw a different error.