### PR TITLE
[server-wallet]: Restore knex as mutable property of Wallet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,10 +472,9 @@ workflows:
           requires:
             - prepare
 
-      # TODO: enable server-wallet-profiling
-      # - server-wallet-profiling:
-      #     requires:
-      #       - prepare
+      - server-wallet-profiling:
+          requires:
+            - prepare
       - server-wallet-stress-test:
           requires:
             - prepare


### PR DESCRIPTION
Previously the test [would **pass** despite throwing a runtime error](https://app.circleci.com/pipelines/github/statechannels/statechannels/8956/workflows/f5416351-b446-43f5-b4b6-5d183f8b16ff/jobs/42603/parallel-runs/0/steps/0-105). I suppose that means the flame graphs that were generated were not representative of a full "cycle" of usage, as one part of the usage would fail; in particular, calls to `Wallet.getState` (which happened within `PayerClient.makePayment`)?

#2602 fixed the runtime error, but now [the test **fails** because it goes too long without output](https://app.circleci.com/pipelines/github/statechannels/statechannels/9130/workflows/711e983b-7525-4c5e-b163-47fafa91f5fc/jobs/43795/parallel-runs/0/steps/0-105).

The test goes too long without output because `waitForServerToStart` hangs forever, and this is because an error occurs when starting the wallet with `timingMetrics` which is then suppressed. This is the error:

```
/statechannels/packages/server-wallet/lib/src/metrics.js:64
                objectOrFunction[fk] = perf_hooks_1.performance.timerify(objectOrFunction[fk]);
                                     ^

TypeError: Cannot set property knex of #<Wallet> which has only a getter
    at Object.recordFunctionMetrics (/statechannels/packages/server-wallet/lib/src/metrics.js:64:38)
```

I tried to understand why `recordFunctionMetrics` needed to be able to edit `knex`, but I couldn't figure it out. So, this PR makes `knex` a property on `Wallet` again so that `recordFunctionMetrics` can do its job.

Closes #2565

✅ [Green tick](https://app.circleci.com/pipelines/github/statechannels/statechannels/9158/workflows/4ec8dd0c-2005-458f-b88c-1f789adb69e3/jobs/43988/parallel-runs/0/steps/0-105)

Summary:
- At one point the script ran successfully and the job passed
- Then the script hit a runtime error and the script exited, but the job still passed
- Then the runtime error went away and the script started hanging, causing the job to fail
- This fixes the hanging issue