### PR TITLE
Fetch nonce before creating channel transaction

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -49,6 +49,19 @@ describe('happy path', () => {
       supported: undefined,
     });
   });
+
+  it('creates many channels', async () => {
+    expect(await Channel.query().resultSize()).toEqual(0);
+
+    const createArgs = createChannelArgs({appData: '0xaf00'});
+    const NUM_CHANNELS = 10;
+    const createPromises = Array(NUM_CHANNELS)
+      .fill(createArgs)
+      .map(w.createChannel);
+    await expect(Promise.all(createPromises)).resolves.not.toThrow();
+
+    expect(await Channel.query().resultSize()).toEqual(NUM_CHANNELS);
+  }, 10_000);
 });
 
 it("doesn't create a channel if it doesn't have a signing wallet", () =>


### PR DESCRIPTION
It is dangerous to start a query _outside_ a transaction, while
executing a transaction.

What happens if I call `createChannel` 10 times in a row?
1. I max out the connection pool, consuming 8 connections
2. Every ongoing transaction tries to get a new connection, to start
   a new query outside of that transaction to get the next nonce
3. No transaction finishes, since no connections open up

We've reached a deadlock.