### PR TITLE
[server-wallet] Add getSigningAddress to Wallet api

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -1,4 +1,5 @@
 import {ethers} from 'ethers';
+import {Transaction} from 'objection';
 
 import {truncate} from '../../db-admin/db-admin-connection';
 import knex from '../../db/connection';
@@ -7,23 +8,24 @@ import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 
 import {alice} from './fixtures/participants';
 
+const tx = {} as Transaction;
 beforeEach(async () => {
   await truncate(knex);
 });
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {
-    const signignAddress = await Store.getOrCreateSigningAddress();
+    const signignAddress = await Store.getOrCreateSigningAddress(tx);
     expect(signignAddress).toBeDefined();
     expect(ethers.utils.isAddress(signignAddress)).toBeTruthy();
 
-    const signignAddress2 = await Store.getOrCreateSigningAddress();
+    const signignAddress2 = await Store.getOrCreateSigningAddress(tx);
     expect(signignAddress).toEqual(signignAddress2);
   });
 
   it('prepopulated address returned correctly', async () => {
     await seedAlicesSigningWallet(knex);
-    const signignAddress = await Store.getOrCreateSigningAddress();
+    const signignAddress = await Store.getOrCreateSigningAddress(tx);
     expect(signignAddress).toEqual(alice().signingAddress);
   });
 });

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -1,0 +1,29 @@
+import {ethers} from 'ethers';
+
+import {truncate} from '../../db-admin/db-admin-connection';
+import knex from '../../db/connection';
+import {Store} from '../store';
+import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+
+import {alice} from './fixtures/participants';
+
+beforeEach(async () => {
+  await truncate(knex);
+});
+
+describe('signingAddress', () => {
+  it('generate address then get address', async () => {
+    const signignAddress = await Store.getOrCreateSigningAddress();
+    expect(signignAddress).toBeDefined();
+    expect(ethers.utils.isAddress(signignAddress)).toBeTruthy();
+
+    const signignAddress2 = await Store.getOrCreateSigningAddress();
+    expect(signignAddress).toEqual(signignAddress2);
+  });
+
+  it('prepopulated address returned correctly', async () => {
+    await seedAlicesSigningWallet(knex);
+    const signignAddress = await Store.getOrCreateSigningAddress();
+    expect(signignAddress).toEqual(alice().signingAddress);
+  });
+});

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -1,31 +1,34 @@
 import {ethers} from 'ethers';
-import {Transaction} from 'objection';
 
 import {truncate} from '../../db-admin/db-admin-connection';
 import knex from '../../db/connection';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {SigningWallet} from '../../models/signing-wallet';
 
 import {alice} from './fixtures/participants';
 
-const tx = {} as Transaction;
 beforeEach(async () => {
   await truncate(knex);
 });
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {
-    const signingAddress = await Store.getOrCreateSigningAddress(tx);
-    expect(signingAddress).toBeDefined();
-    expect(ethers.utils.isAddress(signingAddress)).toBeTruthy();
+    await SigningWallet.transaction(async tx => {
+      const signingAddress = await Store.getOrCreateSigningAddress(tx);
+      expect(signingAddress).toBeDefined();
+      expect(ethers.utils.isAddress(signingAddress)).toBeTruthy();
 
-    const signingAddress2 = await Store.getOrCreateSigningAddress(tx);
-    expect(signingAddress).toEqual(signingAddress2);
+      const signingAddress2 = await Store.getOrCreateSigningAddress(tx);
+      expect(signingAddress).toEqual(signingAddress2);
+    });
   });
 
   it('prepopulated address returned correctly', async () => {
-    await seedAlicesSigningWallet(knex);
-    const signingAddress = await Store.getOrCreateSigningAddress(tx);
-    expect(signingAddress).toEqual(alice().signingAddress);
+    await SigningWallet.transaction(async tx => {
+      await seedAlicesSigningWallet(knex);
+      const signingAddress = await Store.getOrCreateSigningAddress(tx);
+      expect(signingAddress).toEqual(alice().signingAddress);
+    });
   });
 });

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -15,17 +15,17 @@ beforeEach(async () => {
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {
-    const signignAddress = await Store.getOrCreateSigningAddress(tx);
-    expect(signignAddress).toBeDefined();
-    expect(ethers.utils.isAddress(signignAddress)).toBeTruthy();
+    const signingAddress = await Store.getOrCreateSigningAddress(tx);
+    expect(signingAddress).toBeDefined();
+    expect(ethers.utils.isAddress(signingAddress)).toBeTruthy();
 
-    const signignAddress2 = await Store.getOrCreateSigningAddress(tx);
-    expect(signignAddress).toEqual(signignAddress2);
+    const signingAddress2 = await Store.getOrCreateSigningAddress(tx);
+    expect(signingAddress).toEqual(signingAddress2);
   });
 
   it('prepopulated address returned correctly', async () => {
     await seedAlicesSigningWallet(knex);
-    const signignAddress = await Store.getOrCreateSigningAddress(tx);
-    expect(signignAddress).toEqual(alice().signingAddress);
+    const signingAddress = await Store.getOrCreateSigningAddress(tx);
+    expect(signingAddress).toEqual(alice().signingAddress);
   });
 });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -74,6 +74,10 @@ export class Wallet implements WalletInterface {
     return participant;
   }
 
