### PR TITLE
Validate the db config

### DIFF
--- a/packages/server-wallet/src/db/config.ts
+++ b/packages/server-wallet/src/db/config.ts
@@ -3,16 +3,4 @@ import {knexSnakeCaseMappers} from 'objection';
 
 import walletConfig from '../config';
 
-export const dbConfig: Config = {
-  client: 'postgres',
-
-  connection: walletConfig.postgresDatabaseUrl || {
-    host: walletConfig.postgresHost,
-    port: Number(walletConfig.postgresPort),
-    database: walletConfig.postgresDBName,
-    user: walletConfig.postgresDBUser,
-    password: walletConfig.postgresDBPassword,
-  },
-
-  ...knexSnakeCaseMappers(),
-};
+export const dbConfig: Config = {...walletConfig.dbConfig, ...knexSnakeCaseMappers()};


### PR DESCRIPTION
Provides a useful error in this sort of scenario.
```
packages/e2e-testing/src on  master [!] on ☁️  us-west-1 
❯ SERVER_DB_NAME=payment ts-node payment-server.ts start
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"

/Users/andrewstewart/Code/magmo/monorepo/packages/server-wallet/src/config.ts:30
  else throw new Error(`Expected process.env.${key} to be a string`);
             ^
Error: Expected process.env.SERVER_DB_USER to be a string
```