### PR TITLE
Export configured knex

### DIFF
--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -2,5 +2,6 @@ import {Message} from '@statechannels/wallet-core';
 
 import {Wallet} from './wallet';
 import {Outgoing} from './protocols/actions';
+import adminKnex from './db-admin/db-admin-connection';
 
-export {Wallet, Message, Outgoing};
+export {Wallet, Message, Outgoing, adminKnex as WalletKnex};


### PR DESCRIPTION
Builds on https://github.com/statechannels/statechannels/pull/2531.

Exporting configured knex is intended to help packages that use `server-wallet` and need to migrate the `server-wallet` database.