### PR TITLE
v0.3.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
     "packages/*",
     "packages/docs-website"
   ],
-  "version": "0.3.1",
+  "version": "0.3.4",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "patch-package": "6.2.0"
   },
   "devDependencies": {
-    "@statechannels/devtools": "^0.3.0",
+    "@statechannels/devtools": "^0.3.4",
     "@types/prettier": "1.19.0",
     "eslint-plugin-import": "2.20.0",
     "husky": "3.0.7",

--- a/packages/benchmarking/package.json
+++ b/packages/benchmarking/package.json
@@ -1,12 +1,12 @@
 {
   "name": "benchmarking",
   "description": "Scripts used to time the xstate wallet",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "George Knee",
   "devDependencies": {
-    "@statechannels/channel-client": "^0.3.1",
-    "@statechannels/iframe-channel-provider": "^0.3.1",
-    "@statechannels/nitro-protocol": "^0.3.2",
+    "@statechannels/channel-client": "^0.3.4",
+    "@statechannels/iframe-channel-provider": "^0.3.4",
+    "@statechannels/nitro-protocol": "^0.3.4",
     "@types/http-server": "0.10.0",
     "@types/webpack": "4.41.12",
     "ethers": "4.0.48",

--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -50,5 +50,5 @@
     "test": "jest",
     "test:ci": "jest --runInBand"
   },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@statechannels/channel-client",
   "description": "Browser-compatible JS client implementing the State Channels Client API",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "snario <liam@l4v.io>",
   "dependencies": {
-    "@statechannels/client-api-schema": "^0.3.1",
-    "@statechannels/iframe-channel-provider": "^0.3.1",
+    "@statechannels/client-api-schema": "^0.3.4",
+    "@statechannels/iframe-channel-provider": "^0.3.4",
     "ethers": "4.0.48",
     "eventemitter3": "4.0.0",
     "loglevel": "1.6.8"

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/client-api-schema",
   "description": "JSON-RPC Schema and TypeScript typings for the State Channels Client API",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "snario <liam@l4v.io>",
   "contributors": [
     "Alex Gap <alex.gap@consensys.net>",

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -48,5 +48,5 @@
     "test": "jest",
     "test:ci": "yarn test --ci --runInBand"
   },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/devtools",
   "description": "Scripts used for our team development processes",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "statechannels",
   "bin": {
     "start-shared-ganache": "lib/src/ganache/start-ganache-script.js"

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -66,5 +66,5 @@
     "prepare": "yarn build:typescript",
     "start:shared-ganache": "node lib/src/ganache/start-ganache-script.js"
   },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/docs-website/website/package.json
+++ b/packages/docs-website/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-website",
   "description": "Documentation for @statechannels packages",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "private": "true",
   "author": "statechannels",
   "bugs": "https://github.com/statechannels/statechannels/issues",
@@ -23,9 +23,9 @@
   },
   "dependencies": {
     "@microsoft/api-documenter": "^7.8.21",
-    "@statechannels/channel-client": "^0.3.1",
-    "@statechannels/iframe-channel-provider": "^0.3.1",
-    "@statechannels/nitro-protocol": "^0.3.2",
+    "@statechannels/channel-client": "^0.3.4",
+    "@statechannels/iframe-channel-provider": "^0.3.4",
+    "@statechannels/nitro-protocol": "^0.3.4",
     "docusaurus": "1.11.1",
     "highlight.js": "10.0.2",
     "highlightjs-solidity": "https://github.com/highlightjs/highlightjs-solidity",

--- a/packages/iframe-channel-provider/package.json
+++ b/packages/iframe-channel-provider/package.json
@@ -77,5 +77,5 @@
     "test:coverage": "jest --coverage"
   },
   "types": "dist/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/iframe-channel-provider/package.json
+++ b/packages/iframe-channel-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statechannels/iframe-channel-provider",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "browser": "dist/iframe-channel-provider.js",
   "browserslist": {
     "production": [
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.9.2",
-    "@statechannels/client-api-schema": "^0.3.1",
+    "@statechannels/client-api-schema": "^0.3.4",
     "@types/debug": "4.1.5",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@statechannels/integration-tests",
   "description": "Tests that integrate various @statechannels/ pakages",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "George Knee",
   "devDependencies": {
-    "@statechannels/channel-client": "^0.3.1",
-    "@statechannels/client-api-schema": "^0.3.1",
-    "@statechannels/iframe-channel-provider": "^0.3.1",
+    "@statechannels/channel-client": "^0.3.4",
+    "@statechannels/client-api-schema": "^0.3.4",
+    "@statechannels/iframe-channel-provider": "^0.3.4",
     "@types/node": "13.5.1",
     "@types/wait-on": "4.0.0",
     "canvas": "2.6.1",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -21,5 +21,5 @@
   "scripts": {
     "integration-tests": "jest"
   },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@statechannels/jest-gas-reporter",
   "description": "A jest reporter that reports the gas used by various calls to ethereum contracts.",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "Alex Gap <alex@magmo.com>",
   "dependencies": {
-    "@statechannels/devtools": "^0.3.1",
+    "@statechannels/devtools": "^0.3.4",
     "easy-table": "1.1.1",
     "ethers": "4.0.48",
     "path": "0.12.7",

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -40,5 +40,5 @@
     "prepare": "yarn build"
   },
   "types": "lib/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/nitro-protocol",
   "description": "A protocol for state channel networks",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "author": "statechannels",
   "browser": "dist/nitro-protocol.min.js",
   "bugs": "https://github.com/statechannels/monorepo/issues",
@@ -10,7 +10,7 @@
     "ethers": "4.0.48"
   },
   "devDependencies": {
-    "@statechannels/devtools": "^0.3.1",
+    "@statechannels/devtools": "^0.3.4",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/jest": "25.1.0",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -85,5 +85,5 @@
     "test:contracts": "jest -c ./config/jest/jest.contracts.config.js"
   },
   "types": "lib/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -88,5 +88,6 @@
     "test:e2e": "SERVER_DB_NAME=payer yarn jest -c ./jest/jest.e2e.config.js",
     "test:stress": "SERVER_DB_NAME=payer yarn jest -c ./jest/jest.stress.config.js --runInBand"
   },
-  "types": "lib/src/wallet/index.d.ts"
+  "types": "lib/src/wallet/index.d.ts",
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -5,9 +5,9 @@
   "author": "",
   "dependencies": {
     "@bitauth/libauth": "1.17.1",
-    "@statechannels/client-api-schema": "^0.3.1",
-    "@statechannels/nitro-protocol": "^0.3.2",
-    "@statechannels/wallet-core": "^0.3.1",
+    "@statechannels/client-api-schema": "^0.3.4",
+    "@statechannels/nitro-protocol": "^0.3.4",
+    "@statechannels/wallet-core": "^0.3.4",
     "ethers": "5.0.7",
     "fp-ts": "2.7.0",
     "knex": "0.20.9",
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@pacote/jest-either": "4.0.4",
-    "@statechannels/devtools": "^0.3.1",
+    "@statechannels/devtools": "^0.3.4",
     "@types/body-parser": "^1.19.0",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@statechannels/wallet-core",
   "description": "State channel wallet components.",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "Alex Gap",
   "dependencies": {
-    "@statechannels/nitro-protocol": "^0.3.1",
-    "@statechannels/wire-format": "^0.3.1",
+    "@statechannels/nitro-protocol": "^0.3.4",
+    "@statechannels/wire-format": "^0.3.4",
     "ethers": "5.0.7",
     "lodash": "4.17.19"
   },
   "devDependencies": {
     "@babel/core": "7.8.3",
-    "@statechannels/devtools": "^0.3.1",
+    "@statechannels/devtools": "^0.3.4",
     "@types/babel__core": "7.1.7",
     "@types/lodash": "4.14.149",
     "awesome-typescript-loader": "5.2.1",

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -39,5 +39,5 @@
     "test:ci": "yarn test --ci --runInBand"
   },
   "types": "lib/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/wire-format/package.json
+++ b/packages/wire-format/package.json
@@ -45,5 +45,5 @@
     "test": "jest",
     "test:ci": "yarn test --ci --runInBand"
   },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/wire-format/package.json
+++ b/packages/wire-format/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/wire-format",
   "description": "JSON-RPC Schema and TypeScript typings for the Wallet-to-Wallet Message Format",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "Tom Close",
   "contributors": [],
   "dependencies": {

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -150,5 +150,5 @@
     "test:with-chain": "jest --runInBand -c ./config/jest/jest.with-chain.config.js",
     "build-storybook": "build-storybook"
   },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226"
 }

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/xstate-wallet",
   "description": "State channel wallet using xstate.",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "author": "Alex Gap",
   "babel": {
     "presets": [
@@ -25,10 +25,10 @@
     "@rimble/connection-banner": "1.2.3",
     "@rimble/utils": "1.2.3",
     "@sentry/browser": "5.15.5",
-    "@statechannels/client-api-schema": "^0.3.1",
-    "@statechannels/nitro-protocol": "^0.3.2",
-    "@statechannels/wallet-core": "^0.3.1",
-    "@statechannels/wire-format": "^0.3.1",
+    "@statechannels/client-api-schema": "^0.3.4",
+    "@statechannels/nitro-protocol": "^0.3.4",
+    "@statechannels/wallet-core": "^0.3.4",
+    "@statechannels/wire-format": "^0.3.4",
     "@xstate/react": "1.0.0-rc.3",
     "async-lock": "1.2.2",
     "awesome-typescript-loader": "5.2.1",
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@babel/core": "^7.11.4",
     "@babel/preset-env": "^7.11.0",
-    "@statechannels/devtools": "^0.3.1",
+    "@statechannels/devtools": "^0.3.4",
     "@storybook/addon-actions": "^6.0.16",
     "@storybook/addon-essentials": "^6.0.16",
     "@storybook/addon-info": "5.3.19",


### PR DESCRIPTION
`server-wallet` was published at version 0.3.4, with dependencies that were not published. Hence, I tried (and [mostly succeeded](https://github.com/statechannels/statechannels/issues/2497)) to publish all packages at 0.3.4.

These versions have already been published.