### PR TITLE
[server-wallet] Enforce one row for signing_wallets table

### DIFF
--- a/packages/server-wallet/src/db/migrations/20200812081700_signing_wallet.ts
+++ b/packages/server-wallet/src/db/migrations/20200812081700_signing_wallet.ts
@@ -1,18 +1,27 @@
 import * as Knex from 'knex';
 
 const signingWallet = 'signing_wallets';
-const oneRowConstraint = 'one_row_constraint';
+const enforceOneRow = 'enforce_one_row';
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.alterTable(signingWallet, table =>
     table
-      .integer(oneRowConstraint)
-      .unique(oneRowConstraint)
+      .integer(enforceOneRow)
+      .unique(enforceOneRow)
       .notNullable()
       .defaultTo(1)
   );
+
+  // https://github.com/knex/knex/issues/266 will add check constraints to knex
+  await knex.raw(`\
+    ALTER TABLE ${signingWallet}
+    ADD CONSTRAINT one_row_constraint
+    CHECK (
+      ${enforceOneRow} = 1
+    )
+  `);
 }
 
 export async function down(knex: Knex): Promise<any> {
-  await knex.schema.alterTable(signingWallet, table => table.dropColumn(oneRowConstraint));
+  await knex.schema.alterTable(signingWallet, table => table.dropColumn(enforceOneRow));
 }

--- a/packages/server-wallet/src/db/migrations/20200812081700_signing_wallet.ts
+++ b/packages/server-wallet/src/db/migrations/20200812081700_signing_wallet.ts
@@ -1,0 +1,18 @@
+import * as Knex from 'knex';
+
+const signingWallet = 'signing_wallets';
+const oneRowConstraint = 'one_row_constraint';
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.alterTable(signingWallet, table =>
+    table
+      .integer(oneRowConstraint)
+      .unique(oneRowConstraint)
+      .notNullable()
+      .defaultTo(1)
+  );
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.alterTable(signingWallet, table => table.dropColumn(oneRowConstraint));
+}

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -4,7 +4,6 @@ import {truncate} from '../../db-admin/db-admin-connection';
 import knex from '../../db/connection';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
-import {SigningWallet} from '../../models/signing-wallet';
 
 import {alice} from './fixtures/participants';
 
@@ -14,21 +13,17 @@ beforeEach(async () => {
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {
-    await SigningWallet.transaction(async tx => {
-      const signingAddress = await Store.getOrCreateSigningAddress(tx);
-      expect(signingAddress).toBeDefined();
-      expect(ethers.utils.isAddress(signingAddress)).toBeTruthy();
+    const signingAddress = await Store.getOrCreateSigningAddress();
+    expect(signingAddress).toBeDefined();
+    expect(ethers.utils.isAddress(signingAddress)).toBeTruthy();
 
-      const signingAddress2 = await Store.getOrCreateSigningAddress(tx);
-      expect(signingAddress).toEqual(signingAddress2);
-    });
+    const signingAddress2 = await Store.getOrCreateSigningAddress();
+    expect(signingAddress).toEqual(signingAddress2);
   });
 
   it('prepopulated address returned correctly', async () => {
-    await SigningWallet.transaction(async tx => {
-      await seedAlicesSigningWallet(knex);
-      const signingAddress = await Store.getOrCreateSigningAddress(tx);
-      expect(signingAddress).toEqual(alice().signingAddress);
-    });
+    await seedAlicesSigningWallet(knex);
+    const signingAddress = await Store.getOrCreateSigningAddress();
+    expect(signingAddress).toEqual(alice().signingAddress);
   });
 });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -75,9 +75,7 @@ export class Wallet implements WalletInterface {
   }
 
   public async getSigningAddress(): Promise<string> {
-    return SigningWallet.transaction(async tx => {
-      return await Store.getOrCreateSigningAddress(tx);
-    });
+    return await Store.getOrCreateSigningAddress();
   }
 
   async createChannel(args: CreateChannelParams): SingleChannelResult {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -34,7 +34,7 @@ class UniqueViolationError extends Error {
 }
 
 function isUniqueViolationError(error: any): error is UniqueViolationError {
-  return error?.name === 'UniqueViolationError' && error?.columns[0] === 'one_row_constraint';
+  return error?.name === 'UniqueViolationError' && error?.columns[0] === 'enforce_one_row';
 }
 
 const throwMissingChannel: MissingAppHandler<any> = (channelId: string) => {


### PR DESCRIPTION
Fixes https://github.com/statechannels/statechannels/issues/2455

With a database constraint, the database will prevent creating more than one `signing_wallet` rows.