### PR TITLE
Store objectives in the DB and introduce crash tolerance test

### DIFF
--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.seqdiag
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.seqdiag
@@ -1,0 +1,17 @@
+participant WalletA
+participant AppA
+participant AppB
+participant WalletB
+AppA->WalletA: createChannel
+WalletA-->WalletB: 0a
+WalletB->AppB: 'proposed'
+Note over WalletB: crash/restart
+AppB->WalletB: joinChannel
+WalletB-->WalletA: 0b
+WalletA->AppA: result
+AppA->WalletA: updateFunding(A)
+AppB->WalletB: updateFunding(A)
+AppA->WalletA: updateFunding(B)
+WalletA-->WalletB: 3a
+AppB->WalletB: updateFunding(B)
+WalletB-->WalletA: 3b

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -1,0 +1,194 @@
+import {
+  CreateChannelParams,
+  Participant,
+  Allocation,
+  CloseChannelParams,
+} from '@statechannels/client-api-schema';
+import {makeDestination} from '@statechannels/wallet-core';
+import {BigNumber, ethers} from 'ethers';
+
+import {defaultConfig as processEnvConfig} from '../../config';
+import {Wallet} from '../../wallet';
+import {getChannelResultFor, getPayloadFor} from '../test-helpers';
+
+const a = new Wallet({...processEnvConfig, postgresDBName: 'TEST_A'});
+const b = new Wallet({...processEnvConfig, postgresDBName: 'TEST_B'}); // Wallet that will "crash"
+const b2 = new Wallet({...processEnvConfig, postgresDBName: 'TEST_B'}); // Wallet that will "restart" (same db)
+// TODO needs to have same signing address as b? Pass in thru config
+
+let channelId: string;
+let participantA: Participant;
+let participantB: Participant;
+
+beforeAll(async () => {
+  await a.dbAdmin().createDB();
+  await b.dbAdmin().createDB();
+  await Promise.all([a.dbAdmin().migrateDB(), b.dbAdmin().migrateDB()]);
+
+  participantA = {
+    signingAddress: await a.getSigningAddress(),
+    participantId: 'a',
+    destination: makeDestination(
+      '0xaaaa000000000000000000000000000000000000000000000000000000000001'
+    ),
+  };
+  participantB = {
+    signingAddress: await b.getSigningAddress(),
+    participantId: 'b',
+    destination: makeDestination(
+      '0xbbbb000000000000000000000000000000000000000000000000000000000002'
+    ),
+  };
+});
+afterAll(async () => {
+  // Don't destory b here, it get's destroyed midway through test
+  await Promise.all([a.destroy(), b2.destroy()]);
+  await a.dbAdmin().dropDB();
+  await b2.dbAdmin().dropDB(); // Only need to drop the db once as it is shared with b
+});
+
+it.only('Create a fake-funded channel between two wallets, of which one crashes midway through ', async () => {
+  const allocation: Allocation = {
+    allocationItems: [
+      {destination: participantA.destination, amount: BigNumber.from(1).toHexString()},
+      {destination: participantB.destination, amount: BigNumber.from(1).toHexString()},
+    ],
+    token: '0x00', // must be even length
+  };
+
+  const createChannelParams: CreateChannelParams = {
+    participants: [participantA, participantB],
+    allocations: [allocation],
+    appDefinition: ethers.constants.AddressZero,
+    appData: '0x00', // must be even length
+    fundingStrategy: 'Direct',
+  };
+
+  //        A <> B
+  // PreFund0
+  const resultA0 = await a.createChannel(createChannelParams);
+
+  // TODO compute the channelId for a better test
+  channelId = resultA0.channelResults[0].channelId;
+
+  expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
+    status: 'opening',
+    turnNum: 0,
+  });
+
+  //    > PreFund0A
+  const resultB0 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+
+  expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
+    status: 'proposed',
+    turnNum: 0,
+  });
+
+  // Destory Wallet b and restart Wallet b2
+  await b.destroy();
+
+  //      PreFund0B
+  const resultB1 = await b2.joinChannel({channelId});
+  expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
+    status: 'opening',
+    turnNum: 0,
+  });
+
+  //  PreFund0B <
+  const resultA1 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
+
+  /**
+   * In this case, there is no auto-advancing to the running stage. Instead we have
+   * an intermediate 'opening' stage where each party must fund their channel. A funds
+   * first, and then B funds. A and B both signs turnNum 3 on the call to updateFundingForChannels
+   * and then sends the newly signed state to each other at the same time.
+   */
+
+  expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
+    status: 'opening',
+    turnNum: 0,
+  });
+
+  const depositByA = {channelId, token: '0x00', amount: BigNumber.from(1).toHexString()}; // A sends 1 ETH (1 total)
+
+  // This would have been triggered by A's Chain Service by request
+  await a.updateFundingForChannels([depositByA]);
+  await b2.updateFundingForChannels([depositByA]);
+
+  // Then, this would be triggered by B's Chain Service after observing A's deposit
+  const depositByB = {channelId, token: '0x00', amount: BigNumber.from(2).toHexString()}; // B sends 1 ETH (2 total)
+
+  // < PostFund3B
+  const resultA2 = await a.updateFundingForChannels([depositByB]);
+
+  // PostFund3A >
+  const resultB2 = await b2.updateFundingForChannels([depositByB]);
+
+  expect(getChannelResultFor(channelId, resultA2.channelResults)).toMatchObject({
+    status: 'opening', // Still opening because turnNum 3 is not supported yet, but is signed by A
+    turnNum: 0,
+  });
+
+  expect(getChannelResultFor(channelId, resultB2.channelResults)).toMatchObject({
+    status: 'opening', // Still opening because turnNum 3 is not supported yet, but is signed by B
+    turnNum: 0,
+  });
+
+  //  PostFund3B <
+  const resultA3 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB2.outbox));
+  expect(getChannelResultFor(channelId, resultA3.channelResults)).toMatchObject({
+    status: 'running',
+    turnNum: 3,
+  });
+
+  //  > PostFund3A
+  const resultB3 = await b2.pushMessage(getPayloadFor(participantB.participantId, resultA2.outbox));
+  expect(getChannelResultFor(channelId, resultB3.channelResults)).toMatchObject({
+    status: 'running',
+    turnNum: 3,
+  });
+});
+
+it('Rejects b closing with `not your turn`', async () => {
+  const closeChannelParams: CloseChannelParams = {
+    channelId,
+  };
+
+  const bCloseChannel = b2.closeChannel(closeChannelParams);
+
+  await expect(bCloseChannel).rejects.toMatchObject(new Error('not my turn'));
+});
+
+it('Closes the channel', async () => {
+  const closeChannelParams: CloseChannelParams = {
+    channelId,
+  };
+
+  // A generates isFinal4
+  const aCloseChannelResult = await a.closeChannel(closeChannelParams);
+
+  expect(getChannelResultFor(channelId, [aCloseChannelResult.channelResult])).toMatchObject({
+    status: 'closing',
+    turnNum: 4,
+  });
+
+  const bPushMessageResult = await b.pushMessage(
+    getPayloadFor(participantB.participantId, aCloseChannelResult.outbox)
+  );
+
+  // B pushed isFinal4, generated countersigned isFinal4
+  expect(getChannelResultFor(channelId, bPushMessageResult.channelResults)).toMatchObject({
+    status: 'closed',
+    turnNum: 4,
+  });
+
+  // A pushed the countersigned isFinal4
+  const aPushMessageResult = await a.pushMessage(
+    getPayloadFor(participantA.participantId, bPushMessageResult.outbox)
+  );
+
+  expect(getChannelResultFor(channelId, aPushMessageResult.channelResults)).toMatchObject({
+    status: 'closed',
+    turnNum: 4,
+  });
+});

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -83,9 +83,8 @@ it('Create a fake-funded channel between two wallets, of which one crashes midwa
   });
 
   // Destory Wallet b and restart Wallet b2
-  // await b.destroy();
-  // b = new Wallet({...processEnvConfig, postgresDBName: 'TEST_B'}); // Wallet that will "restart" (same db)
-  // TODO needs to have same signing address as b? Pass in thru config
+  await b.destroy();
+  b = new Wallet({...processEnvConfig, postgresDBName: 'TEST_B'}); // Wallet that will "restart" (same db)
 
   //      PreFund0B
   const resultB1 = await b.joinChannel({channelId});

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -47,7 +47,7 @@ afterAll(async () => {
   await b2.dbAdmin().dropDB(); // Only need to drop the db once as it is shared with b
 });
 
