### PR TITLE
[server-wallet] Fail profile job on error

### DIFF
--- a/packages/server-wallet/e2e-test/e2e-utils.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils.ts
@@ -41,7 +41,7 @@ export const triggerPayments = async (
   );
 
   return new Promise((resolve, reject) => {
-    payerScript.on('exit', (code, signal) => {
+    payerScript.on('exit', (code, _signal) => {
       if (code === 0) {
         resolve();
       } else {

--- a/packages/server-wallet/e2e-test/e2e-utils.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils.ts
@@ -39,7 +39,17 @@ export const triggerPayments = async (
   payerScript.on('message', message =>
     console.log(PerformanceTimer.formatResults(JSON.parse(message as any)))
   );
-  await new Promise(resolve => payerScript.on('exit', resolve));
+
+  return new Promise((resolve, reject) => {
+    payerScript.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject();
+      }
+    });
+    payerScript.on('error', reject);
+  });
 };
 
 /**

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -8,18 +8,25 @@ import {Wallet as ServerWallet} from '../../src';
 import {Bytes32, Address} from '../../src/type-aliases';
 import {recordFunctionMetrics, timerFactory} from '../../src/metrics';
 import {payerConfig} from '../e2e-utils';
-import {defaultConfig} from '../../src/config';
+import {defaultConfig, ServerWalletConfig} from '../../src/config';
 
 export default class PayerClient {
-  private readonly wallet: ServerWallet = recordFunctionMetrics(
-    new ServerWallet(payerConfig),
-    payerConfig.timingMetrics
-  );
+  private readonly wallet: ServerWallet;
+  constructor(
+    private readonly pk: Bytes32,
+    private readonly receiverHttpServerURL: string,
+    readonly config?: ServerWalletConfig
+  ) {
+    this.wallet = recordFunctionMetrics(
+      new ServerWallet(this.config || payerConfig),
+      payerConfig.timingMetrics
+    );
+  }
+
   public async destroy(): Promise<void> {
     await this.wallet.destroy();
   }
   private time = timerFactory(defaultConfig.timingMetrics, 'payerClient');
-  constructor(private readonly pk: Bytes32, private readonly receiverHttpServerURL: string) {}
 
   public readonly participantId = 'payer';
 

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -33,7 +33,7 @@ export default {
         channels.map(channel => channel.toString(16))
       )
       .example(
-        'payer --database payer --channels 0xf00 0x123 0xabc',
+        'start --database payer --channels 0xf00 0x123 0xabc',
         'Makes payments with three channels'
       ),
 

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -1,6 +1,4 @@
 import {Argv} from 'yargs';
-import {Model} from 'objection';
-import Knex from 'knex';
 import _ from 'lodash';
 import {configureEnvVariables} from '@statechannels/devtools';
 configureEnvVariables();
@@ -8,7 +6,7 @@ configureEnvVariables();
 import PayerClient from '../payer/client';
 import {alice} from '../../src/wallet/__test__/fixtures/signing-wallets';
 import {recordFunctionMetrics} from '../../src/metrics';
-import {extractDBConfigFromServerWalletConfig, defaultConfig} from '../../src/config';
+import {defaultConfig} from '../../src/config';
 
 import {PerformanceTimer} from './timers';
 
@@ -42,13 +40,11 @@ export default {
   handler: async (argv: {[key: string]: any} & Argv['argv']): Promise<void> => {
     const {database, numPayments, channels} = argv;
 
-    const knex = Knex(
-      _.merge(extractDBConfigFromServerWalletConfig(defaultConfig), {connection: {database}})
-    );
-    Model.knex(knex);
-
     const payerClient = recordFunctionMetrics(
-      new PayerClient(alice().privateKey, `http://127.0.0.1:65535`)
+      new PayerClient(alice().privateKey, `http://127.0.0.1:65535`, {
+        ...defaultConfig,
+        postgresDBName: database,
+      })
     );
 
     const performanceTimer = new PerformanceTimer(channels || [], numPayments);

--- a/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
+++ b/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
@@ -38,7 +38,6 @@ const startReceiver = async (
   server.stdout?.on('data', data => console.log(data.toString()));
   server.stderr?.on('data', data => {
     console.error(data.toString());
-    process.exit(1);
   });
 
   return {

--- a/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
+++ b/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
@@ -73,7 +73,11 @@ async function generateData(type: 'BubbleProf' | 'FlameGraph' | 'Doctor'): Promi
 
   await waitForServerToStart(receiverServer);
 
-  await triggerPayments(channelIds, NUM_PAYMENTS);
+  try {
+    await triggerPayments(channelIds, NUM_PAYMENTS);
+  } catch (error) {
+    process.exit(1);
+  }
 
   kill(receiverServer.server.pid, 'SIGINT');
 

--- a/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
+++ b/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
@@ -1,4 +1,4 @@
-import {exec} from 'child_process';
+import {exec, ChildProcess} from 'child_process';
 
 import {configureEnvVariables} from '@statechannels/devtools';
 
@@ -20,54 +20,31 @@ import kill = require('tree-kill');
 const startReceiver = async (
   profiling: 'FlameGraph' | 'BubbleProf' | 'Doctor'
 ): Promise<ReceiverServer> => {
+  let server: ChildProcess;
   if (profiling === 'FlameGraph') {
-    const server = exec(
-      `npx clinic flame --collect-only -- node ./lib/e2e-test/receiver/server.js`,
-      {
-        env: {
-          // eslint-disable-next-line
-          ...process.env,
-          SERVER_DB_NAME: 'receiver',
-        },
-      }
-    );
-    return {
-      server: server,
-      url: `http://127.0.0.1:65535`,
-    };
+    server = exec(`npx clinic flame --collect-only -- node ./lib/e2e-test/receiver/server.js`);
   } else if (profiling == 'Doctor') {
-    const server = exec(
-      `npx clinic doctor --collect-only -- node  ./lib/e2e-test/receiver/server.js`,
-      {
-        env: {
-          // eslint-disable-next-line
-          ...process.env,
-          SERVER_DB_NAME: 'receiver',
-        },
-      }
-    );
-
-    return {
-      server: server,
-      url: `http://127.0.0.1:65535`,
-    };
+    server = exec(`npx clinic doctor --collect-only -- node  ./lib/e2e-test/receiver/server.js`);
   } else {
-    const server = exec(
-      `npx clinic bubbleprof --collect-only -- node  ./lib/e2e-test/receiver/server.js`,
-      {
-        env: {
-          // eslint-disable-next-line
-          ...process.env,
-          SERVER_DB_NAME: 'receiver',
-        },
-      }
+    server = exec(
+      `npx clinic bubbleprof --collect-only -- node  ./lib/e2e-test/receiver/server.js`
     );
-
-    return {
-      server: server,
-      url: `http://127.0.0.1:65535`,
-    };
   }
+
+  server.on('error', data => {
+    console.error(data.toString());
+    process.exit(1);
+  });
+  server.stdout?.on('data', data => console.log(data.toString()));
+  server.stderr?.on('data', data => {
+    console.error(data.toString());
+    process.exit(1);
+  });
+
+  return {
+    server: server,
+    url: `http://127.0.0.1:65535`,
+  };
 };
 
 const NUM_CHANNELS = 20;

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -111,6 +111,7 @@ export class Wallet implements WalletInterface {
     this.getState = this.getState.bind(this);
     this.pushMessage = this.pushMessage.bind(this);
     this.takeActions = this.takeActions.bind(this);
+    this.destroy = this.destroy.bind(this);
 
     // set up timing metrics
     if (this.walletConfig.timingMetrics) {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -124,8 +124,7 @@ export class Wallet implements WalletInterface {
 
   public async destroy(): Promise<void> {
     await this.manager.destroy();
-    await this.store.destroy();
-    await this.knex.destroy();
+    await this.store.destroy(); // TODO this destroys this.knex(), which seems quite unexpected
   }
 
   public async syncChannel({channelId}: SyncChannelParams): SingleChannelResult {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24844,14 +24844,6 @@ scheduler@^0.13.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"


### PR DESCRIPTION
- [x] ~Expose problem with a nonzero exit code~
~Find a fix - suspect something to do with using `recordFunctionMetrics()` (I get a different error if I don't use that)  metrics~
 ~Apply fix~

#2565 Has been now been solved, but this PR:

-  inserts a change which makes the test properly fail if there is an error (which could save us in the future). 
- changes the `PayerClient` to accept configuration in it's constructor
- a little bit of refactoring here and there


