### PR TITLE
[server-wallet] Allow registering of bytecode

### DIFF
--- a/packages/server-wallet/e2e-test/e2e-utils.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils.ts
@@ -13,12 +13,15 @@ import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
 import {Channel} from '../src/models/channel';
 import {
   extractDBConfigFromServerWalletConfig,
-  defaultConfig,
   ServerWalletConfig,
+  defaultTestConfig,
 } from '../src/config';
 
-export const payerConfig: ServerWalletConfig = {...defaultConfig, postgresDBName: 'payer'};
-export const receiverConfig: ServerWalletConfig = {...defaultConfig, postgresDBName: 'receiver'};
+export const payerConfig: ServerWalletConfig = {...defaultTestConfig, postgresDBName: 'payer'};
+export const receiverConfig: ServerWalletConfig = {
+  ...defaultTestConfig,
+  postgresDBName: 'receiver',
+};
 
 import {PerformanceTimer} from './payer/timers';
 

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -6,7 +6,7 @@ configureEnvVariables();
 import PayerClient from '../payer/client';
 import {alice} from '../../src/wallet/__test__/fixtures/signing-wallets';
 import {recordFunctionMetrics} from '../../src/metrics';
-import {defaultConfig} from '../../src/config';
+import {defaultTestConfig} from '../../src/config';
 
 import {PerformanceTimer} from './timers';
 
