### PR TITLE
Benchmark some wallet code, fix a serious bug, and speed things up

### DIFF
--- a/packages/nitro-protocol/src/contract/force-move-app.ts
+++ b/packages/nitro-protocol/src/contract/force-move-app.ts
@@ -25,10 +25,7 @@ export async function validTransition(
   );
 }
 
-export async function createValidTransitionTransaction(
-  fromState: State,
-  toState: State
-): Promise<TransactionRequest> {
+export function createValidTransitionTransaction(fromState: State, toState: State): {data: string} {
   const numberOfParticipants = toState.channel.participants.length;
   const fromVariablePart = getVariablePart(fromState);
   const toVariablePart = getVariablePart(toState);

--- a/packages/server-wallet/benchmarks/get-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/get-channel.benchmark.ts
@@ -1,0 +1,40 @@
+import _ from 'lodash';
+import {configureEnvVariables} from '@statechannels/devtools';
+configureEnvVariables();
+
+import adminKnex from '../src/db-admin/db-admin-connection';
+import knex from '../src/db/connection';
+import {seedAlicesSigningWallet} from '../src/db/seeds/1_signing_wallet_seeds';
+import {withSupportedState} from '../src/models/__test__/fixtures/channel';
+import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
+import {Channel} from '../src/models/channel';
+import {Wallet} from '../src/wallet';
+
+async function benchmark(): Promise<void> {
+  await adminKnex.migrate.rollback();
+  await adminKnex.migrate.latest();
+
+  await seedAlicesSigningWallet(knex);
+  const c = withSupportedState()({vars: [stateVars()]});
+  const result = await Channel.query().insert(c);
+
+  c.protocolState;
+
+  result.protocolState;
+
+  const wallet = new Wallet();
+
+  const NUM_CALLS = 100;
+  const iter = _.range(NUM_CALLS);
+  const key = `getChannel x ${NUM_CALLS}`;
+  console.time(key);
+  for (const _i of iter) {
+    await wallet.getState({channelId: c.channelId});
+  }
+  console.timeEnd(key);
+
+  await adminKnex.destroy();
+  await knex.destroy();
+}
+
+benchmark();

--- a/packages/server-wallet/benchmarks/get-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/get-channel.benchmark.ts
@@ -28,6 +28,7 @@ async function benchmark(): Promise<void> {
   const iter = _.range(NUM_CALLS);
   const key = `getChannel x ${NUM_CALLS}`;
   console.time(key);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for (const _i of iter) {
     await wallet.getState({channelId: c.channelId});
   }

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -12,10 +12,10 @@ import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
 import {Channel} from '../src/models/channel';
 import {Wallet} from '../src/wallet';
 
-const NUM_UPDATES = walletConfig.timingMetrics ? 5 : 50;
+const NUM_UPDATES = walletConfig.timingMetrics ? 10 : 50;
 const iter = _.range(NUM_UPDATES);
 
-async function setup() {
+async function setup(): Promise<Channel[]> {
   await seedAlicesSigningWallet(knex);
 
   const channels = [];
@@ -48,15 +48,11 @@ async function benchmark(): Promise<void> {
   }
   console.timeEnd(key);
 
-  console.time((key = 'setup'));
   channels = await setup();
-  console.timeEnd(key);
-
-  console.log(channels.length);
 
   console.time((key = `concurrent x ${NUM_UPDATES}`));
   await Promise.all(
-    channels.slice(0, 10).map(async channel =>
+    channels.map(async channel =>
       wallet.updateChannel({
         channelId: channel.channelId,
         allocations: [{token: AddressZero, allocationItems: []}],

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -3,6 +3,7 @@ import {AddressZero} from '@ethersproject/constants';
 import {configureEnvVariables} from '@statechannels/devtools';
 configureEnvVariables();
 
+import walletConfig from '../src/config';
 import adminKnex from '../src/db-admin/db-admin-connection';
 import knex from '../src/db/connection';
 import {seedAlicesSigningWallet} from '../src/db/seeds/1_signing_wallet_seeds';
@@ -16,7 +17,7 @@ async function benchmark(): Promise<void> {
   await adminKnex.migrate.latest();
 
   await seedAlicesSigningWallet(knex);
-  const NUM_UPDATES = 10;
+  const NUM_UPDATES = walletConfig.timingMetrics ? 5 : 50;
   const iter = _.range(NUM_UPDATES);
 
   const channels = [];

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -51,16 +51,15 @@ async function benchmark(): Promise<void> {
   channels = await setup();
 
   console.time((key = `concurrent x ${NUM_UPDATES}`));
-  false &&
-    (await Promise.all(
-      channels.map(async channel =>
-        wallet.updateChannel({
-          channelId: channel.channelId,
-          allocations: [{token: AddressZero, allocationItems: []}],
-          appData: '0x',
-        })
-      )
-    ));
+  await Promise.all(
+    channels.map(async channel =>
+      wallet.updateChannel({
+        channelId: channel.channelId,
+        allocations: [{token: AddressZero, allocationItems: []}],
+        appData: '0x',
+      })
+    )
+  );
 
   console.timeEnd(key);
 

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -51,15 +51,16 @@ async function benchmark(): Promise<void> {
   channels = await setup();
 
   console.time((key = `concurrent x ${NUM_UPDATES}`));
-  await Promise.all(
-    channels.map(async channel =>
-      wallet.updateChannel({
-        channelId: channel.channelId,
-        allocations: [{token: AddressZero, allocationItems: []}],
-        appData: '0x',
-      })
-    )
-  );
+  false &&
+    (await Promise.all(
+      channels.map(async channel =>
+        wallet.updateChannel({
+          channelId: channel.channelId,
+          allocations: [{token: AddressZero, allocationItems: []}],
+          appData: '0x',
+        })
+      )
+    ));
 
   console.timeEnd(key);
 

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -1,0 +1,47 @@
+import _ from 'lodash';
+import {AddressZero} from '@ethersproject/constants';
+import {configureEnvVariables} from '@statechannels/devtools';
+configureEnvVariables();
+
+import adminKnex from '../src/db-admin/db-admin-connection';
+import knex from '../src/db/connection';
+import {seedAlicesSigningWallet} from '../src/db/seeds/1_signing_wallet_seeds';
+import {withSupportedState} from '../src/models/__test__/fixtures/channel';
+import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
+import {Channel} from '../src/models/channel';
+import {Wallet} from '../src/wallet';
+
+async function benchmark(): Promise<void> {
+  await adminKnex.migrate.rollback();
+  await adminKnex.migrate.latest();
+
+  await seedAlicesSigningWallet(knex);
+  const NUM_UPDATES = 20;
+  const iter = _.range(NUM_UPDATES);
+
+  const channels = [];
+  for (const channelNonce of iter) {
+    const c = withSupportedState()({channelNonce, vars: [stateVars({turnNum: 3})]});
+    await Channel.query().insert(c);
+
+    channels.push(c);
+  }
+
+  const wallet = new Wallet();
+
+  const key = `updateChannel x ${NUM_UPDATES}`;
+  console.time(key);
+  for (const i of iter) {
+    await wallet.updateChannel({
+      channelId: channels[i].channelId,
+      allocations: [{token: AddressZero, allocationItems: []}],
+      appData: '0x',
+    });
+  }
+  console.timeEnd(key);
+
+  await adminKnex.destroy();
+  await knex.destroy();
+}
+
+benchmark();

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -12,7 +12,7 @@ import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
 import {Channel} from '../src/models/channel';
 import {Wallet} from '../src/wallet';
 
-const NUM_UPDATES = walletConfig.timingMetrics ? 10 : 50;
+const NUM_UPDATES = walletConfig.timingMetrics ? 10 : 100;
 const iter = _.range(NUM_UPDATES);
 
 async function setup(): Promise<Channel[]> {

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -16,7 +16,7 @@ async function benchmark(): Promise<void> {
   await adminKnex.migrate.latest();
 
   await seedAlicesSigningWallet(knex);
-  const NUM_UPDATES = 20;
+  const NUM_UPDATES = 10;
   const iter = _.range(NUM_UPDATES);
 
   const channels = [];

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -5,6 +5,7 @@ import {Wallet} from 'ethers';
 import {makeDestination, BN, Message} from '@statechannels/wallet-core';
 import {Message as WireMessage} from '@statechannels/wire-format';
 
+import walletConfig from '../../src/config';
 import {Wallet as ServerWallet} from '../../src';
 import {Bytes32, Address} from '../../src/type-aliases';
 
@@ -110,10 +111,8 @@ export default class PayerClient {
   }
 }
 
-// eslint-disable-next-line no-process-env
-const TIME = !!process.env.TIMING_METRICS;
 async function time<T>(label: string, cb: () => Promise<T>): Promise<T> {
-  if (TIME) {
+  if (walletConfig.timingMetrics) {
     console.time(label);
     const result = await cb();
     console.timeEnd(label);

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -2,6 +2,7 @@ import {Message as WireMessage} from '@statechannels/wire-format';
 import {Message, makeDestination} from '@statechannels/wallet-core';
 import {Participant} from '@statechannels/client-api-schema';
 
+import walletConfig from '../../src/config';
 import {bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
 import {Wallet} from '../../src/wallet';
 
@@ -45,9 +46,8 @@ export default class ReceiverController {
 }
 
 // eslint-disable-next-line no-process-env
-const TIME = !!process.env.TIMING_METRICS;
 async function time<T>(label: string, cb: () => Promise<T>): Promise<T> {
-  if (TIME) {
+  if (walletConfig.timingMetrics) {
     console.time(label);
     const result = await cb();
     console.timeEnd(label);

--- a/packages/server-wallet/src/__test__/evm-validator.test.ts
+++ b/packages/server-wallet/src/__test__/evm-validator.test.ts
@@ -15,6 +15,8 @@ beforeEach(async () => {
   await AppBytecode.query().insert([appBytecode()]);
 });
 
+const mockTx: any = undefined;
+
 it('returns true for a valid transition', async () => {
   // Sanity check that we're validating with byte code
   expect(
@@ -28,7 +30,7 @@ it('returns true for a valid transition', async () => {
     appDefinition: COUNTING_APP_DEFINITION,
     appData: utils.defaultAbiCoder.encode(['uint256'], [2]),
   });
-  expect(await validateTransitionWithEVM(fromState, toState)).toBe(true);
+  expect(await validateTransitionWithEVM(fromState, toState, mockTx)).toBe(true);
 });
 
 it('returns false for an invalid transition', async () => {
@@ -44,7 +46,7 @@ it('returns false for an invalid transition', async () => {
     appDefinition: COUNTING_APP_DEFINITION,
     appData: utils.defaultAbiCoder.encode(['uint256'], [1]),
   });
-  expect(await validateTransitionWithEVM(fromState, toState)).toBe(false);
+  expect(await validateTransitionWithEVM(fromState, toState, mockTx)).toBe(false);
 });
 
 it('skips validating when no byte code exists for the app definition', async () => {
@@ -55,5 +57,5 @@ it('skips validating when no byte code exists for the app definition', async () 
   const state = createState({
     appDefinition: UNDEFINED_APP_DEFINITION,
   });
-  expect(await validateTransitionWithEVM(state, state)).toBe(true);
+  expect(await validateTransitionWithEVM(state, state, mockTx)).toBe(true);
 });

--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -17,6 +17,7 @@ interface ServerWalletConfig {
   ethAssetHolderAddress?: string;
   debugKnex?: string;
   skipEvmValidation: boolean;
+  timingMetrics: boolean;
 }
 
 // TODO: Nest configuration options inside keys like db, server, wallet, debug, etc
@@ -39,6 +40,7 @@ const config: ServerWalletConfig = {
   ethAssetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
   debugKnex: process.env.DEBUG_KNEX,
   skipEvmValidation: (process.env.SKIP_EVM_VALIDATION || 'false').toLowerCase() === 'true',
+  timingMetrics: process.env.TIMING_METRICS === 'ON',
 };
 
 if (['test', 'development', 'production'].indexOf(config.nodeEnv) === -1) {

--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -4,7 +4,7 @@ import * as PureEVM from 'pure-evm';
 import {utils} from 'ethers';
 
 import {AppBytecode} from './models/app-bytecode';
-import {logger} from './logger';
+// import {logger} from './logger';
 import config from './config';
 
 /**
@@ -27,9 +27,9 @@ export const validateTransitionWithEVM = async (
     undefined
   );
   if (!bytecode) {
-    logger.warn(
-      `No bytecode found for appDefinition ${from.appDefinition} and chain id ${config.chainNetworkID}. Skipping valid transition check`
-    );
+    // logger.warn(
+    //   `No bytecode found for appDefinition ${from.appDefinition} and chain id ${config.chainNetworkID}. Skipping valid transition check`
+    // );
     return true;
   }
 

--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -16,7 +16,10 @@ export const validateTransitionWithEVM = async (
   to: State
 ): Promise<boolean | undefined> => {
   if (from.appDefinition !== to.appDefinition) {
-    throw new Error('States are using different appDefinitions');
+    logger.error('Invalid transition', {
+      error: new Error('States are using different appDefinitions'),
+    });
+    return false;
   }
   const bytecode = await AppBytecode.getBytecode(
     config.chainNetworkID,

--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -8,6 +8,9 @@ import {AppBytecode} from './models/app-bytecode';
 import {logger} from './logger';
 import config from './config';
 
+const MISSING = '0x';
+const bytecodeCache: Record<string, string | undefined> = {};
+
 /**
  * Takes two states and runs the validateTransition in an evm (pureevm) if the bytecode exists in the DB.
  * Returns a promise that resolves to true if the validateTransition returns true false otherwise
@@ -23,8 +26,11 @@ export const validateTransitionWithEVM = async (
     });
     return false;
   }
-  const bytecode = await AppBytecode.getBytecode(config.chainNetworkID, from.appDefinition, tx);
-  if (!bytecode) {
+  const bytecode =
+    bytecodeCache[from.appDefinition] ??
+    (bytecodeCache[from.appDefinition] =
+      (await AppBytecode.getBytecode(config.chainNetworkID, from.appDefinition, tx)) || MISSING);
+  if (bytecode === MISSING) {
     // logger.warn(
     //   `No bytecode found for appDefinition ${from.appDefinition} and chain id ${config.chainNetworkID}. Skipping valid transition check`
     // );

--- a/packages/server-wallet/src/metrics.ts
+++ b/packages/server-wallet/src/metrics.ts
@@ -1,12 +1,12 @@
+import walletConfig from './config';
+
 export const timerFactory = (prefix: string) => async <T>(
   label: string,
   cb: () => Promise<T>
 ): Promise<T> => time(`${prefix}: ${label}`, cb);
 
-// eslint-disable-next-line no-process-env
-const TIME = !!process.env.TIMING_METRICS;
 async function time<T>(label: string, cb: () => Promise<T>): Promise<T> {
-  if (TIME) {
+  if (walletConfig.timingMetrics) {
     console.time(label);
     const result = await cb();
     console.timeEnd(label);

--- a/packages/server-wallet/src/metrics.ts
+++ b/packages/server-wallet/src/metrics.ts
@@ -1,5 +1,6 @@
 import walletConfig from './config';
 
+// TODO: We should return a sync and an async timer
 export const timerFactory = (prefix: string) => async <T>(
   label: string,
   cb: () => Promise<T>

--- a/packages/server-wallet/src/metrics.ts
+++ b/packages/server-wallet/src/metrics.ts
@@ -1,0 +1,17 @@
+export const timerFactory = (prefix: string) => async <T>(
+  label: string,
+  cb: () => Promise<T>
+): Promise<T> => time(`${prefix}: ${label}`, cb);
+
+// eslint-disable-next-line no-process-env
+const TIME = !!process.env.TIMING_METRICS;
+async function time<T>(label: string, cb: () => Promise<T>): Promise<T> {
+  if (TIME) {
+    console.time(label);
+    const result = await cb();
+    console.timeEnd(label);
+    return result;
+  } else {
+    return await cb();
+  }
+}

--- a/packages/server-wallet/src/models/signing-wallet.ts
+++ b/packages/server-wallet/src/models/signing-wallet.ts
@@ -4,6 +4,7 @@ import {ethers} from 'ethers';
 
 import {Address, Bytes32} from '../type-aliases';
 import {Values} from '../errors/wallet-error';
+import {fastSignState} from '../utilities/signatures';
 
 export class SigningWallet extends Model {
   readonly id!: number;
@@ -47,10 +48,7 @@ export class SigningWallet extends Model {
   async signState(state: State): Promise<SignatureEntry> {
     return {
       signer: this.address,
-      // TODO: fastSignState appears to actually slow down updateChannel, the one
-      // place where this is called.
-      // signature: (await fastSignState(state, this.privateKey)).signature
-      signature: signState(state, this.privateKey),
+      signature: (await fastSignState(state, this.privateKey)).signature,
     };
   }
 }

--- a/packages/server-wallet/src/models/signing-wallet.ts
+++ b/packages/server-wallet/src/models/signing-wallet.ts
@@ -4,7 +4,6 @@ import {ethers} from 'ethers';
 
 import {Address, Bytes32} from '../type-aliases';
 import {Values} from '../errors/wallet-error';
-import {fastSignState} from '../utilities/signatures';
 
 export class SigningWallet extends Model {
   readonly id!: number;
@@ -48,7 +47,10 @@ export class SigningWallet extends Model {
   async signState(state: State): Promise<SignatureEntry> {
     return {
       signer: this.address,
-      signature: (await fastSignState(state, this.privateKey)).signature,
+      // TODO: fastSignState appears to actually slow down updateChannel, the one
+      // place where this is called.
+      // signature: (await fastSignState(state, this.privateKey)).signature
+      signature: signState(state, this.privateKey),
     };
   }
 }

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -23,6 +23,8 @@ describe('addSignedState', () => {
       signatures: [{signer: alice().address, signature: BOB_SIGNATURE}],
     };
 
-    await expect(Store.addSignedState(signedState, tx)).rejects.toThrow('Invalid signature');
+    await expect(Store.addSignedState(undefined, signedState, tx)).rejects.toThrow(
+      'Invalid signature'
+    );
   });
 });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -211,9 +211,7 @@ export class Wallet implements WalletInterface {
 
   async getState({channelId}: GetStateParams): SingleChannelResult {
     try {
-      const {channelResult} = await Channel.query()
-        .where({channelId})
-        .first();
+      const {channelResult} = await Channel.forId(channelId, undefined);
 
       return {
         channelResult,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -167,7 +167,8 @@ export const Store = {
   },
 
   addSignedState: async function(signedState: SignedState, tx: Transaction): Promise<Channel> {
-    const timer = timerFactory('    add signed state');
+    const channelId = calculateChannelId(signedState);
+    const timer = timerFactory(`    add signed state ${channelId}`);
 
     await timer('validating signatures', async () => validateSignatures(signedState));
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -184,7 +184,7 @@ export const Store = {
       const {supported} = channel;
       if (
         !(await timer('validating transition', async () =>
-          validateTransitionWithEVM(supported, signedState)
+          validateTransitionWithEVM(supported, signedState, tx)
         ))
       ) {
         throw new StoreError('Invalid state transition', {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -124,7 +124,7 @@ export const Store = {
     );
 
     const sender = channel.participants[channel.myIndex].participantId;
-    const data = {signedStates: [addHash(signedState)]};
+    const data = await timer('adding hash', async () => ({signedStates: [addHash(signedState)]}));
     const notMe = (_p: any, i: number): boolean => i !== channel.myIndex;
 
     const outgoing = state.participants.filter(notMe).map(({participantId: recipient}) => ({
@@ -202,11 +202,13 @@ export const Store = {
 
     let channelVars = channel.vars;
 
-    channelVars = addState(channelVars, signedState);
+    channelVars = await timer('adding state', async () => addState(channelVars, signedState));
 
     channelVars = clearOldStates(channelVars, channel.isSupported ? channel.support : undefined);
 
-    validateInvariants(channelVars, channel.myAddress);
+    await timer('validating invariants', async () =>
+      validateInvariants(channelVars, channel.myAddress)
+    );
 
     const cols = {...channel.channelConstants, vars: channelVars};
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -179,19 +179,18 @@ export const Store = {
       getOrCreateChannel(signedState, signingAddress, tx)
     );
 
-    if (
-      !(await timer(
-        'validating transition',
-        async () =>
-          !config.skipEvmValidation &&
-          channel.supported &&
-          validateTransitionWithEVM(channel.supported, signedState)
-      ))
-    ) {
-      throw new StoreError('Invalid state transition', {
-        from: channel.supported,
-        to: signedState,
-      });
+    if (!config.skipEvmValidation && channel.supported) {
+      const {supported} = channel;
+      if (
+        !(await timer('validating transition', async () =>
+          validateTransitionWithEVM(supported, signedState)
+        ))
+      ) {
+        throw new StoreError('Invalid state transition', {
+          from: channel.supported,
+          to: signedState,
+        });
+      }
     }
 
     let channelVars = channel.vars;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -334,8 +334,6 @@ function addState(
   vars: SignedStateVarsWithHash[],
   signedState: SignedState
 ): SignedStateVarsWithHash[] {
-  validateSignatures(signedState);
-
   const clonedVariables = _.cloneDeep(vars);
   const stateHash = hashState(signedState);
   const existingStateIndex = clonedVariables.findIndex(v => v.stateHash === stateHash);


### PR DESCRIPTION
This adds a naive `timerFactory` which lets us [time](https://github.com/statechannels/statechannels/compare/ags/wallet-benchmarks?expand=1#diff-da530680787955aca14faaf1899bcce0R87) some async, and slow sync function calls.

By [inspecting the output](https://github.com/statechannels/statechannels/commit/a65e6001b59b373cad67982938ead7be0c84f057) and auditing the code, I removed a number of database queries.

I also used [`fastSignState`](https://github.com/statechannels/statechannels/commit/d1bf1f3e75ef1e8d9a8bb88c000196c55d6fba4d) implemented by @kerzhner , which was a huge time saver in the stress test:
- [before d1bf1f3e75ef1e8d9a8bb88c000196c55d6fba4d](https://app.circleci.com/pipelines/github/statechannels/statechannels/8670/workflows/995f686f-d3f7-4c08-a3db-8166ef22270a/jobs/40855)
- [after d1bf1f3e75ef1e8d9a8bb88c000196c55d6fba4d](https://app.circleci.com/pipelines/github/statechannels/statechannels/8671/workflows/037cf4d9-0d52-4196-9362-1f5008fb2288/jobs/40862)

Finally, I identified a [serious bug](https://github.com/statechannels/statechannels/commit/ce077a490da229364da286fdfce8f22e87fd416b) which would create a deadlock when too many update channel calls are made simultaenously.

# Results
## On master (d6929e0)
```
monorepo/packages/server-wallet on  master [$!?] is 📦 v0.3.0 via ⬢ v12.16.3 on ☁️  us-west-1 took 2s 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 2597.107ms
concurrent x 100: 0.007ms
```

Stress test on master (with 100 channels)
```
┌─────────────────────────────────────┬────────────────────┬───────────────────┬───────────────────┐
│ Action                              │ Min (MS)           │ Max (MS)          │ Avg (MS)          │
├─────────────────────────────────────┼────────────────────┼───────────────────┼───────────────────┤
│ Individual makePayment call         │ 1561.1062720008194 │ 6970.285530000925 │ 3949.791616135605 │
├─────────────────────────────────────┼────────────────────┼───────────────────┼───────────────────┤
│ 25 consecutive calls of makePayment │ 97704.9870209992   │ 99348.86164898798 │ 98744.79040339016 │
└─────────────────────────────────────┴────────────────────┴───────────────────┴───────────────────┘
```


## This branch (d1bf1f3)
```
monorepo/packages/server-wallet on  ags/wallet-benchmarks [$?] is 📦 v0.3.0 via ⬢ v12.16.3 on ☁️  us-west-1 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 1449.653ms
concurrent x 100: 1392.089ms
```

[Stress test](https://app.circleci.com/pipelines/github/statechannels/statechannels/8671/workflows/037cf4d9-0d52-4196-9362-1f5008fb2288/jobs/40862/parallel-runs/0/steps/0-104) (also 100 channels)

```
┌─────────────────────────────────────┬────────────────────┬───────────────────┬───────────────────┐
│ Action                              │ Min (MS)           │ Max (MS)          │ Avg (MS)          │
├─────────────────────────────────────┼────────────────────┼───────────────────┼───────────────────┤
│ Individual makePayment call         │ 1481.4771390110254 │ 4240.864399001002 │ 2173.318449879604 │
├─────────────────────────────────────┼────────────────────┼───────────────────┼───────────────────┤
│ 25 consecutive calls of makePayment │ 53470.81020399928  │ 55041.33449099958 │ 54332.96124699011 │
└─────────────────────────────────────┴────────────────────┴───────────────────┴───────────────────┘
```

# Remaining improvements
- [ ] Repeat for `pushMessage`
- [x] Getting the address from an ethers wallet is slow
- [ ] verifying signatures with ethers is slow
- [ ] hashing states with ethers is slow