### PR TITLE
Add methods to wallet for batch processing

### DIFF
--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -70,25 +70,28 @@ export default class PayerClient {
   public async createPayerChannel(receiver: Participant): Promise<ChannelResult> {
     const {
       outbox: [{params}],
-      channelResult: {channelId},
-    } = await this.wallet.createChannel({
-      appData: '0x',
-      appDefinition: AddressZero,
-      fundingStrategy: 'Direct',
-      participants: [this.me, receiver],
-      allocations: [
-        {
-          token: AddressZero,
-          allocationItems: [
-            {
-              amount: BN.from(0),
-              destination: this.destination,
-            },
-            {amount: BN.from(0), destination: receiver.destination},
-          ],
-        },
-      ],
-    });
+      channelResults: [{channelId}],
+    } = await this.wallet.createChannels(
+      {
+        appData: '0x',
+        appDefinition: AddressZero,
+        fundingStrategy: 'Direct',
+        participants: [this.me, receiver],
+        allocations: [
+          {
+            token: AddressZero,
+            allocationItems: [
+              {
+                amount: BN.from(0),
+                destination: this.destination,
+              },
+              {amount: BN.from(0), destination: receiver.destination},
+            ],
+          },
+        ],
+      },
+      1
+    );
 
     const reply = await this.messageReceiverAndExpectReply(params.data);
 

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -47,11 +47,13 @@ export default class ReceiverController {
     if (channelResult && channelResult.turnNum % 2 === 0) {
       const {
         outbox: [messageToSendToPayer],
-      } = await this.time('react', async () =>
-        (channelResult.status === 'proposed' ? this.wallet.joinChannel : this.wallet.updateChannel)(
-          channelResult
-        )
-      );
+      } = await this.time('react', async () => {
+        if (channelResult.status === 'proposed') {
+          return this.wallet.joinChannels([channelResult.channelId]);
+        } else {
+          return this.wallet.updateChannel(channelResult);
+        }
+      });
 
       const walletResponse = messageToSendToPayer.params.data as Payload;
 

--- a/packages/server-wallet/src/onchain-service/__onchain-test__/onchain-service.test.ts
+++ b/packages/server-wallet/src/onchain-service/__onchain-test__/onchain-service.test.ts
@@ -99,7 +99,7 @@ describe('OnchainTransactionService', () => {
     });
 
     // Check mock
-    expect(channelWallet.updateChannelFunding).toHaveBeenCalled();
+    expect(channelWallet.updateFundingForChannels).toHaveBeenCalled();
   });
 
   it('should not fail if channel is already registered', async () => {

--- a/packages/server-wallet/src/onchain-service/onchain-service.ts
+++ b/packages/server-wallet/src/onchain-service/onchain-service.ts
@@ -241,11 +241,13 @@ export class OnchainService implements OnchainServiceInterface {
     fundingEvt.attach(e => {
       // Call the appropriate callback on the wallet
       this.channelWallet &&
-        this.channelWallet.updateChannelFunding({
-          channelId: e.channelId,
-          amount: BN.from(e.amount),
-          token: info.tokenAddress,
-        });
+        this.channelWallet.updateFundingForChannels([
+          {
+            channelId: e.channelId,
+            amount: BN.from(e.amount),
+            token: info.tokenAddress,
+          },
+        ]);
     });
 
     // Post to evt on every onchain deposit event

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -23,9 +23,9 @@ describe('happy path', () => {
     expect(await Channel.query(w.knex).resultSize()).toEqual(0);
 
     const appData = '0xaf00';
-    const createPromise = w.createChannel(createChannelArgs({appData}));
+    const createPromise = w.createChannels(createChannelArgs({appData}), 1);
     await expect(createPromise).resolves.toMatchObject({
-      channelResult: {channelId: expect.any(String)},
+      channelResults: [{channelId: expect.any(String)}],
     });
 
     await expect(createPromise).resolves.toMatchObject({
@@ -49,9 +49,9 @@ describe('happy path', () => {
           },
         },
       ],
-      channelResult: {channelId: expect.any(String), turnNum: 0, appData},
+      channelResults: [{channelId: expect.any(String), turnNum: 0, appData}],
     });
-    const {channelId} = (await createPromise).channelResult;
+    const {channelId} = (await createPromise).channelResults[0];
     expect(await Channel.query(w.knex).resultSize()).toEqual(1);
 
     const updated = await Channel.forId(channelId, w.knex);
@@ -81,4 +81,4 @@ describe('happy path', () => {
 });
 
 it("doesn't create a channel if it doesn't have a signing wallet", () =>
-  expect(w.createChannel(createChannelArgs())).rejects.toThrow('Not in channel'));
+  expect(w.createChannels(createChannelArgs(), 1)).rejects.toThrow('Not in channel'));

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -72,11 +72,13 @@ it('sends the post fund setup when the funding event is provided', async () => {
   const c = channel({vars: [stateWithHashSignedBy(alice(), bob())({turnNum: 0})]});
   await Channel.query(w.knex).insert(c);
   const {channelId} = c;
-  const result = await w.updateChannelFunding({
-    channelId: c.channelId,
-    token: '0x00',
-    amount: BN.from(4),
-  });
+  const result = await w.updateFundingForChannels([
+    {
+      channelId: c.channelId,
+      token: '0x00',
+      amount: BN.from(4),
+    },
+  ]);
 
   await expect(
     Funding.getFundingAmount(w.knex, channelId, ETH_ASSET_HOLDER_ADDRESS)
@@ -92,6 +94,6 @@ it('sends the post fund setup when the funding event is provided', async () => {
         },
       },
     ],
-    channelResult: {channelId: c.channelId, turnNum: 0}, // The turnNum is coming from the supported state so we expect it be 0 still
+    channelResults: [{channelId: c.channelId, turnNum: 0}], // The turnNum is coming from the supported state so we expect it be 0 still
   });
 });

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -69,8 +69,7 @@ export type WalletInterface = {
 
   // App channel management
   createChannels(args: CreateChannelParams, amountOfChannels: number): MultipleChannelResult;
-  createChannel(args: CreateChannelParams): SingleChannelResult;
-  joinChannel(args: JoinChannelParams): SingleChannelResult;
+
   joinChannels(channelIds: ChannelId[]): MultipleChannelResult;
   updateChannel(args: UpdateChannelParams): SingleChannelResult;
   closeChannel(args: CloseChannelParams): SingleChannelResult;
@@ -78,7 +77,6 @@ export type WalletInterface = {
   getState(args: GetStateParams): SingleChannelResult;
   syncChannel(args: SyncChannelParams): SingleChannelResult;
 
-  updateChannelFunding(args: UpdateChannelFundingParams): SingleChannelResult;
   updateFundingForChannels(args: UpdateChannelFundingParams[]): MultipleChannelResult;
   // Wallet <-> Wallet communication
   pushMessage(m: unknown): MultipleChannelResult;
@@ -113,10 +111,10 @@ export class Wallet implements WalletInterface, ChainEventListener {
     this.updateChannelFunding = this.updateChannelFunding.bind(this);
     this.updateFundingForChannels = this.updateFundingForChannels.bind(this);
     this.getSigningAddress = this.getSigningAddress.bind(this);
-    this.createChannel = this.createChannel.bind(this);
+
     this.createChannels = this.createChannels.bind(this);
     this.createChannelInternal = this.createChannelInternal.bind(this);
-    this.joinChannel = this.joinChannel.bind(this);
+
     this.joinChannels = this.joinChannels.bind(this);
     this.updateChannel = this.updateChannel.bind(this);
     this.updateChannelInternal = this.updateChannelInternal.bind(this);
@@ -206,7 +204,7 @@ export class Wallet implements WalletInterface, ChainEventListener {
       outbox: mergeOutgoing(outgoing),
     };
   }
-  public async updateChannelFunding({
+  private async updateChannelFunding({
     channelId,
     token,
     amount,
@@ -246,12 +244,6 @@ export class Wallet implements WalletInterface, ChainEventListener {
       channelResults: mergeChannelResults(channelResults),
       outbox: mergeOutgoing(outgoing.map(n => n.notice)),
     };
-  }
-
-  async createChannel(args: CreateChannelParams): SingleChannelResult {
-    const {participants} = args;
-    const channelNonce = await this.store.nextNonce(participants.map(p => p.signingAddress));
-    return this.createChannelInternal(args, channelNonce);
   }
 
   async createChannelInternal(

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -89,7 +89,7 @@ export type WalletInterface = {
   // Register chain <-> Wallet communication
   attachChainService(provider: OnchainServiceInterface): void;
 
-  mergeMessages(messages: Message[]): Message;
+  mergeMessages(messages: Message[]): MultipleChannelMessage;
 };
 
 export class Wallet implements WalletInterface, ChainEventListener {
@@ -141,7 +141,7 @@ export class Wallet implements WalletInterface, ChainEventListener {
     this.attachChainService(this.chainService);
   }
 
-  public mergeMessages(messages: Message[]): Message {
+  public mergeMessages(messages: Message[]): MultipleChannelMessage {
     const channelResults = mergeChannelResults(
       messages
         .map(m => (isSingleChannelMessage(m) ? [m.channelResult] : m.channelResults))
@@ -149,9 +149,7 @@ export class Wallet implements WalletInterface, ChainEventListener {
     );
 
     const outbox = mergeOutgoing(messages.map(m => m.outbox).reduce((m1, m2) => m1.concat(m2)));
-    return channelResults.length === 1
-      ? {channelResult: channelResults[0], outbox}
-      : {channelResults, outbox};
+    return {channelResults, outbox};
   }
 
   public async destroy(): Promise<void> {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -73,8 +73,8 @@ export type WalletInterface = {
   getState(args: GetStateParams): SingleChannelResult;
   syncChannel(args: SyncChannelParams): SingleChannelResult;
 
-  updateChannelFunding(args: UpdateChannelFundingParams): void;
-
+  updateChannelFunding(args: UpdateChannelFundingParams): SingleChannelResult;
+  updateFundingForChannels(args: UpdateChannelFundingParams[]): MultipleChannelResult;
   // Wallet <-> Wallet communication
   pushMessage(m: unknown): MultipleChannelResult;
 
@@ -104,6 +104,7 @@ export class Wallet implements WalletInterface, ChainEventListener {
     // Bind methods to class instance
     this.getParticipant = this.getParticipant.bind(this);
     this.updateChannelFunding = this.updateChannelFunding.bind(this);
+    this.updateFundingForChannels = this.updateFundingForChannels.bind(this);
     this.getSigningAddress = this.getSigningAddress.bind(this);
     this.createChannel = this.createChannel.bind(this);
     this.createChannels = this.createChannels.bind(this);
@@ -175,6 +176,17 @@ export class Wallet implements WalletInterface, ChainEventListener {
     return participant;
   }
 
+  public async updateFundingForChannels(args: UpdateChannelFundingParams[]): MultipleChannelResult {
+    const results = await Promise.all(args.map(a => this.updateChannelFunding(a)));
+
+    const channelResults = results.map(r => r.channelResult);
+    const outgoing = results.map(r => r.outbox).reduce((p, c) => p.concat(c));
+
+    return {
+      channelResults: mergeChannelResults(channelResults),
+      outbox: mergeOutgoing(outgoing),
+    };
+  }
   public async updateChannelFunding({
     channelId,
     token,


### PR DESCRIPTION
This PR introduces three new methods to the wallet API:
- JoinChannels - Allows the joining of multiple channels in one call to the wallet.
- UpdateFundingForChannels - Allows the updating of funding for multiple channels in one call to the wallet.
- MergeMessages - Merges multiple messages into one message. This is useful for merging the result of different API calls in one request/response cycle. 