### PR TITLE
Add Unfunded and Unknown funding strategies

### DIFF
--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -342,7 +342,9 @@
       "enum": [
         "Direct",
         "Ledger",
-        "Virtual"
+        "Virtual",
+        "Unfunded",
+        "Unknown"
       ],
       "type": "string"
     },

--- a/packages/client-api-schema/src/methods/CreateChannel.ts
+++ b/packages/client-api-schema/src/methods/CreateChannel.ts
@@ -2,7 +2,7 @@ import {Participant, Allocation, Address, ChannelResult} from '../data-types';
 import {JsonRpcRequest, JsonRpcResponse, JsonRpcError} from '../jsonrpc-header-types';
 import {ErrorCodes as AllErrors} from '../error-codes';
 
-export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual';
+export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
 export interface CreateChannelParams {
   participants: Participant[];
   allocations: Allocation[];

--- a/packages/server-wallet/src/db/migrations/20200915140300_chain_service.ts
+++ b/packages/server-wallet/src/db/migrations/20200915140300_chain_service.ts
@@ -1,13 +1,18 @@
 import * as Knex from 'knex';
+import {FundingStrategy} from '@statechannels/client-api-schema';
 
 const channels = 'channels';
 const chainServiceRequests = 'chain_service_requests';
 const fundingStrategy = 'funding_strategy';
+const defaultFundingStrategy: FundingStrategy = 'Unknown';
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.alterTable(channels, table => {
     table.specificType(chainServiceRequests, 'text[]').notNullable();
-    table.string(fundingStrategy).notNullable();
+    table
+      .string(fundingStrategy)
+      .notNullable()
+      .defaultTo(defaultFundingStrategy);
   });
 }
 

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -121,7 +121,9 @@
               "enum": [
                 "Direct",
                 "Ledger",
-                "Virtual"
+                "Virtual",
+                "Unfunded",
+                "Unknown"
               ],
               "type": "string"
             },
@@ -335,7 +337,9 @@
               "enum": [
                 "Direct",
                 "Ledger",
-                "Virtual"
+                "Virtual",
+                "Unfunded",
+                "Unknown"
               ],
               "type": "string"
             },

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -80,7 +80,7 @@ type _Objective<Name, Data> = {
   type: Name;
   data: Data;
 };
-type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual';
+type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
 export type CreateChannel = _Objective<
   'CreateChannel',
   {

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -20,7 +20,7 @@ import {Store} from './store';
 import {ApproveBudgetAndFund, CloseLedgerAndWithdraw, Application} from './workflows';
 import {ethereumEnableWorkflow} from './workflows/ethereum-enable';
 import {Wallet as WalletUi} from './ui/wallet';
-import {MessagingServiceInterface} from './messaging';
+import {MessagingServiceInterface, supportedFundingStrategyOrThrow} from './messaging';
 import {ADD_LOGS} from './config';
 import {logger} from './logger';
 
@@ -60,12 +60,13 @@ export class ChannelWallet {
           )}, no new workflow will be spawned`
         );
       } else {
+        const fundingStrategy = supportedFundingStrategyOrThrow(objective.data.fundingStrategy);
         // Note that it's important to start the workflow first, before sending ChannelProposed.
         // This way, the workflow is listening to JOIN_CHANNEL right from the get go.
         this.startWorkflow(
           Application.workflow(this.store, this.messagingService, {
             type: 'JOIN_CHANNEL',
-            fundingStrategy: objective.data.fundingStrategy,
+            fundingStrategy,
             channelId: objective.data.targetChannelId,
             applicationDomain: 'TODO' // FIXME
           }),

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -15,7 +15,8 @@ import {
   CloseAndWithdrawRequest,
   StateChannelsErrorResponse,
   ChallengeChannelRequest,
-  parseResponse
+  parseResponse,
+  FundingStrategy
 } from '@statechannels/client-api-schema';
 import {fromEvent, Observable} from 'rxjs';
 import {validateMessage} from '@statechannels/wire-format';
@@ -317,10 +318,7 @@ async function convertToInternalEvent(
       if (!isSimpleEthAllocation(outcome)) {
         throw new Error('Currently only a simple ETH allocation is supported');
       }
-      const fundingStrategy = request.params.fundingStrategy;
-      if (fundingStrategy == 'Unfunded' || fundingStrategy == 'Unknown') {
-        throw new Error(`Unsupported funding strategy ${fundingStrategy}`);
-      }
+      const fundingStrategy = supportedFundingStrategyOrThrow(request.params.fundingStrategy);
       return {
         type: 'CREATE_CHANNEL',
         ...request.params,
@@ -355,4 +353,15 @@ async function convertToInternalEvent(
         appData: request.params.appData
       };
   }
+}
+
+export type SupportedFundingStrategy = Exclude<FundingStrategy, 'Unknown' | 'Unfunded'>;
+function isSupportedFundingStrategy(fs: FundingStrategy): fs is SupportedFundingStrategy {
+  return fs !== 'Unfunded' && fs !== 'Unknown';
+}
+export function supportedFundingStrategyOrThrow(fs: FundingStrategy): SupportedFundingStrategy {
+  if (!isSupportedFundingStrategy(fs)) {
+    throw new Error(`Unsupported funding strategy ${fs}`);
+  }
+  return fs;
 }

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -317,9 +317,14 @@ async function convertToInternalEvent(
       if (!isSimpleEthAllocation(outcome)) {
         throw new Error('Currently only a simple ETH allocation is supported');
       }
+      const fundingStrategy = request.params.fundingStrategy;
+      if (fundingStrategy == 'Unfunded' || fundingStrategy == 'Unknown') {
+        throw new Error(`Unsupported funding strategy ${fundingStrategy}`);
+      }
       return {
         type: 'CREATE_CHANNEL',
         ...request.params,
+        fundingStrategy,
         participants: request.params.participants.map(convertToInternalParticipant),
         outcome,
         challengeDuration: CHALLENGE_DURATION,

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -13,7 +13,7 @@ import {
 } from 'xstate';
 import {filter, map, distinctUntilChanged} from 'rxjs/operators';
 import {StateVariables, serializeChannelEntry} from '@statechannels/wallet-core';
-import {FundingStrategy, StateChannelsError} from '@statechannels/client-api-schema';
+import {StateChannelsError} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {
@@ -30,13 +30,13 @@ import {unreachable} from '../utils';
 import {logger} from '../logger';
 import {CONCLUDE_TIMEOUT} from '../constants';
 import {createMockGuard} from '../utils/workflow-utils';
-import {MessagingServiceInterface} from '../messaging';
+import {MessagingServiceInterface, SupportedFundingStrategy} from '../messaging';
 
 import {ConcludeChannel, CreateAndFund, ChallengeChannel, Confirm as CCC} from './';
 
 export interface WorkflowContext {
   applicationDomain: string;
-  fundingStrategy: FundingStrategy;
+  fundingStrategy: SupportedFundingStrategy;
   channelId?: string;
   requestObserver?: any;
   updateObserver?: any;


### PR DESCRIPTION
Per discussion during standup, we discussed that a wallet might:
- Receive a prefund state without an objective.
- Later receive an objective that specifies how a channel should be funded.

The server wallet should default to the `Unknown` funding type for the case above. The `Unfunded` type is also added to support channels that do not have funding.

Also addresses https://github.com/statechannels/statechannels/pull/2561#discussion_r491503249