### PR TITLE
[monorepo] Improvements to Publishing workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "postinstall": "patch-package",
     "preinstall": "npx typesync",
     "prepare": "lerna run --concurrency 8 --stream prepare",
-    "publish": "lerna publish --yes from-package patch",
     "release:netlify": "lerna run release:netlify --stream -- --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) $([ $(git rev-parse --abbrev-ref HEAD) = master ] && echo --prod)",
     "release:netlify:incremental": "lerna run release:netlify --stream --since $(git merge-base $CIRCLE_BRANCH origin/master) -- --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD)",
     "release:netlify:production": "lerna run release:netlify:production --stream -- --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) --prod",

--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -49,6 +49,5 @@
     "prepare": "rm -rf lib && yarn build",
     "test": "jest",
     "test:ci": "jest --runInBand"
-  },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  }
 }

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -47,6 +47,5 @@
     "prepare": "rm -rf lib; yarn build",
     "test": "jest",
     "test:ci": "yarn test --ci --runInBand"
-  },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -65,6 +65,5 @@
     "precommit": "lint-staged --quiet",
     "prepare": "yarn build:typescript",
     "start:shared-ganache": "node lib/src/ganache/start-ganache-script.js"
-  },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  }
 }

--- a/packages/docs-website/website/package.json
+++ b/packages/docs-website/website/package.json
@@ -15,8 +15,7 @@
     "publish-gh-pages": "docusaurus-publish",
     "release:netlify": "netlify deploy --site $NITRO_PROTOCOL_NETLIFY_ID --dir=build/docs-website",
     "rename-version": "docusaurus-rename-version",
-    "version": "docusaurus-version $npm_package_version",
-    "postversion": "git add versions.json",
+    "version": "docusaurus-version $npm_package_version && git add versions.json",
     "write-translations": "docusaurus-write-translations"
   },
   "devDependencies": {

--- a/packages/docs-website/website/package.json
+++ b/packages/docs-website/website/package.json
@@ -16,6 +16,7 @@
     "release:netlify": "netlify deploy --site $NITRO_PROTOCOL_NETLIFY_ID --dir=build/docs-website",
     "rename-version": "docusaurus-rename-version",
     "version": "docusaurus-version $npm_package_version",
+    "postversion": "git add versions.json",
     "write-translations": "docusaurus-write-translations"
   },
   "devDependencies": {

--- a/packages/iframe-channel-provider/package.json
+++ b/packages/iframe-channel-provider/package.json
@@ -76,6 +76,5 @@
     "test:ci": "CI=true jest --runInBand --ci --all --detectOpenHandles",
     "test:coverage": "jest --coverage"
   },
-  "types": "dist/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "types": "dist/src/index.d.ts"
 }

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -20,6 +20,5 @@
   "repository": "statechannels/monorepo/blob/master/packages/integration-tests",
   "scripts": {
     "integration-tests": "jest"
-  },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  }
 }

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -39,6 +39,5 @@
     "precommit": "lint-staged --quiet",
     "prepare": "yarn build"
   },
-  "types": "lib/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "types": "lib/src/index.d.ts"
 }

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -84,6 +84,5 @@
     "test:ci:contracts": "yarn test:contracts --all --ci --runInBand --bail",
     "test:contracts": "jest -c ./config/jest/jest.contracts.config.js"
   },
-  "types": "lib/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "types": "lib/src/index.d.ts"
 }

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -38,6 +38,5 @@
     "test": "jest -c ./config/jest/jest.config.js",
     "test:ci": "yarn test --ci --runInBand"
   },
-  "types": "lib/src/index.d.ts",
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  "types": "lib/src/index.d.ts"
 }

--- a/packages/wire-format/package.json
+++ b/packages/wire-format/package.json
@@ -44,6 +44,5 @@
     "prepare": "yarn build",
     "test": "jest",
     "test:ci": "yarn test --ci --runInBand"
-  },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  }
 }

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -149,6 +149,5 @@
     "test:ci": "yarn test --ci --runInBand && yarn test:with-chain",
     "test:with-chain": "jest --runInBand -c ./config/jest/jest.with-chain.config.js",
     "build-storybook": "build-storybook"
-  },
-  "gitHead": "991fbdfee56075b77c80d068e93e13ffed2f745c"
+  }
 }


### PR DESCRIPTION
Ensures clean working directory when running `lerna version`, so that immediately running `lerna publish` will not error out. See #2497 . It essentially rolls the `versions.json` file in our docs website in with the package.json files when the version commit is made. 


Also deletes `gitHead` entries, and removes an unecessary script from the top level `package.json`. Unfortunately I think `gitHead` entries will still be generated (and they shouldn't). It's difficult to test this without publishing things to npm. 