### PR TITLE
Migrate from submitTransaction to fundChannel

### DIFF
--- a/packages/server-wallet/src/mock-chain-service/index.ts
+++ b/packages/server-wallet/src/mock-chain-service/index.ts
@@ -1,0 +1,17 @@
+import {Address} from '@statechannels/client-api-schema';
+
+import {Bytes32, Uint256} from '../type-aliases';
+
+type SubmissionStatus = 'Success' | 'Fail';
+type FundChannelArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  expectedHeld: Uint256;
+  amount: Uint256;
+};
+export class OnchainService {
+  static fundChannel(_arg: FundChannelArg): Promise<SubmissionStatus> {
+    const submissionStatus: SubmissionStatus = 'Success';
+    return Promise.resolve(submissionStatus);
+  }
+}

--- a/packages/server-wallet/src/protocols/__test__/application.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/application.test.ts
@@ -1,9 +1,10 @@
 import {simpleEthAllocation, BN, Uint256, State} from '@statechannels/wallet-core';
 import matchers from '@pacote/jest-either';
+import {ethers} from 'ethers';
 
 import {protocol} from '../application';
 import {alice, bob} from '../../wallet/__test__/fixtures/participants';
-import {SignState, submitTransaction} from '../actions';
+import {SignState, fundChannel} from '../actions';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {applicationProtocolState} from './fixtures/application-protocol-state';
@@ -27,14 +28,22 @@ const funded = (): Uint256 => BN.from(5);
 const notFunded = (): Uint256 => BN.from(0);
 
 const signState = (state: Partial<State>): Partial<SignState> => ({type: 'SignState', ...state});
+const fundChannelAction1 = fundChannel({
+  channelId: channel().channelId,
+  assetHolderAddress: ethers.constants.AddressZero,
+  expectedHeld: BN.from(0),
+  amount: BN.from(5),
+});
+
+const fundChannelAction2 = {...fundChannelAction1, expectedHeld: BN.from(5)};
 
 test.each`
-  supported        | latestSignedByMe | latest           | funding      | action                                                                                            | cond                                                                     | result
-  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${funded}    | ${signState(postFundState)}                                                                       | ${'when the prefund state is supported, and the channel is funded'}      | ${'signs the postfund state'}
-  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${notFunded} | ${submitTransaction({channelId: channel().channelId, transactionRequest: {}, transactionId: ''})} | ${'when the prefund state is supported, and alice is first to deposit'}  | ${'submits transaction'}
-  ${prefundState2} | ${prefundState2} | ${prefundState2} | ${funded}    | ${submitTransaction({channelId: channel().channelId, transactionRequest: {}, transactionId: ''})} | ${'when the prefund state is supported, and alice is secont to deposit'} | ${'submits transaction'}
-  ${closingState}  | ${postFundState} | ${closingState}  | ${funded}    | ${signState(closingState)}                                                                        | ${'when the postfund state is supported, and the channel is closing'}    | ${'signs the final state'}
-  ${closingState2} | ${runningState}  | ${closingState2} | ${funded}    | ${signState(closingState2)}                                                                       | ${'when the postfund state is supported, and the channel is closing'}    | ${'signs the final state'}
+  supported        | latestSignedByMe | latest           | funding      | action                      | cond                                                                     | result
+  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${funded}    | ${signState(postFundState)} | ${'when the prefund state is supported, and the channel is funded'}      | ${'signs the postfund state'}
+  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${notFunded} | ${fundChannelAction1}       | ${'when the prefund state is supported, and alice is first to deposit'}  | ${'submits transaction'}
+  ${prefundState2} | ${prefundState2} | ${prefundState2} | ${funded}    | ${fundChannelAction2}       | ${'when the prefund state is supported, and alice is secont to deposit'} | ${'submits transaction'}
+  ${closingState}  | ${postFundState} | ${closingState}  | ${funded}    | ${signState(closingState)}  | ${'when the postfund state is supported, and the channel is closing'}    | ${'signs the final state'}
+  ${closingState2} | ${runningState}  | ${closingState2} | ${funded}    | ${signState(closingState2)} | ${'when the postfund state is supported, and the channel is closing'}    | ${'signs the final state'}
 `('$result $cond', ({supported, latest, latestSignedByMe, funding, action}) => {
   const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe, funding}});
   expect(protocol(ps)).toMatchObject(action);

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -1,8 +1,7 @@
-import {StateChannelsNotification} from '@statechannels/client-api-schema';
+import {StateChannelsNotification, Address} from '@statechannels/client-api-schema';
 import {StateVariables} from '@statechannels/wallet-core';
-import {providers} from 'ethers';
 
-import {Bytes32} from '../type-aliases';
+import {Bytes32, Uint256} from '../type-aliases';
 
 /*
 Actions that protocols can declare.
@@ -11,11 +10,12 @@ Actions that protocols can declare.
 export type Notice = Omit<StateChannelsNotification, 'jsonrpc'>;
 export type SignState = {type: 'SignState'; channelId: Bytes32} & StateVariables;
 export type NotifyApp = {type: 'NotifyApp'; notice: Notice};
-export type SubmitTransaction = {
-  type: 'SubmitTransaction';
+export type FundChannel = {
+  type: 'FundChannel';
   channelId: Bytes32;
-  transactionRequest: providers.TransactionRequest;
-  transactionId: string;
+  assetHolderAddress: Address;
+  expectedHeld: Uint256;
+  amount: Uint256;
 };
 
 /*
@@ -27,7 +27,7 @@ export const noAction = undefined;
 const actionConstructor = <A extends ProtocolAction = ProtocolAction>(type: A['type']) => (
   props: Omit<A, 'type'>
 ): A => ({...props, type} as A);
-export const submitTransaction = actionConstructor<SubmitTransaction>('SubmitTransaction');
+export const fundChannel = actionConstructor<FundChannel>('FundChannel');
 export const notifyApp = actionConstructor<NotifyApp>('NotifyApp');
 export const signState = actionConstructor<SignState>('SignState');
 
@@ -37,9 +37,9 @@ const guard = <T extends ProtocolAction>(type: ProtocolAction['type']) => (
 
 export const isSignState = guard<SignState>('SignState');
 export const isNotifyApp = guard<NotifyApp>('NotifyApp');
-export const isSubmitTransaction = guard<SubmitTransaction>('SubmitTransaction');
+export const isFundChannel = guard<FundChannel>('FundChannel');
 
 export type Outgoing = Notice;
 export const isOutgoing = isNotifyApp;
 
-export type ProtocolAction = SignState | NotifyApp | SubmitTransaction;
+export type ProtocolAction = SignState | NotifyApp | FundChannel;

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -46,6 +46,7 @@ import {Funding} from '../models/funding';
 import {OnchainServiceInterface} from '../onchain-service';
 import {timerFactory, recordFunctionMetrics, setupMetrics} from '../metrics';
 import {ServerWalletConfig, extractDBConfigFromServerWalletConfig} from '../config';
+import {OnchainService} from '../mock-chain-service';
 
 import {Store, AppHandler, MissingAppHandler} from './store';
 
@@ -426,8 +427,9 @@ export class Wallet implements WalletInterface {
               outgoing.map(n => outbox.push(n.notice));
               return;
             }
-            case 'SubmitTransaction':
+            case 'FundChannel':
               await this.store.addChainServiceRequest(action.channelId, 'fund', tx);
+              await OnchainService.fundChannel(action);
               return;
             default:
               throw 'Unimplemented';


### PR DESCRIPTION
This is the first step for the wallet to use the new, rich `OnchainService` api.