### PR TITLE
unregisterChannel chain service api

### DIFF
--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -169,6 +169,7 @@ describe('registerChannel', () => {
             amount: BN.from(5),
           });
           counter++;
+          chainService.unregisterChannel(channelId);
           resolve();
           break;
         default:

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -50,6 +50,10 @@ export class MockChainService implements ChainServiceInterface {
     return;
   }
 
+  unregisterChannel(_channelId: Bytes32): void {
+    return;
+  }
+
   concludeAndWithdraw(_finalizationProof: SignedState[]): Promise<providers.TransactionResponse> {
     return Promise.resolve(mockTransactoinResponse);
   }


### PR DESCRIPTION
Consider the case of a long running, gateway server wallet. The wallet will manage one ledger channel for each indexer. If there is indexer turnover, the server wallet will continuously create new ledger channels and register those channels with the chain service. Channel registration consumes resources as a new observable is created every time a channel is registered.

unregisterChannel api should be called when a wallet no longer cares about channel chain events.