### PR TITLE
Minimal hashing

### DIFF
--- a/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
+++ b/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
@@ -69,11 +69,11 @@ const startReceiver = async (
     };
   }
 };
+
+const NUM_CHANNELS = 20;
+const NUM_PAYMENTS = 20;
+
 async function generateData(type: 'BubbleProf' | 'FlameGraph' | 'Doctor'): Promise<void> {
-  const receiverServer = await startReceiver(type);
-
-  await waitForServerToStart(receiverServer);
-
   const [SWPayer, SWReceiver] = [knexPayer, knexReceiver].map(knex => SigningWallet.bindKnex(knex));
 
   await Promise.all([knexPayer, knexReceiver].map(db => truncate(db)));
@@ -88,10 +88,15 @@ async function generateData(type: 'BubbleProf' | 'FlameGraph' | 'Doctor'): Promi
     alice().privateKey,
     getParticipant('receiver', bob().privateKey),
     bob().privateKey,
-    100,
+    NUM_CHANNELS,
     knexPayer
   );
-  await triggerPayments(channelIds);
+
+  const receiverServer = await startReceiver(type);
+
+  await waitForServerToStart(receiverServer);
+
+  await triggerPayments(channelIds, NUM_PAYMENTS);
 
   kill(receiverServer.server.pid, 'SIGINT');
 

--- a/packages/server-wallet/src/models/signing-wallet.ts
+++ b/packages/server-wallet/src/models/signing-wallet.ts
@@ -1,5 +1,5 @@
 import {JSONSchema, Model, Pojo, ModelOptions} from 'objection';
-import {SignatureEntry, State, signState} from '@statechannels/wallet-core';
+import {SignatureEntry, State, signState, StateWithHash} from '@statechannels/wallet-core';
 import {ethers} from 'ethers';
 
 import {Address, Bytes32} from '../type-aliases';
@@ -45,7 +45,7 @@ export class SigningWallet extends Model {
     };
   }
 
