### PR TITLE
Server wallet uses wire format

### DIFF
--- a/packages/server-wallet/readme.md
+++ b/packages/server-wallet/readme.md
@@ -29,6 +29,7 @@ SERVER_DB_PORT=5432
 For any environment variables specific to local setup, such as postgres host or port, do not modify `.env` files checked into the repository. Instead, add the variables to `.env.test.local` (or to other local `.env` files). Specifically, you might want to override `SERVER_DB_USER`, `SERVER_DB_HOST` and `SERVER_DB_PORT`.
 
 ```
+echo "SERVER_DB_USER=postgres" > .env.test.local # you probably need to do at least this
 yarn install
 NODE_ENV=test yarn db:create
 NODE_ENV=test yarn db:migrate

--- a/packages/server-wallet/readme.md
+++ b/packages/server-wallet/readme.md
@@ -29,7 +29,7 @@ SERVER_DB_PORT=5432
 For any environment variables specific to local setup, such as postgres host or port, do not modify `.env` files checked into the repository. Instead, add the variables to `.env.test.local` (or to other local `.env` files). Specifically, you might want to override `SERVER_DB_USER`, `SERVER_DB_HOST` and `SERVER_DB_PORT`.
 
 ```
-echo "SERVER_DB_USER=postgres" > .env.test.local # you probably need to do at least this
+echo "SERVER_DB_USER=postgres" > .env.test.local # you probably need to do at least this (if you're on a mac)
 yarn install
 NODE_ENV=test yarn db:create
 NODE_ENV=test yarn db:migrate

--- a/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
@@ -5,12 +5,6 @@ import {createState} from './states';
 
 const emptyMessage = {};
 
