### PR TITLE
[server-wallet/e2e-test] Run ping client in a separate process

### DIFF
--- a/packages/server-wallet/e2e-test/e2e-utils/ping.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils/ping.ts
@@ -27,7 +27,7 @@ Model.knex(knex);
 
 console.log(`numPings: ${numPings}`);
 
-(async (): Promise<any> => {
+(async (): Promise<void> => {
   const pingClient = new PingClient(alice().privateKey, `http://127.0.0.1:65535`);
   await Promise.all(
     (channels || []).map(async channelId => {

--- a/packages/server-wallet/e2e-test/e2e-utils/ping.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils/ping.ts
@@ -31,12 +31,11 @@ console.log(`numPings: ${numPings}`);
   const pingClient = new PingClient(alice().privateKey, `http://127.0.0.1:65535`);
   await Promise.all(
     (channels || []).map(async channelId => {
-      for (const i of _.range(numPings)) {
-        console.log(`PINGING ${i}`);
+      for (const _i of _.range(numPings)) {
         await pingClient.ping(channelId);
       }
     })
   );
 
-  console.log('DONE');
+  process.exit();
 })();

--- a/packages/server-wallet/e2e-test/e2e-utils/ping.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils/ping.ts
@@ -30,11 +30,12 @@ console.log(`numPings: ${numPings}`);
 (async (): Promise<void> => {
   const pingClient = new PingClient(alice().privateKey, `http://127.0.0.1:65535`);
   await Promise.all(
-    (channels || []).map(async channelId => {
-      for (const _i of _.range(numPings)) {
-        await pingClient.ping(channelId);
-      }
-    })
+    (channels || []).map(async channelId =>
+      _.range(numPings).reduce(
+        async p => p.then(() => pingClient.ping(channelId)),
+        Promise.resolve()
+      )
+    )
   );
 
   process.exit();

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -98,17 +98,7 @@ describe('pinging', () => {
 
     const pingScript = childProcess.spawn(`yarn`, args);
     pingScript.on('error', logger.error);
-
-    await new Promise(resolve => {
-      pingScript.on('exit', _data => resolve());
-
-      // FIXME: I would expect `.on('exit', resolve)` to work, but it does not,
-      // jest warns 'Jest did not exit one second after the test run has completed.'
-      // This indicates to me that the spawned process does not exit, even after logging 'DONE'
-      pingScript.stdout.on('data', data => data.toString() === 'DONE\n' && resolve());
-    });
-
-    await pingScript.kill();
+    await new Promise(resolve => pingScript.on('exit', resolve));
   };
 
   beforeEach(async () => {

--- a/packages/server-wallet/e2e-test/scripts/ping.ts
+++ b/packages/server-wallet/e2e-test/scripts/ping.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs';
+import {Model} from 'objection';
+import Knex from 'knex';
+import _ from 'lodash';
+
+import {dbCofig} from '../../src/db-config';
+import PingClient from '../ping/client';
+import {alice} from '../../src/wallet/__test__/fixtures/signing-wallets';
+
+const {database, channels} = yargs
+  .command('ping', 'Ping many channels concurrently')
+  .example('ping --database ping --channels 0xf00 0x123 0xabc', 'Pings three channels')
+  .options({
+    database: {type: 'string', demandOption: true},
+    channels: {type: 'array', demandOption: true},
+  })
+  .coerce('channels', (channels: number[]): string[] =>
+    channels.map(channel => channel.toString(16))
+  ).argv;
+
+const knex = Knex(_.merge(dbCofig, {connection: {database}}));
+Model.knex(knex);
+
+(async (): Promise<any> => {
+  const pingClient = new PingClient(alice().privateKey, `http://127.0.0.1:65535`);
+  await Promise.all((channels || []).map(async channelId => pingClient.ping(channelId)));
+
+  console.log('DONE');
+})();

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -27,6 +27,7 @@
     "@types/pg": "7.14.0",
     "@types/pino": "6.0.0",
     "@types/prettier": "1.19.0",
+    "@types/yargs": "^15.0.5",
     "@typescript-eslint/eslint-plugin": "2.18.0",
     "@typescript-eslint/parser": "2.18.0",
     "body-parser": "1.19.0",
@@ -45,7 +46,8 @@
     "prettier": "1.19.1",
     "ts-jest": "25.0.0",
     "ts-node": "8.9.1",
-    "typescript": "3.7.5"
+    "typescript": "3.7.5",
+    "yargs": "^15.4.1"
   },
   "license": "MIT",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,7 +5193,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^15.0.0":
+"@types/yargs@^15.0.0", "@types/yargs@^15.0.5":
   version "15.0.5"
   resolved "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
   integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
@@ -25325,7 +25325,7 @@ yargs@^12.0.1, yargs@^12.0.2:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^15.3.0, yargs@^15.3.1:
+yargs@^15.3.0, yargs@^15.3.1, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
- Creates a `ping.ts` script which accepts command line arguments, using yargs
- `e2e.test.ts` spawns a `ping` process, rather than creating a ping client within the same process as the jest test runnier

This makes it easier to create v1 & v2 stress tests: we can spawn multiple `ping` scripts to represent different actors. They can have different databases (different indexers) or the same database (simulating horizontal scaling).