### PR TITLE
chore (server-wallet): fix update-channel benchmark

### DIFF
--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -24,7 +24,7 @@ async function setup(): Promise<Channel[]> {
   const channels = [];
   for (const channelNonce of iter) {
     const c = withSupportedState()({channelNonce, vars: [stateVars({turnNum: 3})]});
-    await Channel.query().insert(c);
+    await Channel.query(knex).insert(c);
 
     channels.push(c);
   }


### PR DESCRIPTION
Every time I want to run this benchmark on `master`, I need to make this
change locally.