### PR TITLE
Remove nohoist

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,6 @@
   "workspaces": {
     "packages": [
       "packages/*"
-    ],
-    "nohoist": [
-      "**/ethers"
     ]
   }
 }


### PR DESCRIPTION
This shouldn't be necessary as all packages use the same version of ethers. Hoisting should save a little bit of disk space (modest, though since ethers is small). 

