### PR TITLE
Rename wallet-core Message -> Payload

### DIFF
--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import {ChannelResult, Participant} from '@statechannels/client-api-schema';
 import {Wallet, constants} from 'ethers';
 const {AddressZero} = constants;
-import {makeDestination, BN, Message} from '@statechannels/wallet-core';
+import {makeDestination, BN, Payload} from '@statechannels/wallet-core';
 import {Message as WireMessage} from '@statechannels/wire-format';
 
 import {Wallet as ServerWallet} from '../../src';
@@ -82,7 +82,7 @@ export default class PayerClient {
       ],
     });
 
-    const reply = await this.messageReceiverAndExpectReply((params as WireMessage).data as Message);
+    const reply = await this.messageReceiverAndExpectReply((params as WireMessage).data as Payload);
 
     await this.wallet.pushMessage(reply);
 
@@ -102,20 +102,20 @@ export default class PayerClient {
     } = await this.time(`update ${channelId}`, async () => this.wallet.updateChannel(channel));
 
     const reply = await this.time(`send message ${channelId}`, async () =>
-      this.messageReceiverAndExpectReply((params as WireMessage).data as Message)
+      this.messageReceiverAndExpectReply((params as WireMessage).data as Payload)
     );
 
     await this.time(`push message ${channelId}`, async () => this.wallet.pushMessage(reply));
   }
 
