### PR TITLE
ci: Add publish and publish-canary workflows

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,39 @@
+name: Publish Packages (canary)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  canary-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          # pulls all commits and tags (needed for lerna / semantic release to correctly version)
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.16.3
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-yarn-cache-v0-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-v0-
+
+      - name: yarn install
+        # skip the prepare step here, as lerna publish will run prepare before publishing
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          SKIP_PREPARE=true yarn install
+
+      - name: Configure CI Git User
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: publish packages to npm
+        run: yarn run lerna publish --canary --force-publish --preid next.$(git rev-parse --short HEAD) --dist-tag next --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish Packages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          # pulls all commits and tags (needed for lerna / semantic release to correctly version)
+          fetch-depth: 0
+
+      - name: Check that we're on master
+        if: github.ref != 'refs/heads/master'
+        run: exit 1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.16.3
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-yarn-cache-v0-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-cache-v0-
+
+      - name: yarn install
+        # skip the prepare step here, as lerna publish will run prepare before publishing
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          SKIP_PREPARE=true yarn install
+
+      - name: Configure CI Git User
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+      - name: publish packages to npm
+        run: |
+          yarn run lerna version --conventional-commits --yes --exact --no-push --message "Publish [skip ci]"
+          yarn run lerna publish from-git --yes
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: update-master-with-published-versions
+          title: Updates published versions [please merge ASAP]
+          body: Updates to the versions and changelogs created by the `Publish Packages` action
+
+      - name: push commit tags
+        run: git push --tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: publish packages to npm
         run: |
-          yarn run lerna version --conventional-commits --yes --exact --no-push --message "Publish [skip ci]"
+          yarn run lerna version --conventional-commits --yes --exact --no-push --message "chore(release): publish [skip ci]"
           yarn run lerna publish from-git --yes
 
       - name: Create Pull Request

--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,8 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "packages": [
-    "packages/*"
-  ],
-  "version": "0.3.10",
+  "packages": ["packages/*"],
+  "version": "independent",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Mostly copy-paste from the graph monorepo. 

Questions:
---
- We are not doing conventional commits very strictly in this repo. #2617 would help with that?
- Do we keep with lockstep versioning? Will these actions work with that?