-it.only('Create a fake-funded channel between two wallets, of which one crashes midway through ', async () => {
+it('Create a fake-funded channel between two wallets, of which one crashes midway through ', async () => {
   const allocation: Allocation = {
     allocationItems: [
       {destination: participantA.destination, amount: BigNumber.from(1).toHexString()},

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -86,7 +86,9 @@ it('Create a fake-funded channel between two wallets ', async () => {
   // after joinChannel, B double-signs PreFund0
   const bJoinChannelOutput = await b.approveObjective(
     // eslint-disable-next-line
-    bProposeChannelPushOutput.objectivesToApprove![0].objectiveId
+    bProposeChannelPushOutput.objectivesToApprove![0].objectiveId,
+    // eslint-disable-next-line
+    bProposeChannelPushOutput.objectivesToApprove![0].type
   );
   expect(getChannelResultFor(channelId, [bJoinChannelOutput.channelResult])).toMatchObject({
     status: 'opening',

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -84,7 +84,10 @@ it('Create a fake-funded channel between two wallets ', async () => {
   });
 
   // after joinChannel, B double-signs PreFund0
-  const bJoinChannelOutput = await b.joinChannel({channelId});
+  const bJoinChannelOutput = await b.approveObjective(
+    // eslint-disable-next-line
+    bProposeChannelPushOutput.objectivesToApprove![0].objectiveId
+  );
   expect(getChannelResultFor(channelId, [bJoinChannelOutput.channelResult])).toMatchObject({
     status: 'opening',
     turnNum: 0,

--- a/packages/server-wallet/src/__test__/test-helpers.ts
+++ b/packages/server-wallet/src/__test__/test-helpers.ts
@@ -17,6 +17,6 @@ export function getChannelResultFor(
     channelResult => channelResult.channelId === channelId
   );
   if (filteredChannelResults.length != 1)
-    throw Error(`Expected exactly one message in outbox: found ${filteredChannelResults.length}`);
+    throw Error(`Expected exactly one channel result: found ${filteredChannelResults.length}`);
   return filteredChannelResults[0];
 }

--- a/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
@@ -4,7 +4,7 @@ const tableName = 'open-channel-objectives';
 
 export async function up(knex: Knex): Promise<any> {
   return knex.schema.createTable(tableName, function(table) {
-    table.integer('objective_id').primary();
+    table.integer('objective_id'); // TODO make primary key (we would violate this constraint now)
     table.string('status');
     table.string('type');
     table.string('target_channel_id');

--- a/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
@@ -4,7 +4,7 @@ const tableName = 'open-channel-objectives';
 
 export async function up(knex: Knex): Promise<any> {
   return knex.schema.createTable(tableName, function(table) {
-    table.integer('objectiveId');
+    table.integer('objectiveId').primary();
     table.string('status');
     table.string('type');
     table.string('targetChannelId');

--- a/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex';
+
+const tableName = 'open-channel-objectives';
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.createTable(tableName, function(table) {
+    table.integer('objectiveId');
+    table.string('status');
+    table.string('type');
+    table.string('targetChannelId');
+    table.string('fundingStrategy');
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable(tableName);
+}

--- a/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174039_open-channel-objectives.ts
@@ -4,11 +4,11 @@ const tableName = 'open-channel-objectives';
 
 export async function up(knex: Knex): Promise<any> {
   return knex.schema.createTable(tableName, function(table) {
-    table.integer('objectiveId').primary();
+    table.integer('objective_id').primary();
     table.string('status');
     table.string('type');
-    table.string('targetChannelId');
-    table.string('fundingStrategy');
+    table.string('target_channel_id');
+    table.string('funding_strategy');
   });
 }
 

--- a/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
@@ -8,7 +8,6 @@ export async function up(knex: Knex): Promise<any> {
     table.string('status');
     table.string('type');
     table.string('target_channel_id');
-    table.string('funding_strategy');
   });
 }
 

--- a/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
@@ -1,6 +1,6 @@
 import * as Knex from 'knex';
 
-const tableName = 'open-channel-objectives';
+const tableName = 'close-channel-objectives';
 
 export async function up(knex: Knex): Promise<any> {
   return knex.schema.createTable(tableName, function(table) {

--- a/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
@@ -1,0 +1,17 @@
+import * as Knex from 'knex';
+
+const tableName = 'open-channel-objectives';
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.createTable(tableName, function(table) {
+    table.integer('objectiveId');
+    table.string('status');
+    table.string('type');
+    table.string('targetChannelId');
+    table.string('fundingStrategy');
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable(tableName);
+}

--- a/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
@@ -4,11 +4,11 @@ const tableName = 'close-channel-objectives';
 
 export async function up(knex: Knex): Promise<any> {
   return knex.schema.createTable(tableName, function(table) {
-    table.integer('objectiveId').primary();
+    table.integer('objective_id').primary();
     table.string('status');
     table.string('type');
-    table.string('targetChannelId');
-    table.string('fundingStrategy');
+    table.string('target_channel_id');
+    table.string('funding_strategy');
   });
 }
 

--- a/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174040_close-channel-objectives.ts
@@ -4,7 +4,7 @@ const tableName = 'close-channel-objectives';
 
 export async function up(knex: Knex): Promise<any> {
   return knex.schema.createTable(tableName, function(table) {
-    table.integer('objectiveId');
+    table.integer('objectiveId').primary();
     table.string('status');
     table.string('type');
     table.string('targetChannelId');

--- a/packages/server-wallet/src/errors/wallet-error.ts
+++ b/packages/server-wallet/src/errors/wallet-error.ts
@@ -2,6 +2,7 @@ export type Values<E> = E[keyof E];
 export abstract class WalletError extends Error {
   static readonly errors = {
     ChannelError: 'ChannelError',
+    ApproveObjectiveError: 'ApproveObjectiveError',
     JoinChannelError: 'JoinChannelError',
     CloseChannelError: 'CloseChannelError',
     UpdateChannelError: 'UpdateChannelError',

--- a/packages/server-wallet/src/handlers/approve-objective.ts
+++ b/packages/server-wallet/src/handlers/approve-objective.ts
@@ -1,0 +1,21 @@
+import {WalletError, Values} from '../errors/wallet-error';
+
+export interface ApproveObjectiveHandlerParams {
+  objectiveId: string;
+}
+
+export class ApproveObjectiveError extends WalletError {
+  readonly type = WalletError.errors.ApproveObjectiveError;
+
+  static readonly reasons = {
+    objectiveNotFound: 'objective not found',
+    unimplemented: 'objective not implemented',
+  } as const;
+
+  constructor(
+    reason: Values<typeof ApproveObjectiveError.reasons>,
+    public readonly data: any = undefined
+  ) {
+    super(reason);
+  }
+}

--- a/packages/server-wallet/src/models/close-channel-objective.ts
+++ b/packages/server-wallet/src/models/close-channel-objective.ts
@@ -42,9 +42,6 @@ export class CloseChannelObjective extends Model {
       throw Error(
         'You may only store an CloseChannel objective in the close-channel-objectives tables'
       );
-    console.log(
-      `inserting objective ${objectiveToBeStored.objectiveId} with target channel ${objectiveToBeStored.data.targetChannelId}`
-    );
     return CloseChannelObjective.query(tx).insert({
       objectiveId: objectiveToBeStored.objectiveId,
       status: objectiveToBeStored.status,
@@ -63,7 +60,6 @@ export class CloseChannelObjective extends Model {
       })
     | undefined
   > {
-    console.log(`getting objective for target channel ${targetChannelId}`);
     const objective = await CloseChannelObjective.query(tx)
       .select()
       .first()
@@ -101,7 +97,6 @@ export class CloseChannelObjective extends Model {
       })
     | undefined
   > {
-    console.log(`getting objective ${objectiveId}`);
     const objective = await CloseChannelObjective.query(tx).findById(objectiveId);
     if (!objective) return undefined;
     return extract(objective);

--- a/packages/server-wallet/src/models/close-channel-objective.ts
+++ b/packages/server-wallet/src/models/close-channel-objective.ts
@@ -1,0 +1,92 @@
+import {CloseChannel} from '@statechannels/wallet-core';
+import {Model, TransactionOrKnex} from 'objection';
+
+import {ObjectiveStoredInDB} from '../wallet/store';
+
+export class CloseChannelObjective extends Model {
+  readonly objectiveId!: ObjectiveStoredInDB['objectiveId'];
+  readonly status!: ObjectiveStoredInDB['status'];
+  readonly type!: 'CloseChannel';
+  readonly targetChannelId!: string;
+
+  static tableName = 'close-channel-objectives';
+  static get idColumn(): string[] {
+    return ['objectiveId'];
+  }
+
+  static async insert(
+    objectiveToBeStored: ObjectiveStoredInDB,
+    tx: TransactionOrKnex
+  ): Promise<CloseChannelObjective> {
+    if (objectiveToBeStored.type !== 'CloseChannel')
+      throw Error(
+        'You may only store an CloseChannel objective in the close-channel-objectives tables'
+      );
+    console.log(
+      `inserting objective ${objectiveToBeStored.objectiveId} with target channel ${objectiveToBeStored.data.targetChannelId}`
+    );
+    return CloseChannelObjective.query(tx).insert({
+      objectiveId: objectiveToBeStored.objectiveId,
+      status: objectiveToBeStored.status,
+      type: 'CloseChannel',
+      targetChannelId: objectiveToBeStored.data.targetChannelId,
+    });
+  }
+
+  static async forTargetChannelId(
+    targetChannelId: string,
+    tx: TransactionOrKnex
+  ): Promise<
+    | (CloseChannel & {
+        objectiveId: number;
+        status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+      })
+    | undefined
+  > {
+    console.log(`getting objective for target channel ${targetChannelId}`);
+    const objective = await CloseChannelObjective.query(tx)
+      .select()
+      .first()
+      .where({targetChannelId: targetChannelId});
+    if (!objective) return undefined;
+    return {
+      objectiveId: objective.objectiveId,
+      status: objective.status,
+      type: 'CloseChannel',
+      participants: [],
+      data: {
+        targetChannelId: objective.targetChannelId,
+      },
+    };
+  }
+
+  static async forId(
+    objectiveId: number,
+    tx: TransactionOrKnex
+  ): Promise<
+    | (CloseChannel & {
+        objectiveId: number;
+        status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+      })
+    | undefined
+  > {
+    console.log(`getting objective ${objectiveId}`);
+    const objective = await CloseChannelObjective.query(tx).findById(objectiveId);
+    if (!objective) return undefined;
+    return {
+      objectiveId: objective.objectiveId,
+      status: objective.status,
+      type: 'CloseChannel',
+      participants: [],
+      data: {
+        targetChannelId: objective.targetChannelId,
+      },
+    };
+  }
+
+  static async approve(objectiveId: number, tx: TransactionOrKnex): Promise<void> {
+    await CloseChannelObjective.query(tx)
+      .findById(objectiveId)
+      .patch({status: 'approved'});
+  }
+}

--- a/packages/server-wallet/src/models/close-channel-objective.ts
+++ b/packages/server-wallet/src/models/close-channel-objective.ts
@@ -3,6 +3,26 @@ import {Model, TransactionOrKnex} from 'objection';
 
 import {ObjectiveStoredInDB} from '../wallet/store';
 
+function extract(
+  objective: CloseChannelObjective | undefined
+):
+  | (CloseChannel & {
+      objectiveId: number;
+      status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+    })
+  | undefined {
+  if (objective === undefined) return undefined;
+  return {
+    objectiveId: objective.objectiveId,
+    status: objective.status,
+    type: 'CloseChannel',
+    participants: [],
+    data: {
+      targetChannelId: objective.targetChannelId,
+    },
+  };
+}
+
 export class CloseChannelObjective extends Model {
   readonly objectiveId!: ObjectiveStoredInDB['objectiveId'];
   readonly status!: ObjectiveStoredInDB['status'];
@@ -49,15 +69,26 @@ export class CloseChannelObjective extends Model {
       .first()
       .where({targetChannelId: targetChannelId});
     if (!objective) return undefined;
-    return {
-      objectiveId: objective.objectiveId,
-      status: objective.status,
-      type: 'CloseChannel',
-      participants: [],
-      data: {
-        targetChannelId: objective.targetChannelId,
-      },
-    };
+    return extract(objective);
+  }
+
+  static async forTargetChannelIds(
+    targetChannelIds: string[],
+    tx: TransactionOrKnex
+  ): Promise<
+    (
+      | (CloseChannel & {
+          objectiveId: number;
+          status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+        })
+      | undefined
+    )[]
+  > {
+    const objectives = await CloseChannelObjective.query(tx)
+      .select()
+      .whereIn('targetChannelId', targetChannelIds);
+
+    return objectives.map(extract);
   }
 
   static async forId(
@@ -73,20 +104,18 @@ export class CloseChannelObjective extends Model {
     console.log(`getting objective ${objectiveId}`);
     const objective = await CloseChannelObjective.query(tx).findById(objectiveId);
     if (!objective) return undefined;
-    return {
-      objectiveId: objective.objectiveId,
-      status: objective.status,
-      type: 'CloseChannel',
-      participants: [],
-      data: {
-        targetChannelId: objective.targetChannelId,
-      },
-    };
+    return extract(objective);
   }
 
   static async approve(objectiveId: number, tx: TransactionOrKnex): Promise<void> {
     await CloseChannelObjective.query(tx)
       .findById(objectiveId)
       .patch({status: 'approved'});
+  }
+
+  static async succeed(objectiveId: number, tx: TransactionOrKnex): Promise<void> {
+    await CloseChannelObjective.query(tx)
+      .findById(objectiveId)
+      .patch({status: 'succeeded'});
   }
 }

--- a/packages/server-wallet/src/models/open-channel-objective.ts
+++ b/packages/server-wallet/src/models/open-channel-objective.ts
@@ -44,9 +44,6 @@ export class OpenChannelObjective extends Model {
       throw Error(
         'You may only store an OpenChannel objective in the open-channel-objectives tables'
       );
-    console.log(
-      `inserting objective ${objectiveToBeStored.objectiveId} with target channel ${objectiveToBeStored.data.targetChannelId}`
-    );
     return OpenChannelObjective.query(tx).insert({
       objectiveId: objectiveToBeStored.objectiveId,
       status: objectiveToBeStored.status,
@@ -66,7 +63,6 @@ export class OpenChannelObjective extends Model {
       })
     | undefined
   > {
-    console.log(`getting objective for target channel ${targetChannelId}`);
     const objective = await OpenChannelObjective.query(tx)
       .select()
       .first()
@@ -104,7 +100,6 @@ export class OpenChannelObjective extends Model {
       })
     | undefined
   > {
-    console.log(`getting objective ${objectiveId}`);
     const objective = await OpenChannelObjective.query(tx).findById(objectiveId);
     if (!objective) return undefined;
     return extract(objective);

--- a/packages/server-wallet/src/models/open-channel-objective.ts
+++ b/packages/server-wallet/src/models/open-channel-objective.ts
@@ -1,0 +1,83 @@
+import {FundingStrategy} from '@statechannels/client-api-schema';
+import {isOpenChannel} from '@statechannels/wallet-core';
+import {Model, TransactionOrKnex} from 'objection';
+
+import {ObjectiveStoredInDB} from '../wallet/store';
+
+export class OpenChannelObjective extends Model {
+  readonly objectiveId!: ObjectiveStoredInDB['objectiveId'];
+  readonly status!: ObjectiveStoredInDB['status'];
+  readonly type!: ObjectiveStoredInDB['type'];
+  readonly targetChannelId!: string;
+  readonly fundingStrategy!: FundingStrategy;
+
+  static tableName = 'open-channel-objectives';
+  static get idColumn(): string[] {
+    return ['objectiveId'];
+  }
+
+  static async insert(
+    objectiveToBeStored: ObjectiveStoredInDB,
+    tx: TransactionOrKnex
+  ): Promise<OpenChannelObjective> {
+    if (!isOpenChannel(objectiveToBeStored))
+      throw Error(
+        'You may only store an OpenChannel objective in the open-channel-objectives tables'
+      );
+    console.log(
+      `inserting objective ${objectiveToBeStored.objectiveId} with target channel ${objectiveToBeStored.data.targetChannelId}`
+    );
+    return OpenChannelObjective.query(tx).insert({
+      objectiveId: objectiveToBeStored.objectiveId,
+      status: objectiveToBeStored.status,
+      type: 'OpenChannel',
+      targetChannelId: objectiveToBeStored.data.targetChannelId,
+      fundingStrategy: objectiveToBeStored.data.fundingStrategy,
+    });
+  }
+
+  static async forTargetChannelId(
+    targetChannelId: string,
+    tx: TransactionOrKnex
+  ): Promise<ObjectiveStoredInDB | undefined> {
+    console.log(`getting objective for target channel ${targetChannelId}`);
+    const objective = await OpenChannelObjective.query(tx)
+      .select()
+      .first()
+      .where({targetChannelId: targetChannelId});
+    if (!objective) return undefined;
+    return {
+      objectiveId: objective.objectiveId,
+      status: objective.status,
+      type: 'OpenChannel',
+      data: {
+        targetChannelId: objective.targetChannelId,
+        fundingStrategy: objective.fundingStrategy,
+      },
+    };
+  }
+
+  static async forId(
+    objectiveId: number,
+    tx: TransactionOrKnex
+  ): Promise<ObjectiveStoredInDB | undefined> {
+    console.log(`getting objective ${objectiveId}`);
+    const objective = await OpenChannelObjective.query(tx).findById(objectiveId);
+    if (!objective) return undefined;
+    return {
+      objectiveId: objective.objectiveId,
+      status: objective.status,
+      type: 'OpenChannel',
+      data: {
+        targetChannelId: objective.targetChannelId,
+        fundingStrategy: objective.fundingStrategy,
+      },
+    };
+  }
+
+  static async approve(objectiveId: number, tx: TransactionOrKnex): Promise<void> {
+    await OpenChannelObjective.query(tx)
+      .findById(objectiveId)
+      .patch({status: 'approved'});
+  }
+}

--- a/packages/server-wallet/src/models/open-channel-objective.ts
+++ b/packages/server-wallet/src/models/open-channel-objective.ts
@@ -1,5 +1,5 @@
 import {FundingStrategy} from '@statechannels/client-api-schema';
-import {isOpenChannel} from '@statechannels/wallet-core';
+import {isOpenChannel, OpenChannel} from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 
 import {ObjectiveStoredInDB} from '../wallet/store';
@@ -7,7 +7,7 @@ import {ObjectiveStoredInDB} from '../wallet/store';
 export class OpenChannelObjective extends Model {
   readonly objectiveId!: ObjectiveStoredInDB['objectiveId'];
   readonly status!: ObjectiveStoredInDB['status'];
-  readonly type!: ObjectiveStoredInDB['type'];
+  readonly type!: 'OpenChannel';
   readonly targetChannelId!: string;
   readonly fundingStrategy!: FundingStrategy;
 
@@ -39,7 +39,13 @@ export class OpenChannelObjective extends Model {
   static async forTargetChannelId(
     targetChannelId: string,
     tx: TransactionOrKnex
-  ): Promise<ObjectiveStoredInDB | undefined> {
+  ): Promise<
+    | (OpenChannel & {
+        objectiveId: number;
+        status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+      })
+    | undefined
+  > {
     console.log(`getting objective for target channel ${targetChannelId}`);
     const objective = await OpenChannelObjective.query(tx)
       .select()
@@ -50,6 +56,7 @@ export class OpenChannelObjective extends Model {
       objectiveId: objective.objectiveId,
       status: objective.status,
       type: 'OpenChannel',
+      participants: [],
       data: {
         targetChannelId: objective.targetChannelId,
         fundingStrategy: objective.fundingStrategy,
@@ -60,7 +67,13 @@ export class OpenChannelObjective extends Model {
   static async forId(
     objectiveId: number,
     tx: TransactionOrKnex
-  ): Promise<ObjectiveStoredInDB | undefined> {
+  ): Promise<
+    | (OpenChannel & {
+        objectiveId: number;
+        status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+      })
+    | undefined
+  > {
     console.log(`getting objective ${objectiveId}`);
     const objective = await OpenChannelObjective.query(tx).findById(objectiveId);
     if (!objective) return undefined;
@@ -68,6 +81,7 @@ export class OpenChannelObjective extends Model {
       objectiveId: objective.objectiveId,
       status: objective.status,
       type: 'OpenChannel',
+      participants: [],
       data: {
         targetChannelId: objective.targetChannelId,
         fundingStrategy: objective.fundingStrategy,

--- a/packages/server-wallet/src/models/open-channel-objective.ts
+++ b/packages/server-wallet/src/models/open-channel-objective.ts
@@ -115,4 +115,10 @@ export class OpenChannelObjective extends Model {
       .findById(objectiveId)
       .patch({status: 'approved'});
   }
+
+  static async succeed(objectiveId: number, tx: TransactionOrKnex): Promise<void> {
+    await OpenChannelObjective.query(tx)
+      .findById(objectiveId)
+      .patch({status: 'succeeded'});
+  }
 }

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -1,0 +1,44 @@
+import {simpleEthAllocation, BN, State} from '@statechannels/wallet-core';
+import matchers from '@pacote/jest-either';
+
+import {protocol} from '../close-channel';
+import {alice} from '../../wallet/__test__/fixtures/participants';
+import {SignState} from '../actions';
+
+import {applicationProtocolState} from './fixtures/protocol-state';
+
+expect.extend(matchers);
+
+const outcome = simpleEthAllocation([{amount: BN.from(5), destination: alice().destination}]);
+
+const postFundState = {outcome, turnNum: 3};
+const closingState = {outcome, turnNum: 4, isFinal: true};
+
+const runningState = {outcome, turnNum: 7};
+const closingState2 = {outcome, turnNum: 8, isFinal: true};
+
+const signState = (state: Partial<State>): Partial<SignState> => ({type: 'SignState', ...state});
+
+// TODO: (Stored Objectives) write a test to confirm it signs a new isFinal state if you tell it to
+
+test.each`
+  supported        | latestSignedByMe | latest           | action                      | cond                                                                  | result
+  ${closingState}  | ${postFundState} | ${closingState}  | ${signState(closingState)}  | ${'when the postfund state is supported, and the channel is closing'} | ${'signs the final state'}
+  ${closingState2} | ${runningState}  | ${closingState2} | ${signState(closingState2)} | ${'when the postfund state is supported, and the channel is closing'} | ${'signs the final state'}
+`('$result $cond', ({supported, latest, latestSignedByMe, action}) => {
+  const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe}});
+  expect(protocol(ps)).toMatchObject(action);
+});
+
+// todo: add the following test case once https://github.com/statechannels/the-graph/issues/80 is resolved
+//
+test.each`
+  supported       | latestSignedByMe | latest          | cond
+  ${closingState} | ${closingState}  | ${closingState} | ${'when I have signed a final state'}
+`('takes no action $cond', ({supported, latest, latestSignedByMe}) => {
+  const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe}});
+  expect(protocol(ps)).toMatchObject({
+    type: 'CompleteObjective',
+    channelId: ps.app.channelId,
+  });
+});

--- a/packages/server-wallet/src/protocols/__test__/fixtures/protocol-state.ts
+++ b/packages/server-wallet/src/protocols/__test__/fixtures/protocol-state.ts
@@ -5,7 +5,7 @@ import {
   channel,
   withSupportedState as channelWithSupportedState,
 } from '../../../models/__test__/fixtures/channel';
-import {ProtocolState} from '../../application';
+import {ProtocolState} from '../../close-channel';
 import {stateVars} from '../../../wallet/__test__/fixtures/state-vars';
 
 export const applicationProtocolState = fixture({app: channel().protocolState});

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -2,12 +2,12 @@ import {simpleEthAllocation, BN, Uint256, State} from '@statechannels/wallet-cor
 import matchers from '@pacote/jest-either';
 import {ethers} from 'ethers';
 
-import {protocol} from '../application';
+import {protocol} from '../open-channel';
 import {alice, bob} from '../../wallet/__test__/fixtures/participants';
 import {SignState, fundChannel} from '../actions';
 import {channel} from '../../models/__test__/fixtures/channel';
 
-import {applicationProtocolState} from './fixtures/application-protocol-state';
+import {applicationProtocolState} from './fixtures/protocol-state';
 
 expect.extend(matchers);
 
@@ -19,10 +19,6 @@ const outcome2 = simpleEthAllocation([
 const prefundState = {outcome, turnNum: 0};
 const prefundState2 = {outcome: outcome2, turnNum: 0};
 const postFundState = {outcome, turnNum: 2};
-const closingState = {outcome, turnNum: 4, isFinal: true};
-
-const runningState = {outcome, turnNum: 7};
-const closingState2 = {outcome, turnNum: 8, isFinal: true};
 
 const funded = (): Uint256 => BN.from(5);
 const notFunded = (): Uint256 => BN.from(0);
@@ -42,8 +38,6 @@ test.each`
   ${prefundState}  | ${prefundState}  | ${prefundState}  | ${funded}    | ${signState(postFundState)} | ${'when the prefund state is supported, and the channel is funded'}      | ${'signs the postfund state'}
   ${prefundState}  | ${prefundState}  | ${prefundState}  | ${notFunded} | ${fundChannelAction1}       | ${'when the prefund state is supported, and alice is first to deposit'}  | ${'submits transaction'}
   ${prefundState2} | ${prefundState2} | ${prefundState2} | ${funded}    | ${fundChannelAction2}       | ${'when the prefund state is supported, and alice is secont to deposit'} | ${'submits transaction'}
-  ${closingState}  | ${postFundState} | ${closingState}  | ${funded}    | ${signState(closingState)}  | ${'when the postfund state is supported, and the channel is closing'}    | ${'signs the final state'}
-  ${closingState2} | ${runningState}  | ${closingState2} | ${funded}    | ${signState(closingState2)} | ${'when the postfund state is supported, and the channel is closing'}    | ${'signs the final state'}
 `('$result $cond', ({supported, latest, latestSignedByMe, funding, action}) => {
   const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe, funding}});
   expect(protocol(ps)).toMatchObject(action);
@@ -54,10 +48,16 @@ test.each`
   ${undefined}     | ${prefundState}  | ${prefundState}  | ${funded}    | ${'when I have signed the prefund state, but it is not supported'}
   ${undefined}     | ${undefined}     | ${undefined}     | ${funded}    | ${'when there is no state'}
   ${prefundState}  | ${postFundState} | ${postFundState} | ${funded}    | ${'when the prefund state is supported, and I have signed the postfund state'}
-  ${postFundState} | ${postFundState} | ${postFundState} | ${funded}    | ${'when the postfund state is supported'}
-  ${closingState}  | ${closingState}  | ${closingState}  | ${funded}    | ${'when I have signed a final state'}
   ${prefundState2} | ${prefundState2} | ${prefundState2} | ${notFunded} | ${'when the prefund state is supported, and alice is second to deposit'}
 `('takes no action $cond', ({supported, latest, latestSignedByMe, funding}) => {
   const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe, funding}});
   expect(protocol(ps)).toBeUndefined();
+});
+
+test.each`
+  supported        | latestSignedByMe | latest           | funding   | cond
+  ${postFundState} | ${postFundState} | ${postFundState} | ${funded} | ${'when the postfund state is supported'}
+`('takes no action $cond', ({supported, latest, latestSignedByMe, funding}) => {
+  const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe, funding}});
+  expect(protocol(ps)).toMatchObject({channelId: ps.app.channelId, type: 'CompleteObjective'});
 });

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -16,6 +16,10 @@ export type FundChannel = {
   expectedHeld: Uint256;
   amount: Uint256;
 };
+export type CompleteObjective = {
+  type: 'CompleteObjective';
+  /* TODO: (Stored Objectives) put objective id here? */ channelId: Bytes32;
+};
 
 /*
 Action creators
@@ -28,6 +32,7 @@ const actionConstructor = <A extends ProtocolAction = ProtocolAction>(type: A['t
 ): A => ({...props, type} as A);
 export const fundChannel = actionConstructor<FundChannel>('FundChannel');
 export const signState = actionConstructor<SignState>('SignState');
+export const completeObjective = actionConstructor<CompleteObjective>('CompleteObjective');
 
 const guard = <T extends ProtocolAction>(type: ProtocolAction['type']) => (
   a: ProtocolAction
@@ -38,4 +43,4 @@ export const isFundChannel = guard<FundChannel>('FundChannel');
 
 export type Outgoing = Notice;
 
-export type ProtocolAction = SignState | FundChannel;
+export type ProtocolAction = SignState | FundChannel | CompleteObjective;

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -1,0 +1,40 @@
+import {State} from '@statechannels/wallet-core';
+
+import {Protocol, ProtocolResult, ChannelState, stage, Stage} from './state';
+import {signState, noAction, CompleteObjective, completeObjective} from './actions';
+
+export type ProtocolState = {app: ChannelState};
+
+const stageGuard = (guardStage: Stage) => (s: State | undefined): s is State =>
+  !!s && stage(s) === guardStage;
+
+const isFinal = stageGuard('Final');
+
+const signFinalState = (ps: ProtocolState): ProtocolResult | false =>
+  ps.app.supported &&
+  // Either sign the first isFinal state if its my turn
+  (((ps.app.latest.turnNum + 1) % ps.app.latest.participants.length === ps.app.myIndex &&
+    !isFinal(ps.app.latest) &&
+    !isFinal(ps.app.latestSignedByMe) &&
+    signState({
+      channelId: ps.app.channelId,
+      ...ps.app.supported,
+      turnNum: ps.app.supported.turnNum + 1,
+      isFinal: true,
+    })) ||
+    // Or, countersign a given final state
+    (isFinal(ps.app.latest) &&
+      !isFinal(ps.app.latestSignedByMe) &&
+      signState({
+        channelId: ps.app.channelId,
+        ...ps.app.supported,
+        turnNum: ps.app.latest.turnNum,
+      })));
+
+const completeCloseChannel = (ps: ProtocolState): CompleteObjective | false =>
+  isFinal(ps.app.supported) &&
+  isFinal(ps.app.latestSignedByMe) &&
+  completeObjective({channelId: ps.app.channelId});
+
+export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>
+  completeCloseChannel(ps) || signFinalState(ps) || noAction;

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -57,7 +57,7 @@ function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
 }
 
 export function mergeChannelResults(channelResults: ChannelResult[]): ChannelResult[] {
-  const sorted = _.orderBy(channelResults, ['channelId', 'turnNum'], ['desc', 'desc']);
+  const sorted = _.orderBy(_.reverse(channelResults), ['channelId', 'turnNum'], ['desc', 'desc']);
 
-  return _.uniqWith(sorted, (a, b) => a.channelId === b.channelId);
+  return _.sortedUniqBy(sorted, a => a.channelId);
 }

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -36,6 +36,29 @@ describe('directly funded app', () => {
 
     await Channel.query(w.knex).insert(c2);
     const channelIds = [c1, c2].map(c => c.channelId);
+
+    w.store.objectives[c1.channelNonce] = {
+      type: 'OpenChannel',
+      participants: c1.participants,
+      data: {
+        targetChannelId: c1.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'pending',
+      objectiveId: c1.channelNonce,
+    };
+
+    w.store.objectives[c2.channelNonce] = {
+      type: 'OpenChannel',
+      participants: c2.participants,
+      data: {
+        targetChannelId: c2.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'pending',
+      objectiveId: c2.channelNonce,
+    };
+
     const result = await w.joinChannels(channelIds);
     expect(result).toMatchObject({
       outbox: [
@@ -63,6 +86,17 @@ describe('directly funded app', () => {
     const current = await Channel.forId(channelId, w.knex);
     expect(current.protocolState).toMatchObject({latest: preFS, supported: undefined});
 
+    w.store.objectives[current.channelNonce] = {
+      type: 'OpenChannel',
+      participants: current.participants,
+      data: {
+        targetChannelId: current.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'pending',
+      objectiveId: current.channelNonce,
+    };
+
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [{params: {recipient: 'bob', sender: 'alice', data: {signedStates: [preFS]}}}],
       // channelResults: [{channelId, turnNum: 0, appData, status: 'funding'}],
@@ -86,6 +120,17 @@ describe('directly funded app', () => {
     const channelId = c.channelId;
     const current = await Channel.forId(channelId, w.knex);
     expect(current.latest).toMatchObject(preFS);
+
+    w.store.objectives[current.channelNonce] = {
+      type: 'OpenChannel',
+      participants: current.participants,
+      data: {
+        targetChannelId: current.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'pending',
+      objectiveId: current.channelNonce,
+    };
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [
@@ -115,6 +160,17 @@ describe('directly funded app', () => {
     const channelId = c.channelId;
     const current = await Channel.forId(channelId, w.knex);
     expect(current.latest).toMatchObject(preFS);
+
+    w.store.objectives[current.channelNonce] = {
+      type: 'OpenChannel',
+      participants: current.participants,
+      data: {
+        targetChannelId: current.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'pending',
+      objectiveId: current.channelNonce,
+    };
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -9,10 +9,13 @@ import {bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {alice} from '../fixtures/participants';
 import {defaultConfig} from '../../../config';
+import {OpenChannelObjective} from '../../../models/open-channel-objective';
+import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
   w = new Wallet(defaultConfig);
+  await new DBAdmin(w.knex).migrateDB();
   await truncate(w.knex);
 });
 
@@ -37,27 +40,33 @@ describe('directly funded app', () => {
     await Channel.query(w.knex).insert(c2);
     const channelIds = [c1, c2].map(c => c.channelId);
 
-    // w.store.objectives[c1.channelNonce] = {
-    //   type: 'OpenChannel',
-    //   participants: c1.participants,
-    //   data: {
-    //     targetChannelId: c1.channelId,
-    //     fundingStrategy: 'Direct',
-    //   },
-    //   status: 'pending',
-    //   objectiveId: c1.channelNonce,
-    // };
+    await OpenChannelObjective.insert(
+      {
+        type: 'OpenChannel',
+        participants: c1.participants,
+        data: {
+          targetChannelId: c1.channelId,
+          fundingStrategy: 'Direct',
+        },
+        status: 'pending',
+        objectiveId: c1.channelNonce,
+      },
+      w.knex
+    );
 
-    // w.store.objectives[c2.channelNonce] = {
-    //   type: 'OpenChannel',
-    //   participants: c2.participants,
-    //   data: {
-    //     targetChannelId: c2.channelId,
-    //     fundingStrategy: 'Direct',
-    //   },
-    //   status: 'pending',
-    //   objectiveId: c2.channelNonce,
-    // };
+    await OpenChannelObjective.insert(
+      {
+        type: 'OpenChannel',
+        participants: c2.participants,
+        data: {
+          targetChannelId: c2.channelId,
+          fundingStrategy: 'Direct',
+        },
+        status: 'pending',
+        objectiveId: c2.channelNonce,
+      },
+      w.knex
+    );
 
     const result = await w.joinChannels(channelIds);
     expect(result).toMatchObject({
@@ -86,16 +95,19 @@ describe('directly funded app', () => {
     const current = await Channel.forId(channelId, w.knex);
     expect(current.protocolState).toMatchObject({latest: preFS, supported: undefined});
 
-    // w.store.objectives[current.channelNonce] = {
-    //   type: 'OpenChannel',
-    //   participants: current.participants,
-    //   data: {
-    //     targetChannelId: current.channelId,
-    //     fundingStrategy: 'Direct',
-    //   },
-    //   status: 'pending',
-    //   objectiveId: current.channelNonce,
-    // };
+    await OpenChannelObjective.insert(
+      {
+        type: 'OpenChannel',
+        participants: current.participants,
+        data: {
+          targetChannelId: current.channelId,
+          fundingStrategy: 'Direct',
+        },
+        status: 'pending',
+        objectiveId: current.channelNonce,
+      },
+      w.knex
+    );
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [{params: {recipient: 'bob', sender: 'alice', data: {signedStates: [preFS]}}}],
@@ -121,16 +133,19 @@ describe('directly funded app', () => {
     const current = await Channel.forId(channelId, w.knex);
     expect(current.latest).toMatchObject(preFS);
 
-    // w.store.objectives[current.channelNonce] = {
-    //   type: 'OpenChannel',
-    //   participants: current.participants,
-    //   data: {
-    //     targetChannelId: current.channelId,
-    //     fundingStrategy: 'Direct',
-    //   },
-    //   status: 'pending',
-    //   objectiveId: current.channelNonce,
-    // };
+    await OpenChannelObjective.insert(
+      {
+        type: 'OpenChannel',
+        participants: current.participants,
+        data: {
+          targetChannelId: current.channelId,
+          fundingStrategy: 'Direct',
+        },
+        status: 'pending',
+        objectiveId: current.channelNonce,
+      },
+      w.knex
+    );
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [
@@ -161,16 +176,19 @@ describe('directly funded app', () => {
     const current = await Channel.forId(channelId, w.knex);
     expect(current.latest).toMatchObject(preFS);
 
-    // w.store.objectives[current.channelNonce] = {
-    //   type: 'OpenChannel',
-    //   participants: current.participants,
-    //   data: {
-    //     targetChannelId: current.channelId,
-    //     fundingStrategy: 'Direct',
-    //   },
-    //   status: 'pending',
-    //   objectiveId: current.channelNonce,
-    // };
+    await OpenChannelObjective.insert(
+      {
+        type: 'OpenChannel',
+        participants: current.participants,
+        data: {
+          targetChannelId: current.channelId,
+          fundingStrategy: 'Direct',
+        },
+        status: 'pending',
+        objectiveId: current.channelNonce,
+      },
+      w.knex
+    );
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -37,27 +37,27 @@ describe('directly funded app', () => {
     await Channel.query(w.knex).insert(c2);
     const channelIds = [c1, c2].map(c => c.channelId);
 
-    w.store.objectives[c1.channelNonce] = {
-      type: 'OpenChannel',
-      participants: c1.participants,
-      data: {
-        targetChannelId: c1.channelId,
-        fundingStrategy: 'Direct',
-      },
-      status: 'pending',
-      objectiveId: c1.channelNonce,
-    };
+    // w.store.objectives[c1.channelNonce] = {
+    //   type: 'OpenChannel',
+    //   participants: c1.participants,
+    //   data: {
+    //     targetChannelId: c1.channelId,
+    //     fundingStrategy: 'Direct',
+    //   },
+    //   status: 'pending',
+    //   objectiveId: c1.channelNonce,
+    // };
 
-    w.store.objectives[c2.channelNonce] = {
-      type: 'OpenChannel',
-      participants: c2.participants,
-      data: {
-        targetChannelId: c2.channelId,
-        fundingStrategy: 'Direct',
-      },
-      status: 'pending',
-      objectiveId: c2.channelNonce,
-    };
+    // w.store.objectives[c2.channelNonce] = {
+    //   type: 'OpenChannel',
+    //   participants: c2.participants,
+    //   data: {
+    //     targetChannelId: c2.channelId,
+    //     fundingStrategy: 'Direct',
+    //   },
+    //   status: 'pending',
+    //   objectiveId: c2.channelNonce,
+    // };
 
     const result = await w.joinChannels(channelIds);
     expect(result).toMatchObject({
@@ -86,16 +86,16 @@ describe('directly funded app', () => {
     const current = await Channel.forId(channelId, w.knex);
     expect(current.protocolState).toMatchObject({latest: preFS, supported: undefined});
 
-    w.store.objectives[current.channelNonce] = {
-      type: 'OpenChannel',
-      participants: current.participants,
-      data: {
-        targetChannelId: current.channelId,
-        fundingStrategy: 'Direct',
-      },
-      status: 'pending',
-      objectiveId: current.channelNonce,
-    };
+    // w.store.objectives[current.channelNonce] = {
+    //   type: 'OpenChannel',
+    //   participants: current.participants,
+    //   data: {
+    //     targetChannelId: current.channelId,
+    //     fundingStrategy: 'Direct',
+    //   },
+    //   status: 'pending',
+    //   objectiveId: current.channelNonce,
+    // };
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [{params: {recipient: 'bob', sender: 'alice', data: {signedStates: [preFS]}}}],
@@ -121,16 +121,16 @@ describe('directly funded app', () => {
     const current = await Channel.forId(channelId, w.knex);
     expect(current.latest).toMatchObject(preFS);
 
-    w.store.objectives[current.channelNonce] = {
-      type: 'OpenChannel',
-      participants: current.participants,
-      data: {
-        targetChannelId: current.channelId,
-        fundingStrategy: 'Direct',
-      },
-      status: 'pending',
-      objectiveId: current.channelNonce,
-    };
+    // w.store.objectives[current.channelNonce] = {
+    //   type: 'OpenChannel',
+    //   participants: current.participants,
+    //   data: {
+    //     targetChannelId: current.channelId,
+    //     fundingStrategy: 'Direct',
+    //   },
+    //   status: 'pending',
+    //   objectiveId: current.channelNonce,
+    // };
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [
@@ -161,16 +161,16 @@ describe('directly funded app', () => {
     const current = await Channel.forId(channelId, w.knex);
     expect(current.latest).toMatchObject(preFS);
 
-    w.store.objectives[current.channelNonce] = {
-      type: 'OpenChannel',
-      participants: current.participants,
-      data: {
-        targetChannelId: current.channelId,
-        fundingStrategy: 'Direct',
-      },
-      status: 'pending',
-      objectiveId: current.channelNonce,
-    };
+    // w.store.objectives[current.channelNonce] = {
+    //   type: 'OpenChannel',
+    //   participants: current.participants,
+    //   data: {
+    //     targetChannelId: current.channelId,
+    //     fundingStrategy: 'Direct',
+    //   },
+    //   status: 'pending',
+    //   objectiveId: current.channelNonce,
+    // };
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -176,16 +176,16 @@ describe('when the application protocol returns an action', () => {
     const c = channel({vars: [addHash(state)]});
     await Channel.query(wallet.knex).insert(c);
 
-    wallet.store.objectives[0] = {
-      type: 'OpenChannel',
-      objectiveId: 0,
-      status: 'approved',
-      participants: c.participants,
-      data: {
-        targetChannelId: c.channelId,
-        fundingStrategy: 'Unfunded', // Could also be Direct, funding is empty
-      },
-    };
+    // wallet.store.objectives[0] = {
+    //   type: 'OpenChannel',
+    //   objectiveId: 0,
+    //   status: 'approved',
+    //   participants: c.participants,
+    //   data: {
+    //     targetChannelId: c.channelId,
+    //     fundingStrategy: 'Unfunded', // Could also be Direct, funding is empty
+    //   },
+    // };
 
     expect(c.latestSignedByMe?.turnNum).toEqual(0);
     expect(c.supported).toBeUndefined();

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -12,9 +12,14 @@ import {truncate} from '../../../db-admin/db-admin-connection';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
 import {defaultConfig} from '../../../config';
+import {OpenChannelObjective} from '../../../models/open-channel-objective';
 
 jest.setTimeout(20_000);
 const wallet = new Wallet(defaultConfig);
+
+beforeAll(async () => {
+  await wallet.dbAdmin().migrateDB();
+});
 
 afterAll(async () => {
   await wallet.destroy();
@@ -176,16 +181,19 @@ describe('when the application protocol returns an action', () => {
     const c = channel({vars: [addHash(state)]});
     await Channel.query(wallet.knex).insert(c);
 
-    // wallet.store.objectives[0] = {
-    //   type: 'OpenChannel',
-    //   objectiveId: 0,
-    //   status: 'approved',
-    //   participants: c.participants,
-    //   data: {
-    //     targetChannelId: c.channelId,
-    //     fundingStrategy: 'Unfunded', // Could also be Direct, funding is empty
-    //   },
-    // };
+    await OpenChannelObjective.insert(
+      {
+        type: 'OpenChannel',
+        objectiveId: 0,
+        status: 'approved',
+        participants: c.participants,
+        data: {
+          targetChannelId: c.channelId,
+          fundingStrategy: 'Unfunded', // Could also be Direct, funding is empty
+        },
+      },
+      wallet.knex
+    );
 
     expect(c.latestSignedByMe?.turnNum).toEqual(0);
     expect(c.supported).toBeUndefined();

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -37,27 +37,27 @@ it('sends the post fund setup when the funding event is provided for multiple ch
   await Channel.query(w.knex).insert(c2);
   const channelIds = [c1, c2].map(c => c.channelId);
 
-  w.store.objectives[c1.channelNonce] = {
-    type: 'OpenChannel',
-    participants: c1.participants,
-    data: {
-      targetChannelId: c1.channelId,
-      fundingStrategy: 'Direct',
-    },
-    status: 'approved',
-    objectiveId: c1.channelNonce,
-  };
+  // w.store.objectives[c1.channelNonce] = {
+  //   type: 'OpenChannel',
+  //   participants: c1.participants,
+  //   data: {
+  //     targetChannelId: c1.channelId,
+  //     fundingStrategy: 'Direct',
+  //   },
+  //   status: 'approved',
+  //   objectiveId: c1.channelNonce,
+  // };
 
-  w.store.objectives[c2.channelNonce] = {
-    type: 'OpenChannel',
-    participants: c2.participants,
-    data: {
-      targetChannelId: c2.channelId,
-      fundingStrategy: 'Direct',
-    },
-    status: 'approved',
-    objectiveId: c2.channelNonce,
-  };
+  // w.store.objectives[c2.channelNonce] = {
+  //   type: 'OpenChannel',
+  //   participants: c2.participants,
+  //   data: {
+  //     targetChannelId: c2.channelId,
+  //     fundingStrategy: 'Direct',
+  //   },
+  //   status: 'approved',
+  //   objectiveId: c2.channelNonce,
+  // };
 
   const result = await w.updateFundingForChannels(
     channelIds.map(cId => ({
@@ -99,16 +99,16 @@ it('sends the post fund setup when the funding event is provided', async () => {
   await Channel.query(w.knex).insert(c);
   const {channelId} = c;
 
-  w.store.objectives[c.channelNonce] = {
-    type: 'OpenChannel',
-    participants: c.participants,
-    data: {
-      targetChannelId: c.channelId,
-      fundingStrategy: 'Direct',
-    },
-    status: 'approved',
-    objectiveId: c.channelNonce,
-  };
+  // w.store.objectives[c.channelNonce] = {
+  //   type: 'OpenChannel',
+  //   participants: c.participants,
+  //   data: {
+  //     targetChannelId: c.channelId,
+  //     fundingStrategy: 'Direct',
+  //   },
+  //   status: 'approved',
+  //   objectiveId: c.channelNonce,
+  // };
 
   const result = await w.updateFundingForChannels([
     {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -38,7 +38,7 @@ it('sends the post fund setup when the funding event is provided for multiple ch
   await Channel.query(w.knex).insert(c2);
   const channelIds = [c1, c2].map(c => c.channelId);
 
-  OpenChannelObjective.insert(
+  await OpenChannelObjective.insert(
     {
       type: 'OpenChannel',
       participants: c1.participants,
@@ -52,7 +52,7 @@ it('sends the post fund setup when the funding event is provided for multiple ch
     w.knex
   );
 
-  OpenChannelObjective.insert(
+  await OpenChannelObjective.insert(
     {
       type: 'OpenChannel',
       participants: c2.participants,
@@ -106,16 +106,19 @@ it('sends the post fund setup when the funding event is provided', async () => {
   await Channel.query(w.knex).insert(c);
   const {channelId} = c;
 
-  // w.store.objectives[c.channelNonce] = {
-  //   type: 'OpenChannel',
-  //   participants: c.participants,
-  //   data: {
-  //     targetChannelId: c.channelId,
-  //     fundingStrategy: 'Direct',
-  //   },
-  //   status: 'approved',
-  //   objectiveId: c.channelNonce,
-  // };
+  await OpenChannelObjective.insert(
+    {
+      type: 'OpenChannel',
+      participants: c.participants,
+      data: {
+        targetChannelId: c.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'approved',
+      objectiveId: c.channelNonce,
+    },
+    w.knex
+  );
 
   const result = await w.updateFundingForChannels([
     {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -36,6 +36,29 @@ it('sends the post fund setup when the funding event is provided for multiple ch
   await Channel.query(w.knex).insert(c1);
   await Channel.query(w.knex).insert(c2);
   const channelIds = [c1, c2].map(c => c.channelId);
+
+  w.store.objectives[c1.channelNonce] = {
+    type: 'OpenChannel',
+    participants: c1.participants,
+    data: {
+      targetChannelId: c1.channelId,
+      fundingStrategy: 'Direct',
+    },
+    status: 'approved',
+    objectiveId: c1.channelNonce,
+  };
+
+  w.store.objectives[c2.channelNonce] = {
+    type: 'OpenChannel',
+    participants: c2.participants,
+    data: {
+      targetChannelId: c2.channelId,
+      fundingStrategy: 'Direct',
+    },
+    status: 'approved',
+    objectiveId: c2.channelNonce,
+  };
+
   const result = await w.updateFundingForChannels(
     channelIds.map(cId => ({
       channelId: cId,
@@ -75,6 +98,18 @@ it('sends the post fund setup when the funding event is provided', async () => {
   const c = channel({vars: [stateWithHashSignedBy(alice(), bob())({turnNum: 0})]});
   await Channel.query(w.knex).insert(c);
   const {channelId} = c;
+
+  w.store.objectives[c.channelNonce] = {
+    type: 'OpenChannel',
+    participants: c.participants,
+    data: {
+      targetChannelId: c.channelId,
+      fundingStrategy: 'Direct',
+    },
+    status: 'approved',
+    objectiveId: c.channelNonce,
+  };
+
   const result = await w.updateFundingForChannels([
     {
       channelId: c.channelId,

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -10,6 +10,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {defaultConfig} from '../../../config';
+import {OpenChannelObjective} from '../../../models/open-channel-objective';
 
 const {AddressZero} = ethers.constants;
 
@@ -37,27 +38,33 @@ it('sends the post fund setup when the funding event is provided for multiple ch
   await Channel.query(w.knex).insert(c2);
   const channelIds = [c1, c2].map(c => c.channelId);
 
-  // w.store.objectives[c1.channelNonce] = {
-  //   type: 'OpenChannel',
-  //   participants: c1.participants,
-  //   data: {
-  //     targetChannelId: c1.channelId,
-  //     fundingStrategy: 'Direct',
-  //   },
-  //   status: 'approved',
-  //   objectiveId: c1.channelNonce,
-  // };
+  OpenChannelObjective.insert(
+    {
+      type: 'OpenChannel',
+      participants: c1.participants,
+      data: {
+        targetChannelId: c1.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'approved',
+      objectiveId: c1.channelNonce,
+    },
+    w.knex
+  );
 
-  // w.store.objectives[c2.channelNonce] = {
-  //   type: 'OpenChannel',
-  //   participants: c2.participants,
-  //   data: {
-  //     targetChannelId: c2.channelId,
-  //     fundingStrategy: 'Direct',
-  //   },
-  //   status: 'approved',
-  //   objectiveId: c2.channelNonce,
-  // };
+  OpenChannelObjective.insert(
+    {
+      type: 'OpenChannel',
+      participants: c2.participants,
+      data: {
+        targetChannelId: c2.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'approved',
+      objectiveId: c2.channelNonce,
+    },
+    w.knex
+  );
 
   const result = await w.updateFundingForChannels(
     channelIds.map(cId => ({

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -23,6 +23,7 @@ import {
   ChannelConstants,
   Payload,
   Objective,
+  isOpenChannel,
 } from '@statechannels/wallet-core';
 import * as Either from 'fp-ts/lib/Either';
 import Knex from 'knex';
@@ -290,10 +291,15 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
     };
   }
 
-  async approveObjective(objectiveId: number): Promise<SingleChannelOutput> {
-    const objective = this.store.objectives[objectiveId];
-    // TOOD handle other types of objective
-    // const objective = await OpenChannelObjective.forId(objectiveId, this.knex); // TODO handle other types of objective
+  async approveObjective(
+    objectiveId: number,
+    type: Objective['type']
+  ): Promise<SingleChannelOutput> {
+    let objective: ObjectiveStoredInDB | undefined;
+    if (type === 'OpenChannel')
+      objective = await OpenChannelObjective.forId(objectiveId, this.knex);
+    // TODO handle other types of objective
+    else objective = this.store.objectives[objectiveId];
 
     if (!objective)
       throw new ApproveObjective.ApproveObjectiveError(

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -30,10 +30,12 @@ import _ from 'lodash';
 import {Bytes32, Uint256} from '../type-aliases';
 import {Outgoing, ProtocolAction} from '../protocols/actions';
 import {logger} from '../logger';
-import * as Application from '../protocols/application';
+import * as OpenChannelProtocol from '../protocols/open-channel';
+import * as CloseChannelProtocol from '../protocols/close-channel';
 import * as UpdateChannel from '../handlers/update-channel';
 import * as CloseChannel from '../handlers/close-channel';
 import * as JoinChannel from '../handlers/join-channel';
+import * as ApproveObjective from '../handlers/approve-objective';
 import * as ChannelState from '../protocols/state';
 import {isWalletError} from '../errors/wallet-error';
 import {timerFactory, recordFunctionMetrics, setupMetrics} from '../metrics';
@@ -49,13 +51,21 @@ import {
 } from '../chain-service';
 import {DBAdmin} from '../db-admin/db-admin';
 
-import {Store, AppHandler, MissingAppHandler} from './store';
+import {Store, AppHandler, MissingAppHandler, ObjectiveStoredInDB} from './store';
 
 // TODO: The client-api does not currently allow for outgoing messages to be
 // declared as the result of a wallet API call.
 // Nor does it allow for multiple channel results
-export type SingleChannelOutput = {outbox: Outgoing[]; channelResult: ChannelResult};
-export type MultipleChannelOutput = {outbox: Outgoing[]; channelResults: ChannelResult[]};
+export type SingleChannelOutput = {
+  outbox: Outgoing[];
+  channelResult: ChannelResult;
+  objectivesToApprove?: Omit<ObjectiveStoredInDB, 'status'>[];
+};
+export type MultipleChannelOutput = {
+  outbox: Outgoing[];
+  channelResults: ChannelResult[];
+  objectivesToApprove?: Omit<ObjectiveStoredInDB, 'status'>[];
+};
 type Message = SingleChannelOutput | MultipleChannelOutput;
 const isSingleChannelMessage = (message: Message): message is SingleChannelOutput =>
   'channelResult' in message;
@@ -278,6 +288,31 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
     };
   }
 
+  async approveObjective(objectiveId: number): Promise<SingleChannelOutput> {
+    const objective = this.store.objectives[objectiveId];
+
+    if (!objective)
+      throw new ApproveObjective.ApproveObjectiveError(
+        ApproveObjective.ApproveObjectiveError.reasons.objectiveNotFound,
+        {objectiveId}
+      );
+
+    if (objective.type !== 'OpenChannel')
+      throw new ApproveObjective.ApproveObjectiveError(
+        ApproveObjective.ApproveObjectiveError.reasons.unimplemented,
+        {type: objective.type}
+      );
+
+    // FIXME: This should probably be done within the critical code of the joinChannel
+    this.store.objectives[objectiveId].status = 'approved';
+
+    const {
+      data: {targetChannelId},
+    } = objective;
+
+    return this.joinChannel({channelId: targetChannelId});
+  }
+
   async joinChannel({channelId}: JoinChannelParams): Promise<SingleChannelOutput> {
     const criticalCode: AppHandler<Promise<SingleChannelOutput>> = async (tx, channel) => {
       const {myIndex, participants} = channel;
@@ -296,6 +331,15 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
         channelId,
       });
     };
+
+    // FIXME: This is just to get existing joinChannel API pattern to keep working
+    /* eslint-disable-next-line */
+    const {objectiveId} = _.find(
+      this.store.objectives,
+      o => o.type === 'OpenChannel' && o.data.targetChannelId === channelId
+    )!;
+    this.store.objectives[objectiveId].status = 'approved';
+    // END FIXME
 
     const {outbox, channelResult} = await this.store.lockApp(
       channelId,
@@ -366,19 +410,29 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
         {channelId}
       );
     };
-    const criticalCode: AppHandler<Promise<SingleChannelOutput>> = async (tx, channel) => {
-      const {myIndex, participants} = channel;
 
-      const nextState = getOrThrow(CloseChannel.closeChannel(channel));
-      const signedState = await this.store.signState(channelId, nextState, tx);
+    const criticalCode: AppHandler<void> = async (tx, channel) => {
+      // TODO: (Objectives Rewrite) Keeping this here b/c we need to do input validation
+      // and check if its our turn and throw an error as existing tests expect
+      getOrThrow(CloseChannel.closeChannel(channel));
 
-      return {
-        outbox: createOutboxFor(channelId, myIndex, participants, {signedStates: [signedState]}),
-        channelResult: ChannelState.toChannelResult(await this.store.getChannel(channelId, tx)),
+      // const {outgoing, channelResult} = await this.store.signState(channelId, nextState, tx);
+      // return {outbox: outgoing.map(n => n.notice), channelResult};
+
+      this.store.objectives[channel.latest.channelNonce] = {
+        type: 'CloseChannel',
+        data: {targetChannelId: channelId},
+        participants: [],
+        status: 'approved',
+        objectiveId: channel.latest.channelNonce,
       };
     };
 
-    return this.store.lockApp(channelId, criticalCode, handleMissingChannel);
+    await this.store.lockApp(channelId, criticalCode, handleMissingChannel);
+
+    const {channelResults, outbox} = await this.takeActions([channelId]);
+
+    return {outbox, channelResult: channelResults[0]};
   }
 
   async getChannels(): Promise<MultipleChannelOutput> {
@@ -430,9 +484,16 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
       };
     }
 
-    const channelIds = await this.store.pushMessage(wirePayload);
+    const {channelIds, objectives, channelResults: fromStoring} = await this.store.pushMessage(
+      wirePayload
+    );
 
     const {channelResults, outbox} = await this.takeActions(channelIds);
+
+    for (const channel of fromStoring) {
+      if (!_.some(channelResults, c => c.channelId === channel.channelId))
+        channelResults.push(channel);
+    }
 
     if (wirePayload.requests && wirePayload.requests.length > 0)
       // Modifies outbox, may append new messages
@@ -441,6 +502,7 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
     return {
       outbox: mergeOutgoing(outbox),
       channelResults: mergeChannelResults(channelResults),
+      objectivesToApprove: objectives,
     };
   }
 
@@ -448,13 +510,35 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
     const outbox: Outgoing[] = [];
     const channelResults: ChannelResult[] = [];
     let error: Error | undefined = undefined;
-    while (channels.length && !error) {
-      await this.store.lockApp(channels[0], async tx => {
+
+    // FIXME: Only get objectives which are:
+    // 1. Approved but not executed yet
+    // 2. Related to one of the channels
+    const objectives = Object.values(this.store.objectives).filter(
+      objective =>
+        // Only supports these two
+        (objective.type === 'OpenChannel' || objective.type === 'CloseChannel') &&
+        // Only runs on those with relevant channels
+        _.includes(channels, objective.data.targetChannelId) &&
+        // Only runs on pending or approved
+        (objective.status === 'approved' || // Need approved b.c. next action to take
+          objective.status === 'pending') /* Need pending because you want new channel result */
+    );
+
+    while (objectives.length && !error) {
+      const objective = objectives[0];
+
+      if (objective.type !== 'OpenChannel' && objective.type !== 'CloseChannel')
+        throw new Error('not implememnted');
+
+      const channel = objective.data.targetChannelId;
+
+      await this.store.lockApp(channel, async tx => {
         // For the moment, we are only considering directly funded app channels.
         // Thus, we can directly fetch the channel record, and immediately construct the protocol state from it.
         // In the future, we can have an App model which collects all the relevant channels for an app channel,
         // and a Ledger model which stores ledger-specific data (eg. queued requests)
-        const app = await this.store.getChannel(channels[0], tx);
+        const app = await this.store.getChannel(channel, tx);
 
         if (!app) {
           throw new Error('Channel not found');
@@ -464,8 +548,8 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
           error = e;
           await tx.rollback(error);
         };
-        const markChannelAsDone = (): void => {
-          channels.shift();
+        const markObjectiveAsDone = (): void => {
+          objectives.shift();
           channelResults.push(ChannelState.toChannelResult(app));
         };
 
@@ -487,17 +571,25 @@ export class Wallet implements WalletInterface, ChainEventSubscriberInterface {
                 amount: BN.from(action.amount),
               });
               return;
+            case 'CompleteObjective':
+              this.store.objectives[objective.objectiveId].status = 'succeeded';
+              markObjectiveAsDone(); // TODO: Awkward to use this for undefined and CompleteObjective
+              return;
             default:
               throw 'Unimplemented';
           }
         };
 
+        const fsm = {OpenChannel: OpenChannelProtocol, CloseChannel: CloseChannelProtocol}[
+          objective.type
+        ];
+
         const nextAction = recordFunctionMetrics(
-          Application.protocol({app}),
+          fsm.protocol({app}),
           this.walletConfig.timingMetrics
         );
 
-        if (!nextAction) markChannelAsDone();
+        if (!nextAction) markObjectiveAsDone();
         else {
           try {
             await doAction(nextAction);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -51,6 +51,7 @@ import {Nonce} from '../models/nonce';
 import {recoverAddress} from '../utilities/signatures';
 import {Outgoing} from '../protocols/actions';
 import {OpenChannelObjective} from '../models/open-channel-objective';
+import {CloseChannelObjective} from '../models/close-channel-objective';
 
 export type AppHandler<T> = (tx: Transaction, channel: ChannelState) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;
@@ -355,7 +356,7 @@ export class Store {
         channel.channelNonce /* TODO: (Stored Objectives) id strategy */
       ] = objectiveToBeStored;
 
-      if (isOpenChannel(objective)) await OpenChannelObjective.insert(objectiveToBeStored, tx);
+      await OpenChannelObjective.insert(objectiveToBeStored, tx);
 
       await Channel.query(tx)
         .where({channelId: channel.channelId})
@@ -388,7 +389,7 @@ export class Store {
         channel.channelNonce /* TODO: (Stored Objectives) id strategy */
       ] = objectiveToBeStored;
 
-      if (isOpenChannel(objective)) await OpenChannelObjective.insert(objectiveToBeStored, tx);
+      await CloseChannelObjective.insert(objectiveToBeStored, tx);
 
       return objectiveToBeStored;
     } else {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -494,7 +494,7 @@ export class Store {
 
       const objective: Objective = {
         type: 'OpenChannel',
-        participants: [],
+        participants,
         data: {
           targetChannelId: channelId,
           fundingStrategy,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -74,11 +74,6 @@ export type ObjectiveStoredInDB = Objective & {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export class Store {
-  // FIXME: (Stored Objectives) Turn into a new DB table
-  public objectives: {
-    [objectiveId: number]: ObjectiveStoredInDB;
-  } = {};
-
   constructor(
     public readonly knex: Knex,
     readonly timingMetrics: boolean,
@@ -351,11 +346,8 @@ export class Store {
           targetChannelId: channelId,
         },
       };
-      // TODO: (Stored Objectives) Does it make sense to do the INSERT here?
-      this.objectives[
-        channel.channelNonce /* TODO: (Stored Objectives) id strategy */
-      ] = objectiveToBeStored;
 
+      // TODO: (Stored Objectives) Does it make sense to do the INSERT here?
       await OpenChannelObjective.insert(objectiveToBeStored, tx);
 
       await Channel.query(tx)
@@ -385,10 +377,6 @@ export class Store {
         },
       };
       // TODO: (Stored Objectives) Does it make sense to do the INSERT here?
-      this.objectives[
-        channel.channelNonce /* TODO: (Stored Objectives) id strategy */
-      ] = objectiveToBeStored;
-
       await CloseChannelObjective.insert(objectiveToBeStored, tx);
 
       return objectiveToBeStored;
@@ -530,10 +518,6 @@ export class Store {
         objectiveId: constants.channelNonce,
         status: 'approved',
       };
-
-      this.objectives[
-        constants.channelNonce /* TODO: (Stored Objectives) id? */
-      ] = objectiveToBeStored;
 
       if (isOpenChannel(objective)) await OpenChannelObjective.insert(objectiveToBeStored, tx);
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -50,6 +50,7 @@ import {Funding} from '../models/funding';
 import {Nonce} from '../models/nonce';
 import {recoverAddress} from '../utilities/signatures';
 import {Outgoing} from '../protocols/actions';
+import {OpenChannelObjective} from '../models/open-channel-objective';
 
 export type AppHandler<T> = (tx: Transaction, channel: ChannelState) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;
@@ -339,17 +340,22 @@ export class Store {
       if (!_.includes(['Direct', 'Unfunded'], objective.data.fundingStrategy))
         throw new StoreError(StoreError.reasons.unimplementedFundingStrategy, {fundingStrategy});
 
-      // TODO: (Stored Objectives) Does it make sense to do the INSERT here?
-      this.objectives[channel.channelNonce /* TODO: (Stored Objectives) id strategy */] = {
-        objectiveId: channel.channelNonce,
+      const objectiveToBeStored: ObjectiveStoredInDB = {
+        objectiveId: channel.channelNonce /* TODO: (Stored Objectives) id strategy */,
+        participants: [],
         status: 'pending',
         type: objective.type,
-        participants: channel.participants,
         data: {
           fundingStrategy,
           targetChannelId: channelId,
         },
       };
+      // TODO: (Stored Objectives) Does it make sense to do the INSERT here?
+      this.objectives[
+        channel.channelNonce /* TODO: (Stored Objectives) id strategy */
+      ] = objectiveToBeStored;
+
+      if (isOpenChannel(objective)) await OpenChannelObjective.insert(objectiveToBeStored, tx);
 
       await Channel.query(tx)
         .where({channelId: channel.channelId})
@@ -357,7 +363,7 @@ export class Store {
         .returning('*')
         .first();
 
-      return this.objectives[channel.channelNonce];
+      return objectiveToBeStored;
     } else if (objective.type === 'CloseChannel') {
       const {
         data: {targetChannelId},
@@ -367,17 +373,24 @@ export class Store {
       if (!channel) {
         throw new StoreError(StoreError.reasons.channelMissing, {channelId: targetChannelId});
       }
-      // TODO: (Stored Objectives) Does it make sense to do the INSERT here?
-      this.objectives[channel.channelNonce /* TODO: (Stored Objectives) id strategy */] = {
+
+      const objectiveToBeStored: ObjectiveStoredInDB = {
         objectiveId: channel.channelNonce,
         status: 'approved', // TODO: (Stored Objectives) Awkward that it 'auto-approves'... :S
         type: objective.type,
-        participants: [], // TODO: (Stored Objectives) Unnecessary param ?
+        participants: [],
         data: {
           targetChannelId,
         },
       };
-      return this.objectives[channel.channelNonce];
+      // TODO: (Stored Objectives) Does it make sense to do the INSERT here?
+      this.objectives[
+        channel.channelNonce /* TODO: (Stored Objectives) id strategy */
+      ] = objectiveToBeStored;
+
+      if (isOpenChannel(objective)) await OpenChannelObjective.insert(objectiveToBeStored, tx);
+
+      return objectiveToBeStored;
     } else {
       throw new StoreError(StoreError.reasons.unimplementedObjective);
     }
@@ -491,8 +504,8 @@ export class Store {
        */
 
       const objective: Objective = {
-        participants: constants.participants,
         type: 'OpenChannel',
+        participants: [],
         data: {
           targetChannelId: channelId,
           fundingStrategy,
@@ -511,11 +524,17 @@ export class Store {
         params: serializeMessage(data, recipient, participants[myIndex].participantId, channelId),
       }));
 
-      this.objectives[constants.channelNonce /* TODO: (Stored Objectives) id? */] = {
+      const objectiveToBeStored: ObjectiveStoredInDB = {
         ...objective,
         objectiveId: constants.channelNonce,
         status: 'approved',
       };
+
+      this.objectives[
+        constants.channelNonce /* TODO: (Stored Objectives) id? */
+      ] = objectiveToBeStored;
+
+      if (isOpenChannel(objective)) await OpenChannelObjective.insert(objectiveToBeStored, tx);
 
       return {outgoing, channelResult: toChannelResult(await this.getChannel(channelId, tx))};
     });

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -99,6 +99,12 @@ export type OpenChannel = _Objective<
     fundingStrategy: FundingStrategy;
   }
 >;
+export type CloseChannel = _Objective<
+  'CloseChannel',
+  {
+    targetChannelId: string;
+  }
+>;
 export type VirtuallyFund = _Objective<
   'VirtuallyFund',
   {
@@ -127,7 +133,13 @@ export type CloseLedger = _Objective<
   }
 >;
 
-export type Objective = OpenChannel | VirtuallyFund | FundGuarantor | FundLedger | CloseLedger;
+export type Objective =
+  | OpenChannel
+  | CloseChannel
+  | VirtuallyFund
+  | FundGuarantor
+  | FundLedger
+  | CloseLedger;
 
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -74,6 +74,39 @@
       ],
       "type": "object"
     },
+    "CloseChannel": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "targetChannelId": {
+              "$ref": "#/definitions/Bytes32"
+            }
+          },
+          "required": [
+            "targetChannelId"
+          ],
+          "type": "object"
+        },
+        "participants": {
+          "items": {
+            "$ref": "#/definitions/Participant"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "CloseChannel",
+          "type": "string"
+        }
+      },
+      "required": [
+        "participants",
+        "type",
+        "data"
+      ],
+      "type": "object"
+    },
     "CloseLedger": {
       "additionalProperties": false,
       "properties": {
@@ -234,6 +267,9 @@
       "anyOf": [
         {
           "$ref": "#/definitions/OpenChannel"
+        },
+        {
+          "$ref": "#/definitions/CloseChannel"
         },
         {
           "$ref": "#/definitions/VirtuallyFund"

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -88,6 +88,12 @@ export type OpenChannel = _Objective<
     fundingStrategy: FundingStrategy;
   }
 >;
+export type CloseChannel = _Objective<
+  'CloseChannel',
+  {
+    targetChannelId: Bytes32;
+  }
+>;
 export type VirtuallyFund = _Objective<
   'VirtuallyFund',
   {
@@ -118,7 +124,13 @@ export type CloseLedger = _Objective<
   }
 >;
 
-export type Objective = OpenChannel | VirtuallyFund | FundGuarantor | FundLedger | CloseLedger;
+export type Objective =
+  | OpenChannel
+  | CloseChannel
+  | VirtuallyFund
+  | FundGuarantor
+  | FundLedger
+  | CloseLedger;
 
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;


### PR DESCRIPTION
- Adds two new database tables, to support open and close channel objectives (separately). 

- Adds a test that would fail on the base branch, where one wallet crashes and restarts (and passes on this branch):
<img width="446" alt="Screenshot 2020-10-16 at 11 22 10" src="https://user-images.githubusercontent.com/1833419/96247345-ecaf6100-0fa1-11eb-8782-0ad44b747d73.png">

TODO (future PRs?) 
- [ ] optimize / DRY out new db schemas
- [ ] review db constraints
- [ ] review objective id scheme / make it unique
