### PR TITLE
[docs-website] Point to latest deployed wallet

### DIFF
--- a/packages/docs-website/docs/app-devs/quick-start-dapp.md
+++ b/packages/docs-website/docs/app-devs/quick-start-dapp.md
@@ -30,7 +30,7 @@ The channel provider needs to be pointed at our hosted wallet:
 
 ```typescript
 await window.channelProvider.mountWalletComponent(
-  'https://xstate-wallet-v-0-3-0.statechannels.org/'
+  'https://xstate-wallet-v-0-3-0.statechannels.org'
 );
 ```
 

--- a/packages/docs-website/docs/app-devs/quick-start-dapp.md
+++ b/packages/docs-website/docs/app-devs/quick-start-dapp.md
@@ -29,7 +29,9 @@ require('@statechannels/iframe-channel-provider');
 The channel provider needs to be pointed at our hosted wallet:
 
 ```typescript
-await window.channelProvider.mountWalletComponent('https://xstate-wallet.statechannels.org');
+await window.channelProvider.mountWalletComponent(
+  'https://xstate-wallet-v-0-3-0.statechannels.org/'
+);
 ```
 
 This step mounts the wallet iFrame in your Dapp, configures communication and performs an initial handshake with the wallet.


### PR DESCRIPTION
We should point app developers at the most recent version of the wallet that we have deployed. In particular, v0.3.0 includes a number of fixes and passes the `integration-test` (so is known to work with `channel-client`, `iframe-channel-provider` and `client-api-schema` all @ 0.3.0). 

AFAIK more recent versions of those packages should also work with the 0.3.0 browser wallet, but we do not yet have a rigorous sem ver workflow in this repo so that is by no means guaranteed. 