### PR TITLE
Enforce max connection pool size of 1 for threads

### DIFF
--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -28,6 +28,7 @@ export interface ServerWalletConfig {
   workerThreadAmount: number;
   logLevel: pino.Level;
   logDestination?: string; // console or undefined will log to console
+  postgresPoolSize?: {max: number; min: number};
 }
 
 // TODO: Nest configuration options inside keys like db, server, wallet, debug, etc
@@ -72,5 +73,6 @@ export function extractDBConfigFromServerWalletConfig(
       password: serverWalletConfig.postgresDBPassword,
     },
     ...knexSnakeCaseMappers(),
+    pool: serverWalletConfig.postgresPoolSize || {},
   };
 }

--- a/packages/server-wallet/src/utilities/workers/worker.ts
+++ b/packages/server-wallet/src/utilities/workers/worker.ts
@@ -10,7 +10,10 @@ import {ServerWalletConfig} from '../../config';
 import {isStateChannelWorkerData} from './worker-data';
 
 // We only expect a worker thread to use one postgres connection but we enforce it just to make sure
-const walletConfig = {...(workerData as ServerWalletConfig), postgresPoolSize: {min: 0, max: 1}};
+const walletConfig: ServerWalletConfig = {
+  ...(workerData as ServerWalletConfig),
+  postgresPoolSize: {min: 0, max: 1},
+};
 
 const logger = createLogger(walletConfig);
 

--- a/packages/server-wallet/src/utilities/workers/worker.ts
+++ b/packages/server-wallet/src/utilities/workers/worker.ts
@@ -9,7 +9,9 @@ import {ServerWalletConfig} from '../../config';
 
 import {isStateChannelWorkerData} from './worker-data';
 
-const walletConfig = workerData as ServerWalletConfig;
+// We only expect a worker thread to use one postgres connection but we enforce it just to make sure
+const walletConfig = {...(workerData as ServerWalletConfig), postgresPoolSize: {min: 0, max: 1}};
+
 const logger = createLogger(walletConfig);
 
 logger.debug(`Worker %o starting`, threadId);


### PR DESCRIPTION
This ensures that worker threads only use one `postgres` connection. (This seems to be the default behaviour but this enforces it)