### PR TITLE
Ags/worker threads

### DIFF
--- a/packages/server-wallet/src/models/signing-wallet.ts
+++ b/packages/server-wallet/src/models/signing-wallet.ts
@@ -5,6 +5,7 @@ import {ethers} from 'ethers';
 import {Address, Bytes32} from '../type-aliases';
 import {Values} from '../errors/wallet-error';
 import {WorkerManager} from '../utilities/workers/manager';
+import {fastSignState} from '../utilities/signatures';
 
 export class SigningWallet extends Model {
   readonly id!: number;
@@ -48,8 +49,7 @@ export class SigningWallet extends Model {
   async signState(state: StateWithHash): Promise<SignatureEntry> {
     return {
       signer: this.address,
-      signature: (await SigningWallet.manager.concurrentSignState(state, this.privateKey))
-        .signature,
+      signature: (await fastSignState(state, this.privateKey)).signature,
     };
   }
 }

--- a/packages/server-wallet/src/utilities/workers/loader.js
+++ b/packages/server-wallet/src/utilities/workers/loader.js
@@ -1,4 +1,4 @@
 const path = require('path');
 
-require('ts-node').register();
+require('ts-node').register({typeCheck: false});
 require(path.resolve(__dirname, './worker.ts'));

--- a/packages/server-wallet/src/utilities/workers/worker-message.ts
+++ b/packages/server-wallet/src/utilities/workers/worker-message.ts
@@ -1,3 +1,4 @@
+import {UpdateChannelParams} from '@statechannels/client-api-schema';
 import {State, StateWithHash} from '@statechannels/wallet-core';
 
 type SignStateRequest = {
@@ -16,24 +17,34 @@ type HashStateRequest = {
   operation: 'HashState ';
   state: State;
 };
-export type StateChannelWorkerData = SignStateRequest | RecoverAddressRequest | HashStateRequest;
+
+type UpdateChannelRequest = {
+  operation: 'UpdateChannel ';
+  args: UpdateChannelParams;
+};
+
+export type StateChannelWorkerData =
+  | SignStateRequest
+  | RecoverAddressRequest
+  | HashStateRequest
+  | UpdateChannelRequest;
 
 export function isStateChannelWorkerData(data: any): data is StateChannelWorkerData {
+  return true;
   return (
     'operation' in data &&
     (data.operation === 'SignState' ||
       data.operation === 'RecoverAddress' ||
-      data.operation === 'HashState')
+      data.operation === 'HashState' ||
+      data.operation === 'UpdateChannel')
   );
 }
 
-export function isSignStateRequest(data: any): data is SignStateRequest {
-  return isStateChannelWorkerData(data) && data.operation === 'SignState';
-}
+const guard = <T extends StateChannelWorkerData>(operation: T['operation']) => (
+  data: any
+): data is T => isStateChannelWorkerData(data) && data.operation === operation;
 
-export function isRecoverAddressRequest(data: any): data is RecoverAddressRequest {
-  return isStateChannelWorkerData(data) && data.operation === 'RecoverAddress';
-}
-export function isHashStateRequest(data: any): data is HashStateRequest {
-  return isStateChannelWorkerData(data) && data.operation === 'HashState ';
-}
+export const isSignStateRequest = guard<SignStateRequest>('SignState');
+export const isRecoverAddressRequest = guard<RecoverAddressRequest>('RecoverAddress');
+export const isHashStateRequest = guard<HashStateRequest>('HashState ');
+export const isUpdateChannelRequest = guard<UpdateChannelRequest>('UpdateChannel ');

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -87,6 +87,9 @@ export type WalletInterface = {
   attachChainService(provider: OnchainServiceInterface): void;
 };
 
+import {WorkerManager} from '../utilities/workers/manager';
+const manager = new WorkerManager();
+
 export class Wallet implements WalletInterface {
   knex: Knex;
   store: Store;
@@ -99,7 +102,7 @@ export class Wallet implements WalletInterface {
     this.getSigningAddress = this.getSigningAddress.bind(this);
     this.createChannel = this.createChannel.bind(this);
     this.joinChannel = this.joinChannel.bind(this);
-    this.updateChannel = this.updateChannel.bind(this);
+    this._updateChannel = this._updateChannel.bind(this);
     this.closeChannel = this.closeChannel.bind(this);
     this.getChannels = this.getChannels.bind(this);
     this.getState = this.getState.bind(this);
@@ -243,7 +246,15 @@ export class Wallet implements WalletInterface {
     return {outbox: outbox.concat(nextOutbox), channelResult: nextChannelResult};
   }
 
-  async updateChannel({channelId, allocations, appData}: UpdateChannelParams): SingleChannelResult {
+  async updateChannel(args: UpdateChannelParams): SingleChannelResult {
+    return manager.updateChannel(args);
+  }
+
+  async _updateChannel({
+    channelId,
+    allocations,
+    appData,
+  }: UpdateChannelParams): SingleChannelResult {
     const timer = timerFactory(this.walletConfig.timingMetrics, `updateChannel ${channelId}`);
     const handleMissingChannel: MissingAppHandler<SingleChannelResult> = () => {
       throw new UpdateChannel.UpdateChannelError(


### PR DESCRIPTION
By putting the entire call to updateChannel in one of your workers, I can get a 2x speedup on my 4 core machine.
master
```
monorepo/packages/server-wallet on  master [$!] is :package: v0.3.6 via ⬢ v12.16.3 on :cloud:  us-west-1 took 33s 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 1111.306ms
concurrent x 100: 690.045ms
^C
```

concurrent updateChannel
```
monorepo/packages/server-wallet on  ags/worker-threads [$] is :package: v0.3.6 via ⬢ v12.16.3 on :cloud:  us-west-1 
❯ ts-node benchmarks/update-channel.benchmark.ts
[@statechannels/devtools] NODE_ENV is undefined — setting to "development"
serial x 100: 1306.597ms
concurrent x 100: 370.224ms
```