@@ -42,7 +42,7 @@ export default {
 
     const payerClient = recordFunctionMetrics(
       new PayerClient(alice().privateKey, `http://127.0.0.1:65535`, {
-        ...defaultConfig,
+        ...defaultTestConfig,
         postgresDBName: database,
       })
     );

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -7,12 +7,12 @@ import {
 import {makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers} from 'ethers';
 
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 
-const a = new Wallet({...defaultConfig, postgresDBName: 'TEST_A'});
-const b = new Wallet({...defaultConfig, postgresDBName: 'TEST_B'});
+const a = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_A'});
+const b = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_B'});
 
 let channelId: string;
 let participantA: Participant;

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -7,12 +7,12 @@ import {
 import {makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers} from 'ethers';
 
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 
-const a = new Wallet({...defaultConfig, postgresDBName: 'TEST_A'});
-const b = new Wallet({...defaultConfig, postgresDBName: 'TEST_B'});
+const a = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_A'});
+const b = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_B'});
 
 let channelId: string;
 let participantA: Participant;

--- a/packages/server-wallet/src/__test__/evm-validator.test.ts
+++ b/packages/server-wallet/src/__test__/evm-validator.test.ts
@@ -56,7 +56,7 @@ it('returns false for an invalid transition', async () => {
   expect(await validateTransitionWithEVM(fromState, toState, knex as any)).toBe(false);
 });
 
-it('skips validating when no byte code exists for the app definition', async () => {
+it('returns false when no byte code exists for the app definition', async () => {
   // Sanity check that the bytecode doesn't exist
   expect(
     await AppBytecode.getBytecode(defaultConfig.chainNetworkID, UNDEFINED_APP_DEFINITION, knex)
@@ -66,5 +66,5 @@ it('skips validating when no byte code exists for the app definition', async () 
       appDefinition: UNDEFINED_APP_DEFINITION,
     })
   );
-  expect(await validateTransitionWithEVM(state, state, knex as any)).toBe(true);
+  expect(await validateTransitionWithEVM(state, state, knex as any)).toBe(false);
 });

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -324,3 +324,10 @@ describe('concludeAndWithdraw', () => {
     await p;
   }, 10_000);
 });
+
+describe('getBytecode', () => {
+  it('returns the bytecode for an app definition', async () => {
+    const bytecode = await chainService.fetchBytecode(ethAssetHolderAddress);
+    expect(bytecode).toMatch(/^0x[A-Fa-f0-9]{64,}$/);
+  });
+});

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -9,7 +9,7 @@ import {
 import {BigNumber, constants, Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 import {Address} from '../../type-aliases';
 import {
   alice as aliceParticipant,
@@ -24,15 +24,15 @@ const erc20AssetHolderAddress = process.env.ERC20_ASSET_HOLDER_ADDRESS!;
 const erc20Address = process.env.ERC20_ADDRESS!;
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 
-if (!defaultConfig.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const rpcEndpoint = defaultConfig.rpcEndpoint;
+if (!defaultTestConfig.rpcEndpoint) throw new Error('rpc endpoint must be defined');
+const rpcEndpoint = defaultTestConfig.rpcEndpoint;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 
 let chainService: ChainService;
 let channelNonce = 0;
 
 beforeAll(() => {
-  chainService = new ChainService(rpcEndpoint, defaultConfig.serverPrivateKey, 50);
+  chainService = new ChainService(rpcEndpoint, defaultTestConfig.serverPrivateKey, 50);
 });
 
 afterAll(() => chainService.destructor());

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -3,7 +3,7 @@ import {BN} from '@statechannels/wallet-core';
 import {Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 import {ChainService} from '../chain-service';
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
@@ -11,15 +11,15 @@ const erc20AssetHolderAddress = process.env.ERC20_ASSET_HOLDER_ADDRESS!;
 const erc20Address = process.env.ERC20_ADDRESS!;
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 
-if (!defaultConfig.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const rpcEndpoint = defaultConfig.rpcEndpoint;
+if (!defaultTestConfig.rpcEndpoint) throw new Error('rpc endpoint must be defined');
+const rpcEndpoint = defaultTestConfig.rpcEndpoint;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
-const ethWallet = new Wallet(defaultConfig.serverPrivateKey, provider);
+const ethWallet = new Wallet(defaultTestConfig.serverPrivateKey, provider);
 
 let chainService: ChainService;
 
 beforeEach(() => {
-  chainService = new ChainService(rpcEndpoint, defaultConfig.serverPrivateKey, 50);
+  chainService = new ChainService(rpcEndpoint, defaultTestConfig.serverPrivateKey, 50);
 });
 
 afterEach(() => chainService.destructor());

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -57,6 +57,7 @@ interface ChainModifierInterface {
   // todo: should these APIs return ethers TransactionResponses? Or is that too detailed for API consumers
   fundChannel(arg: FundChannelArg): Promise<providers.TransactionResponse>;
   concludeAndWithdraw(finalizationProof: SignedState[]): Promise<providers.TransactionResponse>;
+  fetchBytecode(address: string): Promise<string>;
 }
 
 export type ChainServiceInterface = ChainModifierInterface & ChainEventEmitterInterface;
@@ -286,5 +287,9 @@ export class ChainService implements ChainServiceInterface {
     });
 
     return obs.pipe(share());
+  }
+
+  public async fetchBytecode(appDefinition: string): Promise<string> {
+    return this.provider.getCode(appDefinition);
   }
 }

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -57,4 +57,8 @@ export class MockChainService implements ChainServiceInterface {
   concludeAndWithdraw(_finalizationProof: SignedState[]): Promise<providers.TransactionResponse> {
     return Promise.resolve(mockTransactoinResponse);
   }
+
+  async fetchBytecode(_appDefinition: string): Promise<string> {
+    return '0x0';
+  }
 }

--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -60,6 +60,11 @@ export const defaultConfig: ServerWalletConfig = {
   logDestination: process.env.LOG_DESTINATION || 'console',
 };
 
+export const defaultTestConfig = {
+  ...defaultConfig,
+  skipEvmValidation: (process.env.SKIP_EVM_VALIDATION || 'true').toLowerCase() === 'true',
+};
+
 export function extractDBConfigFromServerWalletConfig(
   serverWalletConfig: ServerWalletConfig
 ): Config {

--- a/packages/server-wallet/src/db-admin/db-admin-connection.ts
+++ b/packages/server-wallet/src/db-admin/db-admin-connection.ts
@@ -13,7 +13,7 @@ export default Knex(knexConfig);
 
 export const truncate = async (
   knex: Knex,
-  tables = ['signing_wallets', 'channels', 'nonces']
+  tables = ['signing_wallets', 'channels', 'nonces', 'app_bytecode']
 ): Promise<void> => {
   if (defaultConfig.nodeEnv !== 'development' && defaultConfig.nodeEnv !== 'test') {
     throw 'No admin connection allowed';

--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -32,10 +32,10 @@ export const validateTransitionWithEVM = async (
       (await AppBytecode.getBytecode(defaultConfig.chainNetworkID, from.appDefinition, tx)) ||
       MISSING);
   if (bytecode === MISSING) {
-    // logger.warn(
-    //   `No bytecode found for appDefinition ${from.appDefinition} and chain id ${config.chainNetworkID}. Skipping valid transition check`
-    // );
-    return true;
+    logger.error('Missing bytecode', {
+      error: new Error(`No byte code for ${from.appDefinition}`),
+    });
+    return false;
   }
 
   const {data} = createValidTransitionTransaction(from, to);

--- a/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
+++ b/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
@@ -1,0 +1,30 @@
+import {constants} from 'ethers';
+
+import {truncate} from '../../db-admin/db-admin-connection';
+import {AppBytecode} from '../app-bytecode';
+import {testKnex as knex} from '../../../jest/knex-setup-teardown';
+
+const CHAIN_ID = '0x01';
+const APP_DEFINTION = constants.AddressZero;
+const BYTE_CODE1 = '0x01';
+const BYTE_CODE2 = '0x02';
+describe('AppBytecode model', () => {
+  beforeEach(async () => {
+    truncate(knex);
+  });
+
+  afterAll(async () => await knex.destroy());
+
+  it('can insert a bytecode in an empty database', async () => {
+    await AppBytecode.upsertBytecode(CHAIN_ID, APP_DEFINTION, BYTE_CODE1, knex);
+    const bytecode = await AppBytecode.getBytecode(CHAIN_ID, APP_DEFINTION, knex);
+    expect(bytecode).toMatch(BYTE_CODE1);
+  });
+
+  it('successfully updates when there is an entry', async () => {
+    await AppBytecode.upsertBytecode(CHAIN_ID, APP_DEFINTION, BYTE_CODE1, knex);
+    await AppBytecode.upsertBytecode(CHAIN_ID, APP_DEFINTION, BYTE_CODE2, knex);
+    const bytecode = AppBytecode.getBytecode(CHAIN_ID, APP_DEFINTION, knex);
+    expect(bytecode).toMatch(BYTE_CODE2);
+  });
+});

--- a/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
+++ b/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
@@ -24,7 +24,7 @@ describe('AppBytecode model', () => {
   it('successfully updates when there is an entry', async () => {
     await AppBytecode.upsertBytecode(CHAIN_ID, APP_DEFINTION, BYTE_CODE1, knex);
     await AppBytecode.upsertBytecode(CHAIN_ID, APP_DEFINTION, BYTE_CODE2, knex);
-    const bytecode = AppBytecode.getBytecode(CHAIN_ID, APP_DEFINTION, knex);
+    const bytecode = await AppBytecode.getBytecode(CHAIN_ID, APP_DEFINTION, knex);
     expect(bytecode).toMatch(BYTE_CODE2);
   });
 });

--- a/packages/server-wallet/src/models/app-bytecode.ts
+++ b/packages/server-wallet/src/models/app-bytecode.ts
@@ -18,6 +18,19 @@ export class AppBytecode extends Model implements RequiredColumns {
     return ['chain_id', 'app_definition'];
   }
 
+  static async insertBytecode(
+    chainId: Bytes32,
+    appDefinition: Address,
+    appBytecode: Bytes32,
+    txOrKnex: TransactionOrKnex
+  ): Promise<AppBytecode> {
+    return AppBytecode.query(txOrKnex).insert({
+      chainId,
+      appDefinition,
+      appBytecode,
+    });
+  }
+
   static async getBytecode(
     chainId: Bytes32,
     appDefinition: Address,

--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -3,7 +3,7 @@ import Objection from 'objection';
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {stateWithHashSignedBy2} from './fixtures/states';
@@ -12,7 +12,7 @@ import {alice, bob} from './fixtures/signing-wallets';
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
 });
 
 describe('addSignedState', () => {

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -4,12 +4,12 @@ import {SignedState as WireSignedState} from '@statechannels/wire-format';
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
 });
 
 describe('addSignedState', () => {

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -5,14 +5,14 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {SigningWallet} from '../../models/signing-wallet';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
 });
 
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -5,11 +5,11 @@ import {truncate} from '../../../db-admin/db-admin-connection';
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultConfig} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = new Wallet(defaultConfig);
+  w = new Wallet(defaultTestConfig);
   await truncate(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -3,12 +3,12 @@ import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {truncate} from '../../../db-admin/db-admin-connection';
-import {defaultConfig} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {alice, bob} from '../fixtures/participants';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = new Wallet(defaultConfig);
+  w = new Wallet(defaultTestConfig);
   await truncate(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -8,11 +8,11 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {alice} from '../fixtures/participants';
-import {defaultConfig} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = new Wallet(defaultConfig);
+  w = new Wallet(defaultTestConfig);
   await truncate(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -14,7 +14,7 @@ import {stateVars} from '../fixtures/state-vars';
 import {defaultTestConfig} from '../../../config';
 
 jest.setTimeout(20_000);
-console.log(defaultTestConfig.skipEvmValidation);
+
 const wallet = new Wallet(defaultTestConfig);
 
 afterAll(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -11,10 +11,11 @@ import {stateSignedBy} from '../fixtures/states';
 import {truncate} from '../../../db-admin/db-admin-connection';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
-import {defaultConfig} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 
 jest.setTimeout(20_000);
-const wallet = new Wallet(defaultConfig);
+console.log(defaultTestConfig.skipEvmValidation);
+const wallet = new Wallet(defaultTestConfig);
 
 afterAll(async () => {
   await wallet.destroy();

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -7,12 +7,12 @@ import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import * as participantFixtures from '../fixtures/participants';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 
 let w: Wallet;
 beforeEach(async () => {
   await truncate(knex);
-  w = new Wallet(defaultConfig);
+  w = new Wallet(defaultTestConfig);
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -6,12 +6,12 @@ import {truncate} from '../../../db-admin/db-admin-connection';
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultConfig} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 let w: Wallet;
 beforeEach(async () => {
   await truncate(knex);
-  w = new Wallet(defaultConfig);
+  w = new Wallet(defaultTestConfig);
 });
 afterEach(async () => {
   await w.destroy();

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -9,13 +9,13 @@ import {Wallet} from '../..';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
-import {defaultConfig} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 
 const {AddressZero} = ethers.constants;
 
 let w: Wallet;
 beforeEach(async () => {
-  w = new Wallet(defaultConfig);
+  w = new Wallet(defaultTestConfig);
   await truncate(w.knex);
 });
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -7,7 +7,7 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import adminKnex from '../../db-admin/db-admin-connection';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 
 import {stateVars} from './fixtures/state-vars';
 
@@ -16,7 +16,7 @@ jest.setTimeout(10_000);
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
 });
 
 it('works', async () => {

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -6,7 +6,7 @@ import {channel} from '../../models/__test__/fixtures/channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 
 import {stateWithHashSignedBy} from './fixtures/states';
 import {bob, alice} from './fixtures/signing-wallets';
@@ -16,7 +16,7 @@ let tx: Objection.Transaction;
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
 });
 
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -4,14 +4,14 @@ import {truncate} from '../../db-admin/db-admin-connection';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultConfig} from '../../config';
+import {defaultTestConfig} from '../../config';
 
 import {alice} from './fixtures/participants';
 
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultConfig.timingMetrics, defaultConfig.skipEvmValidation);
+  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
 });
 
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -147,15 +147,12 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
   }
 
   public async registerAppDefintion(appDefinition: string): Promise<void> {
-    if (await AppBytecode.getBytecode(CHAIN_ID, appDefinition, this.knex)) {
-      throw Error(`Bytecode already exists for app ${appDefinition} on chain ${CHAIN_ID}`);
-    }
     const bytecode = await this.chainService.fetchBytecode(appDefinition);
     if (!bytecode) {
       throw Error(`Could not fetch bytecode for ${appDefinition}`);
     }
 
-    await AppBytecode.insertBytecode(CHAIN_ID, appDefinition, bytecode, this.knex);
+    await AppBytecode.upsertBytecode(CHAIN_ID, appDefinition, bytecode, this.knex);
   }
 
   public mergeMessages(messages: Message[]): MultipleChannelOutput {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -134,6 +134,7 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
     this.takeActions = this.takeActions.bind(this);
     this.mergeMessages = this.mergeMessages.bind(this);
     this.destroy = this.destroy.bind(this);
+    this.registerAppDefintion = this.registerAppDefintion.bind(this);
 
     // set up timing metrics
     if (this.walletConfig.timingMetrics) {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -180,6 +180,7 @@ export class Store {
       };
 
       if (
+        !this.skipEvmValidation &&
         !(await timer('validating transition', async () =>
           validateTransitionWithEVM(supportedNitroState, toNitroState(state), tx)
         ))


### PR DESCRIPTION
Exposes a `RegisterAppDefinition` method on the `wallet` that registers the `bytecode` for that `AppDefiniton`. 

This new method uses the `chainService` to fetch the bytecode and then registers it in the database.

Currently the bytecode is overriden if `RegisterAppDefinition` is called twice to play nice with `ganache`. Once we start actually using `ChainId` we may want to throw an error if there already exists bytecode for a given definition.