### PR TITLE
Return channelResults from `pushMessage`

### DIFF
--- a/packages/client-api-schema/src/data-types.ts
+++ b/packages/client-api-schema/src/data-types.ts
@@ -105,14 +105,14 @@ export interface Funds {
 }
 
 export type ChannelStatus =
-  | 'proposed'
-  | 'opening'
-  | 'funding'
-  | 'running'
-  | 'challenging'
-  | 'responding'
-  | 'closing'
-  | 'closed';
+  | 'proposed' // The wallet is storing this channel, but you have not.
+  | 'opening' // You have joined the channel, but it's not ready to use.
+  | 'funding' // Same as 'opening'?
+  | 'running' // You are free to use the channel.
+  | 'challenging' // You cannot use the channel right now. There is a challenge ongoing, but you do not need to do anything.
+  | 'responding' // There is a challenge ongoing, and you must call `updateChannel` in order for the wallet to respond to the challenge.
+  | 'closing' // You cannot use the channel anymore, but your funds are still locked up.
+  | 'closed'; // Your funds have been released from the channel.
 
 export interface ChannelResult {
   participants: Participant[];

--- a/packages/client-api-schema/src/data-types.ts
+++ b/packages/client-api-schema/src/data-types.ts
@@ -105,7 +105,7 @@ export interface Funds {
 }
 
 export type ChannelStatus =
-  | 'proposed' // The wallet is storing this channel, but you have not.
+  | 'proposed' // The wallet is storing this channel, but you have not joined it -- ie. you have not yet signed a state.
   | 'opening' // You have joined the channel, but it's not ready to use.
   | 'funding' // Same as 'opening'?
   | 'running' // You are free to use the channel.

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -352,7 +352,7 @@
       "$ref": "#/definitions/JsonRpcRequest%3C%22GetChannels%22%2Cstructure-946177841-247-273-946177841-217-274-946177841-184-275-946177841-0-344%3E"
     },
     "GetChannelsResponse": {
-      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src%2Fdata-types.ts-2222-2467-src%2Fdata-types.ts-0-2884%5B%5D%3E"
+      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src%2Fdata-types.ts-2698-2994-src%2Fdata-types.ts-0-3411%5B%5D%3E"
     },
     "GetStateParams": {
       "additionalProperties": false,
@@ -899,7 +899,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcNotification<\"UIUpdate\",structure-683137520-795-817-683137520-763-818-683137520-734-819-683137520-0-1271>": {
+    "JsonRpcNotification<\"UIUpdate\",structure-683137520-869-891-683137520-837-892-683137520-808-893-683137520-0-1345>": {
       "additionalProperties": false,
       "description": "Specifies notification headers as per {@link https://www.jsonrpc.org/specification | JSON-RPC 2.0 Specification }",
       "properties": {
@@ -1517,7 +1517,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcResponse<def-interface-src/data-types.ts-2222-2467-src/data-types.ts-0-2884[]>": {
+    "JsonRpcResponse<def-interface-src/data-types.ts-2698-2994-src/data-types.ts-0-3411[]>": {
       "additionalProperties": false,
       "description": "Specifies response headers as per {@link https://www.jsonrpc.org/specification | JSON-RPC 2.0 Specification }",
       "properties": {
@@ -1915,7 +1915,7 @@
       "type": "object"
     },
     "UiNotification": {
-      "$ref": "#/definitions/JsonRpcNotification%3C%22UIUpdate%22%2Cstructure-683137520-795-817-683137520-763-818-683137520-734-819-683137520-0-1271%3E"
+      "$ref": "#/definitions/JsonRpcNotification%3C%22UIUpdate%22%2Cstructure-683137520-869-891-683137520-837-892-683137520-808-893-683137520-0-1345%3E"
     },
     "Uint256": {
       "description": "Uint256",

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -352,7 +352,7 @@
       "$ref": "#/definitions/JsonRpcRequest%3C%22GetChannels%22%2Cstructure-946177841-247-273-946177841-217-274-946177841-184-275-946177841-0-344%3E"
     },
     "GetChannelsResponse": {
-      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src%2Fdata-types.ts-2698-2994-src%2Fdata-types.ts-0-3411%5B%5D%3E"
+      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src%2Fdata-types.ts-2747-3043-src%2Fdata-types.ts-0-3460%5B%5D%3E"
     },
     "GetStateParams": {
       "additionalProperties": false,
@@ -1517,7 +1517,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcResponse<def-interface-src/data-types.ts-2698-2994-src/data-types.ts-0-3411[]>": {
+    "JsonRpcResponse<def-interface-src/data-types.ts-2747-3043-src/data-types.ts-0-3460[]>": {
       "additionalProperties": false,
       "description": "Specifies response headers as per {@link https://www.jsonrpc.org/specification | JSON-RPC 2.0 Specification }",
       "properties": {

--- a/packages/client-api-schema/src/notifications.ts
+++ b/packages/client-api-schema/src/notifications.ts
@@ -4,9 +4,11 @@ import {ChannelResult, Message, DomainBudget} from './data-types';
 // these notifications come *from* the wallet, which is not strictly how JSON-RPC should work
 // (since we treat the wallet as the 'server')
 
-export type ChannelProposedNotification = JsonRpcNotification<'ChannelProposed', ChannelResult>;
 export type ChannelUpdatedNotification = JsonRpcNotification<'ChannelUpdated', ChannelResult>;
+// TODO: Deprecate these. They are redundant, given the `ChannelResult`.
+export type ChannelProposedNotification = JsonRpcNotification<'ChannelProposed', ChannelResult>;
 export type ChannelClosingNotification = JsonRpcNotification<'ChannelClosed', ChannelResult>;
+
 export type MessageQueuedNotification = JsonRpcNotification<'MessageQueued', Message>;
 export type BudgetUpdatedNotification = JsonRpcNotification<'BudgetUpdated', DomainBudget>;
 export type UiNotification = JsonRpcNotification<'UIUpdate', {showWallet: boolean}>;

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -75,7 +75,7 @@ describe('e2e', () => {
     const channel = await payerClient.createPayerChannel(receiver);
 
     expect(channel.participants).toStrictEqual([payer, receiver]);
-    expect(channel.status).toBe('funding');
+    expect(channel.status).toBe('opening');
     expect(channel.turnNum).toBe(0);
 
     expect((await Channel.forId(channel.channelId, undefined)).protocolState).toMatchObject({

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -144,12 +144,13 @@ export class Channel extends Model implements RequiredColumns {
   }
 
   get protocolState(): ChannelState {
-    const {channelId, myIndex, supported, latest, latestSignedByMe} = this;
+    const {channelId, myIndex, supported, latest, latestSignedByMe, support} = this;
 
     return {
       myIndex: myIndex as 0 | 1,
       channelId,
       supported,
+      support,
       latest,
       latestSignedByMe,
       funding: (): Uint256 => '0x0', // TODO: This needs to be populated from the chain

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -49,8 +49,8 @@ const expectResults = async (
   p: Promise<{channelResults: ChannelResult[]}>,
   channelResults: Partial<ChannelResult>[]
 ): Promise<void> => {
-  await expect(p).resolves.toMatchObject({channelResults});
   await expect(p.then(data => data.channelResults)).resolves.toHaveLength(channelResults.length);
+  await expect(p).resolves.toMatchObject({channelResults});
 };
 
 describe('channel results', () => {
@@ -178,10 +178,9 @@ it('takes the next action, when the application protocol returns an action', asy
   expect(c.supported).toBeUndefined();
   const {channelId} = c;
 
-  await expect(
-    wallet.pushMessage(message({signedStates: [stateSignedBy(bob())(state)]}))
-  ).resolves.toMatchObject({
-    channelResults: [{channelId, status: 'funding'}],
+  const p = wallet.pushMessage(message({signedStates: [stateSignedBy(bob())(state)]}));
+  await expectResults(p, [{channelId, status: 'opening'}]);
+  await expect(p).resolves.toMatchObject({
     outbox: [{method: 'MessageQueued', params: {data: {signedStates: [{turnNum: 3}]}}}],
   });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -119,9 +119,7 @@ describe('channel results', () => {
     // The Channel model adds the state hash before persisting
 
     const stateVar = signedStates.map(addHash)[1];
-    const record = await Channel.query()
-      .where('channelId', calculateChannelId(stateVar))
-      .first();
+    const record = await Channel.forId(calculateChannelId(stateVar), undefined);
 
     expect(stateVar).toMatchObject(record.vars[0]);
   });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -208,9 +208,8 @@ const takeActions = async (channels: Bytes32[]): Promise<ExecutionResult> => {
       const doAction = async (action: ProtocolAction): Promise<any> => {
         switch (action.type) {
           case 'SignState': {
-            const {outgoing, channelResult} = await Store.signState(action.channelId, action, tx);
+            const {outgoing} = await Store.signState(action.channelId, action, tx);
             outgoing.map(n => outbox.push(n.notice));
-            channelResults.push(channelResult);
             return;
           }
           default:


### PR DESCRIPTION
- the `toChannelResult: (cs: ChannelState) => ChannelResult` converter properly calculates (my interpretation of) `ChannelStatus`
- the `application` workflow does not notify a `ChannelProposed` notification.
   - I think these notifications are redundant, given that the same data exists on the `ChannelResult`
- `pushMessage` returns the `ChannelResult` computed from each channel, once the channel is "marked as done"

Resolves https://github.com/statechannels/statechannels/issues/2378