### PR TITLE
server-wallet: increase turn numbers for postfund setup

### DIFF
--- a/packages/server-wallet/.vscode/launch.json
+++ b/packages/server-wallet/.vscode/launch.json
@@ -11,7 +11,6 @@
       "args": [
         "node_modules/.bin/jest",
         "--runInBand",
-        "--env=jsdom",
         "--config=${workspaceRoot}/jest/jest.config.js",
         "${relativeFile}"
       ],

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -93,9 +93,11 @@ export default class PayerClient {
       1
     );
 
-    const reply = await this.messageReceiverAndExpectReply(params.data);
+    const prefund2 = await this.messageReceiverAndExpectReply(params.data);
 
-    await this.wallet.pushMessage(reply);
+    const postfund1 = await this.wallet.pushMessage(prefund2);
+    const postfund2 = await this.messageReceiverAndExpectReply(postfund1.outbox[0].params.data);
+    await this.wallet.pushMessage(postfund2);
 
     const {channelResult} = await this.wallet.getState({channelId});
 

--- a/packages/server-wallet/src/__test__/create-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-channel/direct-funding.test.ts
@@ -119,7 +119,6 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // < PostFund3B
   const resultA2 = await a.updateFundingForChannels([depositByB]);
-  // PostFund3A >
   const resultB2 = await b.updateFundingForChannels([depositByB]);
 
   expect(getChannelResultFor(channelId, resultA2.channelResults)).toMatchObject({

--- a/packages/server-wallet/src/__test__/create-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-channel/direct-funding.test.ts
@@ -38,8 +38,14 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   const allocation: Allocation = {
     allocationItems: [
-      {destination: participantA.destination, amount: BigNumber.from(1).toHexString()},
-      {destination: participantB.destination, amount: BigNumber.from(1).toHexString()},
+      {
+        destination: participantA.destination,
+        amount: BigNumber.from(1).toHexString(),
+      },
+      {
+        destination: participantB.destination,
+        amount: BigNumber.from(1).toHexString(),
+      },
     ],
     token: '0x00', // must be even length
   };
@@ -94,18 +100,25 @@ it('Create a fake-funded channel between two wallets ', async () => {
     turnNum: 0,
   });
 
-  const depositByA = {channelId, token: '0x00', amount: BigNumber.from(1).toHexString()}; // A sends 1 ETH (1 total)
+  const depositByA = {
+    channelId,
+    token: '0x00',
+    amount: BigNumber.from(1).toHexString(),
+  }; // A sends 1 ETH (1 total)
 
   // This would have been triggered by A's Chain Service by request
   await a.updateFundingForChannels([depositByA]);
   await b.updateFundingForChannels([depositByA]);
 
   // Then, this would be triggered by B's Chain Service after observing A's deposit
-  const depositByB = {channelId, token: '0x00', amount: BigNumber.from(2).toHexString()}; // B sends 1 ETH (2 total)
+  const depositByB = {
+    channelId,
+    token: '0x00',
+    amount: BigNumber.from(2).toHexString(),
+  }; // B sends 1 ETH (2 total)
 
   // < PostFund3B
   const resultA2 = await a.updateFundingForChannels([depositByB]);
-
   // PostFund3A >
   const resultB2 = await b.updateFundingForChannels([depositByB]);
 
@@ -119,16 +132,16 @@ it('Create a fake-funded channel between two wallets ', async () => {
     turnNum: 0,
   });
 
-  //  PostFund3B <
-  const resultA3 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB2.outbox));
-  expect(getChannelResultFor(channelId, resultA3.channelResults)).toMatchObject({
+  //  > PostFund3A
+  const resultB3 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA2.outbox));
+  expect(getChannelResultFor(channelId, resultB3.channelResults)).toMatchObject({
     status: 'running',
     turnNum: 3,
   });
 
