### PR TITLE
[server-wallet] Remove pre-database query data validation

### DIFF
--- a/packages/server-wallet/src/models/funding.ts
+++ b/packages/server-wallet/src/models/funding.ts
@@ -50,7 +50,7 @@ export class Funding extends Model implements RequiredColumns {
       return await Funding.query(knex).insert({channelId, amount, assetHolder});
     } else {
       return await Funding.query(knex)
-        .update({channelId, amount, assetHolder})
+        .patch({channelId, amount, assetHolder})
         .where({channelId, assetHolder})
         .returning('*')
         .first();

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -175,14 +175,9 @@ export class Store {
   ): Promise<void> {
     const channel = await Channel.forId(channelId, tx);
 
-    const cols: RequiredColumns = {
-      ...channel,
-      chainServiceRequests: [...channel.chainServiceRequests, type],
-    };
-
     await Channel.query(tx)
       .where({channelId: channel.channelId})
-      .update(cols);
+      .update({chainServiceRequests: [...channel.chainServiceRequests, type]});
   }
 
   async getChannel(
@@ -247,15 +242,9 @@ export class Store {
       channel.vars = await addState(channel.vars, singedStateWithHash);
       validateInvariants(channel.vars, channel.myAddress);
 
-      const cols: RequiredColumns = {
-        ...channel,
-        vars: channel.vars,
-        fundingStrategy,
-      };
-
       const result = await Channel.query(tx)
         .where({channelId: channel.channelId})
-        .update(cols)
+        .update({vars: channel.vars, fundingStrategy})
         .returning('*')
         .first();
 
@@ -300,15 +289,10 @@ export class Store {
       validateInvariants(channel.vars, channel.myAddress)
     );
 
-    const cols: RequiredColumns = {
-      ...channel,
-      vars: channel.vars,
-    };
-
     const result = await timer('updating', async () =>
       Channel.query(tx)
         .where({channelId: channel.channelId})
-        .update(cols)
+        .update({vars: channel.vars})
         .returning('*')
         .first()
     );

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -177,7 +177,7 @@ export class Store {
 
     await Channel.query(tx)
       .where({channelId: channel.channelId})
-      .update({chainServiceRequests: [...channel.chainServiceRequests, type]});
+      .patch({chainServiceRequests: [...channel.chainServiceRequests, type]});
   }
 
   async getChannel(
@@ -244,7 +244,7 @@ export class Store {
 
       const result = await Channel.query(tx)
         .where({channelId: channel.channelId})
-        .update({vars: channel.vars, fundingStrategy})
+        .patch({vars: channel.vars, fundingStrategy})
         .returning('*')
         .first();
 
@@ -292,7 +292,7 @@ export class Store {
     const result = await timer('updating', async () =>
       Channel.query(tx)
         .where({channelId: channel.channelId})
-        .update({vars: channel.vars})
+        .patch({vars: channel.vars})
         .returning('*')
         .first()
     );


### PR DESCRIPTION
`update` validates and updates every column of the table for a particular query which seems unnecessary (@andrewgordstewart ?). `patch` should be faster since it is a simpler query.

Tradeoff:
- Faster queries (I think?)
- Less validation