### PR TITLE
[channel-provider] Restore early return to onMessage

### DIFF
--- a/packages/iframe-channel-provider/src/channel-provider.ts
+++ b/packages/iframe-channel-provider/src/channel-provider.ts
@@ -182,6 +182,9 @@ export class IFrameChannelProvider implements IFrameChannelProviderInterface {
   off: OffType = (method, params) => this.events.off(method, params);
 
   protected async onMessage(event: MessageEvent) {
+    if (!event.data.jsonrpc) {
+      return;
+    }
     const message = parseNotification(event.data); // Narrows type, throws if it does not fit the schema
     const notificationMethod = message.method;
     const notificationParams = message.params as any;


### PR DESCRIPTION
We expect a certain number of messages which will not be json-rpc related.

Closes #2438 
