### PR TITLE
WIP - re-optimize wallet

### DIFF
--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -354,7 +354,7 @@ export class Wallet implements WalletInterface {
     const knex = this.knex;
     const store = this.store;
 
-    const message = validatePayload(rawPayload);
+    const wirePayload = validatePayload(rawPayload);
 
     // TODO: Move into utility somewhere?
     function handleRequest(outbox: Outgoing[]): (req: ChannelRequest) => Promise<void> {
@@ -376,14 +376,14 @@ export class Wallet implements WalletInterface {
     }
 
     const channelIds = await Channel.transaction(this.knex, async tx => {
-      return await this.store.pushMessage(message, tx);
+      return await this.store.pushMessage(wirePayload, tx);
     });
 
     const {channelResults, outbox} = await this.takeActions(channelIds);
 
-    if (message.requests && message.requests.length > 0)
+    if (wirePayload.requests && wirePayload.requests.length > 0)
       // Modifies outbox, may append new messages
-      await Promise.all(message.requests.map(handleRequest(outbox)));
+      await Promise.all(wirePayload.requests.map(handleRequest(outbox)));
 
     return {outbox, channelResults};
   }

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -3,7 +3,6 @@ import {
   Objective,
   SignedStateWithHash,
   SignedStateVarsWithHash,
-  Payload,
   State,
   calculateChannelId,
   StateVariables,
@@ -14,7 +13,9 @@ import {
   StateWithHash,
   isCreateChannel,
   hashState,
+  deserializeObjective,
 } from '@statechannels/wallet-core';
+import {Payload as WirePayload, SignedState as WireSignedState} from '@statechannels/wire-format';
 import _ from 'lodash';
 import {HashZero} from '@ethersproject/constants';
 import {ChannelResult, FundingStrategy} from '@statechannels/client-api-schema';
@@ -209,8 +210,10 @@ export class Store {
     return (await Channel.query(knex)).map(channel => channel.protocolState);
   }
 
-  async pushMessage(message: Payload, tx: Transaction): Promise<Bytes32[]> {
-    for (const o of message.objectives || []) {
+  async pushMessage(message: WirePayload, tx: Transaction): Promise<Bytes32[]> {
+    const objectives = message.objectives?.map(deserializeObjective) || [];
+
+    for (const o of objectives) {
       await this.addObjective(o, tx);
     }
 
@@ -223,8 +226,8 @@ export class Store {
       return s !== undefined;
     }
     const objectiveChannelIds =
-      message.objectives
-        ?.map(objective =>
+      objectives
+        .map(objective =>
           isCreateChannel(objective) ? calculateChannelId(objective.data.signedState) : undefined
         )
         .filter(isDefined) || [];

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -30,9 +30,11 @@ export function convertToInternalParticipant(participant: {
   return {...participant, destination: makeDestination(participant.destination)};
 }
 
-export function validatePayload(rawPayload: unknown): Payload {
+type WirePayload = WireMessage['data'];
+
+export function validatePayload(rawPayload: unknown): WirePayload {
   // todo: wire-format should export a validator specially for the payload
-  return deserializeMessage(validateMessage({recipient: '', sender: '', data: rawPayload}));
+  return validateMessage({recipient: '', sender: '', data: rawPayload}).data;
 }
 
 export function deserializeMessage(message: WireMessage): Payload {

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -144,12 +144,14 @@ export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');
 type GetChannel = {type: 'GetChannel'; channelId: Bytes32};
 export type ChannelRequest = GetChannel;
 
+export interface Payload {
+  signedStates?: SignedState[];
+  objectives?: Objective[];
+  requests?: ChannelRequest[];
+}
+
 export interface Message {
   recipient: string; // Identifier of user that the message should be relayed to
   sender: string; // Identifier of user that the message is from
-  data: {
-    signedStates?: SignedState[];
-    objectives?: Objective[];
-    requests?: ChannelRequest[];
-  };
+  data: Payload;
 }


### PR DESCRIPTION
Rough plan:

Tackle `deserializeMessage` first (half done). Do this by pushing the `WirePayload` right down into the wallet store, and rewrite `validateSignatures` to actually return the addresses, instead of checking them against what's there.

Blocked in this by the fact that `pushMessage` isn't the only caller of `addSignedState` - `signState` calls it too, although it definitely shouldn't, as it involves recalculating the `channelId`, that we already know, and validating the signature that we've just created 😳 . Rough plan:

* Factor out the bit that actually adds the state to the store
* Rewrite signState to (1) check the state transition, (2) sign the state, (3) add to the store, using function from point above
* Rewrite `addSignedState` to take a `WireState`

Then remove the `serializeMessage` calls identified [here](https://github.com/statechannels/statechannels/pull/2573). Rough plan:

* Change the `Outbox` format to only ever include wire-messages
* This should remove the need to call `serializeMessage` at the last moment.
* Will also need to address the `CreateChannel` objective, which is constructed in a slightly hacky way from the outbox, and includes a signed state.