+  public async getSigningAddress(): Promise<string> {
+    return await Store.getOrCreateSigningAddress();
+  }
+
   async createChannel(args: CreateChannelParams): SingleChannelResult {
     return Channel.transaction(async tx => {
       const {participants, appDefinition, appData, allocations} = args;

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -75,7 +75,9 @@ export class Wallet implements WalletInterface {
   }
 
   public async getSigningAddress(): Promise<string> {
-    return await Store.getOrCreateSigningAddress();
+    return SigningWallet.transaction(async tx => {
+      return await Store.getOrCreateSigningAddress(tx);
+    });
   }
 
   async createChannel(args: CreateChannelParams): SingleChannelResult {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -17,6 +17,7 @@ import _ from 'lodash';
 import {HashZero} from '@ethersproject/constants';
 import {Either, right} from 'fp-ts/lib/Either';
 import {ChannelResult} from '@statechannels/client-api-schema';
+import {ethers} from 'ethers';
 
 import {Channel, SyncState, RequiredColumns, ChannelError} from '../models/channel';
 import {SigningWallet} from '../models/signing-wallet';
@@ -42,6 +43,17 @@ export const Store = {
       signingAddress: signingKey.address,
       destination: makeDestination(HashZero),
     };
+  },
+
+  getOrCreateSigningAddress: async function(): Promise<string> {
+    let signingWallet = await SigningWallet.query().first();
+    if (!signingWallet) {
+      const randomWallet = ethers.Wallet.createRandom();
+      signingWallet = await SigningWallet.query()
+        .insert({privateKey: randomWallet.privateKey, address: randomWallet.address})
+        .returning('*');
+    }
+    return signingWallet.address;
   },
 
   /**

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -45,13 +45,13 @@ export const Store = {
     };
   },
 
-  getOrCreateSigningAddress: async function(_tx: Transaction): Promise<string> {
-    let signingWallet = await SigningWallet.query().first();
+  getOrCreateSigningAddress: async function(tx: Transaction): Promise<string> {
+    let signingWallet = await SigningWallet.query(tx).first();
     if (!signingWallet) {
       const randomWallet = ethers.Wallet.createRandom();
       // returning('*') only works with Postgres
       // https://vincit.github.io/objection.js/recipes/returning-tricks.html
-      signingWallet = await SigningWallet.query()
+      signingWallet = await SigningWallet.query(tx)
         .insert({
           privateKey: randomWallet.privateKey,
           address: randomWallet.address,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -45,12 +45,17 @@ export const Store = {
     };
   },
 
-  getOrCreateSigningAddress: async function(): Promise<string> {
+  getOrCreateSigningAddress: async function(_tx: Transaction): Promise<string> {
     let signingWallet = await SigningWallet.query().first();
     if (!signingWallet) {
       const randomWallet = ethers.Wallet.createRandom();
+      // returning('*') only works with Postgres
+      // https://vincit.github.io/objection.js/recipes/returning-tricks.html
       signingWallet = await SigningWallet.query()
-        .insert({privateKey: randomWallet.privateKey, address: randomWallet.address})
+        .insert({
+          privateKey: randomWallet.privateKey,
+          address: randomWallet.address,
+        })
         .returning('*');
     }
     return signingWallet.address;


### PR DESCRIPTION
`getSigningAddress` has the following behavior:
- if at least one signing address exists, return it.
- otherwise, create a signing address (and private key), store it, and return it.