-  public emptyMessage(): Promise<Message> {
+  public emptyMessage(): Promise<Payload> {
     return this.messageReceiverAndExpectReply({
       signedStates: [],
       objectives: [],
     });
   }
 
-  private async messageReceiverAndExpectReply(message: Message): Promise<Message> {
+  private async messageReceiverAndExpectReply(message: Payload): Promise<Payload> {
     const {data: reply} = await axios.post(this.receiverHttpServerURL + '/inbox', {message});
     return reply;
   }

--- a/packages/server-wallet/e2e-test/receiver/app.ts
+++ b/packages/server-wallet/e2e-test/receiver/app.ts
@@ -1,6 +1,6 @@
 import bodyParser from 'body-parser';
 import express from 'express';
-import {Message} from '@statechannels/wallet-core';
+import {Payload} from '@statechannels/wallet-core';
 import pino from 'express-pino-logger';
 
 import {logger} from '../logger';
@@ -26,7 +26,7 @@ app.post('/inbox', bodyParser.json(), async (req, res) =>
   res
     .status(200)
     .contentType('application/json')
-    .send(await controller.acceptMessageAndReturnReplies(req.body.message as Message))
+    .send(await controller.acceptMessageAndReturnReplies(req.body.message as Payload))
 );
 
 export default app;

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -1,5 +1,5 @@
 import {Message as WireMessage} from '@statechannels/wire-format';
-import {Message, makeDestination} from '@statechannels/wallet-core';
+import {Payload, makeDestination} from '@statechannels/wallet-core';
 import {Participant} from '@statechannels/client-api-schema';
 
 import {bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
@@ -24,7 +24,7 @@ export default class ReceiverController {
     };
   }
 
-  public async acceptMessageAndReturnReplies(message: Message): Promise<Message> {
+  public async acceptMessageAndReturnReplies(message: Payload): Promise<Payload> {
     const {signedStates, objectives} = message;
 
     const {
@@ -45,7 +45,7 @@ export default class ReceiverController {
         )
       );
 
-      return (messageToSendToPayer.params as WireMessage).data as Message;
+      return (messageToSendToPayer.params as WireMessage).data as Payload;
     }
   }
 }

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -1,7 +1,7 @@
-import {Message} from '@statechannels/wallet-core';
+import {Payload} from '@statechannels/wallet-core';
 
 import {Wallet} from './wallet';
 import {Outgoing} from './protocols/actions';
 import adminKnex from './db-admin/db-admin-connection';
 
-export {Wallet, Message, Outgoing, adminKnex as WalletKnex};
+export {Wallet, Payload as Message, Outgoing, adminKnex as WalletKnex};

--- a/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
@@ -1,18 +1,18 @@
-import {SignedState, Message} from '@statechannels/wallet-core';
+import {SignedState, Payload} from '@statechannels/wallet-core';
 import _ from 'lodash';
 
 import {createState} from './states';
 
 const emptyMessage = {};
 
-export const message = (props?: Partial<Message>): Message => {
-  const defaults: Message = _.cloneDeep(emptyMessage);
+export const message = (props?: Partial<Payload>): Payload => {
+  const defaults: Payload = _.cloneDeep(emptyMessage);
 
   return _.merge(defaults, props);
 };
 
 type WithState = {signedStates: SignedState[]};
-export function messageWithState(props?: Partial<Message>): Message & WithState {
+export function messageWithState(props?: Partial<Payload>): Payload & WithState {
   const defaults = _.merge(emptyMessage, {signedStates: [createState()]});
 
   return _.merge(defaults, props);

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -12,7 +12,7 @@ import {
 } from '@statechannels/client-api-schema';
 import {
   ChannelConstants,
-  Message,
+  Payload,
   ChannelRequest,
   Outcome,
   SignedStateVarsWithHash,
@@ -79,7 +79,7 @@ export type WalletInterface = {
   updateChannelFunding(args: UpdateChannelFundingParams): void;
 
   // Wallet <-> Wallet communication
-  pushMessage(m: Message): MultipleChannelResult;
+  pushMessage(m: Payload): MultipleChannelResult;
 
   // Wallet -> App communication
   onNotification(cb: (notice: StateChannelsNotification) => void): {unsubscribe: () => void};
@@ -349,7 +349,7 @@ export class Wallet implements WalletInterface {
     }
   }
 
-  async pushMessage(message: Message): MultipleChannelResult {
+  async pushMessage(message: Payload): MultipleChannelResult {
     const knex = this.knex;
     const store = this.store;
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -3,7 +3,7 @@ import {
   Objective,
   SignedStateWithHash,
   SignedStateVarsWithHash,
-  Message,
+  Payload,
   State,
   calculateChannelId,
   StateVariables,
@@ -208,7 +208,7 @@ export class Store {
     return (await Channel.query(knex)).map(channel => channel.protocolState);
   }
 
-  async pushMessage(message: Message, tx: Transaction): Promise<Bytes32[]> {
+  async pushMessage(message: Payload, tx: Transaction): Promise<Bytes32[]> {
     for (const o of message.objectives || []) {
       await this.addObjective(o, tx);
     }

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -13,7 +13,7 @@ import {
   Outcome,
   AllocationItem,
   SimpleAllocation,
-  Message,
+  Payload,
   Objective,
   Participant
 } from '../../types';
@@ -29,7 +29,7 @@ export function convertToInternalParticipant(participant: {
   return {...participant, destination: makeDestination(participant.destination)};
 }
 
-export function deserializeMessage(message: WireMessage): Message {
+export function deserializeMessage(message: WireMessage): Payload {
   const signedStates = message?.data?.signedStates?.map(ss => deserializeState(ss));
   const objectives = message?.data?.objectives?.map(objective => deserializeObjective(objective));
 

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -1,7 +1,7 @@
 import {Message as WireMessage, SignedState as WireState} from '@statechannels/wire-format';
 
 import {BN} from '../../bignumber';
-import {Message, SignedState} from '../../types';
+import {Payload, SignedState} from '../../types';
 import {makeDestination} from '../../utils';
 import {calculateChannelId} from '../../state-utils';
 
@@ -150,7 +150,7 @@ export const wireMessageFormat: WireMessage = {
   }
 };
 
-export const internalMessageFormat: Message = {
+export const internalMessageFormat: Payload = {
   signedStates: [internalStateFormat, internalStateFormat2],
   objectives: [
     {

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -12,13 +12,13 @@ import {
   Outcome,
   AllocationItem,
   SimpleAllocation,
-  Message,
+  Payload,
   SimpleGuarantee
 } from '../../types';
 import {calculateChannelId} from '../../state-utils';
 import {formatAmount} from '../../utils';
 
-export function serializeMessage(message: Message, recipient: string, sender: string): WireMessage {
+export function serializeMessage(message: Payload, recipient: string, sender: string): WireMessage {
   const signedStates = (message.signedStates || []).map(ss => serializeState(ss));
   const {objectives} = message;
   return {

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -155,7 +155,7 @@ export const isCloseLedger = guard<CloseLedger>('CloseLedger');
 type GetChannel = {type: 'GetChannel'; channelId: string};
 export type ChannelRequest = GetChannel;
 
-export interface Message {
+export interface Payload {
   signedStates?: SignedState[];
   objectives?: Objective[];
   requests?: ChannelRequest[];

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -9,7 +9,7 @@ import {
 } from '@statechannels/client-api-schema';
 import {filter, take} from 'rxjs/operators';
 import {
-  Message,
+  Payload,
   isOpenChannel,
   OpenChannel,
   serializeChannelEntry
@@ -40,7 +40,7 @@ export class ChannelWallet {
     this.workflows = [];
 
     // Whenever the store wants to send something call sendMessage
-    store.outboxFeed.subscribe(async (m: Message) => {
+    store.outboxFeed.subscribe(async (m: Payload) => {
       this.messagingService.sendMessageNotification(m);
     });
     // Whenever an OpenChannel objective is received

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -20,7 +20,7 @@ import {
 import {fromEvent, Observable} from 'rxjs';
 import {validateMessage} from '@statechannels/wire-format';
 import {
-  Message,
+  Payload,
   DomainBudget,
   Participant,
   unreachable,
@@ -83,7 +83,7 @@ export interface MessagingServiceInterface {
     method: ChannelProposedNotification['method'],
     notificationData: ChannelResult
   );
-  sendMessageNotification(message: Message): Promise<void>;
+  sendMessageNotification(message: Payload): Promise<void>;
   sendDisplayMessage(displayMessage: 'Show' | 'Hide');
   sendResponse(id: number, result: StateChannelsResponse['result']): Promise<void>;
   sendError(id: number, error: StateChannelsErrorResponse['error']): Promise<void>;
@@ -142,7 +142,7 @@ export class MessagingService implements MessagingServiceInterface {
     this.eventEmitter.emit('SendMessage', notification);
   }
 
-  public async sendMessageNotification(message: Message) {
+  public async sendMessageNotification(message: Payload) {
     // TODO: It is awkward to have to generate sender/recipient
     const ourAddress = await this.store.getAddress();
     const sender = ourAddress;

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -11,7 +11,7 @@ import {
   hashState,
   Outcome,
   ChannelStoredData,
-  Message,
+  Payload,
   Objective,
   Participant,
   SignedState,
@@ -38,7 +38,7 @@ import {Errors, DBBackend, ObjectStores} from '.';
 interface InternalEvents {
   channelUpdated: [ChannelStoreEntry];
   newObjective: [Objective];
-  addToOutbox: [Message];
+  addToOutbox: [Payload];
   lockUpdated: [ChannelLock];
 }
 export type ChannelLock = {
@@ -129,7 +129,7 @@ export class Store {
     return merge(newObjectives, currentObjectives);
   }
 
-  get outboxFeed(): Observable<Message> {
+  get outboxFeed(): Observable<Payload> {
     return fromEvent(this._eventEmitter, 'addToOutbox');
   }
 
@@ -406,7 +406,7 @@ export class Store {
     return Object.keys(privateKeys)[0];
   }
 
-  async pushMessage(message: Message) {
+  async pushMessage(message: Payload) {
     await Promise.all(message.signedStates?.map(signedState => this.addState(signedState)) || []);
     message.objectives?.map(o => this.addObjective(o, false));
   }

--- a/packages/xstate-wallet/src/workflows/tests/simple-hub.ts
+++ b/packages/xstate-wallet/src/workflows/tests/simple-hub.ts
@@ -1,4 +1,4 @@
-import {Message, createSignatureEntry} from '@statechannels/wallet-core';
+import {Payload, createSignatureEntry} from '@statechannels/wallet-core';
 import {Observable, fromEvent} from 'rxjs';
 import {EventEmitter} from 'eventemitter3';
 import {ethers} from 'ethers';
@@ -9,11 +9,11 @@ export class SimpleHub {
     private readonly _eventEmitter = new EventEmitter()
   ) {}
 
-  public get outboxFeed(): Observable<Message> {
+  public get outboxFeed(): Observable<Payload> {
     return fromEvent(this._eventEmitter, 'addToOutbox');
   }
 
-  public async pushMessage({signedStates}: Message) {
+  public async pushMessage({signedStates}: Payload) {
     const address = await this.getAddress();
     signedStates?.map(signedState => {
       const {signatures, participants} = signedState;


### PR DESCRIPTION
Before this PR we had `Message` defined in multiple places
```ts
// in wire-protocol
export interface Message {
  recipient: string; // Identifier of user that the message should be relayed to
  sender: string; // Identifier of user that the message is from
  data: {
    signedStates?: SignedState[];
    objectives?: Objective[];
  };
}

// in client-api-schema
export interface Message {
    data: unknown;
    recipient: string;
    sender: string;
}

// in wallet-core
export interface Message {
  signedStates?: SignedState[];
  objectives?: Objective[];
}
```
The wallet core type was totally incompatible with the other two :/. 

This PR renames the wallet-core `Message` to `Payload` - consistent with being the type of `Message['data']` from wire-protocol.
