### PR TITLE
Knex should be implementation detail of Store

### DIFF
--- a/packages/server-wallet/src/metrics.ts
+++ b/packages/server-wallet/src/metrics.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 import Knex from 'knex';
 
-export function setupMetrics(knex: Knex, metricsOutputFile: string): void {
+export function setupMetrics(metricsOutputFile: string): void {
   if (metricsOutputFile) {
     fs.writeFileSync(metricsOutputFile, '', {flag: 'w'});
   }
@@ -20,14 +20,15 @@ export function setupMetrics(knex: Knex, metricsOutputFile: string): void {
       log(entry);
     }
   });
+
   obs.observe({
     // Record multiple
     entryTypes: ['node', 'measure', 'gc', 'function', 'http2', 'http'],
     buffered: false,
   });
+}
 
-  // Add DB query metrics
-
+export function setupDBMetrics(knex: Knex): void {
   knex
     .on('query', query => {
       const uid = query.__knexQueryUid;

--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -3,13 +3,19 @@ import Objection from 'objection';
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {stateWithHashSignedBy2} from './fixtures/states';
 import {alice, bob} from './fixtures/signing-wallets';
 
-const store = new Store(defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+const store = new Store(
+  extractDBConfigFromServerWalletConfig(defaultConfig),
+  defaultConfig.timingMetrics,
+  defaultConfig.skipEvmValidation
+);
+
+afterAll(async () => store.closeDatabaseConnection());
 
 describe('addSignedState', () => {
   let tx: Objection.Transaction;

--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -3,17 +3,13 @@ import Objection from 'objection';
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
+import {defaultConfig} from '../../config';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {stateWithHashSignedBy2} from './fixtures/states';
 import {alice, bob} from './fixtures/signing-wallets';
 
-const store = new Store(
-  extractDBConfigFromServerWalletConfig(defaultConfig),
-  defaultConfig.timingMetrics,
-  defaultConfig.skipEvmValidation
-);
+const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 afterAll(async () => store.closeDatabaseConnection());
 

--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -9,9 +9,11 @@ import {channel} from '../../models/__test__/fixtures/channel';
 import {stateWithHashSignedBy2} from './fixtures/states';
 import {alice, bob} from './fixtures/signing-wallets';
 
-const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+let store: Store;
 
-afterAll(async () => store.closeDatabaseConnection());
+beforeAll(async () => {
+  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+});
 
 describe('addSignedState', () => {
   let tx: Objection.Transaction;

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -4,15 +4,9 @@ import {SignedState as WireSignedState} from '@statechannels/wire-format';
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
+import {defaultConfig} from '../../config';
 
-const store = new Store(
-  extractDBConfigFromServerWalletConfig(defaultConfig),
-  defaultConfig.timingMetrics,
-  defaultConfig.skipEvmValidation
-);
-
-afterAll(async () => store.closeDatabaseConnection());
+const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 describe('addSignedState', () => {
   let tx: Objection.Transaction;

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -4,9 +4,13 @@ import {SignedState as WireSignedState} from '@statechannels/wire-format';
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
 
-const store = new Store(defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+const store = new Store(
+  extractDBConfigFromServerWalletConfig(defaultConfig),
+  defaultConfig.timingMetrics,
+  defaultConfig.skipEvmValidation
+);
 
 describe('addSignedState', () => {
   let tx: Objection.Transaction;

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -12,7 +12,7 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
-afterAll(async () => store.knex.destroy());
+afterAll(async () => store.closeDatabaseConnection());
 
 describe('addSignedState', () => {
   let tx: Objection.Transaction;

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -6,7 +6,11 @@ import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultConfig} from '../../config';
 
-const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+let store: Store;
+
+beforeAll(async () => {
+  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+});
 
 describe('addSignedState', () => {
   let tx: Objection.Transaction;

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -12,6 +12,8 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
+afterAll(async () => store.knex.destroy());
+
 describe('addSignedState', () => {
   let tx: Objection.Transaction;
 

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -22,11 +22,11 @@ const store = new Store(
 describe('getFirstParticipant', () => {
   it('works', async () => {
     await expect(SigningWallet.query(knex)).resolves.toHaveLength(0);
-    const {signingAddress} = await store.getFirstParticipant(knex);
+    const {signingAddress} = await store.getFirstParticipant();
     expect(signingAddress).toBeDefined();
     expect(ethers.utils.isAddress(signingAddress)).toBeTruthy();
 
-    const {signingAddress: signingAddress2} = await store.getFirstParticipant(knex);
+    const {signingAddress: signingAddress2} = await store.getFirstParticipant();
     expect(signingAddress).toEqual(signingAddress2);
     await expect(SigningWallet.query(knex)).resolves.toHaveLength(1);
   });
@@ -34,7 +34,7 @@ describe('getFirstParticipant', () => {
   it('prepopulated address returned correctly', async () => {
     await seedAlicesSigningWallet(knex);
     await expect(SigningWallet.query(knex)).resolves.toHaveLength(1);
-    const {signingAddress, participantId} = await store.getFirstParticipant(knex);
+    const {signingAddress, participantId} = await store.getFirstParticipant();
     expect(signingAddress).toEqual(alice().signingAddress);
     expect(participantId).toEqual(alice().signingAddress);
     await expect(SigningWallet.query(knex)).resolves.toHaveLength(1);

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -5,7 +5,7 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {SigningWallet} from '../../models/signing-wallet';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
+import {defaultConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
@@ -13,13 +13,7 @@ beforeEach(async () => {
   await truncate(knex);
 });
 
-const store = new Store(
-  extractDBConfigFromServerWalletConfig(defaultConfig),
-  defaultConfig.timingMetrics,
-  defaultConfig.skipEvmValidation
-);
-
-afterAll(async () => store.closeDatabaseConnection());
+const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 describe('getFirstParticipant', () => {
   it('works', async () => {

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -5,7 +5,7 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {SigningWallet} from '../../models/signing-wallet';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
@@ -13,7 +13,11 @@ beforeEach(async () => {
   await truncate(knex);
 });
 
-const store = new Store(defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+const store = new Store(
+  extractDBConfigFromServerWalletConfig(defaultConfig),
+  defaultConfig.timingMetrics,
+  defaultConfig.skipEvmValidation
+);
 
 describe('getFirstParticipant', () => {
   it('works', async () => {

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -9,11 +9,15 @@ import {defaultConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
+let store: Store;
+
+beforeAll(async () => {
+  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+});
+
 beforeEach(async () => {
   await truncate(knex);
 });
-
-const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 describe('getFirstParticipant', () => {
   it('works', async () => {

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -19,7 +19,7 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
-afterAll(async () => store.knex.destroy());
+afterAll(async () => store.closeDatabaseConnection());
 
 describe('getFirstParticipant', () => {
   it('works', async () => {

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -19,6 +19,8 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
+afterAll(async () => store.knex.destroy());
+
 describe('getFirstParticipant', () => {
   it('works', async () => {
     await expect(SigningWallet.query(knex)).resolves.toHaveLength(0);

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -80,6 +80,4 @@ describe('happy path', () => {
 });
 
 it("doesn't create a channel if it doesn't have a signing wallet", () =>
-  expect(w.createChannel(createChannelArgs())).rejects.toThrow(
-    'null value in column "signing_address"'
-  ));
+  expect(w.createChannel(createChannelArgs())).rejects.toThrow('Not in channel'));

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -14,7 +14,11 @@ import {stateVars} from './fixtures/state-vars';
 
 jest.setTimeout(10_000);
 
-const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+let store: Store;
+
+beforeAll(async () => {
+  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+});
 
 it('works', async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -20,7 +20,7 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
-afterAll(async () => store.knex.destroy());
+afterAll(async () => store.closeDatabaseConnection());
 
 it('works', async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -27,7 +27,7 @@ it('works', async () => {
 
   const {channelId, latest} = c;
   await expect(
-    store.lockApp(knex, channelId, async tx =>
+    store.lockApp(channelId, async tx =>
       store.signState(channelId, {...latest, turnNum: latest.turnNum + 1}, tx)
     )
   ).resolves.toMatchObject({channelResult: {turnNum: 6}});
@@ -76,7 +76,7 @@ describe('concurrency', () => {
     await Promise.all(
       _.range(numAttempts).map(() =>
         store
-          .lockApp(knex, channelId, async tx => store.signState(channelId, next(c.latest), tx))
+          .lockApp(channelId, async tx => store.signState(channelId, next(c.latest), tx))
           .then(countResolvedPromise)
           .catch(countRejectedPromise)
           .finally(countSettledPromise)
@@ -117,9 +117,7 @@ describe('concurrency', () => {
       await Promise.all(
         channelIds.map(channelId =>
           store
-            .lockApp(knex, channelId, async (tx, c) =>
-              store.signState(channelId, next(c.latest), tx)
-            )
+            .lockApp(channelId, async (tx, c) => store.signState(channelId, next(c.latest), tx))
             .then(countResolvedPromise)
             .finally(countSettledPromise)
         )
@@ -160,13 +158,13 @@ describe('concurrency', () => {
 
 describe('Missing channels', () => {
   it('throws a ChannelError by default', () =>
-    expect(store.lockApp(knex, 'foo', _.noop)).rejects.toThrow(
+    expect(store.lockApp('foo', _.noop)).rejects.toThrow(
       new ChannelError(ChannelError.reasons.channelMissing, {channelId: 'foo'})
     ));
 
   it('calls the onChannelMissing handler when given', () =>
-    expect(store.lockApp(knex, 'foo', _.noop, _.noop)).resolves.not.toThrow());
+    expect(store.lockApp('foo', _.noop, _.noop)).resolves.not.toThrow());
 
   it('calls the onChannelMissing handler with the channel Id when given', () =>
-    expect(store.lockApp(knex, 'foo', _.noop, _.identity)).resolves.toEqual('foo'));
+    expect(store.lockApp('foo', _.noop, _.identity)).resolves.toEqual('foo'));
 });

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -20,6 +20,8 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
+afterAll(async () => store.knex.destroy());
+
 it('works', async () => {
   await seedAlicesSigningWallet(knex);
   const c = withSupportedState()({vars: [stateVars({turnNum: 5})]});

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -89,7 +89,7 @@ describe('concurrency', () => {
     expect(numRejected).toEqual(numAttempts - 1);
     expect(numSettled).toEqual(numAttempts);
 
-    await expect(store.getChannel(channelId, knex)).resolves.toMatchObject({
+    await expect(store.getChannel(channelId)).resolves.toMatchObject({
       latest: {turnNum: 6},
     });
   });
@@ -128,7 +128,7 @@ describe('concurrency', () => {
 
       expect([numResolved, numRejected, numSettled]).toMatchObject([NUM_ATTEMPTS, 0, NUM_ATTEMPTS]);
 
-      await expect(store.getChannel(channelIds[1], knex)).resolves.toMatchObject({
+      await expect(store.getChannel(channelIds[1])).resolves.toMatchObject({
         latest: {turnNum: 6},
       });
     },
@@ -150,7 +150,7 @@ describe('concurrency', () => {
     expect(numRejected).toEqual(0);
     expect(numSettled).toEqual(NUM_ATTEMPTS);
 
-    await expect(store.getChannel(channelId, knex)).resolves.toMatchObject({
+    await expect(store.getChannel(channelId)).resolves.toMatchObject({
       latest: next(c.latest),
     });
   });

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -8,13 +8,17 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import adminKnex from '../../db-admin/db-admin-connection';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
 
 import {stateVars} from './fixtures/state-vars';
 
 jest.setTimeout(10_000);
 
-const store = new Store(defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+const store = new Store(
+  extractDBConfigFromServerWalletConfig(defaultConfig),
+  defaultConfig.timingMetrics,
+  defaultConfig.skipEvmValidation
+);
 
 it('works', async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -8,19 +8,13 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import adminKnex from '../../db-admin/db-admin-connection';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
+import {defaultConfig} from '../../config';
 
 import {stateVars} from './fixtures/state-vars';
 
 jest.setTimeout(10_000);
 
-const store = new Store(
-  extractDBConfigFromServerWalletConfig(defaultConfig),
-  defaultConfig.timingMetrics,
-  defaultConfig.skipEvmValidation
-);
-
-afterAll(async () => store.closeDatabaseConnection());
+const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 it('works', async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -6,20 +6,14 @@ import {channel} from '../../models/__test__/fixtures/channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
+import {defaultConfig} from '../../config';
 
 import {stateWithHashSignedBy} from './fixtures/states';
 import {bob, alice} from './fixtures/signing-wallets';
 
 let tx: Objection.Transaction;
 
-const store = new Store(
-  extractDBConfigFromServerWalletConfig(defaultConfig),
-  defaultConfig.timingMetrics,
-  defaultConfig.skipEvmValidation
-);
-
-afterAll(async () => store.closeDatabaseConnection());
+const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 beforeEach(async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -13,7 +13,11 @@ import {bob, alice} from './fixtures/signing-wallets';
 
 let tx: Objection.Transaction;
 
-const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+let store: Store;
+
+beforeAll(async () => {
+  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+});
 
 beforeEach(async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -19,6 +19,8 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
+afterAll(async () => store.knex.destroy());
+
 beforeEach(async () => {
   await seedAlicesSigningWallet(knex);
 

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -19,7 +19,7 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
-afterAll(async () => store.knex.destroy());
+afterAll(async () => store.closeDatabaseConnection());
 
 beforeEach(async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -6,14 +6,18 @@ import {channel} from '../../models/__test__/fixtures/channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
 
 import {stateWithHashSignedBy} from './fixtures/states';
 import {bob, alice} from './fixtures/signing-wallets';
 
 let tx: Objection.Transaction;
 
-const store = new Store(defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+const store = new Store(
+  extractDBConfigFromServerWalletConfig(defaultConfig),
+  defaultConfig.timingMetrics,
+  defaultConfig.skipEvmValidation
+);
 
 beforeEach(async () => {
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -4,7 +4,7 @@ import {truncate} from '../../db-admin/db-admin-connection';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
@@ -12,7 +12,11 @@ beforeEach(async () => {
   await truncate(knex);
 });
 
-const store = new Store(defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+const store = new Store(
+  extractDBConfigFromServerWalletConfig(defaultConfig),
+  defaultConfig.timingMetrics,
+  defaultConfig.skipEvmValidation
+);
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -18,7 +18,7 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
-afterAll(async () => store.knex.destroy());
+afterAll(async () => store.closeDatabaseConnection());
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -20,17 +20,17 @@ const store = new Store(
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {
-    const signingAddress = await store.getOrCreateSigningAddress(knex);
+    const signingAddress = await store.getOrCreateSigningAddress();
     expect(signingAddress).toBeDefined();
     expect(ethers.utils.isAddress(signingAddress)).toBeTruthy();
 
-    const signingAddress2 = await store.getOrCreateSigningAddress(knex);
+    const signingAddress2 = await store.getOrCreateSigningAddress();
     expect(signingAddress).toEqual(signingAddress2);
   });
 
   it('prepopulated address returned correctly', async () => {
     await seedAlicesSigningWallet(knex);
-    const signingAddress = await store.getOrCreateSigningAddress(knex);
+    const signingAddress = await store.getOrCreateSigningAddress();
     expect(signingAddress).toEqual(alice().signingAddress);
   });
 });

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -8,11 +8,15 @@ import {defaultConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
+let store: Store;
+
+beforeAll(async () => {
+  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+});
+
 beforeEach(async () => {
   await truncate(knex);
 });
-
-const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -18,6 +18,8 @@ const store = new Store(
   defaultConfig.skipEvmValidation
 );
 
+afterAll(async () => store.knex.destroy());
+
 describe('signingAddress', () => {
   it('generate address then get address', async () => {
     const signingAddress = await store.getOrCreateSigningAddress();

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -4,7 +4,7 @@ import {truncate} from '../../db-admin/db-admin-connection';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../../config';
+import {defaultConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
@@ -12,13 +12,7 @@ beforeEach(async () => {
   await truncate(knex);
 });
 
-const store = new Store(
-  extractDBConfigFromServerWalletConfig(defaultConfig),
-  defaultConfig.timingMetrics,
-  defaultConfig.skipEvmValidation
-);
-
-afterAll(async () => store.closeDatabaseConnection());
+const store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
 
 describe('signingAddress', () => {
   it('generate address then get address', async () => {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -277,7 +277,6 @@ export class Wallet implements WalletInterface {
     };
 
     const {outbox, channelResult} = await this.store.lockApp(
-      this.knex,
       channelId,
       criticalCode,
       handleMissingChannel
@@ -315,7 +314,7 @@ export class Wallet implements WalletInterface {
       return {outbox: outgoing.map(n => n.notice), channelResult};
     };
 
-    return this.store.lockApp(this.knex, channelId, criticalCode, handleMissingChannel);
+    return this.store.lockApp(channelId, criticalCode, handleMissingChannel);
   }
 
   async closeChannel({channelId}: CloseChannelParams): SingleChannelResult {
@@ -332,7 +331,7 @@ export class Wallet implements WalletInterface {
       return {outbox: outgoing.map(n => n.notice), channelResult};
     };
 
-    return this.store.lockApp(this.knex, channelId, criticalCode, handleMissingChannel);
+    return this.store.lockApp(channelId, criticalCode, handleMissingChannel);
   }
 
   async getChannels(): MultipleChannelResult {
@@ -408,7 +407,7 @@ export class Wallet implements WalletInterface {
     const channelResults: ChannelResult[] = [];
     let error: Error | undefined = undefined;
     while (channels.length && !error) {
-      await this.store.lockApp(this.knex, channels[0], async tx => {
+      await this.store.lockApp(channels[0], async tx => {
         // For the moment, we are only considering directly funded app channels.
         // Thus, we can directly fetch the channel record, and immediately construct the protocol state from it.
         // In the future, we can have an App model which collects all the relevant channels for an app channel,

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -114,7 +114,6 @@ export class Wallet implements WalletInterface {
   }
 
   public get knex(): Knex {
-    // FIXME: Knex should be an implementation detail of a Store
     return this.store.knex;
   }
 

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -129,7 +129,7 @@ export class Wallet implements WalletInterface {
   }
 
   public async syncChannel({channelId}: SyncChannelParams): SingleChannelResult {
-    const {states, channelState} = await this.store.getStates(channelId, this.knex);
+    const {states, channelState} = await this.store.getStates(channelId);
 
     const {participants, myIndex} = channelState;
 
@@ -358,7 +358,6 @@ export class Wallet implements WalletInterface {
   }
 
   async pushMessage(rawPayload: unknown): MultipleChannelResult {
-    const knex = this.knex;
     const store = this.store;
 
     const wirePayload = validatePayload(rawPayload);
@@ -366,7 +365,7 @@ export class Wallet implements WalletInterface {
     // TODO: Move into utility somewhere?
     function handleRequest(outbox: Outgoing[]): (req: ChannelRequest) => Promise<void> {
       return async ({channelId}: ChannelRequest): Promise<void> => {
-        const {states: signedStates, channelState} = await store.getStates(channelId, knex);
+        const {states: signedStates, channelState} = await store.getStates(channelId);
 
         const {participants, myIndex} = channelState;
 

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -180,7 +180,7 @@ export class Wallet implements WalletInterface {
   }
 
   public async getSigningAddress(): Promise<string> {
-    return await this.store.getOrCreateSigningAddress(this.knex);
+    return await this.store.getOrCreateSigningAddress();
   }
 
   async createChannel(args: CreateChannelParams): SingleChannelResult {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -335,7 +335,7 @@ export class Wallet implements WalletInterface {
   }
 
   async getChannels(): MultipleChannelResult {
-    const channelStates = await this.store.getChannels(this.knex);
+    const channelStates = await this.store.getChannels();
     return {
       channelResults: channelStates.map(ChannelState.toChannelResult),
       outbox: [],

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -88,11 +88,15 @@ export type WalletInterface = {
 };
 
 export class Wallet implements WalletInterface {
-  knex: Knex;
   store: Store;
+
   constructor(readonly walletConfig: ServerWalletConfig) {
-    this.knex = Knex(extractDBConfigFromServerWalletConfig(walletConfig));
-    this.store = new Store(walletConfig.timingMetrics, walletConfig.skipEvmValidation);
+    this.store = new Store(
+      extractDBConfigFromServerWalletConfig(walletConfig),
+      walletConfig.timingMetrics,
+      walletConfig.skipEvmValidation
+    );
+
     // Bind methods to class instance
     this.getParticipant = this.getParticipant.bind(this);
     this.updateChannelFunding = this.updateChannelFunding.bind(this);
@@ -113,6 +117,11 @@ export class Wallet implements WalletInterface {
       }
       setupMetrics(this.knex, walletConfig.metricsOutputFile);
     }
+  }
+
+  public get knex(): Knex {
+    // FIXME: Knex should be an implementation detail of a Store
+    return this.store.knex;
   }
 
   public async destroy(): Promise<void> {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -118,7 +118,7 @@ export class Wallet implements WalletInterface {
   }
 
   public async destroy(): Promise<void> {
-    await this.store.knex.destroy();
+    await this.store.closeDatabaseConnection();
   }
 
   public async syncChannel({channelId}: SyncChannelParams): SingleChannelResult {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -339,10 +339,10 @@ export class Wallet implements WalletInterface {
 
   async getState({channelId}: GetStateParams): SingleChannelResult {
     try {
-      const {channelResult} = await Channel.forId(channelId, this.knex);
+      const channel = await this.store.getChannel(channelId);
 
       return {
-        channelResult,
+        channelResult: ChannelState.toChannelResult(channel),
         outbox: [],
       };
     } catch (err) {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -32,7 +32,6 @@ import {Transaction} from 'objection';
 
 import {Bytes32, Uint256} from '../type-aliases';
 import {Channel} from '../models/channel';
-import {Nonce} from '../models/nonce';
 import {Outgoing, ProtocolAction, isOutgoing} from '../protocols/actions';
 import {SigningWallet} from '../models/signing-wallet';
 import {logger} from '../logger';
@@ -186,10 +185,7 @@ export class Wallet implements WalletInterface {
     const {participants, appDefinition, appData, allocations} = args;
     const outcome: Outcome = deserializeAllocations(allocations);
 
-    const channelNonce = await Nonce.next(
-      this.knex,
-      participants.map(p => p.signingAddress)
-    );
+    const channelNonce = await this.store.nextNonce(participants.map(p => p.signingAddress));
     const channelConstants: ChannelConstants = {
       channelNonce,
       participants: participants.map(convertToParticipant),

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -42,7 +42,6 @@ import * as CloseChannel from '../handlers/close-channel';
 import * as JoinChannel from '../handlers/join-channel';
 import * as ChannelState from '../protocols/state';
 import {isWalletError} from '../errors/wallet-error';
-import {Funding} from '../models/funding';
 import {OnchainServiceInterface} from '../onchain-service';
 import {timerFactory, recordFunctionMetrics, setupMetrics} from '../metrics';
 import {ServerWalletConfig, extractDBConfigFromServerWalletConfig} from '../config';
@@ -125,7 +124,7 @@ export class Wallet implements WalletInterface {
   }
 
   public async destroy(): Promise<void> {
-    await this.knex.destroy();
+    await this.store.knex.destroy();
   }
 
   public async syncChannel({channelId}: SyncChannelParams): SingleChannelResult {
@@ -172,7 +171,7 @@ export class Wallet implements WalletInterface {
   }: UpdateChannelFundingParams): SingleChannelResult {
     const assetHolder = assetHolderAddress(token || Zero) || ETH_ASSET_HOLDER_ADDRESS;
 
-    await Funding.updateFunding(this.knex, channelId, BN.from(amount), assetHolder);
+    await this.store.updateFunding(channelId, BN.from(amount), assetHolder);
 
     const {channelResults, outbox} = await this.takeActions([channelId]);
 

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -115,7 +115,7 @@ export class Wallet implements WalletInterface {
       if (!walletConfig.metricsOutputFile) {
         throw Error('You must define a metrics output file');
       }
-      setupMetrics(this.knex, walletConfig.metricsOutputFile);
+      setupMetrics(walletConfig.metricsOutputFile);
     }
   }
 

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -156,7 +156,7 @@ export class Wallet implements WalletInterface {
     let participant: Participant | undefined = undefined;
 
     try {
-      participant = await this.store.getFirstParticipant(this.knex);
+      participant = await this.store.getFirstParticipant();
     } catch (e) {
       if (isWalletError(e)) logger.error('Wallet failed to get a participant', e);
       else throw e;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -264,9 +264,9 @@ export class Store {
 
   async getStates(
     channelId: Bytes32,
-    txOrKnex: TransactionOrKnex
+    tx?: Transaction
   ): Promise<{states: SignedStateWithHash[]; channelState: ChannelState}> {
-    const channel = await Channel.forId(channelId, txOrKnex);
+    const channel = await Channel.forId(channelId, tx || this.knex);
 
     if (!channel) throw new StoreError(StoreError.reasons.channelMissing);
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -62,7 +62,15 @@ const throwMissingChannel: MissingAppHandler<any> = (channelId: string) => {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export class Store {
-  constructor(readonly timingMetrics: boolean, readonly skipEvmValidation: boolean) {
+  knex: Knex;
+
+  constructor(
+    readonly knexConfig: Knex.Config,
+    readonly timingMetrics: boolean,
+    readonly skipEvmValidation: boolean
+  ) {
+    this.knex = Knex(knexConfig);
+
     if (timingMetrics) {
       this.getFirstParticipant = recordFunctionMetrics(this.getFirstParticipant);
       this.getOrCreateSigningAddress = recordFunctionMetrics(this.getOrCreateSigningAddress);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -42,7 +42,7 @@ import {ChannelState, ChainServiceApi} from '../protocols/state';
 import {WalletError, Values} from '../errors/wallet-error';
 import {Bytes32} from '../type-aliases';
 import {validateTransitionWithEVM} from '../evm-validator';
-import {timerFactory, recordFunctionMetrics} from '../metrics';
+import {timerFactory, recordFunctionMetrics, setupDBMetrics} from '../metrics';
 import {fastRecoverAddress} from '../utilities/signatures';
 import {pick} from '../utilities/helpers';
 
@@ -82,6 +82,8 @@ export class Store {
       this.addObjective = recordFunctionMetrics(this.addObjective);
       this.pushMessage = recordFunctionMetrics(this.pushMessage);
       this.addSignedState = recordFunctionMetrics(this.addSignedState);
+
+      setupDBMetrics(this.knex);
     }
   }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -40,11 +40,12 @@ import {SigningWallet} from '../models/signing-wallet';
 import {addHash} from '../state-utils';
 import {ChannelState, ChainServiceApi} from '../protocols/state';
 import {WalletError, Values} from '../errors/wallet-error';
-import {Bytes32} from '../type-aliases';
+import {Bytes32, Address, Uint256} from '../type-aliases';
 import {validateTransitionWithEVM} from '../evm-validator';
 import {timerFactory, recordFunctionMetrics, setupDBMetrics} from '../metrics';
 import {fastRecoverAddress} from '../utilities/signatures';
 import {pick} from '../utilities/helpers';
+import {Funding} from '../models/funding';
 
 export type AppHandler<T> = (tx: Transaction, channel: ChannelState) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;
@@ -412,6 +413,14 @@ export class Store {
     );
 
     return result;
+  }
+
+  async updateFunding(
+    channelId: string,
+    fromAmount: Uint256,
+    assetHolderAddress: Address
+  ): Promise<void> {
+    await Funding.updateFunding(this.knex, channelId, fromAmount, assetHolderAddress);
   }
 }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -94,6 +94,10 @@ export class Store {
     }
   }
 
+  async closeDatabaseConnection(): Promise<void> {
+    await this.knex.destroy();
+  }
+
   async getFirstParticipant(): Promise<Participant> {
     const signingAddress = await this.getOrCreateSigningAddress();
     return {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -72,7 +72,7 @@ export class Store {
     readonly timingMetrics: boolean,
     readonly skipEvmValidation: boolean
   ) {
-    if (knexOrConfig instanceof Knex) {
+    if (knexOrConfig.client instanceof Knex.Client) {
       this.knex = knexOrConfig as Knex;
     } else {
       this.knex = Knex(knexOrConfig);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -258,11 +258,8 @@ export class Store {
       .patch({chainServiceRequests: [...channel.chainServiceRequests, type]});
   }
 
-  async getChannel(
-    channelId: Bytes32,
-    txOrKnex: TransactionOrKnex
-  ): Promise<ChannelState | undefined> {
-    return (await Channel.forId(channelId, txOrKnex))?.protocolState;
+  async getChannel(channelId: Bytes32, tx?: Transaction): Promise<ChannelState> {
+    return (await Channel.forId(channelId, tx || this.knex))?.protocolState;
   }
 
   async getStates(

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -85,8 +85,8 @@ export class Store {
     }
   }
 
-  async getFirstParticipant(knex: Knex): Promise<Participant> {
-    const signingAddress = await this.getOrCreateSigningAddress(knex);
+  async getFirstParticipant(): Promise<Participant> {
+    const signingAddress = await this.getOrCreateSigningAddress(this.knex);
     return {
       participantId: signingAddress,
       signingAddress,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -68,11 +68,15 @@ export class Store {
   knex: Knex;
 
   constructor(
-    readonly knexConfig: Knex.Config,
+    readonly knexOrConfig: Knex | Knex.Config,
     readonly timingMetrics: boolean,
     readonly skipEvmValidation: boolean
   ) {
-    this.knex = Knex(knexConfig);
+    if (knexOrConfig instanceof Knex) {
+      this.knex = knexOrConfig as Knex;
+    } else {
+      this.knex = Knex(knexOrConfig);
+    }
 
     if (timingMetrics) {
       this.getFirstParticipant = recordFunctionMetrics(this.getFirstParticipant);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -46,6 +46,7 @@ import {timerFactory, recordFunctionMetrics, setupDBMetrics} from '../metrics';
 import {fastRecoverAddress} from '../utilities/signatures';
 import {pick} from '../utilities/helpers';
 import {Funding} from '../models/funding';
+import {Nonce} from '../models/nonce';
 
 export type AppHandler<T> = (tx: Transaction, channel: ChannelState) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;
@@ -421,6 +422,10 @@ export class Store {
     assetHolderAddress: Address
   ): Promise<void> {
     await Funding.updateFunding(this.knex, channelId, fromAmount, assetHolderAddress);
+  }
+
+  async nextNonce(signingAddresses: Address[]): Promise<number> {
+    return await Nonce.next(this.knex, signingAddresses);
   }
 }
 


### PR DESCRIPTION
I think we agree that Knex is an implementation detail of a PostgreSQL specific implementation of a Store, thus it should not be known by a Wallet, especially if we intend on re-using that code in the browser.
