### PR TITLE
[server-wallet]: React to setFunding ChainService calls

### DIFF
--- a/packages/server-wallet/src/mock-chain-service/index.ts
+++ b/packages/server-wallet/src/mock-chain-service/index.ts
@@ -1,6 +1,14 @@
 import {Address} from '@statechannels/client-api-schema';
+import {Evt} from 'evt';
 
 import {Bytes32, Uint256} from '../type-aliases';
+import {
+  OnchainServiceInterface,
+  ChainEventNames,
+  ChannelEventRecordMap,
+  FundingEvent,
+} from '../onchain-service';
+import {Wallet} from '../wallet';
 
 type SubmissionStatus = 'Success' | 'Fail';
 type FundChannelArg = {
@@ -18,9 +26,33 @@ export type SetFundingArg = {
 export interface ChainEventListener {
   setFunding(arg: SetFundingArg): void;
 }
-export class OnchainService {
+export class OnchainService implements OnchainServiceInterface {
   static fundChannel(_arg: FundChannelArg): Promise<SubmissionStatus> {
     const submissionStatus: SubmissionStatus = 'Success';
     return Promise.resolve(submissionStatus);
+  }
+
+  registerChannel(_channelId: Bytes32, _assetHolders: Address[]): Promise<void> {
+    return Promise.resolve();
+  }
+
+  // TODO: remove in v1
+  attachChannelWallet(_wallet: Wallet): void {
+    return;
+  }
+
+  attachHandler<T extends ChainEventNames>(
+    _assetHolderAddr: Address,
+    _event: T,
+    _callback: (event: ChannelEventRecordMap[T]) => void | Promise<void>,
+    _filter?: (event: ChannelEventRecordMap[T]) => boolean,
+    _timeout?: number
+  ): Evt<ChannelEventRecordMap[T]> | Promise<ChannelEventRecordMap[T]> {
+    const mockEvt = new Evt<FundingEvent>();
+    return mockEvt;
+  }
+
+  detachAllHandlers(_assetHolderAddr: Address, _event?: ChainEventNames): void {
+    return;
   }
 }

--- a/packages/server-wallet/src/mock-chain-service/index.ts
+++ b/packages/server-wallet/src/mock-chain-service/index.ts
@@ -9,6 +9,15 @@ type FundChannelArg = {
   expectedHeld: Uint256;
   amount: Uint256;
 };
+export type SetFundingArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  amount: Uint256;
+};
+
+export interface ChainEventListener {
+  setFunding(arg: SetFundingArg): void;
+}
 export class OnchainService {
   static fundChannel(_arg: FundChannelArg): Promise<SubmissionStatus> {
     const submissionStatus: SubmissionStatus = 'Success';

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -96,7 +96,6 @@ export class Wallet implements WalletInterface, ChainEventListener {
       this.walletConfig.timingMetrics,
       this.walletConfig.skipEvmValidation
     );
-    this.chainService = new OnchainService();
 
     // Bind methods to class instance
     this.getParticipant = this.getParticipant.bind(this);
@@ -120,6 +119,9 @@ export class Wallet implements WalletInterface, ChainEventListener {
       }
       setupMetrics(this.walletConfig.metricsOutputFile);
     }
+
+    this.chainService = new OnchainService();
+    this.attachChainService(this.chainService);
   }
 
   public async destroy(): Promise<void> {


### PR DESCRIPTION
The current strategy is to use a mock chain service to mimic the chain service v2 api.