### PR TITLE
fix: Add missing dependency to xstate-wallet

### DIFF
--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -52,6 +52,7 @@
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "pino": "6.2.0",
     "pino-pretty": "4.0.0",
+    "pnp-webpack-plugin": "^1.6.4",
     "postcss-flexbugs-fixes": "4.1.0",
     "postcss-normalize": "7.0.1",
     "postcss-preset-env": "6.7.0",


### PR DESCRIPTION
This is crucial for anyone wanting to use this package as a (dev) dependency