### PR TITLE
Merge Outgoing Messages to same recipient and duplicate channel results

### DIFF
--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -86,15 +86,15 @@ describe('e2e', () => {
 
   it('can create a channel, send signed state via http', async () => {
     const channel = await payerClient.createPayerChannel(receiver);
-
+    // TODO: Verify that we expect a running state result
     expect(channel.participants).toStrictEqual([payer, receiver]);
-    expect(channel.status).toBe('opening');
-    expect(channel.turnNum).toBe(0);
+    expect(channel.status).toBe('running');
+    expect(channel.turnNum).toBe(3);
 
     expect(
       (await ChannelPayer.forId(channel.channelId, ChannelPayer.knex())).protocolState
     ).toMatchObject({
-      supported: {turnNum: 0},
+      supported: {turnNum: 3},
     });
   });
 });

--- a/packages/server-wallet/src/utilities/__test__/messaging.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/messaging.test.ts
@@ -45,10 +45,14 @@ describe('mergeOutgoing', () => {
       params: {recipient: USER1, sender: USER2, data: {signedStates: [state2]}},
     };
 
-    const merged = mergeOutgoing([message1, message2]);
+    const merged = mergeOutgoing([message2, message1]);
     expect(merged).toHaveLength(1);
 
     expect((merged[0] as any).params.data.signedStates).toHaveLength(2);
+    // Merging should sort the states by ascending turnNum
+    expect(
+      (merged[0] as any).params.data.signedStates.map((s: {turnNum: number}) => s.turnNum)
+    ).toEqual([1, 2]);
   });
 
   test('it handles duplicate states', () => {

--- a/packages/server-wallet/src/utilities/__test__/messaging.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/messaging.test.ts
@@ -17,7 +17,7 @@ describe('mergeChannelResults', () => {
     expect(result[0]).toMatchObject({turnNum: 2});
   });
 
-  test("it doesn't merge  different channels", () => {
+  test("it doesn't merge different channels", () => {
     const duplicateChannelResult: ChannelResult[] = [
       channelWithVars({channelId: '0x123'}).channelResult,
       channelWithVars({channelId: '0xabc'}).channelResult,
@@ -52,6 +52,8 @@ describe('mergeOutgoing', () => {
   });
 
   test('it handles duplicate states', () => {
+    // We use two seperate state objects that are equivalent to avoid things passing
+    // due to object references being the same
     const state1 = stateSignedBy()({turnNum: 1});
     const state2 = stateSignedBy()({turnNum: 1});
     const message1: Notice = {

--- a/packages/server-wallet/src/utilities/__test__/messaging.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/messaging.test.ts
@@ -1,4 +1,5 @@
 import {ChannelResult} from '@statechannels/client-api-schema';
+import _ from 'lodash';
 
 import {channelWithVars} from '../../models/__test__/fixtures/channel';
 import {Notice} from '../../protocols/actions';
@@ -56,20 +57,14 @@ describe('mergeOutgoing', () => {
   });
 
   test('it handles duplicate states', () => {
-    // We use two seperate state objects that are equivalent to avoid things passing
-    // due to object references being the same
-    const state1 = stateSignedBy()({turnNum: 1});
-    const state2 = stateSignedBy()({turnNum: 1});
-    const message1: Notice = {
-      method: 'MessageQueued',
-      params: {recipient: USER1, sender: USER2, data: {signedStates: [state1]}},
-    };
-    const message2: Notice = {
-      method: 'MessageQueued',
-      params: {recipient: USER1, sender: USER2, data: {signedStates: [state2]}},
-    };
+    const state = stateSignedBy()({turnNum: 1});
 
-    const merged = mergeOutgoing([message1, message2]);
+    const message: Notice = {
+      method: 'MessageQueued',
+      params: {recipient: USER1, sender: USER2, data: {signedStates: [state]}},
+    };
+    // We perform a deep clone to avoid things passing due to object references being the same
+    const merged = mergeOutgoing([message, _.cloneDeep(message)]);
     expect(merged).toHaveLength(1);
 
     expect((merged[0] as any).params.data.signedStates).toHaveLength(1);

--- a/packages/server-wallet/src/utilities/__test__/messaging.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/messaging.test.ts
@@ -1,0 +1,71 @@
+import {ChannelResult} from '@statechannels/client-api-schema';
+
+import {channelWithVars} from '../../models/__test__/fixtures/channel';
+import {Notice} from '../../protocols/actions';
+import {addHash} from '../../state-utils';
+import {stateSignedBy} from '../../wallet/__test__/fixtures/states';
+import {mergeChannelResults, mergeOutgoing} from '../messaging';
+
+describe('mergeChannelResults', () => {
+  test('it merges channel results with multiple channel id entries', () => {
+    const duplicateChannelResult: ChannelResult[] = [
+      channelWithVars({vars: [addHash(stateSignedBy()({turnNum: 1}))]}).channelResult,
+      channelWithVars({vars: [addHash(stateSignedBy()({turnNum: 2}))]}).channelResult,
+    ];
+    const result = mergeChannelResults(duplicateChannelResult);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({turnNum: 2});
+  });
+
+  test("it doesn't merge  different channels", () => {
+    const duplicateChannelResult: ChannelResult[] = [
+      channelWithVars({channelId: '0x123'}).channelResult,
+      channelWithVars({channelId: '0xabc'}).channelResult,
+    ];
+
+    const result = mergeChannelResults(duplicateChannelResult);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('mergeOutgoing', () => {
+  const USER1 = 'Recipient1';
+  const USER2 = 'Recipient2';
+
+  test('it merges two messages with the same recipient', () => {
+    const state1 = stateSignedBy()({turnNum: 1});
+    const state2 = stateSignedBy()({turnNum: 2});
+
+    const message1: Notice = {
+      method: 'MessageQueued',
+      params: {recipient: USER1, sender: USER2, data: {signedStates: [state1]}},
+    };
+    const message2: Notice = {
+      method: 'MessageQueued',
+      params: {recipient: USER1, sender: USER2, data: {signedStates: [state2]}},
+    };
+
+    const merged = mergeOutgoing([message1, message2]);
+    expect(merged).toHaveLength(1);
+
+    expect((merged[0] as any).params.data.signedStates).toHaveLength(2);
+  });
+
+  test('it handles duplicate states', () => {
+    const state1 = stateSignedBy()({turnNum: 1});
+    const state2 = stateSignedBy()({turnNum: 1});
+    const message1: Notice = {
+      method: 'MessageQueued',
+      params: {recipient: USER1, sender: USER2, data: {signedStates: [state1]}},
+    };
+    const message2: Notice = {
+      method: 'MessageQueued',
+      params: {recipient: USER1, sender: USER2, data: {signedStates: [state2]}},
+    };
+
+    const merged = mergeOutgoing([message1, message2]);
+    expect(merged).toHaveLength(1);
+
+    expect((merged[0] as any).params.data.signedStates).toHaveLength(1);
+  });
+});

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -42,7 +42,11 @@ export function mergeOutgoing(outgoing: Notice[]): Notice[] {
 
 function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
   if (a && b) {
-    return _.uniqWith(_.concat(a, b), _.isEqual);
+    return _.orderBy(
+      _.uniqWith(_.concat(a, b), _.isEqual),
+      ['channelId', 'turnNum'],
+      ['desc', 'asc']
+    );
   } else if (a) {
     return a;
   } else if (b) {
@@ -53,7 +57,7 @@ function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
 }
 
 export function mergeChannelResults(channelResults: ChannelResult[]): ChannelResult[] {
-  const sorted = _.sortBy(channelResults, ['channelId', 'turnNum'], ['desc', 'desc']);
-  console.log(sorted);
+  const sorted = _.orderBy(channelResults, ['channelId', 'turnNum'], ['desc', 'desc']);
+
   return _.uniqWith(sorted, (a, b) => a.channelId === b.channelId);
 }

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -1,0 +1,58 @@
+import {ChannelResult} from '@statechannels/client-api-schema';
+import {Payload} from '@statechannels/wallet-core';
+import _ from 'lodash';
+
+import {Notice} from '../protocols/actions';
+
+// Merges any messages to the same recipient to make
+export function mergeOutgoing(outgoing: Notice[]): Notice[] {
+  if (outgoing.length === 0) return outgoing;
+
+  const senders = outgoing.map(o => o.params.sender);
+  const differentSender = new Set(senders).size !== 1;
+  // This should never happen but it's nice to have a sanity
+  if (differentSender) {
+    throw new Error(`Trying to merge outgoing messages with multiple recipients ${senders}`);
+  }
+
+  const {sender} = outgoing[0].params;
+
+  const mergedOutgoing: Record<string, Payload> = {};
+
+  for (const notice of outgoing) {
+    const {recipient, data} = notice.params;
+    if (!mergedOutgoing[recipient]) {
+      mergedOutgoing[recipient] = {};
+    }
+
+    const {signedStates, requests, objectives} = mergedOutgoing[recipient];
+
+    mergedOutgoing[recipient] = {
+      signedStates: mergeProp(signedStates, (data as Payload).signedStates),
+      requests: mergeProp(requests, (data as Payload).requests),
+      objectives: mergeProp(objectives, (data as Payload).objectives),
+    };
+  }
+  return Object.keys(mergedOutgoing).map(k => ({
+    params: {sender, recipient: k, data: mergedOutgoing[k]},
+    method: 'MessageQueued' as 'MessageQueued',
+  }));
+}
+
+function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
+  if (a && b) {
+    return _.uniqWith(_.concat(a, b), _.isEqual);
+  } else if (a) {
+    return a;
+  } else if (b) {
+    return b;
+  } else {
+    return undefined;
+  }
+}
+
+export function mergeChannelResults(channelResults: ChannelResult[]): ChannelResult[] {
+  const sorted = _.orderBy(channelResults, ['channelId', 'turnNum'], ['desc', 'desc']);
+
+  return _.uniqWith(sorted, (a, b) => a.channelId === b.channelId);
+}

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -20,7 +20,7 @@ export function mergeOutgoing(outgoing: Notice[]): Notice[] {
   const mergedOutgoing: Record<string, Payload> = {};
 
   for (const notice of outgoing) {
-    const {recipient, data} = notice.params;
+    const {recipient, data} = notice.params as {recipient: string; data: Payload};
     if (!mergedOutgoing[recipient]) {
       mergedOutgoing[recipient] = {};
     }
@@ -28,9 +28,9 @@ export function mergeOutgoing(outgoing: Notice[]): Notice[] {
     const {signedStates, requests, objectives} = mergedOutgoing[recipient];
 
     mergedOutgoing[recipient] = {
-      signedStates: mergeProp(signedStates, (data as Payload).signedStates),
-      requests: mergeProp(requests, (data as Payload).requests),
-      objectives: mergeProp(objectives, (data as Payload).objectives),
+      signedStates: mergeProp(signedStates, data.signedStates),
+      requests: mergeProp(requests, data.requests),
+      objectives: mergeProp(objectives, data.objectives),
     };
   }
   return Object.keys(mergedOutgoing).map(k => ({
@@ -52,7 +52,7 @@ function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
 }
 
 export function mergeChannelResults(channelResults: ChannelResult[]): ChannelResult[] {
-  const sorted = _.orderBy(channelResults, ['channelId', 'turnNum'], ['desc', 'desc']);
-
+  const sorted = _.sortBy(channelResults, ['channelId', 'turnNum'], ['desc', 'desc']);
+  console.log(sorted);
   return _.uniqWith(sorted, (a, b) => a.channelId === b.channelId);
 }

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -4,7 +4,8 @@ import _ from 'lodash';
 
 import {Notice} from '../protocols/actions';
 
-// Merges any messages to the same recipient to make
+// Merges any messages to the same recipient into one message
+// This makes message delivery less painful with the request/response model
 export function mergeOutgoing(outgoing: Notice[]): Notice[] {
   if (outgoing.length === 0) return outgoing;
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -74,7 +74,7 @@ describe('happy path', () => {
 
     const result = await w.createChannels(createArgs, NUM_CHANNELS);
     expect(result.channelResults).toHaveLength(NUM_CHANNELS);
-    expect(result.outbox).toHaveLength(NUM_CHANNELS);
+    expect(result.outbox).toHaveLength(1);
 
     expect(await Channel.query(w.knex).resultSize()).toEqual(NUM_CHANNELS);
   }, 10_000);

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -59,10 +59,14 @@ describe('directly funded app', () => {
     expect(current.latest).toMatchObject(preFS);
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
-      // TODO: These outbox items should probably be merged into one outgoing message
       outbox: [
-        {params: {recipient: 'bob', sender: 'alice', data: {signedStates: [preFSWire]}}},
-        {params: {recipient: 'bob', sender: 'alice', data: {signedStates: [postFSWire]}}},
+        {
+          params: {
+            recipient: 'bob',
+            sender: 'alice',
+            data: {signedStates: [preFSWire, postFSWire]},
+          },
+        },
       ],
       // TODO: channelResults is not calculated correctly: see the Channel model's channelResult
       // implementation

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -121,7 +121,7 @@ describe('channel results', () => {
 
     const p = wallet.pushMessage({signedStates: signedStates.map(s => serializeState(s))});
 
-    await expectResults(p, [{turnNum: five}, {turnNum: six, appData: '0x0f00'}]);
+    await expectResults(p, [{turnNum: six, appData: '0x0f00'}, {turnNum: five}]);
 
     const channelsAfter = await Channel.query(wallet.knex).select();
 


### PR DESCRIPTION
This PR implements two new functions that get called in the `wallet`:

- `mergeOutgoing`
- `mergeChannelResults`

`mergeOutgoing` merges multiple messages to the same `receipient` into one message. This allows one client to send all the messages to another in one request/response cycle.

`mergeMultipleChannelResults` merges `ChannelResult[]`s by only allowing one entry per a `channelId`. If there are multiple entries it takes the one with the highest `turnNum` . Fixes #2623 .