### PR TITLE
Chain service calls increaseAllowance for erc20 asset holders

### DIFF
--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -75,7 +75,6 @@
   },
   "main": "lib/src/index.js",
   "scripts": {
-    "chain:test": "npx jest --runInBand -c ./jest/jest.chain.config.js",
     "db:create": "createdb server_wallet_${NODE_ENV}",
     "db:drop": "dropdb server_wallet_${NODE_ENV}",
     "db:migrate": "npx knex migrate:latest --cwd src/db-admin",

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -59,8 +59,9 @@ describe('fundChannel', () => {
     await waitForChannelFunding(5, 5, channelId);
 
     const {request: fundChannelPromise} = fundChannel(5, 5, channelId);
-    // todo: is there a good way to validate that the error thrown is one we expect?
-    await expect(fundChannelPromise).rejects.toThrow();
+    await expect(fundChannelPromise).rejects.toThrow(
+      'cannot estimate gas; transaction may fail or may require manual gas limit'
+    );
   });
 });
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -18,11 +18,11 @@ const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEnd
 
 let chainService: ChainService;
 
-beforeEach(() => {
+beforeAll(() => {
   chainService = new ChainService(rpcEndpoint, defaultConfig.serverPrivateKey, 50);
 });
 
-afterEach(() => chainService.destructor());
+afterAll(() => chainService.destructor());
 
 function fundChannel(
   expectedHeld: number,

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -1,6 +1,6 @@
 import {ContractArtifacts, randomChannelId} from '@statechannels/nitro-protocol';
 import {BN} from '@statechannels/wallet-core';
-import {BigNumber, Contract, providers, Wallet} from 'ethers';
+import {BigNumber, Contract, providers} from 'ethers';
 
 import {defaultConfig} from '../../config';
 import {Address} from '../../type-aliases';
@@ -9,13 +9,11 @@ import {ChainService} from '../chain-service';
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const ethAssetHolderAddress = process.env.ETH_ASSET_HOLDER_ADDRESS!;
 const erc20AssetHolderAddress = process.env.ERC20_ASSET_HOLDER_ADDRESS!;
-const erc20Address = process.env.ERC20_ADDRESS!;
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 
 if (!defaultConfig.rpcEndpoint) throw new Error('rpc endpoint must be defined');
 const rpcEndpoint = defaultConfig.rpcEndpoint;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
-const ethWallet = new Wallet(defaultConfig.serverPrivateKey, provider);
 
 let chainService: ChainService;
 
@@ -67,12 +65,6 @@ describe('fundChannel', () => {
 
 it('Fund erc20', async () => {
   const channelId = randomChannelId();
-  const tokenContract: Contract = new Contract(
-    erc20Address,
-    ContractArtifacts.TokenArtifact.abi,
-    ethWallet
-  );
-  await (await tokenContract.increaseAllowance(erc20AssetHolderAddress, BN.from(5))).wait();
 
   await waitForChannelFunding(0, 5, channelId, erc20AssetHolderAddress);
   const contract: Contract = new Contract(

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -1,0 +1,51 @@
+import {ContractArtifacts, randomChannelId} from '@statechannels/nitro-protocol';
+import {BN} from '@statechannels/wallet-core';
+import {Contract, providers, Wallet} from 'ethers';
+import _ from 'lodash';
+
+import {defaultConfig} from '../../config';
+import {ChainService} from '../chain-service';
+
+/* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
+const erc20AssetHolderAddress = process.env.ERC20_ASSET_HOLDER_ADDRESS!;
+const erc20Address = process.env.ERC20_ADDRESS!;
+/* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
+
+if (!defaultConfig.rpcEndpoint) throw new Error('rpc endpoint must be defined');
+const rpcEndpoint = defaultConfig.rpcEndpoint;
+const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
+const ethWallet = new Wallet(defaultConfig.serverPrivateKey, provider);
+
+let chainService: ChainService;
+
+beforeEach(() => {
+  chainService = new ChainService(rpcEndpoint, defaultConfig.serverPrivateKey, 50);
+});
+
+afterEach(() => chainService.destructor());
+
+// Do not run by default as it takes several minutes
+describe('fundChannel', () => {
+  it.skip('100 simultaneous deposits', async () => {
+    const depositAmount = 5;
+    const iterations = 100;
+    const contract: Contract = new Contract(
+      erc20Address,
+      ContractArtifacts.TokenArtifact.abi,
+      ethWallet
+    );
+    await (await contract.increaseAllowance(erc20AssetHolderAddress, BN.from(500))).wait();
+
+    const promises = _.range(0, iterations).map(() =>
+      chainService.fundChannel({
+        channelId: randomChannelId(),
+        assetHolderAddress: erc20AssetHolderAddress,
+        expectedHeld: BN.from(0),
+        amount: BN.from(depositAmount),
+        allowanceAlreadyIncreased: true,
+      })
+    );
+
+    Promise.all(promises);
+  }, 200_000);
+});

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -28,6 +28,7 @@ export type FundChannelArg = {
   assetHolderAddress: Address;
   expectedHeld: Uint256;
   amount: Uint256;
+  allowanceAlreadyIncreased?: boolean;
 };
 
 export interface ChainEventSubscriberInterface {
@@ -114,7 +115,8 @@ export class ChainService implements ChainServiceInterface {
       ? createETHDepositTransaction
       : createERC20DepositTransaction;
 
-    if (!isEthFunding) {
+    // if the argument object does not specify increaseAllowance, assume true
+    if (!isEthFunding && !arg.allowanceAlreadyIncreased) {
       const assetHolderContract = this.getOrAddContractMapping(assetHolderAddress, 'AssetHolder');
       const tokenAddress = await assetHolderContract.Token();
       const tokenContract = this.getOrAddContractMapping(tokenAddress, 'Token');

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -198,7 +198,7 @@ export class ChainService implements ChainServiceInterface {
     // Create an observable that emits events on contract events
     const obs = new Observable<HoldingUpdatedArg>(subs => {
       // todo: add other event types
-      contract.on('Deposited', (destination, amountDeposited, destinationHoldings) =>
+      contract.on('Deposited', (destination, _amountDeposited, destinationHoldings) =>
         subs.next({
           channelId: destination,
           assetHolderAddress: contract.address,

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -108,6 +108,8 @@ export class ChainService implements ChainServiceInterface {
         const response = await this.ethWallet.sendTransaction(this.transactionQueue[0].request);
         this.transactionQueue[0].resolve(response);
       } catch (e) {
+        // https://github.com/ethers-io/ethers.js/issues/972
+        this.ethWallet.incrementTransactionCount(-1);
         this.transactionQueue[0].resolve(e);
       }
       this.transactionQueue.splice(0, 1);

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -166,7 +166,7 @@ export class ChainService implements ChainServiceInterface {
       to: assetHolderAddress,
       value: isEthFunding ? arg.amount : undefined,
     };
-    return await this.sendTransaction(depositRequest);
+    return this.sendTransaction(depositRequest);
   }
 
   registerChannel(


### PR DESCRIPTION
For erc20 asset holders, the chain service calls `increaseAllowance` before depositing to address https://github.com/statechannels/statechannels/pull/2645#discussion_r499456033. The alternative (which is the implementation prior to this PR) is for the chain service to assume that `increaseAllowance` has already been called prior to the `fundChannel` api call.

This PR also:
- adds a unit test for depositing into a channel with 2 asset holder allocations.
- a stress test that creates 100 deposits (mostly to try to reproduce transaction nonce errors).
- adds a transaction queue to avoid nonce errors.