### PR TITLE
[server-wallet] Pass channelId to serializeMessage

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -87,9 +87,10 @@ describe('channel results', () => {
     const createChannel = createChannelFromState(signedStates[0]);
     await wallet.pushMessage({objectives: [createChannel]});
 
-    await expectResults(wallet.pushMessage({signedStates: signedStates.map(serializeState)}), [
-      {turnNum: zero, status: 'proposed'},
-    ]);
+    await expectResults(
+      wallet.pushMessage({signedStates: signedStates.map(ss => serializeState(ss))}),
+      [{turnNum: zero, status: 'proposed'}]
+    );
   });
 
   it("returns a 'running' channel result when receiving a state in a channel that is now running", async () => {
@@ -115,9 +116,10 @@ describe('channel results', () => {
     const {channelId} = await Channel.query(wallet.knex).insert(channel);
 
     const signedStates = [stateSignedBy([bob()])({turnNum: 10, isFinal: true, participants})];
-    return expectResults(wallet.pushMessage({signedStates: signedStates.map(serializeState)}), [
-      {channelId, turnNum: 10, status: 'closing'},
-    ]);
+    return expectResults(
+      wallet.pushMessage({signedStates: signedStates.map(ss => serializeState(ss))}),
+      [{channelId, turnNum: 10, status: 'closing'}]
+    );
   });
 
   it("returns a 'closed' channel result when receiving a state in a channel that is now closed", async () => {
@@ -273,7 +275,7 @@ describe('when there is a request provided', () => {
       outbox: [
         {
           method: 'MessageQueued',
-          params: {data: {signedStates: signedStates.map(serializeState)}},
+          params: {data: {signedStates: signedStates.map(ss => serializeState(ss))}},
         },
       ],
     });
@@ -304,7 +306,7 @@ describe('when there is a request provided', () => {
       outbox: [
         {
           method: 'MessageQueued',
-          params: {data: {signedStates: signedStates.map(serializeState)}},
+          params: {data: {signedStates: signedStates.map(ss => serializeState(ss))}},
         },
       ],
     });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -136,7 +136,8 @@ export class Wallet implements WalletInterface {
             requests: [{type: 'GetChannel', channelId}],
           },
           recipient,
-          sender
+          sender,
+          channelId
         ),
       })),
       channelResult: ChannelState.toChannelResult(channelState),
@@ -367,7 +368,7 @@ export class Wallet implements WalletInterface {
         peers.map(recipient => {
           outbox.push({
             method: 'MessageQueued',
-            params: serializeMessage({signedStates}, recipient, sender),
+            params: serializeMessage({signedStates}, recipient, sender, channelId),
           });
         });
       };

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -194,7 +194,7 @@ export class Store {
       type: 'NotifyApp' as 'NotifyApp',
       notice: {
         method: 'MessageQueued' as 'MessageQueued',
-        params: serializeMessage(data, recipient, sender),
+        params: serializeMessage(data, recipient, sender, channelId),
       },
     }));
 

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -20,8 +20,13 @@ import {
 import {calculateChannelId} from '../../state-utils';
 import {formatAmount} from '../../utils';
 
-export function serializeMessage(message: Payload, recipient: string, sender: string): WireMessage {
-  const signedStates = (message.signedStates || []).map(serializeState);
+export function serializeMessage(
+  message: Payload,
+  recipient: string,
+  sender: string,
+  channelId?: string
+): WireMessage {
+  const signedStates = (message.signedStates || []).map(ss => serializeState(ss, channelId));
   const objectives = message.objectives?.map(serializeObjective);
   const {requests} = message;
   return {
@@ -31,7 +36,7 @@ export function serializeMessage(message: Payload, recipient: string, sender: st
   };
 }
 
-export function serializeState(state: SignedState): SignedStateWire {
+export function serializeState(state: SignedState, channelId?: string): SignedStateWire {
   const {
     chainId,
     participants,
@@ -53,7 +58,7 @@ export function serializeState(state: SignedState): SignedStateWire {
     appData,
     isFinal,
     outcome: serializeOutcome(state.outcome),
-    channelId: calculateChannelId(state),
+    channelId: channelId || calculateChannelId(state),
     signatures: state.signatures.map(s => s.signature)
   };
 }


### PR DESCRIPTION
It's an optional parameter which means the function can skip computation of the `channelId` in the case it is already known. 