### PR TITLE
Increase concurrency to default for test job

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "start:shared-ganache": "cd packages/devtools && NODE_ENV=development yarn start:shared-ganache",
     "test": "lerna run test --stream --concurrency 8",
     "test:ci": "lerna run test:ci --stream --no-sort --include-dependents",
-    "test:ci:incremental": "yarn test:ci --concurrency 3 --since $(git merge-base $CIRCLE_BRANCH origin/master)"
+    "test:ci:incremental": "yarn test:ci --concurrency 8 --since $(git merge-base $CIRCLE_BRANCH origin/master)"
   },
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "start:shared-ganache": "cd packages/devtools && NODE_ENV=development yarn start:shared-ganache",
     "test": "lerna run test --stream --concurrency 8",
     "test:ci": "lerna run test:ci --stream --no-sort --include-dependents",
-    "test:ci:incremental": "yarn test:ci --concurrency 8 --since $(git merge-base $CIRCLE_BRANCH origin/master)"
+    "test:ci:incremental": "yarn test:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
It makes little sense to limit the concurrency to a smaller value on a PR  than it is on `master` (since if we ran out of memory on the feature branch we would run out of memory on master anyway). We run all tests on master and all or fewer tests on a PR. 