### PR TITLE
adminKnex that gets exported does not "require" devtools

### DIFF
--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/server-wallet",
   "description": "http server statechannel wallet",
-  "version": "0.3.5",
+  "version": "0.3.6-beta-1",
   "author": "",
   "dependencies": {
     "@bitauth/libauth": "1.17.1",

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/server-wallet",
   "description": "http server statechannel wallet",
-  "version": "0.3.6-beta-1",
+  "version": "0.3.6-beta-2",
   "author": "",
   "dependencies": {
     "@bitauth/libauth": "1.17.1",

--- a/packages/server-wallet/src/db-admin/knexfile.ts
+++ b/packages/server-wallet/src/db-admin/knexfile.ts
@@ -1,16 +1,25 @@
-// Populate env vars as knexfile is used directly in yarn scripts
 import * as path from 'path';
 
-import {configureEnvVariables} from '@statechannels/devtools';
 import {Config} from 'knex';
+
+// Populate env vars as knexfile is used directly in yarn scripts
+// FIXME We should not need to depend on devtools at this step.
+try {
+  require('@statechannels/devtools').configureEnvVariables();
+} catch (err) {
+  if (/Cannot find module '@statechannels\/devtools'/.test(err.message))
+    console.warn(`
+WARNING: @statechannels/devtools not detected.
+         Ensure required env variables are properly configured in the shell.
+    `);
+  else throw err;
+}
 
 import {dbConfig} from '../db/config';
 import config from '../config';
 
 const BASE_PATH = path.join(__dirname, '..', 'db');
 const extensions = [path.extname(__filename)];
-
-configureEnvVariables();
 
 let knexConfig: Config = {
   ...dbConfig,


### PR DESCRIPTION
Yes, I know, it does `require` devtools, but it can get by without it.

This is important for projects that depend on the server wallet and import the db-admin-connection. It is a temporary fix, since we aim to remove the use of configureEnvVariables.