### PR TITLE
Remove prettyPrint on pino

### DIFF
--- a/packages/server-wallet/src/logger.ts
+++ b/packages/server-wallet/src/logger.ts
@@ -1,3 +1,3 @@
 import pino from 'pino';
 
-export const logger = pino({prettyPrint: true});
+export const logger = pino();


### PR DESCRIPTION
Seems to be better practice to pipe output through `pino-pretty` e.g.,

```bash
./run-test | pino-pretty
```