-  //  > PostFund3A
-  const resultB3 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA2.outbox));
-  expect(getChannelResultFor(channelId, resultB3.channelResults)).toMatchObject({
+  //  PostFund3B <
+  const resultA3 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
+  expect(getChannelResultFor(channelId, resultA3.channelResults)).toMatchObject({
     status: 'running',
     turnNum: 3,
   });

--- a/packages/server-wallet/src/protocols/__test__/application.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/application.test.ts
@@ -18,7 +18,7 @@ const outcome2 = simpleEthAllocation([
 ]);
 const prefundState = {outcome, turnNum: 0};
 const prefundState2 = {outcome: outcome2, turnNum: 0};
-const postFundState = {outcome, turnNum: 3};
+const postFundState = {outcome, turnNum: 2};
 const closingState = {outcome, turnNum: 4, isFinal: true};
 
 const runningState = {outcome, turnNum: 7};

--- a/packages/server-wallet/src/protocols/application.ts
+++ b/packages/server-wallet/src/protocols/application.ts
@@ -90,7 +90,7 @@ const fundChannel = (ps: ProtocolState): ProtocolResult | false =>
   isDirectlyFunded(ps.app) &&
   requestFundChannelIfMyTurn(ps);
 
-const signPostFundSetup = (ps: ProtocolState): ProtocolResult | false =>
+const signPostfundSetup = (ps: ProtocolState): ProtocolResult | false =>
   myTurnToPostfund(ps) &&
   isFunded(ps) &&
   ps.app.latestSignedByMe &&
@@ -107,4 +107,4 @@ const signFinalState = (ps: ProtocolState): ProtocolResult | false =>
   signState({channelId: ps.app.channelId, ...ps.app.supported});
 
 export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>
-  signPostFundSetup(ps) || fundChannel(ps) || signFinalState(ps) || noAction;
+  signPostfundSetup(ps) || fundChannel(ps) || signFinalState(ps) || noAction;

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -75,13 +75,13 @@ describe('directly funded app', () => {
   it('signs the prefund setup and postfund setup, when there are no deposits to make', async () => {
     const outcome = simpleEthAllocation([]);
     const preFS = {turnNum: 0, outcome};
-    const postFS = {turnNum: 3, outcome};
+    const postFS = {turnNum: 2, outcome};
     const c = channel({vars: [stateWithHashSignedBy(bob())(preFS)]});
     await Channel.query(w.knex).insert(c);
 
     const outcomeWire = serializeOutcome(outcome);
     const preFSWire = {turnNum: 0, outcome: outcomeWire};
-    const postFSWire = {turnNum: 3, outcome: outcomeWire};
+    const postFSWire = {turnNum: 2, outcome: outcomeWire};
 
     const channelId = c.channelId;
     const current = await Channel.forId(channelId, w.knex);

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -183,12 +183,12 @@ describe('when the application protocol returns an action', () => {
     const p = wallet.pushMessage({signedStates: [serializeState(stateSignedBy([bob()])(state))]});
     await expectResults(p, [{channelId, status: 'opening'}]);
     await expect(p).resolves.toMatchObject({
-      outbox: [{method: 'MessageQueued', params: {data: {signedStates: [{turnNum: 3}]}}}],
+      outbox: [{method: 'MessageQueued', params: {data: {signedStates: [{turnNum: 2}]}}}],
     });
 
     const updatedC = await Channel.forId(channelId, wallet.knex);
     expect(updatedC.protocolState).toMatchObject({
-      latestSignedByMe: {turnNum: 3},
+      latestSignedByMe: {turnNum: 2},
       supported: {turnNum: 0},
     });
   });

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -60,8 +60,8 @@ it('sends the post fund setup when the funding event is provided for multiple ch
           sender: 'alice',
           data: {
             signedStates: [
-              {turnNum: 3, channelNonce: 1},
-              {turnNum: 3, channelNonce: 2},
+              {turnNum: 2, channelNonce: 1},
+              {turnNum: 2, channelNonce: 2},
             ],
           },
         },
@@ -91,7 +91,7 @@ it('sends the post fund setup when the funding event is provided', async () => {
         params: {
           recipient: 'bob',
           sender: 'alice',
-          data: {signedStates: [{turnNum: 3}]},
+          data: {signedStates: [{turnNum: 2}]},
         },
       },
     ],


### PR DESCRIPTION
Before this PR, every participant signs postfund state with turn number 3. The challenges with this are:
- https://www.notion.so/Server-wallet-application-Bob-Alice-communication-c0127c3196694e14bd0cf4858955fa96#032978ba91394e87a9774c94fb1222a0.
- Only works for a 2 party channel. That's ok for now.
- Until every participant signs the postfund state, there is no supported postfund state. Maybe that's not a big deal.

With this PR, turn numbers increase for postfund states.
- Alice signs postfund turn 2
- Bob signs postfund turn 3.