-export const message = (props?: Partial<Payload>): Payload => {
-  const defaults: Payload = _.cloneDeep(emptyMessage);
-
-  return _.merge(defaults, props);
-};
-
 type WithState = {signedStates: SignedState[]};
 export function messageWithState(props?: Partial<Payload>): Payload & WithState {
   const defaults = _.merge(emptyMessage, {signedStates: [createState()]});

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -4,6 +4,7 @@ import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {truncate} from '../../../db-admin/db-admin-connection';
 import {defaultConfig} from '../../../config';
+import {alice, bob} from '../fixtures/participants';
 
 let w: Wallet;
 beforeEach(async () => {
@@ -36,7 +37,7 @@ describe('happy path', () => {
             data: {
               objectives: [
                 {
-                  participants: ['alice', 'bob'],
+                  participants: [alice(), bob()],
                   data: {
                     signedState: {turnNum: 0, appData},
                     fundingStrategy: 'Direct',

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -1,4 +1,4 @@
-import {simpleEthAllocation, BN} from '@statechannels/wallet-core';
+import {simpleEthAllocation, serializeOutcome, BN} from '@statechannels/wallet-core';
 
 import {Channel} from '../../../models/channel';
 import {Wallet} from '../..';
@@ -50,6 +50,10 @@ describe('directly funded app', () => {
     const c = channel({vars: [stateWithHashSignedBy(bob())(preFS)]});
     await Channel.query(w.knex).insert(c);
 
+    const outcomeWire = serializeOutcome(outcome);
+    const preFSWire = {turnNum: 0, outcome: outcomeWire};
+    const postFSWire = {turnNum: 3, outcome: outcomeWire};
+
     const channelId = c.channelId;
     const current = await Channel.forId(channelId, w.knex);
     expect(current.latest).toMatchObject(preFS);
@@ -57,8 +61,8 @@ describe('directly funded app', () => {
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       // TODO: These outbox items should probably be merged into one outgoing message
       outbox: [
-        {params: {recipient: 'bob', sender: 'alice', data: {signedStates: [preFS]}}},
-        {params: {recipient: 'bob', sender: 'alice', data: {signedStates: [postFS]}}},
+        {params: {recipient: 'bob', sender: 'alice', data: {signedStates: [preFSWire]}}},
+        {params: {recipient: 'bob', sender: 'alice', data: {signedStates: [postFSWire]}}},
       ],
       // TODO: channelResults is not calculated correctly: see the Channel model's channelResult
       // implementation

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -3,6 +3,7 @@ import {
   simpleEthAllocation,
   CreateChannel,
   SignedState,
+  serializeState,
 } from '@statechannels/wallet-core';
 import {ChannelResult} from '@statechannels/client-api-schema';
 
@@ -11,7 +12,6 @@ import {Wallet} from '../..';
 import {addHash} from '../../../state-utils';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import {alice as aliceP, bob as bobP, charlie as charlieP} from '../fixtures/participants';
-import {message} from '../fixtures/messages';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {stateSignedBy} from '../fixtures/states';
 import {truncate} from '../../../db-admin/db-admin-connection';
@@ -39,7 +39,7 @@ afterAll(async () => {
 beforeEach(async () => seedAlicesSigningWallet(wallet.knex));
 
 it("doesn't throw on an empty message", () => {
-  return expect(wallet.pushMessage(message())).resolves.not.toThrow();
+  return expect(wallet.pushMessage({})).resolves.not.toThrow();
 });
 
 const zero = 0;
@@ -56,7 +56,10 @@ it('stores states contained in the message, in a single channel model', async ()
     stateSignedBy([alice(), bob()])({turnNum: four}),
   ];
   const createChannel: CreateChannel = createChannelFromState(signedStates[0]);
-  await wallet.pushMessage(message({objectives: [createChannel], signedStates: [signedStates[1]]}));
+  await wallet.pushMessage({
+    objectives: [createChannel],
+    signedStates: [serializeState(signedStates[1])],
+  });
 
   const channelsAfter = await Channel.query(wallet.knex).select();
 
@@ -82,9 +85,9 @@ describe('channel results', () => {
 
     const signedStates = [stateSignedBy([bob()])({turnNum: zero})];
     const createChannel: CreateChannel = createChannelFromState(signedStates[0]);
-    await wallet.pushMessage(message({objectives: [createChannel]}));
+    await wallet.pushMessage({objectives: [createChannel]});
 
-    await expectResults(wallet.pushMessage(message({signedStates})), [
+    await expectResults(wallet.pushMessage({signedStates: signedStates.map(serializeState)}), [
       {turnNum: zero, status: 'proposed'},
     ]);
   });
@@ -97,7 +100,7 @@ describe('channel results', () => {
     );
 
     return expectResults(
-      wallet.pushMessage(message({signedStates: [stateSignedBy([bob()])({turnNum: 9})]})),
+      wallet.pushMessage({signedStates: [serializeState(stateSignedBy([bob()])({turnNum: 9}))]}),
       [{channelId, turnNum: 9, status: 'running'}]
     );
   });
@@ -112,7 +115,7 @@ describe('channel results', () => {
     const {channelId} = await Channel.query(wallet.knex).insert(channel);
 
     const signedStates = [stateSignedBy([bob()])({turnNum: 10, isFinal: true, participants})];
-    return expectResults(wallet.pushMessage(message({signedStates})), [
+    return expectResults(wallet.pushMessage({signedStates: signedStates.map(serializeState)}), [
       {channelId, turnNum: 10, status: 'closing'},
     ]);
   });
@@ -123,7 +126,7 @@ describe('channel results', () => {
 
     const signedStates = [stateSignedBy([alice(), bob()])({turnNum: 9, isFinal: true})];
     const createChannel: CreateChannel = createChannelFromState(signedStates[0]);
-    const result = wallet.pushMessage(message({objectives: [createChannel]}));
+    const result = wallet.pushMessage({objectives: [createChannel]});
 
     return expectResults(result, [{turnNum: 9, status: 'closed'}]);
   });
@@ -138,7 +141,7 @@ describe('channel results', () => {
     ];
 
     const createChannelObjectives = signedStates.map(createChannelFromState);
-    const p = wallet.pushMessage(message({objectives: createChannelObjectives}));
+    const p = wallet.pushMessage({objectives: createChannelObjectives});
 
     await expectResults(p, [{turnNum: five}, {turnNum: six, appData: '0x0f00'}]);
 
@@ -162,7 +165,7 @@ it("Doesn't store stale states", async () => {
 
   const signedStates = [stateSignedBy([alice(), bob()])({turnNum: five})];
   const createChannel: CreateChannel = createChannelFromState(signedStates[0]);
-  await wallet.pushMessage(message({objectives: [createChannel]}));
+  await wallet.pushMessage({objectives: [createChannel]});
 
   const afterFirst = await Channel.query(wallet.knex).select();
 
@@ -171,12 +174,12 @@ it("Doesn't store stale states", async () => {
   expect(afterFirst[0].supported).toBeTruthy();
   expect(afterFirst[0].supported?.turnNum).toEqual(five);
 
-  await wallet.pushMessage(message({signedStates: [stateSignedBy()({turnNum: four})]}));
+  await wallet.pushMessage({signedStates: [serializeState(stateSignedBy()({turnNum: four}))]});
   const afterSecond = await Channel.query(wallet.knex).select();
   expect(afterSecond[0].vars).toHaveLength(1);
   expect(afterSecond).toMatchObject(afterFirst);
 
-  await wallet.pushMessage(message({signedStates: [stateSignedBy()({turnNum: six})]}));
+  await wallet.pushMessage({signedStates: [serializeState(stateSignedBy()({turnNum: six}))]});
 
   const afterThird = await Channel.query(wallet.knex).select();
   expect(afterThird[0].vars).toHaveLength(2);
@@ -187,7 +190,7 @@ it("doesn't store states for unknown signing addresses", async () => {
 
   const signedStates = [stateSignedBy([alice(), bob()])({turnNum: five})];
   const objectives = signedStates.map(createChannelFromState);
-  return expect(wallet.pushMessage(message({objectives}))).rejects.toThrow(Error('Not in channel'));
+  return expect(wallet.pushMessage({objectives})).rejects.toThrow(Error('Not in channel'));
 });
 
 describe('when the application protocol returns an action', () => {
@@ -201,7 +204,7 @@ describe('when the application protocol returns an action', () => {
     expect(c.supported).toBeUndefined();
     const {channelId} = c;
 
-    const p = wallet.pushMessage(message({signedStates: [stateSignedBy([bob()])(state)]}));
+    const p = wallet.pushMessage({signedStates: [serializeState(stateSignedBy([bob()])(state))]});
     await expectResults(p, [{channelId, status: 'opening'}]);
     await expect(p).resolves.toMatchObject({
       outbox: [{method: 'MessageQueued', params: {data: {signedStates: [{turnNum: 3}]}}}],
@@ -224,7 +227,9 @@ describe('when the application protocol returns an action', () => {
     const {channelId} = c;
 
     const finalState = {...state, isFinal: true, turnNum: turnNum + 1};
-    const p = wallet.pushMessage(message({signedStates: [stateSignedBy([bob()])(finalState)]}));
+    const p = wallet.pushMessage({
+      signedStates: [serializeState(stateSignedBy([bob()])(finalState))],
+    });
     await expectResults(p, [{channelId, status: 'closed'}]);
     await expect(p).resolves.toMatchObject({
       outbox: [
@@ -245,7 +250,7 @@ describe('when the application protocol returns an action', () => {
 
 describe('when there is a request provided', () => {
   it('has nothing in the outbox if there is no request added', async () => {
-    await expect(wallet.pushMessage(message({requests: []}))).resolves.toMatchObject({
+    await expect(wallet.pushMessage({requests: []})).resolves.toMatchObject({
       outbox: [],
     });
   });
@@ -256,14 +261,14 @@ describe('when there is a request provided', () => {
     expect(channelsBefore).toHaveLength(0);
     const signedStates = [stateSignedBy([bob()])({turnNum: zero})];
     const objectives = signedStates.map(createChannelFromState);
-    await wallet.pushMessage(message({objectives}));
+    await wallet.pushMessage({objectives});
 
     // Get the channelId of that which was added
     const [{channelId}] = await Channel.query(wallet.knex).select();
 
     // Expect a GetChannel request to produce an outbound message with all states
     await expect(
-      wallet.pushMessage(message({requests: [{type: 'GetChannel', channelId}]}))
+      wallet.pushMessage({requests: [{type: 'GetChannel', channelId}]})
     ).resolves.toMatchObject({
       outbox: [
         {
@@ -284,16 +289,17 @@ describe('when there is a request provided', () => {
     ];
 
     const createChannel: CreateChannel = createChannelFromState(signedStates[0]);
-    await wallet.pushMessage(
-      message({objectives: [createChannel], signedStates: [signedStates[1]]})
-    );
+    await wallet.pushMessage({
+      objectives: [createChannel],
+      signedStates: [serializeState(signedStates[1])],
+    });
 
     // Get the channelId of that which was added
     const [{channelId}] = await Channel.query(wallet.knex).select();
 
     // Expect a GetChannel request to produce an outbound message with all states
     await expect(
-      wallet.pushMessage(message({requests: [{type: 'GetChannel', channelId}]}))
+      wallet.pushMessage({requests: [{type: 'GetChannel', channelId}]})
     ).resolves.toMatchObject({
       outbox: [
         {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -23,6 +23,7 @@ import {
   BN,
   Zero,
   SignedState,
+  serializeMessage,
 } from '@statechannels/wallet-core';
 import * as Either from 'fp-ts/lib/Either';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
@@ -132,14 +133,14 @@ export class Wallet implements WalletInterface {
     return {
       outbox: peers.map(recipient => ({
         method: 'MessageQueued',
-        params: {
-          recipient,
-          sender,
-          data: {
+        params: serializeMessage(
+          {
             signedStates: states,
             requests: [{type: 'GetChannel', channelId}],
           },
-        },
+          recipient,
+          sender
+        ),
       })),
       channelResult: ChannelState.toChannelResult(channelState),
     };
@@ -238,7 +239,7 @@ export class Wallet implements WalletInterface {
             data: {
               objectives: [
                 {
-                  participants: [params.sender, params.recipient],
+                  participants,
                   type: 'CreateChannel',
                   data: {
                     signedState: params.data.signedStates[0],
@@ -369,11 +370,7 @@ export class Wallet implements WalletInterface {
         peers.map(recipient => {
           outbox.push({
             method: 'MessageQueued',
-            params: {
-              recipient,
-              sender,
-              data: {signedStates},
-            },
+            params: serializeMessage({signedStates}, recipient, sender),
           });
         });
       };

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -13,6 +13,7 @@ import {
 import {
   ChannelConstants,
   Payload,
+  validatePayload,
   ChannelRequest,
   Outcome,
   SignedStateVarsWithHash,
@@ -349,9 +350,11 @@ export class Wallet implements WalletInterface {
     }
   }
 
-  async pushMessage(message: Payload): MultipleChannelResult {
+  async pushMessage(rawPayload: unknown): MultipleChannelResult {
     const knex = this.knex;
     const store = this.store;
+
+    const message = validatePayload(rawPayload);
 
     // TODO: Move into utility somewhere?
     function handleRequest(outbox: Outgoing[]): (req: ChannelRequest) => Promise<void> {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -12,7 +12,6 @@ import {
 } from '@statechannels/client-api-schema';
 import {
   ChannelConstants,
-  Payload,
   validatePayload,
   ChannelRequest,
   Outcome,
@@ -81,7 +80,7 @@ export type WalletInterface = {
   updateChannelFunding(args: UpdateChannelFundingParams): void;
 
   // Wallet <-> Wallet communication
-  pushMessage(m: Payload): MultipleChannelResult;
+  pushMessage(m: unknown): MultipleChannelResult;
 
   // Wallet -> App communication
   onNotification(cb: (notice: StateChannelsNotification) => void): {unsubscribe: () => void};

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -10,6 +10,7 @@ import {
   ChannelConstants,
   Participant,
   makeDestination,
+  serializeMessage,
   StateWithHash,
   isCreateChannel,
   hashState,
@@ -158,7 +159,7 @@ export class Store {
       type: 'NotifyApp' as 'NotifyApp',
       notice: {
         method: 'MessageQueued' as 'MessageQueued',
-        params: {sender, recipient, data},
+        params: serializeMessage(data, recipient, sender),
       },
     }));
 

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -66,13 +66,19 @@ export function deserializeState(state: SignedStateWire): SignedState {
 }
 
 export function deserializeObjective(objective: ObjectiveWire): Objective {
-  return {
-    ...objective,
-    participants: objective.participants.map(p => ({
-      ...p,
-      destination: makeDestination(p.destination)
-    }))
-  };
+  const participants = objective.participants.map(p => ({
+    ...p,
+    destination: makeDestination(p.destination)
+  }));
+
+  switch (objective.type) {
+    case 'CreateChannel': {
+      const signedState = deserializeState(objective.data.signedState);
+      return {...objective, participants, data: {...objective.data, signedState}};
+    }
+    default:
+      return {...objective, participants};
+  }
 }
 // where do I move between token and asset holder?
 // I have to have asset holder between the wallets, otherwise there is ambiguity

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -5,7 +5,8 @@ import {
   AllocationItem as AllocationItemWire,
   Allocation as AllocationWire,
   Message as WireMessage,
-  isAllocations
+  isAllocations,
+  validateMessage
 } from '@statechannels/wire-format';
 
 import {
@@ -29,13 +30,20 @@ export function convertToInternalParticipant(participant: {
   return {...participant, destination: makeDestination(participant.destination)};
 }
 
+export function validatePayload(rawPayload: unknown): Payload {
+  // todo: wire-format should export a validator specially for the payload
+  return deserializeMessage(validateMessage({recipient: '', sender: '', data: rawPayload}));
+}
+
 export function deserializeMessage(message: WireMessage): Payload {
   const signedStates = message?.data?.signedStates?.map(ss => deserializeState(ss));
   const objectives = message?.data?.objectives?.map(objective => deserializeObjective(objective));
+  const requests = message?.data?.requests;
 
   return {
     signedStates,
-    objectives
+    objectives,
+    requests
   };
 }
 

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -146,6 +146,12 @@ export const wireMessageFormat: WireMessage = {
           }
         ]
       }
+    ],
+    requests: [
+      {
+        type: 'GetChannel',
+        channelId: '0x59fb8a0bff0f4553b0169d4b6cad93f3baa9edd94bd28c954ae0ad1622252967'
+      }
     ]
   }
 };
@@ -171,6 +177,12 @@ export const internalMessageFormat: Payload = {
           signingAddress: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9'
         }
       ]
+    }
+  ],
+  requests: [
+    {
+      type: 'GetChannel',
+      channelId: '0x59fb8a0bff0f4553b0169d4b6cad93f3baa9edd94bd28c954ae0ad1622252967'
     }
   ]
 };

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -22,7 +22,7 @@ import {formatAmount} from '../../utils';
 
 export function serializeMessage(message: Payload, recipient: string, sender: string): WireMessage {
   const signedStates = (message.signedStates || []).map(serializeState);
-  const objectives = (message.objectives || []).map(serializeObjective);
+  const objectives = message.objectives?.map(serializeObjective);
   const {requests} = message;
   return {
     recipient,

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -20,11 +20,11 @@ import {formatAmount} from '../../utils';
 
 export function serializeMessage(message: Payload, recipient: string, sender: string): WireMessage {
   const signedStates = (message.signedStates || []).map(ss => serializeState(ss));
-  const {objectives} = message;
+  const {objectives, requests} = message;
   return {
     recipient,
     sender,
-    data: {signedStates, objectives}
+    data: {signedStates, objectives, requests}
   };
 }
 
@@ -55,7 +55,7 @@ export function serializeState(state: SignedState): SignedStateWire {
   };
 }
 
-function serializeOutcome(outcome: Outcome): OutcomeWire {
+export function serializeOutcome(outcome: Outcome): OutcomeWire {
   switch (outcome.type) {
     case 'SimpleAllocation':
       return [serializeSimpleAllocation(outcome)];

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -126,6 +126,7 @@
               "type": "string"
             },
             "signedState": {
+              "$ref": "#/definitions/SignedState"
             }
           },
           "required": [

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -57,6 +57,25 @@
       "pattern": "^0x([a-fA-F0-9]{64})$",
       "type": "string"
     },
+    "ChannelRequest": {
+      "additionalProperties": false,
+      "properties": {
+        "channelId": {
+          "$ref": "#/definitions/Bytes32"
+        },
+        "type": {
+          "enum": [
+            "GetChannel"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "channelId"
+      ],
+      "type": "object"
+    },
     "CloseLedger": {
       "additionalProperties": false,
       "properties": {
@@ -251,6 +270,12 @@
             "objectives": {
               "items": {
                 "$ref": "#/definitions/Objective"
+              },
+              "type": "array"
+            },
+            "requests": {
+              "items": {
+                "$ref": "#/definitions/ChannelRequest"
               },
               "type": "array"
             },

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -85,7 +85,7 @@ export type CreateChannel = _Objective<
   'CreateChannel',
   {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    signedState: any;
+    signedState: SignedState;
     fundingStrategy: FundingStrategy;
   }
 >;

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -140,11 +140,16 @@ export const isOpenChannel = guard<OpenChannel>('OpenChannel');
 export const isVirtuallyFund = guard<VirtuallyFund>('VirtuallyFund');
 export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');
 
+// channel requests
+type GetChannel = {type: 'GetChannel'; channelId: Bytes32};
+export type ChannelRequest = GetChannel;
+
 export interface Message {
   recipient: string; // Identifier of user that the message should be relayed to
   sender: string; // Identifier of user that the message is from
   data: {
     signedStates?: SignedState[];
     objectives?: Objective[];
+    requests?: ChannelRequest[];
   };
 }


### PR DESCRIPTION
This PR contains a bunch of fixes required to get the server-wallet to communicate using the wire-format:

* Updates wire-format to include the new `requests` property
* Updates wallet-core serde to not drop the `requests` property
* Changes the type of the message handed to `pushMessage` to `unknown`, and then validates the correct format immediately
* Ensures that the messages being sent from the wallet are the right format

The change to `unknown` is really important, as it will prevent users of the wallet from having to cast messages to the right type, as is happening all over the `payment-manager` and `receipt-manager`.

There are potential performance implementations, because converting from the wire-message format and back can involve hashing/signature recovery. In theory, this isn't necessary, as we have the properties already (or need to calculate them anyway), but that would require more changes than I wanted to make in one PR. In any case, we should probably merge, profile and then re-optimize if it turns out to be a problem.