### PR TITLE
Rename wallet-core Message -> Payload

### DIFF
--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import {ChannelResult, Participant} from '@statechannels/client-api-schema';
 import {Wallet, constants} from 'ethers';
 const {AddressZero} = constants;
-import {makeDestination, BN, Message} from '@statechannels/wallet-core';
+import {makeDestination, BN, Payload} from '@statechannels/wallet-core';
 import {Message as WireMessage} from '@statechannels/wire-format';
 
 import {Wallet as ServerWallet} from '../../src';
@@ -82,7 +82,7 @@ export default class PayerClient {
       ],
     });
 
-    const reply = await this.messageReceiverAndExpectReply((params as WireMessage).data as Message);
+    const reply = await this.messageReceiverAndExpectReply((params as WireMessage).data as Payload);
 
     await this.wallet.pushMessage(reply);
 
@@ -102,20 +102,20 @@ export default class PayerClient {
     } = await this.time(`update ${channelId}`, async () => this.wallet.updateChannel(channel));
 
     const reply = await this.time(`send message ${channelId}`, async () =>
-      this.messageReceiverAndExpectReply((params as WireMessage).data as Message)
+      this.messageReceiverAndExpectReply((params as WireMessage).data as Payload)
     );
 
     await this.time(`push message ${channelId}`, async () => this.wallet.pushMessage(reply));
   }
 
