### PR TITLE
Add onAssetTransferred to ChainEventSubscribers

### DIFF
--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -167,7 +167,7 @@ contract NitroAdjudicator is Adjudicator, ForceMove {
                     assetOutcome.allocationOrGuaranteeBytes
                 );
             } else {
-                revert();
+                revert('_transferAllFromAllAssetHolders: AssetOutcomeType is not an allocation');
             }
         }
     }

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -92,7 +92,7 @@
     "start:shared-ganache": "NODE_ENV=development npx start-shared-ganache",
     "start:watch": "nodemon --watch 'src/**/*' -e ts,tsx --exec ts-node ./src/start-dev-server.ts | npx pino-pretty",
     "test": "yarn jest -c ./jest/jest.config.js --runInBand",
-    "test:chain": "RPC_ENDPOINT='http://localhost:8545' jest --runInBand -c ./jest/jest.chain.config.js",
+    "test:chain": "RPC_ENDPOINT='http://localhost:8545' jest -c ./jest/jest.chain.config.js",
     "test:ci": "yarn test --bail && yarn test:chain --bail",
     "test:e2e": "yarn tsc; SERVER_DB_NAME=payer yarn jest -c ./jest/jest.e2e.config.js",
     "test:stress": "yarn tsc;NODE_ENV=test npx ts-node ./e2e-test/scripts/stress-test.ts"

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -173,6 +173,7 @@ describe('registerChannel', () => {
 
     chainService.registerChannel(channelId, [ethAssetHolderAddress], {
       onHoldingUpdated,
+      onAssetTransferred: _.noop,
     });
     await p;
   });
@@ -191,6 +192,7 @@ describe('registerChannel', () => {
           });
           resolve();
         },
+        onAssetTransferred: _.noop,
       })
     );
   });
@@ -223,6 +225,7 @@ describe('registerChannel', () => {
     };
     chainService.registerChannel(channelId, [ethAssetHolderAddress, erc20AssetHolderAddress], {
       onHoldingUpdated,
+      onAssetTransferred: _.noop,
     });
     fundChannel(0, 5, channelId, ethAssetHolderAddress);
     fundChannel(0, 5, channelId, erc20AssetHolderAddress);

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -276,7 +276,7 @@ describe('concludeAndWithdraw', () => {
     expect(await provider.getBalance(aAddress)).toEqual(BigNumber.from(1));
     expect(await provider.getBalance(bAddress)).toEqual(BigNumber.from(3));
     await p;
-  });
+  }, 10_000);
 
   it('Successful concludeAndWithdraw with erc20 allocation', async () => {
     const {channelId, aAddress, bAddress, state, signatures} = await setUpConclude(false);
@@ -321,5 +321,5 @@ describe('concludeAndWithdraw', () => {
     expect(await erc20Contract.balanceOf(bAddress)).toEqual(BigNumber.from(3));
 
     await p;
-  });
+  }, 10_000);
 });

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -1,4 +1,5 @@
 import {providers, constants} from 'ethers';
+import {SignedState} from '@statechannels/wallet-core';
 
 import {Address, Bytes32} from '../type-aliases';
 
@@ -47,5 +48,9 @@ export class MockChainService implements ChainServiceInterface {
     _subscriber: ChainEventSubscriberInterface
   ): void {
     return;
+  }
+
+  concludeAndWithdraw(_finalizationProof: SignedState[]): Promise<providers.TransactionResponse> {
+    return Promise.resolve(mockTransactoinResponse);
   }
 }

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -47,6 +47,7 @@ import {
   MockChainService,
   ChainEventSubscriberInterface,
   HoldingUpdatedArg,
+  AssetTransferredArg,
 } from '../chain-service';
 import {DBAdmin} from '../db-admin/db-admin';
 
@@ -535,6 +536,10 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
 
   dbAdmin(): DBAdmin {
     return new DBAdmin(this.knex);
+  }
+
+  onAssetTransferred(_arg: AssetTransferredArg): void {
+    // todo: implement me
   }
 }
 

--- a/packages/server-wallet/tsconfig.json
+++ b/packages/server-wallet/tsconfig.json
@@ -2,14 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    // ["es2017", "esnext.bigint", "dom"] needed for https://github.com/bitauth/libauth#typescript-types
-    "lib": [
-      "es5",
-      "es6",
-      "ES2017",
-      "esnext.bigint",
-      "dom"
-    ],
+    "lib": ["ES2019", "dom"],
     "target": "es2019",
     "module": "commonjs",
     "outDir": "lib",
@@ -31,10 +24,5 @@
       "path": "../wallet-core"
     }
   ],
-  "include": [
-    "src",
-    "e2e-test",
-    "deployment",
-    "jest"
-  ]
+  "include": ["src", "e2e-test", "deployment", "jest"]
 }


### PR DESCRIPTION
This PR build on https://github.com/statechannels/statechannels/pull/2661.

After a `ChainEventSubscriber` registers a channel with the chain service, the chain service will relay `AssetTransferred` events via `onAssetTransferred` api.