-  async signState(state: State): Promise<SignatureEntry> {
+  async signState(state: StateWithHash): Promise<SignatureEntry> {
     return {
       signer: this.address,
       signature: (await fastSignState(state, this.privateKey)).signature,

--- a/packages/server-wallet/src/utilities/__test__/signatures.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/signatures.test.ts
@@ -1,6 +1,12 @@
 import {Wallet} from 'ethers';
 import {AddressZero} from '@ethersproject/constants';
-import {State, simpleEthAllocation, signState, getSignerAddress} from '@statechannels/wallet-core';
+import {
+  State,
+  simpleEthAllocation,
+  signState,
+  getSignerAddress,
+  hashState,
+} from '@statechannels/wallet-core';
 import _ from 'lodash';
 
 import {participant} from '../../wallet/__test__/fixtures/participants';
@@ -51,7 +57,8 @@ it('getSignerAddress vs fastRecover', async () => {
     const signedState = await fastSignState(state, privateKey);
     try {
       const recovered = getSignerAddress(signedState.state, signedState.signature);
-      const fastRecovered = fastRecoverAddress(signedState.state, signedState.signature);
+      const stateHash = hashState(signedState.state);
+      const fastRecovered = fastRecoverAddress(signedState.state, signedState.signature, stateHash);
       expect(recovered).toEqual(fastRecovered);
     } catch (error) {
       logger.info({error, state, privateKey});

--- a/packages/server-wallet/src/utilities/__test__/signatures.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/signatures.test.ts
@@ -12,6 +12,7 @@ import _ from 'lodash';
 import {participant} from '../../wallet/__test__/fixtures/participants';
 import {fastSignState, fastRecoverAddress} from '../signatures';
 import {logger} from '../../logger';
+import {addHash} from '../../state-utils';
 
 it('sign vs fastSign', async () => {
   _.range(5).map(async channelNonce => {
@@ -29,7 +30,7 @@ it('sign vs fastSign', async () => {
     };
 
     const signedState = signState(state, privateKey);
-    const fastSignedState = fastSignState(state, privateKey);
+    const fastSignedState = fastSignState(addHash(state), privateKey);
     try {
       expect(signedState).toEqual((await fastSignedState).signature);
     } catch (error) {
@@ -54,7 +55,7 @@ it('getSignerAddress vs fastRecover', async () => {
       challengeDuration: 0x5,
     };
 
-    const signedState = await fastSignState(state, privateKey);
+    const signedState = await fastSignState(addHash(state), privateKey);
     try {
       const recovered = getSignerAddress(signedState.state, signedState.signature);
       const stateHash = hashState(signedState.state);

--- a/packages/server-wallet/src/utilities/signatures.ts
+++ b/packages/server-wallet/src/utilities/signatures.ts
@@ -1,6 +1,6 @@
 import {instantiateSecp256k1, Secp256k1, RecoveryId} from '@bitauth/libauth';
 import {utils, Wallet} from 'ethers';
-import {State, hashState, calculateChannelId} from '@statechannels/wallet-core';
+import {State, calculateChannelId, StateWithHash} from '@statechannels/wallet-core';
 
 let secp256k1: Secp256k1;
 export const initialized: Promise<any> = instantiateSecp256k1().then(m => (secp256k1 = m));
@@ -10,7 +10,7 @@ const cachedAddress = (privateKey: string): string =>
   knownWallets[privateKey] || (knownWallets[privateKey] = new Wallet(privateKey).address);
 
 export async function fastSignState(
-  state: State,
+  state: StateWithHash,
   privateKey: string
 ): Promise<{state: State; signature: string}> {
   const address = cachedAddress(privateKey);
@@ -18,9 +18,9 @@ export async function fastSignState(
     throw new Error("The state must be signed with a participant's private key");
   }
 
-  const hashedState = hashState(state);
+  const {stateHash} = state;
 
-  const signature = await fastSignData(hashedState, privateKey);
+  const signature = await fastSignData(stateHash, privateKey);
   return {state, signature};
 }
 

--- a/packages/server-wallet/src/utilities/signatures.ts
+++ b/packages/server-wallet/src/utilities/signatures.ts
@@ -24,8 +24,7 @@ export async function fastSignState(
   return {state, signature};
 }
 
-export function fastRecoverAddress(state: State, signature: string): string {
-  const stateHash = hashState(state);
+export function fastRecoverAddress(state: State, signature: string, stateHash: string): string {
   const recover = Number.parseInt('0x' + signature.slice(-2)) - 27;
 
   const digest = Buffer.from(hashMessage(stateHash).substr(2), 'hex');

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -2,6 +2,7 @@ import Objection from 'objection';
 
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
+import {addHash} from '../../state-utils';
 
 import {createState} from './fixtures/states';
 import {alice} from './fixtures/signing-wallets';
@@ -18,10 +19,10 @@ describe('addSignedState', () => {
   const BOB_SIGNATURE =
     '0x36a5fd36a1c9a85afdeee3f9471579656eefceb08bc0ff53d194a67d6433c6385cc8c9aa049306fc7cce901f7b3345bccde311cceadc74a40a89a9d74d86d9b91b';
   it('throws on an invalid signature', async () => {
-    const signedState = {
+    const signedState = addHash({
       ...createState(),
       signatures: [{signer: alice().address, signature: BOB_SIGNATURE}],
-    };
+    });
 
     await expect(Store.addSignedState(undefined, signedState, tx)).rejects.toThrow(
       'Invalid signature'

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -80,6 +80,7 @@ export interface Signed {
 export interface Hashed {
   stateHash: string;
 }
+export type StateWithHash = State & Hashed;
 export type SignedState = State & Signed;
 export type SignedStateWithHash = SignedState & Hashed;
 


### PR DESCRIPTION
This PR reduces the number of times that a (running) state is hashed to exactly once per wallet. This is the minimum number of times (since Alice can't trust the hash of the state that Bob sends Alice).

This is inspired by the [flamegraph](https://41825-209829093-gh.circle-artifacts.com/0/home/circleci/project/artifacts/1288.clinic-flame.html#selectedNode=6302&zoomedNode=&exclude=8000-0-0-0-780&merged=true) generated eg. on the current master.

Locally, I observed significant reductions in the time to run a stress test.

I also observed:
```
monorepo/packages/server-wallet on  ags/minimal-hashing [⇡$] is 📦 v0.3.4 via ⬢ v12.16.3 on ☁️  us-west-1 took 11s 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 926.527ms
concurrent x 100: 611.480ms

monorepo/packages/server-wallet on  ags/minimal-hashing [⇡$] is 📦 v0.3.4 via ⬢ v12.16.3 on ☁️  us-west-1 took 11s 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 972.824ms
concurrent x 100: 646.256ms

monorepo/packages/server-wallet on  master [$] is 📦 v0.3.4 via ⬢ v12.16.3 on ☁️  us-west-1 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 1245.383ms
concurrent x 100: 988.024ms

monorepo/packages/server-wallet on  master [$] is 📦 v0.3.4 via ⬢ v12.16.3 on ☁️  us-west-1 took 12s 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 1259.899ms
concurrent x 100: 831.417ms
```

On circle, I did not observe a significant speedup on the stress test [after removing _some_ of the redundant hashing](https://app.circleci.com/pipelines/github/statechannels/statechannels/8831/workflows/d7397072-00fd-4416-8005-91fc55c1e003/jobs/41833). There is a significant variance in the metric reported by the stress test, so this may be an outlier. (This variance is an issue that might solve itself as we change some things about the design of the stress test.)