-  public emptyMessage(): Promise<Message> {
+  public emptyMessage(): Promise<Payload> {
     return this.messageReceiverAndExpectReply({
       signedStates: [],
       objectives: [],
     });
   }
 
-  private async messageReceiverAndExpectReply(message: Message): Promise<Message> {
+  private async messageReceiverAndExpectReply(message: Payload): Promise<Payload> {
     const {data: reply} = await axios.post(this.receiverHttpServerURL + '/inbox', {message});
     return reply;
   }

--- a/packages/server-wallet/e2e-test/receiver/app.ts
+++ b/packages/server-wallet/e2e-test/receiver/app.ts
@@ -1,6 +1,6 @@
 import bodyParser from 'body-parser';
 import express from 'express';
-import {Message} from '@statechannels/wallet-core';
+import {Payload} from '@statechannels/wallet-core';
 import pino from 'express-pino-logger';
 
 import {logger} from '../logger';
@@ -26,7 +26,7 @@ app.post('/inbox', bodyParser.json(), async (req, res) =>
   res
     .status(200)
     .contentType('application/json')
-    .send(await controller.acceptMessageAndReturnReplies(req.body.message as Message))
+    .send(await controller.acceptMessageAndReturnReplies(req.body.message as Payload))
 );
 
 export default app;

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -1,5 +1,5 @@
 import {Message as WireMessage} from '@statechannels/wire-format';
-import {Message, makeDestination} from '@statechannels/wallet-core';
+import {Payload, makeDestination} from '@statechannels/wallet-core';
 import {Participant} from '@statechannels/client-api-schema';
 
 import {bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
@@ -24,7 +24,7 @@ export default class ReceiverController {
     };
   }
 
-  public async acceptMessageAndReturnReplies(message: Message): Promise<Message> {
+  public async acceptMessageAndReturnReplies(message: Payload): Promise<Payload> {
     const {signedStates, objectives} = message;
 
     const {
@@ -45,7 +45,7 @@ export default class ReceiverController {
         )
       );
 
-      return (messageToSendToPayer.params as WireMessage).data as Message;
+      return (messageToSendToPayer.params as WireMessage).data as Payload;
     }
   }
 }

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -1,7 +1,7 @@
-import {Message} from '@statechannels/wallet-core';
+import {Payload} from '@statechannels/wallet-core';
 
 import {Wallet} from './wallet';
 import {Outgoing} from './protocols/actions';
 import adminKnex from './db-admin/db-admin-connection';
 
-export {Wallet, Message, Outgoing, adminKnex as WalletKnex};
+export {Wallet, Payload, Outgoing, adminKnex as WalletKnex};

--- a/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
@@ -1,18 +1,18 @@
-import {SignedState, Message} from '@statechannels/wallet-core';
+import {SignedState, Payload} from '@statechannels/wallet-core';
 import _ from 'lodash';
 
 import {createState} from './states';
 
 const emptyMessage = {};
 
-export const message = (props?: Partial<Message>): Message => {
-  const defaults: Message = _.cloneDeep(emptyMessage);
+export const message = (props?: Partial<Payload>): Payload => {
+  const defaults: Payload = _.cloneDeep(emptyMessage);
 
   return _.merge(defaults, props);
 };
 
 type WithState = {signedStates: SignedState[]};
-export function messageWithState(props?: Partial<Message>): Message & WithState {
+export function messageWithState(props?: Partial<Payload>): Payload & WithState {
   const defaults = _.merge(emptyMessage, {signedStates: [createState()]});
 
   return _.merge(defaults, props);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -3,7 +3,7 @@ import {
   Objective,
   SignedStateWithHash,
   SignedStateVarsWithHash,
-  Message,
+  Payload,
   State,
   calculateChannelId,
   StateVariables,
@@ -208,7 +208,7 @@ export class Store {
     return (await Channel.query(knex)).map(channel => channel.protocolState);
   }
 
-  async pushMessage(message: Message, tx: Transaction): Promise<Bytes32[]> {
+  async pushMessage(message: Payload, tx: Transaction): Promise<Bytes32[]> {
     for (const o of message.objectives || []) {
       await this.addObjective(o, tx);
     }

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -13,7 +13,7 @@ import {
   Outcome,
   AllocationItem,
   SimpleAllocation,
-  Message,
+  Payload,
   Objective,
   Participant
 } from '../../types';
@@ -29,7 +29,9 @@ export function convertToInternalParticipant(participant: {
   return {...participant, destination: makeDestination(participant.destination)};
 }
 
-export function deserializeMessage(message: WireMessage): Message {
+// validatePayload
+
+export function deserializeMessage(message: WireMessage): Payload {
   const signedStates = message?.data?.signedStates?.map(ss => deserializeState(ss));
   const objectives = message?.data?.objectives?.map(objective => deserializeObjective(objective));
 

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -1,7 +1,7 @@
 import {Message as WireMessage, SignedState as WireState} from '@statechannels/wire-format';
 
 import {BN} from '../../bignumber';
-import {Message, SignedState} from '../../types';
+import {Payload, SignedState} from '../../types';
 import {makeDestination} from '../../utils';
 import {calculateChannelId} from '../../state-utils';
 
@@ -150,7 +150,7 @@ export const wireMessageFormat: WireMessage = {
   }
 };
 
-export const internalMessageFormat: Message = {
+export const internalMessageFormat: Payload = {
   signedStates: [internalStateFormat, internalStateFormat2],
   objectives: [
     {

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -12,15 +12,15 @@ import {
   Outcome,
   AllocationItem,
   SimpleAllocation,
-  Message,
+  Payload,
   SimpleGuarantee
 } from '../../types';
 import {calculateChannelId} from '../../state-utils';
 import {formatAmount} from '../../utils';
 
-export function serializeMessage(message: Message, recipient: string, sender: string): WireMessage {
-  const signedStates = (message.signedStates || []).map(ss => serializeState(ss));
-  const {objectives} = message;
+export function serializeMessage(payload: Payload, recipient: string, sender: string): WireMessage {
+  const signedStates = (payload.signedStates || []).map(ss => serializeState(ss));
+  const {objectives} = payload;
   return {
     recipient,
     sender,

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -155,7 +155,7 @@ export const isCloseLedger = guard<CloseLedger>('CloseLedger');
 type GetChannel = {type: 'GetChannel'; channelId: string};
 export type ChannelRequest = GetChannel;
 
-export interface Message {
+export interface Payload {
   signedStates?: SignedState[];
   objectives?: Objective[];
   requests?: ChannelRequest[];

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -9,7 +9,7 @@ import {
 } from '@statechannels/client-api-schema';
 import {filter, take} from 'rxjs/operators';
 import {
-  Message,
+  Payload,
   isOpenChannel,
   OpenChannel,
   serializeChannelEntry
@@ -40,7 +40,7 @@ export class ChannelWallet {
     this.workflows = [];
 
     // Whenever the store wants to send something call sendMessage
-    store.outboxFeed.subscribe(async (m: Message) => {
+    store.outboxFeed.subscribe(async (m: Payload) => {
       this.messagingService.sendMessageNotification(m);
     });
     // Whenever an OpenChannel objective is received


### PR DESCRIPTION
Before this PR we had `Message` defined in multiple places
```ts
// in wire-protocol
export interface Message {
  recipient: string; // Identifier of user that the message should be relayed to
  sender: string; // Identifier of user that the message is from
  data: {
    signedStates?: SignedState[];
    objectives?: Objective[];
  };
}

// in client-api-schema
export interface Message {
    data: unknown;
    recipient: string;
    sender: string;
}

// in wallet-core
export interface Message {
  signedStates?: SignedState[];
  objectives?: Objective[];
}
```
The wallet core type was totally incompatible with the other two :/. 

This PR renames the wallet-core `Message` to `Payload` - consistent with being the type of `Message['data']` from wire-protocol.

