### PR TITLE
chore: remove reference to wallet-core signState

### DIFF
--- a/packages/server-wallet/src/models/__test__/fixtures/channel.ts
+++ b/packages/server-wallet/src/models/__test__/fixtures/channel.ts
@@ -41,9 +41,7 @@ const signVars = (signingWallets: SigningWallet[]) => (channel: Channel): Channe
   const {channelConstants, vars} = channel;
   vars.map(
     state =>
-      (state.signatures = signingWallets.map(sw =>
-        sw.syncSignState({...channelConstants, ...state})
-      ))
+      (state.signatures = signingWallets.map(sw => sw.signState({...channelConstants, ...state})))
   );
 
   return channel;

--- a/packages/server-wallet/src/models/__test__/signing-wallet.test.ts
+++ b/packages/server-wallet/src/models/__test__/signing-wallet.test.ts
@@ -1,0 +1,22 @@
+import {addHash} from '../../state-utils';
+import {alice} from '../../wallet/__test__/fixtures/signing-wallets';
+import {createState} from '../../wallet/__test__/fixtures/states';
+
+const signingWallet = alice();
+
+const state = createState();
+const stateWithHash = addHash(state);
+
+const expectedResult = {
+  signature:
+    '0xc822d44e1452d7d869bbf5ae1d274d01a6f8dee9cd9e7ddb4089882b911ef9bb7c30a36208e9088f9b96748b2aa345e523693cce5fde823c8ebab92db202275c1c',
+  signer: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf',
+};
+describe('SigningWallet class', () => {
+  it('signs a State', () => {
+    expect(signingWallet.signState(state)).toMatchObject(expectedResult);
+  });
+  it('signs a StateWithHash', () => {
+    expect(signingWallet.signState(stateWithHash)).toMatchObject(expectedResult);
+  });
+});

--- a/packages/server-wallet/src/utilities/signatures.ts
+++ b/packages/server-wallet/src/utilities/signatures.ts
@@ -7,16 +7,13 @@ const knownWallets: Record<string, string> = {};
 const cachedAddress = (privateKey: string): string =>
   knownWallets[privateKey] || (knownWallets[privateKey] = new Wallet(privateKey).address);
 
-export async function signState(
-  state: State,
-  privateKey: string
-): Promise<{state: State; signature: string}> {
+export function signState(state: State, privateKey: string): {state: State; signature: string} {
   const address = cachedAddress(privateKey);
   if (state.participants.map(p => p.signingAddress).indexOf(address) < 0) {
     throw new Error("The state must be signed with a participant's private key");
   }
 
-  const signature = await wasmUtils.signState(toNitroState(state), privateKey).signature;
+  const signature = wasmUtils.signState(toNitroState(state), privateKey).signature;
   return {state, signature};
 }
 

--- a/packages/server-wallet/src/wallet/__test__/fixtures/states.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/states.ts
@@ -37,7 +37,7 @@ const defaultState: State = {
 const signatureCache: Record<string, SignatureEntry> = {};
 const _signState = (s: State, sw: SigningWallet): SignatureEntry => {
   const key = `${sw.privateKey}-${hashState(s)}`;
-  return (signatureCache[key] = signatureCache[key] || sw.syncSignState(s));
+  return (signatureCache[key] = signatureCache[key] || sw.signState(s));
 };
 
 export const createState = fixture(defaultState, overwriteOutcome);


### PR DESCRIPTION
- And all signing is now sync (not async)
- SigningWallet.signState can take a State or StateWithHash, adds the hash if necessary