### PR TITLE
Remove CreateChannel objective

### DIFF
--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -259,6 +259,9 @@ export type ErrorCodes = {
         NotYourTurn: 403;
         ChannelClosed: 404;
     };
+    SyncChannel: {
+        ChannelNotFound: 1400;
+    };
     PushMessage: {
         WrongParticipant: 900;
     };
@@ -283,7 +286,7 @@ export type ErrorCodes = {
 export type ExternalDestination = string;
 
 // @public (undocumented)
-export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual';
+export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
 
 // @public (undocumented)
 export interface Funds {
@@ -542,10 +545,31 @@ export type StateChannelsNotificationType = {
 };
 
 // @public (undocumented)
-export type StateChannelsRequest = CreateChannelRequest | JoinChannelRequest | UpdateChannelRequest | GetWalletInformationRequest | EnableEthereumRequest | GetStateRequest | PushMessageRequest | ChallengeChannelRequest | GetBudgetRequest | ApproveBudgetAndFundRequest | CloseChannelRequest | CloseAndWithdrawRequest | GetChannelsRequest;
+export type StateChannelsRequest = CreateChannelRequest | SyncChannelRequest | JoinChannelRequest | UpdateChannelRequest | GetWalletInformationRequest | EnableEthereumRequest | GetStateRequest | PushMessageRequest | ChallengeChannelRequest | GetBudgetRequest | ApproveBudgetAndFundRequest | CloseChannelRequest | CloseAndWithdrawRequest | GetChannelsRequest;
 
 // @public (undocumented)
-export type StateChannelsResponse = CreateChannelResponse | JoinChannelResponse | UpdateChannelResponse | GetWalletInformationResponse | EnableEthereumResponse | GetStateResponse | PushMessageResponse | ChallengeChannelResponse | GetBudgetResponse | CloseChannelResponse | ApproveBudgetAndFundResponse | CloseAndWithdrawResponse | GetChannelsResponse;
+export type StateChannelsResponse = CreateChannelResponse | SyncChannelResponse | JoinChannelResponse | UpdateChannelResponse | GetWalletInformationResponse | EnableEthereumResponse | GetStateResponse | PushMessageResponse | ChallengeChannelResponse | GetBudgetResponse | CloseChannelResponse | ApproveBudgetAndFundResponse | CloseAndWithdrawResponse | GetChannelsResponse;
+
+// Warning: (ae-forgotten-export) The symbol "ChannelNotFound" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type SyncChannelError = ChannelNotFound_6;
+
+// @public (undocumented)
+export interface SyncChannelParams {
+    // (undocumented)
+    channelId: ChannelId;
+}
+
+// Warning: (ae-incompatible-release-tags) The symbol "SyncChannelRequest" is marked as @public, but its signature references "JsonRpcRequest" which is marked as @beta
+//
+// @public (undocumented)
+export type SyncChannelRequest = JsonRpcRequest<'SyncChannel', SyncChannelParams>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "SyncChannelResponse" is marked as @public, but its signature references "JsonRpcResponse" which is marked as @beta
+//
+// @public (undocumented)
+export type SyncChannelResponse = JsonRpcResponse<{}>;
 
 // @public (undocumented)
 export interface TokenBudget {

--- a/packages/client-api-schema/temp/client-api-schema.api.md
+++ b/packages/client-api-schema/temp/client-api-schema.api.md
@@ -259,6 +259,9 @@ export type ErrorCodes = {
         NotYourTurn: 403;
         ChannelClosed: 404;
     };
+    SyncChannel: {
+        ChannelNotFound: 1400;
+    };
     PushMessage: {
         WrongParticipant: 900;
     };
@@ -283,7 +286,7 @@ export type ErrorCodes = {
 export type ExternalDestination = string;
 
 // @public (undocumented)
-export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual';
+export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
 
 // @public (undocumented)
 export interface Funds {
@@ -542,10 +545,31 @@ export type StateChannelsNotificationType = {
 };
 
 // @public (undocumented)
-export type StateChannelsRequest = CreateChannelRequest | JoinChannelRequest | UpdateChannelRequest | GetWalletInformationRequest | EnableEthereumRequest | GetStateRequest | PushMessageRequest | ChallengeChannelRequest | GetBudgetRequest | ApproveBudgetAndFundRequest | CloseChannelRequest | CloseAndWithdrawRequest | GetChannelsRequest;
+export type StateChannelsRequest = CreateChannelRequest | SyncChannelRequest | JoinChannelRequest | UpdateChannelRequest | GetWalletInformationRequest | EnableEthereumRequest | GetStateRequest | PushMessageRequest | ChallengeChannelRequest | GetBudgetRequest | ApproveBudgetAndFundRequest | CloseChannelRequest | CloseAndWithdrawRequest | GetChannelsRequest;
 
 // @public (undocumented)
-export type StateChannelsResponse = CreateChannelResponse | JoinChannelResponse | UpdateChannelResponse | GetWalletInformationResponse | EnableEthereumResponse | GetStateResponse | PushMessageResponse | ChallengeChannelResponse | GetBudgetResponse | CloseChannelResponse | ApproveBudgetAndFundResponse | CloseAndWithdrawResponse | GetChannelsResponse;
+export type StateChannelsResponse = CreateChannelResponse | SyncChannelResponse | JoinChannelResponse | UpdateChannelResponse | GetWalletInformationResponse | EnableEthereumResponse | GetStateResponse | PushMessageResponse | ChallengeChannelResponse | GetBudgetResponse | CloseChannelResponse | ApproveBudgetAndFundResponse | CloseAndWithdrawResponse | GetChannelsResponse;
+
+// Warning: (ae-forgotten-export) The symbol "ChannelNotFound" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type SyncChannelError = ChannelNotFound_6;
+
+// @public (undocumented)
+export interface SyncChannelParams {
+    // (undocumented)
+    channelId: ChannelId;
+}
+
+// Warning: (ae-incompatible-release-tags) The symbol "SyncChannelRequest" is marked as @public, but its signature references "JsonRpcRequest" which is marked as @beta
+//
+// @public (undocumented)
+export type SyncChannelRequest = JsonRpcRequest<'SyncChannel', SyncChannelParams>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "SyncChannelResponse" is marked as @public, but its signature references "JsonRpcResponse" which is marked as @beta
+//
+// @public (undocumented)
+export type SyncChannelResponse = JsonRpcResponse<{}>;
 
 // @public (undocumented)
 export interface TokenBudget {

--- a/packages/server-wallet/src/errors/wallet-error.ts
+++ b/packages/server-wallet/src/errors/wallet-error.ts
@@ -12,7 +12,10 @@ export abstract class WalletError extends Error {
 
   abstract readonly type: Values<typeof WalletError.errors>;
   static readonly reasons: {[key: string]: string};
-  constructor(reason: Values<typeof WalletError.reasons>, public readonly data: any = undefined) {
+  constructor(
+    public readonly reason: Values<typeof WalletError.reasons>,
+    public readonly data: any = undefined
+  ) {
     super(reason);
   }
 }

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -107,15 +107,11 @@ export class Channel extends Model implements RequiredColumns {
   static jsonAttributes = ['vars', 'participants'];
 
   static async forId(channelId: Bytes32, txOrKnex: TransactionOrKnex): Promise<Channel> {
-    const result = Channel.query(txOrKnex)
+    return Channel.query(txOrKnex)
       .where({channelId})
       .withGraphFetched('signingWallet')
       .withGraphFetched('funding')
       .first();
-
-    if (!result) throw new ChannelError(ChannelError.reasons.channelMissing, {channelId});
-
-    return result;
   }
 
   $beforeValidate(jsonSchema: JSONSchema, json: Pojo, _opt: ModelOptions): JSONSchema {

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -323,6 +323,18 @@ export class Channel extends Model implements RequiredColumns {
   }
 }
 
+export function isChannelError(err: any): err is ChannelError {
+  if (err.type === WalletError.errors.ChannelError) return true;
+  return false;
+}
+
+export function isChannelMissingError(err: any): err is ChannelError {
+  if (isChannelError(err) && err.reason === ChannelError.reasons.channelMissing) {
+    return true;
+  }
+  return false;
+}
+
 export class ChannelError extends WalletError {
   readonly type = WalletError.errors.ChannelError;
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -35,13 +35,14 @@ describe('happy path', () => {
             recipient: 'bob',
             sender: 'alice',
             data: {
+              signedStates: [{turnNum: 0, appData}],
               objectives: [
                 {
                   participants: [alice(), bob()],
                   data: {
-                    signedState: {turnNum: 0, appData},
                     fundingStrategy: 'Direct',
                   },
+                  type: 'OpenChannel',
                 },
               ],
             },

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -1,11 +1,5 @@
-import {
-  calculateChannelId,
-  simpleEthAllocation,
-  SignedState,
-  serializeState,
-} from '@statechannels/wallet-core';
+import {calculateChannelId, simpleEthAllocation, serializeState} from '@statechannels/wallet-core';
 import {ChannelResult} from '@statechannels/client-api-schema';
-import {CreateChannel as CreateChannelWire} from '@statechannels/wire-format';
 
 import {Channel} from '../../../models/channel';
 import {Wallet} from '../..';
@@ -21,17 +15,6 @@ import {defaultConfig} from '../../../config';
 
 jest.setTimeout(20_000);
 const wallet = new Wallet(defaultConfig);
-
-function createChannelFromState(signedState: SignedState): CreateChannelWire {
-  return {
-    participants: [],
-    type: 'CreateChannel',
-    data: {
-      signedState: serializeState(signedState),
-      fundingStrategy: 'Direct',
-    },
-  };
-}
 
 afterAll(async () => {
   await wallet.destroy();
@@ -55,10 +38,8 @@ it('stores states contained in the message, in a single channel model', async ()
     stateSignedBy([alice()])({turnNum: five}),
     stateSignedBy([alice(), bob()])({turnNum: four}),
   ];
-  const createChannel = createChannelFromState(signedStates[0]);
   await wallet.pushMessage({
-    objectives: [createChannel],
-    signedStates: signedStates.map(serializeState),
+    signedStates: signedStates.map(s => serializeState(s)),
   });
 
   const channelsAfter = await Channel.query(wallet.knex).select();
@@ -138,7 +119,7 @@ describe('channel results', () => {
       stateSignedBy([alice(), bob()])({turnNum: six, channelNonce: 567, appData: '0x0f00'}),
     ];
 
-    const p = wallet.pushMessage({signedStates: signedStates.map(serializeState)});
+    const p = wallet.pushMessage({signedStates: signedStates.map(s => serializeState(s))});
 
     await expectResults(p, [{turnNum: five}, {turnNum: six, appData: '0x0f00'}]);
 
@@ -267,11 +248,7 @@ describe('when there is a request provided', () => {
       outbox: [
         {
           method: 'MessageQueued',
-<<<<<<< HEAD
-          params: {data: {signedStates: signedStates.map(ss => serializeState(ss))}},
-=======
           params: {data: {signedStates}},
->>>>>>> test: fix push-message test
         },
       ],
     });
@@ -284,7 +261,7 @@ describe('when there is a request provided', () => {
     const signedStates = [
       stateSignedBy([alice()])({turnNum: five}),
       stateSignedBy([alice(), bob()])({turnNum: four}),
-    ].map(serializeState);
+    ].map(s => serializeState(s));
 
     await wallet.pushMessage({
       signedStates,
@@ -300,11 +277,7 @@ describe('when there is a request provided', () => {
       outbox: [
         {
           method: 'MessageQueued',
-<<<<<<< HEAD
-          params: {data: {signedStates: signedStates.map(ss => serializeState(ss))}},
-=======
           params: {data: {signedStates}},
->>>>>>> test: fix push-message test
         },
       ],
     });

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -83,14 +83,9 @@ describe('channel results', () => {
     const channelsBefore = await Channel.query(wallet.knex).select();
     expect(channelsBefore).toHaveLength(0);
 
-    const signedStates = [stateSignedBy([bob()])({turnNum: zero})];
-    const createChannel = createChannelFromState(signedStates[0]);
-    await wallet.pushMessage({objectives: [createChannel]});
+    const signedStates = [serializeState(stateSignedBy([bob()])({turnNum: zero}))];
 
-    await expectResults(
-      wallet.pushMessage({signedStates: signedStates.map(ss => serializeState(ss))}),
-      [{turnNum: zero, status: 'proposed'}]
-    );
+    await expectResults(wallet.pushMessage({signedStates}), [{turnNum: zero, status: 'proposed'}]);
   });
 
   it("returns a 'running' channel result when receiving a state in a channel that is now running", async () => {
@@ -126,9 +121,10 @@ describe('channel results', () => {
     const channelsBefore = await Channel.query(wallet.knex).select();
     expect(channelsBefore).toHaveLength(0);
 
-    const signedStates = [stateSignedBy([alice(), bob()])({turnNum: 9, isFinal: true})];
-    const createChannel = createChannelFromState(signedStates[0]);
-    const result = wallet.pushMessage({objectives: [createChannel]});
+    const signedStates = [
+      serializeState(stateSignedBy([alice(), bob()])({turnNum: 9, isFinal: true})),
+    ];
+    const result = wallet.pushMessage({signedStates});
 
     return expectResults(result, [{turnNum: 9, status: 'closed'}]);
   });
@@ -142,8 +138,7 @@ describe('channel results', () => {
       stateSignedBy([alice(), bob()])({turnNum: six, channelNonce: 567, appData: '0x0f00'}),
     ];
 
-    const createChannelObjectives = signedStates.map(createChannelFromState);
-    const p = wallet.pushMessage({objectives: createChannelObjectives});
+    const p = wallet.pushMessage({signedStates: signedStates.map(serializeState)});
 
     await expectResults(p, [{turnNum: five}, {turnNum: six, appData: '0x0f00'}]);
 
@@ -165,9 +160,8 @@ it("Doesn't store stale states", async () => {
   const channelsBefore = await Channel.query(wallet.knex).select();
   expect(channelsBefore).toHaveLength(0);
 
-  const signedStates = [stateSignedBy([alice(), bob()])({turnNum: five})];
-  const createChannel = createChannelFromState(signedStates[0]);
-  await wallet.pushMessage({objectives: [createChannel]});
+  const signedStates = [serializeState(stateSignedBy([alice(), bob()])({turnNum: five}))];
+  await wallet.pushMessage({signedStates});
 
   const afterFirst = await Channel.query(wallet.knex).select();
 
@@ -190,9 +184,8 @@ it("Doesn't store stale states", async () => {
 it("doesn't store states for unknown signing addresses", async () => {
   await truncate(wallet.knex, ['signing_wallets']);
 
-  const signedStates = [stateSignedBy([alice(), bob()])({turnNum: five})];
-  const objectives = signedStates.map(createChannelFromState);
-  return expect(wallet.pushMessage({objectives})).rejects.toThrow(Error('Not in channel'));
+  const signedStates = [serializeState(stateSignedBy([alice(), bob()])({turnNum: five}))];
+  return expect(wallet.pushMessage({signedStates})).rejects.toThrow(Error('Not in channel'));
 });
 
 describe('when the application protocol returns an action', () => {
@@ -261,9 +254,8 @@ describe('when there is a request provided', () => {
     // Set up test by adding a single state into the DB via pushMessage call
     const channelsBefore = await Channel.query(wallet.knex).select();
     expect(channelsBefore).toHaveLength(0);
-    const signedStates = [stateSignedBy([bob()])({turnNum: zero})];
-    const objectives = signedStates.map(createChannelFromState);
-    await wallet.pushMessage({objectives});
+    const signedStates = [serializeState(stateSignedBy([bob()])({turnNum: zero}))];
+    await wallet.pushMessage({signedStates});
 
     // Get the channelId of that which was added
     const [{channelId}] = await Channel.query(wallet.knex).select();
@@ -275,7 +267,11 @@ describe('when there is a request provided', () => {
       outbox: [
         {
           method: 'MessageQueued',
+<<<<<<< HEAD
           params: {data: {signedStates: signedStates.map(ss => serializeState(ss))}},
+=======
+          params: {data: {signedStates}},
+>>>>>>> test: fix push-message test
         },
       ],
     });
@@ -288,12 +284,10 @@ describe('when there is a request provided', () => {
     const signedStates = [
       stateSignedBy([alice()])({turnNum: five}),
       stateSignedBy([alice(), bob()])({turnNum: four}),
-    ];
+    ].map(serializeState);
 
-    const createChannel = createChannelFromState(signedStates[0]);
     await wallet.pushMessage({
-      objectives: [createChannel],
-      signedStates: [serializeState(signedStates[1])],
+      signedStates,
     });
 
     // Get the channelId of that which was added
@@ -306,7 +300,11 @@ describe('when there is a request provided', () => {
       outbox: [
         {
           method: 'MessageQueued',
+<<<<<<< HEAD
           params: {data: {signedStates: signedStates.map(ss => serializeState(ss))}},
+=======
+          params: {data: {signedStates}},
+>>>>>>> test: fix push-message test
         },
       ],
     });

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -58,7 +58,7 @@ it('stores states contained in the message, in a single channel model', async ()
   const createChannel = createChannelFromState(signedStates[0]);
   await wallet.pushMessage({
     objectives: [createChannel],
-    signedStates: [serializeState(signedStates[1])],
+    signedStates: signedStates.map(serializeState),
   });
 
   const channelsAfter = await Channel.query(wallet.knex).select();

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -20,7 +20,6 @@ import {
   assetHolderAddress,
   BN,
   Zero,
-  SignedState,
   serializeMessage,
   ChannelConstants,
 } from '@statechannels/wallet-core';
@@ -202,37 +201,7 @@ export class Wallet implements WalletInterface {
       outcome,
       fundingStrategy
     );
-
-    // todo: clean up the construction of the Objective
-    // todo: do not assume Direct funding
-    const outbox: Outgoing[] = outgoing.map(n => {
-      const params = n.notice.params as {
-        sender: string;
-        recipient: string;
-        data: {signedStates: SignedState[]};
-      };
-      return {
-        method: 'MessageQueued' as const,
-        params: {
-          ...n.notice.params,
-          data: {
-            signedStates: params.data.signedStates,
-            objectives: [
-              {
-                participants,
-                type: 'CreateChannel',
-                data: {
-                  signedState: params.data.signedStates[0],
-                  fundingStrategy: 'Direct',
-                },
-              },
-            ],
-          },
-        },
-      };
-    });
-
-    return {outbox, channelResult};
+    return {outbox: outgoing.map(n => n.notice), channelResult};
   }
 
   async joinChannel({channelId}: JoinChannelParams): SingleChannelResult {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -216,6 +216,7 @@ export class Wallet implements WalletInterface {
         params: {
           ...n.notice.params,
           data: {
+            signedStates: params.data.signedStates,
             objectives: [
               {
                 participants,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -328,6 +328,10 @@ export class Store {
 
       // fetch the channel to make sure the channel exists
       const channel = await Channel.forId(channelId, tx);
+      if (!channel) {
+        throw new StoreError(StoreError.reasons.channelMissing, {channelId});
+      }
+
       return await Channel.query(tx)
         .where({channelId: channel.channelId})
         .patch({fundingStrategy})

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -93,14 +93,7 @@ export function deserializeObjective(objective: ObjectiveWire): Objective {
     destination: makeDestination(p.destination)
   }));
 
-  switch (objective.type) {
-    case 'CreateChannel': {
-      const signedState = deserializeState(objective.data.signedState);
-      return {...objective, participants, data: {...objective.data, signedState}};
-    }
-    default:
-      return {...objective, participants};
-  }
+  return {...objective, participants};
 }
 // where do I move between token and asset holder?
 // I have to have asset holder between the wallets, otherwise there is ambiguity

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -4,8 +4,7 @@ import {
   AllocationItem as AllocationItemWire,
   Allocation as AllocationWire,
   Guarantee as GuaranteeWire,
-  Message as WireMessage,
-  Objective as ObjectiveWire
+  Message as WireMessage
 } from '@statechannels/wire-format';
 
 import {
@@ -14,7 +13,6 @@ import {
   AllocationItem,
   SimpleAllocation,
   Payload,
-  Objective,
   SimpleGuarantee
 } from '../../types';
 import {calculateChannelId} from '../../state-utils';
@@ -26,8 +24,8 @@ export function serializeMessage(
   sender: string,
   channelId?: string
 ): WireMessage {
-  const signedStates = (message.signedStates || []).map(ss => serializeState(ss, channelId));
-  const objectives = message.objectives?.map(serializeObjective);
+  const signedStates = (message.signedStates || []).map(s => serializeState(s, channelId));
+  const objectives = message.objectives;
   const {requests} = message;
   return {
     recipient,
@@ -61,18 +59,6 @@ export function serializeState(state: SignedState, channelId?: string): SignedSt
     channelId: channelId || calculateChannelId(state),
     signatures: state.signatures.map(s => s.signature)
   };
-}
-
-export function serializeObjective(objective: Objective): ObjectiveWire {
-  switch (objective.type) {
-    case 'CreateChannel':
-      return {
-        ...objective,
-        data: {...objective.data, signedState: serializeState(objective.data.signedState)}
-      };
-    default:
-      return objective;
-  }
 }
 
 export function serializeOutcome(outcome: Outcome): OutcomeWire {

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -92,13 +92,6 @@ type _Objective<Name, Data> = {
   type: Name;
   data: Data;
 };
-export type CreateChannel = _Objective<
-  'CreateChannel',
-  {
-    signedState: SignedState;
-    fundingStrategy: FundingStrategy;
-  }
->;
 export type OpenChannel = _Objective<
   'OpenChannel',
   {
@@ -134,18 +127,10 @@ export type CloseLedger = _Objective<
   }
 >;
 
-// todo: CreateChannel and OpenChannel should be collapsed into one objective
-export type Objective =
-  | CreateChannel
-  | OpenChannel
-  | VirtuallyFund
-  | FundGuarantor
-  | FundLedger
-  | CloseLedger;
+export type Objective = OpenChannel | VirtuallyFund | FundGuarantor | FundLedger | CloseLedger;
 
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;
-export const isCreateChannel = guard<CreateChannel>('CreateChannel');
 export const isOpenChannel = guard<OpenChannel>('OpenChannel');
 export const isVirtuallyFund = guard<VirtuallyFund>('VirtuallyFund');
 export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');

--- a/packages/wallet-core/src/wire-protocol.ts
+++ b/packages/wallet-core/src/wire-protocol.ts
@@ -6,14 +6,10 @@ type _Objective<Name, Data> = {
   participants: Participant[];
   type: Name;
 } & Data;
-export type CreateChannel = _Objective<
-  'CreateChannel',
-  {
-    signedState: SignedState;
-    fundingStrategy: FundingStrategy;
-  }
+export type OpenChannel = _Objective<
+  'OpenChannel',
+  {targetChannelId: string; fundingStrategy: FundingStrategy}
 >;
-export type OpenChannel = _Objective<'OpenChannel', {targetChannelId: string}>;
 export type VirtuallyFund = _Objective<
   'VirtuallyFund',
   {targetChannelId: string; jointChannelId: string}
@@ -23,7 +19,7 @@ export type FundGuarantor = _Objective<
   {jointChannelId: string; ledgerChannelId: string; guarantorId: string}
 >;
 
-export type Objective = CreateChannel | OpenChannel | VirtuallyFund | FundGuarantor;
+export type Objective = OpenChannel | VirtuallyFund | FundGuarantor;
 
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -111,52 +111,6 @@
       ],
       "type": "object"
     },
-    "CreateChannel": {
-      "additionalProperties": false,
-      "properties": {
-        "data": {
-          "additionalProperties": false,
-          "properties": {
-            "fundingStrategy": {
-              "enum": [
-                "Direct",
-                "Ledger",
-                "Virtual",
-                "Unfunded",
-                "Unknown"
-              ],
-              "type": "string"
-            },
-            "signedState": {
-              "$ref": "#/definitions/SignedState"
-            }
-          },
-          "required": [
-            "signedState",
-            "fundingStrategy"
-          ],
-          "type": "object"
-        },
-        "participants": {
-          "items": {
-            "$ref": "#/definitions/Participant"
-          },
-          "type": "array"
-        },
-        "type": {
-          "enum": [
-            "CreateChannel"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "participants",
-        "type",
-        "data"
-      ],
-      "type": "object"
-    },
     "FundGuarantor": {
       "additionalProperties": false,
       "properties": {
@@ -286,9 +240,6 @@
     },
     "Objective": {
       "anyOf": [
-        {
-          "$ref": "#/definitions/CreateChannel"
-        },
         {
           "$ref": "#/definitions/OpenChannel"
         },

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -81,14 +81,6 @@ type _Objective<Name, Data> = {
   data: Data;
 };
 type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
-export type CreateChannel = _Objective<
-  'CreateChannel',
-  {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    signedState: SignedState;
-    fundingStrategy: FundingStrategy;
-  }
->;
 export type OpenChannel = _Objective<
   'OpenChannel',
   {
@@ -126,13 +118,7 @@ export type CloseLedger = _Objective<
   }
 >;
 
-export type Objective =
-  | CreateChannel
-  | OpenChannel
-  | VirtuallyFund
-  | FundGuarantor
-  | FundLedger
-  | CloseLedger;
+export type Objective = OpenChannel | VirtuallyFund | FundGuarantor | FundLedger | CloseLedger;
 
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;


### PR DESCRIPTION
For background, reference https://www.notion.so/Channel-creation-9f16c02442704490bde6203284f18026#b37bf705e2f742ada29eb1f005fdccd1.

The wallet:
- Sends an `OpenChannel` objective after signing state with turn 0.
- Creates a new channel in the database upon receiving a new state for which a channel does not exist.
- Updates `fundingStrategy` upon receiving the `OpenChannel` objective. 