### PR TITLE
[docs-website] Inject algolia api key to source code

### DIFF
--- a/packages/docs-website/docusaurus.config.js
+++ b/packages/docs-website/docusaurus.config.js
@@ -82,7 +82,7 @@ module.exports = {
       }
     },
     algolia: {
-      apiKey: process.env.ALGOLIA_API_KEY,
+      apiKey: '1868e7d6465afaecbff245a9bd7627bb',
       indexName: 'statechannels'
     },
     prism: {

--- a/packages/docs-website/package.json
+++ b/packages/docs-website/package.json
@@ -9,7 +9,7 @@
     "api-documenter": "node scripts/api-documenter.js",
     "build:netlify": "yarn build",
     "examples": "docusaurus-examples",
-    "start": "yarn trigger-api-generation && yarn api-documenter && ALGOLIA_API_KEY='a-secret-that-is-known-to-circleci' docusaurus start",
+    "start": "yarn trigger-api-generation && yarn api-documenter && docusaurus start",
     "trigger-api-generation": "cd ../.. && yarn lerna run generate-api cd packages/docs-website",
     "build": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus build",
     "publish-gh-pages": "docusaurus-publish",


### PR DESCRIPTION
Avoids relying on environment variables, which had led to some hacks and bad dev experience (`yarn build` failed with an uninformative error message if you didn't have the right env var set). 

I checked with the algolia team and this key is OK to check in to source control.

