### PR TITLE
disable server wallet profiling on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,9 +440,10 @@ workflows:
           requires:
             - prepare
 
-      - server-wallet-profiling:
-          requires:
-            - prepare
+      # TODO: enable server-wallet-profiling
+      # - server-wallet-profiling:
+      #     requires:
+      #       - prepare
       - server-wallet-stress-test:
           requires:
             - prepare


### PR DESCRIPTION
1. it was flickering on circle
2. I think it is now _broken_ on circle (I think I know why...)
3. the last flamegraph I looked at was useless, since it now seems to profile a bunch of test setup code

Related to https://github.com/statechannels/statechannels/issues/2565