### PR TITLE
Disambiguate WireMessage and Message a bit

### DIFF
--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -28,6 +28,7 @@ let SWPayer: typeof SigningWallet;
 let SWReceiver: typeof SigningWallet;
 
 let receiverServer: ReceiverServer;
+
 beforeAll(async () => {
   receiverServer = startReceiverServer();
   await waitForServerToStart(receiverServer);
@@ -65,11 +66,9 @@ describe('e2e', () => {
   });
 
   it('can do a simple end-to-end flow with no signed states', async () => {
-    const ret = await payerClient.emptyMessage();
-    expect(ret.sender).toBe('receiver');
-    expect(ret.recipient).toBe('payer');
-    expect(ret.data.signedStates?.length).toBe(0);
-    expect(ret.data.objectives?.length).toBe(0);
+    const {signedStates, objectives} = await payerClient.emptyMessage();
+    expect(signedStates?.length).toBe(0);
+    expect(objectives?.length).toBe(0);
   });
 
   it('can create a channel, send signed state via http', async () => {

--- a/packages/server-wallet/e2e-test/receiver/app.ts
+++ b/packages/server-wallet/e2e-test/receiver/app.ts
@@ -1,6 +1,6 @@
 import bodyParser from 'body-parser';
 import express from 'express';
-import {Message} from '@statechannels/wire-format';
+import {Message} from '@statechannels/wallet-core';
 import pino from 'express-pino-logger';
 
 import {logger} from '../logger';
@@ -10,6 +10,7 @@ import ReceiverController from './controller';
 const controller = new ReceiverController();
 
 const app = express();
+
 app.use(pino({logger: logger as any}));
 
 app.post('/status', (_req, res) => res.status(200).send('OK'));

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -1,5 +1,5 @@
-import {Message} from '@statechannels/wire-format';
-import {SignedState, makeDestination, calculateChannelId} from '@statechannels/wallet-core';
+import {Message as WireMessage} from '@statechannels/wire-format';
+import {Message, makeDestination, calculateChannelId} from '@statechannels/wallet-core';
 import {Participant} from '@statechannels/client-api-schema';
 
 import {bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
@@ -19,42 +19,29 @@ export default class ReceiverController {
   }
 
   public async acceptMessageAndReturnReplies(message: Message): Promise<Message> {
-    const {
-      recipient: to,
-      sender: from,
-      data: {signedStates},
-    } = message;
-
-    // FIXME: server-wallet is using wallet-core, not wire-format for
-    // types of messages between parties. e2e-test uses wire-format
-    const convertedSignedStates = (signedStates as unknown) as SignedState[];
+    const {signedStates} = message;
 
     // FIXME: At this point, outbox should have ChannelUpdated or something
     // waiting on https://github.com/statechannels/statechannels/pull/2370
-    await this.wallet.pushMessage({
-      signedStates: convertedSignedStates,
-      to,
-      from,
-    });
+    await this.wallet.pushMessage(message);
 
-    if (convertedSignedStates.length === 0) {
+    if (!signedStates || signedStates?.length === 0) {
       return {
-        recipient: from,
-        sender: this.myParticipantID,
-        data: {signedStates: [], objectives: []},
+        signedStates: [],
+        objectives: [],
       };
+    } else {
+      const {channelResult} = await this.wallet.getState({
+        channelId: calculateChannelId(signedStates[0]),
+      });
+
+      const {
+        outbox: [messageToSendToPayer],
+      } = await (channelResult.turnNum < 4 ? this.wallet.joinChannel : this.wallet.updateChannel)(
+        channelResult
+      );
+
+      return (messageToSendToPayer.params as WireMessage).data as Message;
     }
-
-    const {channelResult} = await this.wallet.getState({
-      channelId: calculateChannelId({...convertedSignedStates[0]}),
-    });
-
-    const {
-      outbox: [messageToSendToPayer],
-    } = await (channelResult.turnNum < 4 ? this.wallet.joinChannel : this.wallet.updateChannel)(
-      channelResult
-    );
-
-    return messageToSendToPayer.params as Message;
   }
 }

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -1,3 +1,5 @@
+import {Message} from '@statechannels/wallet-core';
+
 import {Wallet} from './wallet';
 
-export {Wallet};
+export {Wallet, Message};

--- a/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
@@ -1,20 +1,18 @@
-import {SignedState} from '@statechannels/wallet-core';
+import {SignedState, Message} from '@statechannels/wallet-core';
 import _ from 'lodash';
-
-import {AddressedMessage} from '../..';
 
 import {createState} from './states';
 
-const emptyMessage = {to: 'alice', from: 'bob'};
+const emptyMessage = {};
 
-export const message = (props?: Partial<AddressedMessage>): AddressedMessage => {
-  const defaults: AddressedMessage = _.cloneDeep(emptyMessage);
+export const message = (props?: Partial<Message>): Message => {
+  const defaults: Message = _.cloneDeep(emptyMessage);
 
   return _.merge(defaults, props);
 };
 
 type WithState = {signedStates: SignedState[]};
-export function messageWithState(props?: Partial<AddressedMessage>): AddressedMessage & WithState {
+export function messageWithState(props?: Partial<Message>): Message & WithState {
   const defaults = _.merge(emptyMessage, {signedStates: [createState()]});
 
   return _.merge(defaults, props);

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -32,8 +32,6 @@ import {Store, AppHandler, MissingAppHandler} from './store';
 
 export {CreateChannelParams};
 
-export type AddressedMessage = Message & {to: string; from: string};
-
 // TODO: The client-api does not currently allow for outgoing messages to be
 // declared as the result of a wallet API call.
 // Nor does it allow for multiple channel results
@@ -50,7 +48,7 @@ export type WalletInterface = {
   getState(args: GetStateParams): SingleChannelResult;
 
   // Wallet <-> Wallet communication
-  pushMessage(m: AddressedMessage): MultipleChannelResult;
+  pushMessage(m: Message): MultipleChannelResult;
 
   // Wallet -> App communication
   onNotification(cb: (notice: StateChannelsNotification) => void): {unsubscribe: () => void};
@@ -161,7 +159,7 @@ export class Wallet implements WalletInterface {
     }
   }
 
-  async pushMessage(message: AddressedMessage): MultipleChannelResult {
+  async pushMessage(message: Message): MultipleChannelResult {
     const channelIds = await Channel.transaction(async tx => {
       return await Store.pushMessage(message, tx);
     });


### PR DESCRIPTION
It's still confusing that `pushMessage` accepts a `Message` but `MessageQueued` is a `WireMessage`, but at least now the difference is more jarring.
