### PR TITLE
Add ~/.cache/yarn to save_cache list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ integration_test_settings: &integration_test_settings
 
 save_dep: &save_dep
   save_cache:
-    key: v6-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v7-dependency-cache-{{ checksum "yarn.lock" }}
     paths:
       - ~/.cache/yarn
       - node_modules
@@ -49,7 +49,7 @@ save_dep: &save_dep
 
 restore_dep: &restore_dep
   restore_cache:
-    key: v6-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v7-dependency-cache-{{ checksum "yarn.lock" }}
 
 save_built_artifacts: &save_built_artifacts
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ save_dep: &save_dep
   save_cache:
     key: v6-dependency-cache-{{ checksum "yarn.lock" }}
     paths:
+      - ~/.cache/yarn
       - node_modules
       - packages/benchmarking/node_modules
       - packages/channel-client/node_modules


### PR DESCRIPTION
<img width="1145" alt="Screenshot 2020-09-15 at 22 16 17" src="https://user-images.githubusercontent.com/1833419/93265834-16a61580-f7a1-11ea-8604-d248d8e0077f.png">

I never saw this before on circle.