### PR TITLE
liam/ledger funding

### DIFF
--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -8,6 +8,12 @@ import {DBAdmin} from '../src/db-admin/db-admin';
 
 export let testKnex: Knex;
 
+// Helpful tip...
+// If you encounter
+// MigrationLocked: Migration table is already locked
+// Then add the following to beforeAll:
+// await adminKnex.raw('DELETE FROM knex_migrations_lock WHERE is_locked = 1;');
+
 beforeAll(async () => {
   testKnex = Knex(extractDBConfigFromServerWalletConfig(defaultConfig));
   await new DBAdmin(testKnex).truncateDB();

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -44,7 +44,7 @@ afterAll(async () => {
   await b.dbAdmin().dropDB();
 });
 
-it('Create a fake-funded channel between two wallets ', async () => {
+it('Create a directly funded channel between two wallets ', async () => {
   const allocation: Allocation = {
     allocationItems: [
       {

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding-simplified.seqdiag
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding-simplified.seqdiag
@@ -1,0 +1,14 @@
+participant WalletA
+participant AppA
+participant AppB
+participant WalletB
+AppA->WalletA: createChannel
+WalletA-->WalletB: A-0a
+WalletB->AppB: 'proposed'
+AppB->WalletB: joinChannel
+WalletB-->WalletA: A-0b, L-5b
+WalletA->AppA: 'opening'
+WalletA-->WalletB: A-3a, L-5a
+WalletB->AppB: 'running'
+WalletB-->WalletA: A-3b
+WalletA->AppA: 'running'

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -15,7 +15,6 @@ import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 const a = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_A'});
 const b = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_B'});
 
-let channelId: string;
 let participantA: Participant;
 let participantB: Participant;
 
@@ -38,63 +37,6 @@ beforeAll(async () => {
       '0xbbbb000000000000000000000000000000000000000000000000000000000002'
     ),
   };
-
-  /**
-   * Create a directly funded channel that will be used as the ledger channel.
-   *
-   * Note that this is just a simplification of the direct-funding test.
-   */
-
-  // TODO: Play around with these numbers and test underflow scenarios
-  const aDepositAmtETH = BN.from(1);
-  const bDepositAmtETH = BN.from(1);
-
-  const ledgerChannelArgs = {
-    participants: [participantA, participantB],
-    allocations: [
-      {
-        allocationItems: [
-          {
-            destination: participantA.destination,
-            amount: aDepositAmtETH,
-          },
-          {
-            destination: participantB.destination,
-            amount: bDepositAmtETH,
-          },
-        ],
-        token: ETH_ASSET_HOLDER_ADDRESS,
-      },
-    ],
-    appDefinition: ethers.constants.AddressZero,
-    appData: '0x00',
-    fundingStrategy: 'Direct' as const,
-  };
-  const resultA0 = await a.createChannel(ledgerChannelArgs);
-  channelId = resultA0.channelResults[0].channelId;
-  await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
-  const resultB1 = await b.joinChannel({channelId});
-  await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
-  const fundingPostADeposit = {
-    channelId,
-    token: ETH_ASSET_HOLDER_ADDRESS,
-    amount: aDepositAmtETH,
-  };
-  await a.updateFundingForChannels([fundingPostADeposit]);
-  await b.updateFundingForChannels([fundingPostADeposit]);
-  const fundingPostBDeposit = {
-    channelId,
-    token: ETH_ASSET_HOLDER_ADDRESS,
-    amount: BN.add(aDepositAmtETH, bDepositAmtETH),
-  };
-  const resultA2 = await a.updateFundingForChannels([fundingPostBDeposit]);
-  await b.updateFundingForChannels([fundingPostBDeposit]);
-  const resultB3 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA2.outbox));
-  await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
-
-  // FIXME: Should not need to do this
-  a.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
-  b.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
 });
 
 afterAll(async () => {
@@ -106,154 +48,228 @@ afterAll(async () => {
   b.store.eraseLedgerDataFromMemory();
 });
 
-it('Create a ledger funded channel between two wallets ', async () => {
-  const allocation: Allocation = {
-    allocationItems: [
-      {
-        destination: participantA.destination,
-        amount: BN.from(1),
-      },
-      {
-        destination: participantB.destination,
-        amount: BN.from(1),
-      },
-    ],
-    token: ETH_ASSET_HOLDER_ADDRESS, // must be even length
-  };
+describe('Ledger channels', () => {
+  /**
+   * Create a directly funded channel that will be used as the ledger channel.
+   *
+   * Note that this is just a simplification of the direct-funding test.
+   */
+  beforeAll(async () => {
+    const aDepositAmtETH = BN.from(2);
+    const bDepositAmtETH = BN.from(2);
+    const ledgerChannelArgs = {
+      participants: [participantA, participantB],
+      allocations: [
+        {
+          allocationItems: [
+            {
+              destination: participantA.destination,
+              amount: aDepositAmtETH,
+            },
+            {
+              destination: participantB.destination,
+              amount: bDepositAmtETH,
+            },
+          ],
+          token: ETH_ASSET_HOLDER_ADDRESS,
+        },
+      ],
+      appDefinition: ethers.constants.AddressZero,
+      appData: '0x00',
+      fundingStrategy: 'Direct' as const,
+    };
+    const resultA0 = await a.createChannel(ledgerChannelArgs);
+    const channelId = resultA0.channelResults[0].channelId;
+    await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+    const resultB1 = await b.joinChannel({channelId});
+    await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
+    const fundingPostADeposit = {
+      channelId,
+      token: ETH_ASSET_HOLDER_ADDRESS,
+      amount: aDepositAmtETH,
+    };
+    await a.updateFundingForChannels([fundingPostADeposit]);
+    await b.updateFundingForChannels([fundingPostADeposit]);
+    const fundingPostBDeposit = {
+      channelId,
+      token: ETH_ASSET_HOLDER_ADDRESS,
+      amount: BN.add(aDepositAmtETH, bDepositAmtETH),
+    };
+    const resultA2 = await a.updateFundingForChannels([fundingPostBDeposit]);
+    await b.updateFundingForChannels([fundingPostBDeposit]);
+    const resultB3 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA2.outbox)
+    );
+    await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
 
-  const createChannelParams: CreateChannelParams = {
-    participants: [participantA, participantB],
-    allocations: [allocation],
-    appDefinition: ethers.constants.AddressZero,
-    appData: '0x00', // must be even length
-    fundingStrategy: 'Ledger',
-  };
-
-  //        A <> B
-  // PreFund0
-  const resultA0 = await a.createChannel(createChannelParams);
-
-  // TODO compute the channelId for a better test
-  channelId = resultA0.channelResults[0].channelId;
-
-  expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
+    // FIXME: Should not need to do this
+    a.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
+    b.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
   });
 
-  expect(resultA0.outbox[0].params.data).toMatchObject({
-    signedStates: [
-      {turnNum: 0}, // The application's post fund
-    ],
+  /**
+   * App channel used for the next three tests (open & close)
+   */
+  let channelId: string;
+
+  it('can fund a channel by ledger between two wallets ', async () => {
+    // TODO: Play around with these numbers and test underflow scenarios
+    const allocation: Allocation = {
+      allocationItems: [
+        {
+          destination: participantA.destination,
+          amount: BN.from(1),
+        },
+        {
+          destination: participantB.destination,
+          amount: BN.from(1),
+        },
+      ],
+      token: ETH_ASSET_HOLDER_ADDRESS, // must be even length
+    };
+
+    const createChannelParams: CreateChannelParams = {
+      participants: [participantA, participantB],
+      allocations: [allocation],
+      appDefinition: ethers.constants.AddressZero,
+      appData: '0x00', // must be even length
+      fundingStrategy: 'Ledger',
+    };
+
+    //        A <> B
+    // PreFund0
+    const resultA0 = await a.createChannel(createChannelParams);
+
+    // TODO compute the channelId for a better test
+    channelId = resultA0.channelResults[0].channelId;
+
+    expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
+      status: 'opening',
+      turnNum: 0,
+    });
+
+    expect(resultA0.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {turnNum: 0}, // The application's post fund
+      ],
+    });
+
+    //    > PreFund0A
+    const resultB0 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA0.outbox)
+    );
+
+    expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
+      status: 'proposed',
+      turnNum: 0,
+    });
+
+    //       PreFund0B
+    //   LedgerUpdateB
+    const resultB1 = await b.joinChannel({channelId});
+
+    expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
+      status: 'opening',
+      turnNum: 1,
+    });
+
+    expect(resultB1.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {turnNum: 5}, // The ledger channel update
+        {turnNum: 1}, // The application's pre fund
+      ],
+    });
+
+    //        PreFund0B <
+    //    LedgerUpdateB <
+    // LedgerUpdateA
+    // PostFund2A
+    const resultA1 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB1.outbox)
+    );
+
+    expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
+      status: 'running',
+      turnNum: 2,
+    });
+
+    expect(resultA1.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {turnNum: 5}, // The ledger channel update
+        {turnNum: 2}, // The application's post fund
+      ],
+    });
+
+    // > PostFund3A
+    // > LedgerUpdateA
+    //     PostFund3B
+    const resultB3 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA1.outbox)
+    );
+
+    expect(getChannelResultFor(channelId, resultB3.channelResults)).toMatchObject({
+      status: 'running',
+      turnNum: 3,
+    });
+
+    expect(resultB3.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {turnNum: 3}, // The application's post fund
+      ],
+    });
+
+    //    PostFund3B <
+    const resultA3 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB3.outbox)
+    );
+
+    expect(getChannelResultFor(channelId, resultA3.channelResults)).toMatchObject({
+      status: 'running',
+      turnNum: 3,
+    });
   });
 
-  //    > PreFund0A
-  const resultB0 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+  it('rejects b closing with `not your turn`', async () => {
+    const closeChannelParams: CloseChannelParams = {
+      channelId,
+    };
 
-  expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
-    status: 'proposed',
-    turnNum: 0,
+    const bCloseChannel = b.closeChannel(closeChannelParams);
+
+    await expect(bCloseChannel).rejects.toMatchObject(new Error('not my turn'));
   });
 
-  //       PreFund0B
-  //   LedgerUpdateB
-  const resultB1 = await b.joinChannel({channelId});
+  it('can close a ledger funded channel', async () => {
+    const closeChannelParams: CloseChannelParams = {
+      channelId,
+    };
 
-  expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
-    status: 'opening',
-    turnNum: 1,
-  });
+    // A generates isFinal4
+    const aCloseChannelResult = await a.closeChannel(closeChannelParams);
 
-  expect(resultB1.outbox[0].params.data).toMatchObject({
-    signedStates: [
-      {turnNum: 5}, // The ledger channel update
-      {turnNum: 1}, // The application's pre fund
-    ],
-  });
+    expect(getChannelResultFor(channelId, [aCloseChannelResult.channelResult])).toMatchObject({
+      status: 'closing',
+      turnNum: 4,
+    });
 
-  //        PreFund0B <
-  //    LedgerUpdateB <
-  // LedgerUpdateA
-  // PostFund2A
-  const resultA1 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
+    const bPushMessageResult = await b.pushMessage(
+      getPayloadFor(participantB.participantId, aCloseChannelResult.outbox)
+    );
 
-  expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
-    status: 'running',
-    turnNum: 2,
-  });
+    // B pushed isFinal4, generated countersigned isFinal4
+    expect(getChannelResultFor(channelId, bPushMessageResult.channelResults)).toMatchObject({
+      status: 'closed',
+      turnNum: 4,
+    });
 
-  expect(resultA1.outbox[0].params.data).toMatchObject({
-    signedStates: [
-      {turnNum: 5}, // The ledger channel update
-      {turnNum: 2}, // The application's post fund
-    ],
-  });
+    // A pushed the countersigned isFinal4
+    const aPushMessageResult = await a.pushMessage(
+      getPayloadFor(participantA.participantId, bPushMessageResult.outbox)
+    );
 
-  // > PostFund3A
-  // > LedgerUpdateA
-  //     PostFund3B
-  const resultB3 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA1.outbox));
-
-  expect(getChannelResultFor(channelId, resultB3.channelResults)).toMatchObject({
-    status: 'running',
-    turnNum: 3,
-  });
-
-  expect(resultB3.outbox[0].params.data).toMatchObject({
-    signedStates: [
-      {turnNum: 3}, // The application's post fund
-    ],
-  });
-
-  //    PostFund3B <
-  const resultA3 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
-
-  expect(getChannelResultFor(channelId, resultA3.channelResults)).toMatchObject({
-    status: 'running',
-    turnNum: 3,
-  });
-});
-
-it('Rejects b closing with `not your turn`', async () => {
-  const closeChannelParams: CloseChannelParams = {
-    channelId,
-  };
-
-  const bCloseChannel = b.closeChannel(closeChannelParams);
-
-  await expect(bCloseChannel).rejects.toMatchObject(new Error('not my turn'));
-});
-
-it('Closes the channel', async () => {
-  const closeChannelParams: CloseChannelParams = {
-    channelId,
-  };
-
-  // A generates isFinal4
-  const aCloseChannelResult = await a.closeChannel(closeChannelParams);
-
-  expect(getChannelResultFor(channelId, [aCloseChannelResult.channelResult])).toMatchObject({
-    status: 'closing',
-    turnNum: 4,
-  });
-
-  const bPushMessageResult = await b.pushMessage(
-    getPayloadFor(participantB.participantId, aCloseChannelResult.outbox)
-  );
-
-  // B pushed isFinal4, generated countersigned isFinal4
-  expect(getChannelResultFor(channelId, bPushMessageResult.channelResults)).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-  });
-
-  // A pushed the countersigned isFinal4
-  const aPushMessageResult = await a.pushMessage(
-    getPayloadFor(participantA.participantId, bPushMessageResult.outbox)
-  );
-
-  expect(getChannelResultFor(channelId, aPushMessageResult.channelResults)).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
+    expect(getChannelResultFor(channelId, aPushMessageResult.channelResults)).toMatchObject({
+      status: 'closed',
+      turnNum: 4,
+    });
   });
 });

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -1,0 +1,210 @@
+import {CreateChannelParams, Participant, Allocation} from '@statechannels/client-api-schema';
+import {BN, makeDestination} from '@statechannels/wallet-core';
+import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
+import {ethers} from 'ethers';
+
+import {defaultTestConfig} from '../../config';
+import {Wallet} from '../../wallet';
+import {getChannelResultFor, getPayloadFor} from '../test-helpers';
+
+const a = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_A'});
+const b = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_B'});
+
+let channelId: string;
+let participantA: Participant;
+let participantB: Participant;
+
+beforeAll(async () => {
+  await a.dbAdmin().createDB();
+  await b.dbAdmin().createDB();
+  await Promise.all([a.dbAdmin().migrateDB(), b.dbAdmin().migrateDB()]);
+
+  participantA = {
+    signingAddress: await a.getSigningAddress(),
+    participantId: 'a',
+    destination: makeDestination(
+      '0xaaaa000000000000000000000000000000000000000000000000000000000001'
+    ),
+  };
+  participantB = {
+    signingAddress: await b.getSigningAddress(),
+    participantId: 'b',
+    destination: makeDestination(
+      '0xbbbb000000000000000000000000000000000000000000000000000000000002'
+    ),
+  };
+
+  /**
+   * Create a directly funded channel that will be used as the ledger channel.
+   *
+   * Note that this is just a simplification of the direct-funding test.
+   */
+
+  // TODO: Play around with these numbers and test underflow scenarios
+  const aDepositAmtETH = BN.from(1);
+  const bDepositAmtETH = BN.from(1);
+
+  const ledgerChannelArgs = {
+    participants: [participantA, participantB],
+    allocations: [
+      {
+        allocationItems: [
+          {
+            destination: participantA.destination,
+            amount: aDepositAmtETH,
+          },
+          {
+            destination: participantB.destination,
+            amount: bDepositAmtETH,
+          },
+        ],
+        token: ETH_ASSET_HOLDER_ADDRESS,
+      },
+    ],
+    appDefinition: ethers.constants.AddressZero,
+    appData: '0x00',
+    fundingStrategy: 'Direct' as const,
+  };
+  const resultA0 = await a.createChannel(ledgerChannelArgs);
+  channelId = resultA0.channelResults[0].channelId;
+  await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+  const resultB1 = await b.joinChannel({channelId});
+  await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
+  const fundingPostADeposit = {
+    channelId,
+    token: ETH_ASSET_HOLDER_ADDRESS,
+    amount: aDepositAmtETH,
+  };
+  await a.updateFundingForChannels([fundingPostADeposit]);
+  await b.updateFundingForChannels([fundingPostADeposit]);
+  const fundingPostBDeposit = {
+    channelId,
+    token: ETH_ASSET_HOLDER_ADDRESS,
+    amount: BN.add(aDepositAmtETH, bDepositAmtETH),
+  };
+  const resultA2 = await a.updateFundingForChannels([fundingPostBDeposit]);
+  await b.updateFundingForChannels([fundingPostBDeposit]);
+  const resultB3 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA2.outbox));
+  await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
+
+  // FIXME: Should not need to do this
+  a.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
+  b.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
+});
+
+afterAll(async () => {
+  await Promise.all([a.destroy(), b.destroy()]);
+  await a.dbAdmin().dropDB();
+  await b.dbAdmin().dropDB();
+  // TODO: Add to the truncate / dropDB method
+  a.store.eraseLedgerDataFromMemory();
+  b.store.eraseLedgerDataFromMemory();
+});
+
+it('Create a ledger funded channel between two wallets ', async () => {
+  const allocation: Allocation = {
+    allocationItems: [
+      {
+        destination: participantA.destination,
+        amount: BN.from(1),
+      },
+      {
+        destination: participantB.destination,
+        amount: BN.from(1),
+      },
+    ],
+    token: ETH_ASSET_HOLDER_ADDRESS, // must be even length
+  };
+
+  const createChannelParams: CreateChannelParams = {
+    participants: [participantA, participantB],
+    allocations: [allocation],
+    appDefinition: ethers.constants.AddressZero,
+    appData: '0x00', // must be even length
+    fundingStrategy: 'Ledger',
+  };
+
+  //        A <> B
+  // PreFund0
+  const resultA0 = await a.createChannel(createChannelParams);
+
+  // TODO compute the channelId for a better test
+  channelId = resultA0.channelResults[0].channelId;
+
+  expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
+    status: 'opening',
+    turnNum: 0,
+  });
+
+  expect(resultA0.outbox[0].params.data).toMatchObject({
+    signedStates: [
+      {turnNum: 0}, // The application's post fund
+    ],
+  });
+
+  //    > PreFund0A
+  const resultB0 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+
+  expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
+    status: 'proposed',
+    turnNum: 0,
+  });
+
+  //       PreFund0B
+  //   LedgerUpdateB
+  const resultB1 = await b.joinChannel({channelId});
+
+  expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
+    status: 'opening',
+    turnNum: 1,
+  });
+
+  expect(resultB1.outbox[0].params.data).toMatchObject({
+    signedStates: [
+      {turnNum: 5}, // The ledger channel update
+      {turnNum: 1}, // The application's pre fund
+    ],
+  });
+
+  //        PreFund0B <
+  //    LedgerUpdateB <
+  // LedgerUpdateA
+  // PostFund2A
+  const resultA1 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
+
+  expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
+    status: 'running',
+    turnNum: 2,
+  });
+
+  expect(resultA1.outbox[0].params.data).toMatchObject({
+    signedStates: [
+      {turnNum: 5}, // The ledger channel update
+      {turnNum: 2}, // The application's post fund
+    ],
+  });
+
+  // > PostFund3A
+  // > LedgerUpdateA
+  //     PostFund3B
+  const resultB3 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA1.outbox));
+
+  expect(getChannelResultFor(channelId, resultB3.channelResults)).toMatchObject({
+    status: 'running',
+    turnNum: 3,
+  });
+
+  expect(resultB3.outbox[0].params.data).toMatchObject({
+    signedStates: [
+      {turnNum: 3}, // The application's post fund
+    ],
+  });
+
+  //    PostFund3B <
+  const resultA3 = await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
+
+  expect(getChannelResultFor(channelId, resultA3.channelResults)).toMatchObject({
+    status: 'running',
+    turnNum: 3,
+  });
+});

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -43,70 +43,73 @@ afterAll(async () => {
   await Promise.all([a.destroy(), b.destroy()]);
   await a.dbAdmin().dropDB();
   await b.dbAdmin().dropDB();
+});
+
+/**
+ * Create a directly funded channel that will be used as the ledger channel.
+ *
+ * Note that this is just a simplification of the direct-funding test.
+ */
+let ledgerChannelId: string;
+beforeEach(async () => {
+  const aDepositAmtETH = BN.from(5);
+  const bDepositAmtETH = BN.from(5);
+  const ledgerChannelArgs = {
+    participants: [participantA, participantB],
+    allocations: [
+      {
+        allocationItems: [
+          {
+            destination: participantA.destination,
+            amount: aDepositAmtETH,
+          },
+          {
+            destination: participantB.destination,
+            amount: bDepositAmtETH,
+          },
+        ],
+        token: ETH_ASSET_HOLDER_ADDRESS,
+      },
+    ],
+    appDefinition: ethers.constants.AddressZero,
+    appData: '0x00',
+    fundingStrategy: 'Direct' as const,
+  };
+  const resultA0 = await a.createChannel(ledgerChannelArgs);
+  const channelId = resultA0.channelResults[0].channelId;
+  await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+  const resultB1 = await b.joinChannel({channelId});
+  await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
+  const fundingPostADeposit = {
+    channelId,
+    token: ETH_ASSET_HOLDER_ADDRESS,
+    amount: aDepositAmtETH,
+  };
+  await a.updateFundingForChannels([fundingPostADeposit]);
+  await b.updateFundingForChannels([fundingPostADeposit]);
+  const fundingPostBDeposit = {
+    channelId,
+    token: ETH_ASSET_HOLDER_ADDRESS,
+    amount: BN.add(aDepositAmtETH, bDepositAmtETH),
+  };
+  const resultA2 = await a.updateFundingForChannels([fundingPostBDeposit]);
+  await b.updateFundingForChannels([fundingPostBDeposit]);
+  const resultB3 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA2.outbox));
+  await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
+
+  // FIXME: Should not need to do this
+  a.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
+  b.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
+  ledgerChannelId = channelId;
+});
+
+afterEach(async () => {
   // TODO: Add to the truncate / dropDB method
   a.store.eraseLedgerDataFromMemory();
   b.store.eraseLedgerDataFromMemory();
 });
 
-describe('Ledger channels', () => {
-  /**
-   * Create a directly funded channel that will be used as the ledger channel.
-   *
-   * Note that this is just a simplification of the direct-funding test.
-   */
-  beforeAll(async () => {
-    const aDepositAmtETH = BN.from(2);
-    const bDepositAmtETH = BN.from(2);
-    const ledgerChannelArgs = {
-      participants: [participantA, participantB],
-      allocations: [
-        {
-          allocationItems: [
-            {
-              destination: participantA.destination,
-              amount: aDepositAmtETH,
-            },
-            {
-              destination: participantB.destination,
-              amount: bDepositAmtETH,
-            },
-          ],
-          token: ETH_ASSET_HOLDER_ADDRESS,
-        },
-      ],
-      appDefinition: ethers.constants.AddressZero,
-      appData: '0x00',
-      fundingStrategy: 'Direct' as const,
-    };
-    const resultA0 = await a.createChannel(ledgerChannelArgs);
-    const channelId = resultA0.channelResults[0].channelId;
-    await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
-    const resultB1 = await b.joinChannel({channelId});
-    await a.pushMessage(getPayloadFor(participantA.participantId, resultB1.outbox));
-    const fundingPostADeposit = {
-      channelId,
-      token: ETH_ASSET_HOLDER_ADDRESS,
-      amount: aDepositAmtETH,
-    };
-    await a.updateFundingForChannels([fundingPostADeposit]);
-    await b.updateFundingForChannels([fundingPostADeposit]);
-    const fundingPostBDeposit = {
-      channelId,
-      token: ETH_ASSET_HOLDER_ADDRESS,
-      amount: BN.add(aDepositAmtETH, bDepositAmtETH),
-    };
-    const resultA2 = await a.updateFundingForChannels([fundingPostBDeposit]);
-    await b.updateFundingForChannels([fundingPostBDeposit]);
-    const resultB3 = await b.pushMessage(
-      getPayloadFor(participantB.participantId, resultA2.outbox)
-    );
-    await a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
-
-    // FIXME: Should not need to do this
-    a.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
-    b.__setLedger(channelId, ETH_ASSET_HOLDER_ADDRESS);
-  });
-
+describe('Funding a single channel', () => {
   /**
    * App channel used for the next three tests (open & close)
    */
@@ -175,7 +178,7 @@ describe('Ledger channels', () => {
 
     expect(resultB1.outbox[0].params.data).toMatchObject({
       signedStates: [
-        {turnNum: 5}, // The ledger channel update
+        {channelId: ledgerChannelId, turnNum: 5},
         {turnNum: 1}, // The application's pre fund
       ],
     });
@@ -195,7 +198,7 @@ describe('Ledger channels', () => {
 
     expect(resultA1.outbox[0].params.data).toMatchObject({
       signedStates: [
-        {turnNum: 5}, // The ledger channel update
+        {channelId: ledgerChannelId, turnNum: 5},
         {turnNum: 2}, // The application's post fund
       ],
     });
@@ -271,5 +274,291 @@ describe('Ledger channels', () => {
       status: 'closed',
       turnNum: 4,
     });
+  });
+});
+
+describe('Funding multiple channels concurrently', () => {
+  it('can fund 2 channels by ledger, both proposed by Alice', async () => {
+    // TODO: Play around with these numbers and test underflow scenarios
+    const allocation: Allocation = {
+      allocationItems: [
+        {
+          destination: participantA.destination,
+          amount: BN.from(1),
+        },
+        {
+          destination: participantB.destination,
+          amount: BN.from(1),
+        },
+      ],
+      token: ETH_ASSET_HOLDER_ADDRESS, // must be even length
+    };
+
+    const createChannelParams: CreateChannelParams = {
+      participants: [participantA, participantB],
+      allocations: [allocation],
+      appDefinition: ethers.constants.AddressZero,
+      appData: '0x00', // must be even length
+      fundingStrategy: 'Ledger',
+    };
+
+    // PreFund0A-1
+    const resultA0 = await a.createChannel(createChannelParams);
+    // PreFund0A-2
+    const resultA0alt = await a.createChannel(createChannelParams);
+
+    // TODO compute the channelId1 for a better test
+    const channelId1 = resultA0.channelResults[0].channelId;
+    const channelId2 = resultA0alt.channelResults[0].channelId;
+
+    //    > PreFund0A-1
+    await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+    //    > PreFund0A-2
+    await b.pushMessage(getPayloadFor(participantB.participantId, resultA0alt.outbox));
+
+    //         PreFund0B-1
+    //     LedgerUpdateB-1
+    const resultB1 = await b.joinChannel({channelId: channelId1});
+
+    expect(resultB1.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: ledgerChannelId, turnNum: 5}, // Funding channel 1 only
+        {turnNum: 1}, // Application 1's pre fund
+      ],
+    });
+
+    //         PreFund0B-2
+    const resultB1alt = await b.joinChannel({channelId: channelId2});
+
+    // ⚠️ IMPORTANT ⚠️
+    // Since B already sent LedgerUpdateB-1, he does not sign any new update
+    expect(resultB1alt.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {turnNum: 1}, // Application 2's pre fund
+      ],
+    });
+
+    // PreFund0B-1 <
+    // LedgerUpdateB-1 <
+    // LedgerUpdateA-1
+    // PostFundA-1
+    const resultA1 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB1.outbox)
+    );
+
+    expect(resultA1.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: ledgerChannelId, turnNum: 5},
+        {turnNum: 2}, // Application 1's post fund
+      ],
+    });
+
+    // PreFund0B-2 <
+    // LedgerUpdateA-2
+    const resultA1alt = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB1alt.outbox)
+    );
+
+    expect(resultA1alt.outbox[0].params.data).toMatchObject({
+      signedStates: [{channelId: ledgerChannelId, turnNum: 7}],
+    });
+
+    //       > LedgerUpdateA-1
+    //       > PostFundA-1
+    //       LedgerUpdateB-2
+    //       PostFundB-1
+    const resultB2 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA1.outbox)
+    );
+
+    expect(resultB2.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: ledgerChannelId, turnNum: 7},
+        {channelId: channelId1, turnNum: 3}, // Application 1's post fund
+      ],
+    });
+
+    //       > LedgerUpdateA-2
+    const resultB2alt = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA1alt.outbox)
+    );
+
+    expect(resultB2alt.outbox).toMatchObject([]);
+
+    //      < LedgerUpdateB-2
+    //      < PostFundB-1
+    // PostFundA-2
+    const resultA3 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB2.outbox)
+    );
+
+    expect(resultA3.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: channelId2, turnNum: 2}, // Application 2's post fund
+      ],
+    });
+
+    //       > LedgerUpdateA-2
+    //       PostFundB-2
+    const resultB3alt = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA3.outbox)
+    );
+
+    expect(resultB3alt.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: channelId2, turnNum: 3}, // Application 2's post fund
+      ],
+    });
+  });
+
+  it('can fund 2 channels by ledger, different proposers for each', async () => {
+    // TODO: Play around with these numbers and test underflow scenarios
+    const allocation: Allocation = {
+      allocationItems: [
+        {
+          destination: participantA.destination,
+          amount: BN.from(1),
+        },
+        {
+          destination: participantB.destination,
+          amount: BN.from(1),
+        },
+      ],
+      token: ETH_ASSET_HOLDER_ADDRESS, // must be even length
+    };
+
+    const createChannelParams: CreateChannelParams = {
+      participants: [participantA, participantB],
+      allocations: [allocation],
+      appDefinition: ethers.constants.AddressZero,
+      appData: '0x00', // must be even length
+      fundingStrategy: 'Ledger',
+    };
+
+    // PreFund0A-1
+    const resultA0 = await a.createChannel(createChannelParams);
+    const channelId1 = resultA0.channelResults[0].channelId;
+
+    //    > PreFund0A-1
+    await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
+
+    // PreFund0B-2
+    const resultB0 = await b.createChannel(createChannelParams);
+    const channelId2 = resultB0.channelResults[0].channelId;
+
+    // PreFund0B-2 <
+    await a.pushMessage(getPayloadFor(participantA.participantId, resultB0.outbox));
+
+    //         PreFund0B-1
+    //     LedgerUpdateB-1
+    const resultB1 = await b.joinChannel({channelId: channelId1});
+
+    expect(resultB1.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: ledgerChannelId, turnNum: 5}, // Funding channel 1 only
+        {turnNum: 1}, // Application 1's pre fund (1 b/c Bob is second in array)
+      ],
+    });
+
+    // PreFund0A-2
+    // LedgerUpdateA-2
+    const resultA1 = await a.joinChannel({channelId: channelId2});
+
+    expect(resultA1.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: ledgerChannelId, turnNum: 5}, // Funding channel 2 only
+        {turnNum: 0}, // Application 2's pre fund (0 b/c Alice is first in array)
+      ],
+    });
+
+    // PreFund0B-1 <
+    // LedgerUpdateB-1 <
+    // LedgerUpdateA-null
+    const resultA2 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB1.outbox)
+    );
+
+    expect(resultA2.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {turnNum: 7}, // The ledger channel counterproposal (just funding 1)
+      ],
+    });
+
+    //     > PreFund0A-2 <
+    //     > LedgerUpdateA-2
+    //     LedgerUpdateB-null
+    const resultB2 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA1.outbox)
+    );
+
+    expect(resultB2.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {turnNum: 7}, // The ledger channel counterproposal (null effect)
+      ],
+    });
+
+    // LedgerUpdateB-null <
+    // LedgerUpdateA-1+2
+    const resultA3 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB2.outbox)
+    );
+
+    expect(resultA3.outbox[0].params.data).toMatchObject({
+      signedStates: [{channelId: ledgerChannelId, turnNum: 9}],
+    });
+
+    //     > LedgerUpdateA-null
+    //     LedgerUpdateB-1+2
+    const resultB3 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA2.outbox)
+    );
+
+    expect(resultB3.outbox[0].params.data).toMatchObject({
+      signedStates: [{channelId: ledgerChannelId, turnNum: 9}],
+    });
+
+    // LedgerUpdateB-1+2 <
+    // PostFundA-1
+    // PostFundA-2
+    const resultA4 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB3.outbox)
+    );
+
+    expect(resultA4.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: channelId1, turnNum: 2}, // Application 1's post fund
+        {channelId: channelId2, turnNum: 2}, // Application 2's post fund
+      ],
+    });
+
+    //     > LedgerUpdateA-1+2
+    const resultB4 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA3.outbox)
+    );
+
+    expect(resultB4.outbox).toMatchObject([]);
+
+    //     > PostFundA-1
+    //     > PostFundA-2
+    //       PostFundB-1
+    //       PostFundB-2
+    const resultB5 = await b.pushMessage(
+      getPayloadFor(participantB.participantId, resultA4.outbox)
+    );
+
+    expect(resultB5.outbox[0].params.data).toMatchObject({
+      signedStates: [
+        {channelId: channelId1, turnNum: 3}, // Application 1's post fund
+        {channelId: channelId2, turnNum: 3}, // Application 2's post fund
+      ],
+    });
+
+    // PostFundB-1 <
+    // PostFundB-2 <
+    const resultA5 = await a.pushMessage(
+      getPayloadFor(participantA.participantId, resultB5.outbox)
+    );
+
+    expect(resultA5.outbox).toMatchObject([]);
   });
 });

--- a/packages/server-wallet/src/__test__/test-helpers.ts
+++ b/packages/server-wallet/src/__test__/test-helpers.ts
@@ -1,4 +1,5 @@
 import {ChannelResult} from '@statechannels/client-api-schema';
+import {Payload, SignedState} from '@statechannels/wire-format';
 
 import {Outgoing} from '..';
 
@@ -19,4 +20,14 @@ export function getChannelResultFor(
   if (filteredChannelResults.length != 1)
     throw Error(`Expected exactly one channel result: found ${filteredChannelResults.length}`);
   return filteredChannelResults[0];
+}
+
+export function getSignedStateFor(channelId: string, outbox: Outgoing[]): SignedState {
+  // eslint-disable-next-line
+  const filteredSignedStates = (outbox[0]!.params.data as Payload).signedStates!.filter(
+    ss => ss.channelId === channelId
+  );
+  if (filteredSignedStates.length != 1)
+    throw Error(`Expected exactly one channel result: found ${filteredSignedStates.length}`);
+  return filteredSignedStates[0];
 }

--- a/packages/server-wallet/src/handlers/join-channel.ts
+++ b/packages/server-wallet/src/handlers/join-channel.ts
@@ -20,6 +20,7 @@ export class JoinChannelError extends WalletError {
     channelNotFound: 'channel not found',
     invalidTurnNum: 'latest state must be turn 0',
     alreadySignedByMe: 'already signed prefund setup',
+    internalChannel: 'channel is managed by wallet and cannot be modified by API',
   } as const;
 
   constructor(

--- a/packages/server-wallet/src/handlers/update-channel.ts
+++ b/packages/server-wallet/src/handlers/update-channel.ts
@@ -26,6 +26,7 @@ export class UpdateChannelError extends WalletError {
     invalidLatestState: 'must have latest state',
     notInRunningStage: 'channel must be in running state',
     notMyTurn: 'it is not my turn',
+    internalChannel: 'channel is managed by wallet and cannot be modified by API',
   } as const;
 
   constructor(

--- a/packages/server-wallet/src/models/__test__/fixtures/channel.ts
+++ b/packages/server-wallet/src/models/__test__/fixtures/channel.ts
@@ -28,7 +28,7 @@ export const channel: Fixture<Channel> = (props?: DeepPartial<RequiredColumns>) 
 
   columns.vars.map(s => (s = dropNonVariables(addHash({...columns, ...s}))));
   (columns as any).channelId = calculateChannelId(columns);
-  const channel = Channel.fromJson({...columns, fundingStrategy: 'Direct'});
+  const channel = Channel.fromJson({...columns});
 
   return channel;
 };

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -149,6 +149,7 @@ export class Channel extends Model implements RequiredColumns {
       supported,
       latest,
       latestSignedByMe,
+      latestNotSignedByMe,
       support,
       participants,
       chainServiceRequests,
@@ -166,6 +167,7 @@ export class Channel extends Model implements RequiredColumns {
       support,
       latest,
       latestSignedByMe,
+      latestNotSignedByMe,
       funding,
       chainServiceRequests,
       fundingStrategy,
@@ -240,6 +242,12 @@ export class Channel extends Model implements RequiredColumns {
 
   get latest(): SignedStateWithHash {
     return {...this.channelConstants, ...this.signedStates[0]};
+  }
+
+  get latestNotSignedByMe(): SignedStateWithHash | undefined {
+    const signed = this.signedStates.find(s => !this.mySignature(s.signatures));
+    if (!signed) return undefined;
+    return {...this.channelConstants, ...signed};
   }
 
   private get _supported(): SignedStateWithHash | undefined {

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -146,6 +146,7 @@ export class Channel extends Model implements RequiredColumns {
     const {
       channelId,
       myIndex,
+      channelNonce,
       supported,
       latest,
       latestSignedByMe,
@@ -161,6 +162,7 @@ export class Channel extends Model implements RequiredColumns {
     };
     return {
       myIndex: myIndex as 0 | 1,
+      channelNonce,
       participants,
       channelId,
       supported,

--- a/packages/server-wallet/src/models/ledger-requests.ts
+++ b/packages/server-wallet/src/models/ledger-requests.ts
@@ -7,7 +7,6 @@ import {Bytes32} from '../type-aliases';
 export type LedgerRequestStatus =
   | 'pending' // Request added to DB to be approved or rejected
   | 'rejected' // Rejected due to lack of available funds or some other reason
-  | 'approved' // Funds have been allocated and request is expected to go through
   | 'succeeded' // Counterparty signed back and update was applied
   | 'failed'; // Rejected for an unexpected reason (some error occurred)
 

--- a/packages/server-wallet/src/models/ledger-requests.ts
+++ b/packages/server-wallet/src/models/ledger-requests.ts
@@ -1,0 +1,62 @@
+import _ from 'lodash';
+import {Transaction} from 'objection';
+
+import {Bytes32} from '../type-aliases';
+
+// TODO: Is this the same as an objective?
+export type LedgerRequestStatus =
+  | 'pending' // Request added to DB to be approved or rejected
+  | 'rejected' // Rejected due to lack of available funds or some other reason
+  | 'approved' // Funds have been allocated and request is expected to go through
+  | 'succeeded' // Counterparty signed back and update was applied
+  | 'failed'; // Rejected for an unexpected reason (some error occurred)
+
+export type LedgerRequestType = {
+  ledgerChannelId: Bytes32;
+  fundingChannelId: Bytes32;
+  status: LedgerRequestStatus;
+};
+
+export class LedgerRequests {
+  // Store requests for the ledger's funds
+  private requests: {
+    [fundingChannelId: string]: LedgerRequestType;
+  } = {};
+
+  async getRequest(
+    channelId: Bytes32,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    tx?: Transaction
+  ): Promise<LedgerRequestType> {
+    return this.requests[channelId];
+  }
+
+  async setRequest(
+    channelId: Bytes32,
+    request: LedgerRequestType,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    tx?: Transaction
+  ): Promise<void> {
+    this.requests[channelId] = request;
+  }
+
+  async setRequestStatus(
+    channelId: Bytes32,
+    status: LedgerRequestStatus,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    tx?: Transaction
+  ): Promise<void> {
+    this.requests[channelId].status = status;
+  }
+
+  async getPendingRequests(
+    ledgerChannelId: Bytes32,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    tx?: Transaction
+  ): Promise<LedgerRequestType[]> {
+    return _.chain(this.requests)
+      .mapValues()
+      .filter(['ledgerChannelId', ledgerChannelId])
+      .value();
+  }
+}

--- a/packages/server-wallet/src/protocols/__test__/fixtures/channel-state.ts
+++ b/packages/server-wallet/src/protocols/__test__/fixtures/channel-state.ts
@@ -6,6 +6,7 @@ import {alice, bob} from '../../../wallet/__test__/fixtures/participants';
 
 const defaultChannelState: ChannelStateWithSupported = {
   channelId: '0x1234',
+  channelNonce: 1,
   myIndex: 0,
   participants: [alice(), bob()],
   supported: stateWithHashSignedBy()({turnNum: 3}),

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -25,10 +25,6 @@ export type RequestLedgerFunding = {
   channelId: Bytes32;
   assetHolderAddress: Address;
 };
-export type SignLedgerStateForRequests = StateVariables & {
-  type: 'SignLedgerStateForRequests';
-  channelId: Bytes32;
-};
 export type MarkLedgerFundingRequestsAsComplete = {
   type: 'MarkLedgerFundingRequestsAsComplete';
   doneRequests: Bytes32[];
@@ -63,14 +59,13 @@ export type OpenChannelProtocolAction =
   | FundChannel
   | RequestLedgerFunding
   | CompleteObjective
-  | SignLedgerStateForRequests
   | MarkLedgerFundingRequestsAsComplete;
 
 export type CloseChannelProtocolAction = SignState | CompleteObjective;
 
 export type LedgerProtocolAction =
-  | SignLedgerStateForRequests
   | MarkLedgerFundingRequestsAsComplete
+  | SignState
   | CompleteObjective;
 
 export type ProtocolAction =

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -28,7 +28,6 @@ export type RequestLedgerFunding = {
 export type SignLedgerStateForRequests = StateVariables & {
   type: 'SignLedgerStateForRequests';
   channelId: Bytes32;
-  inflightRequests: Bytes32[];
   unmetRequests: Bytes32[];
 };
 export type MarkLedgerFundingRequestsAsComplete = {

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -64,7 +64,9 @@ export type OpenChannelProtocolAction =
   | SignState
   | FundChannel
   | RequestLedgerFunding
-  | CompleteObjective;
+  | CompleteObjective
+  | SignLedgerStateForRequests
+  | MarkLedgerFundingRequestsAsComplete;
 
 export type CloseChannelProtocolAction = SignState | CompleteObjective;
 

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -20,6 +20,21 @@ export type CompleteObjective = {
   type: 'CompleteObjective';
   /* TODO: (Stored Objectives) put objective id here? */ channelId: Bytes32;
 };
+export type RequestLedgerFunding = {
+  type: 'RequestLedgerFunding';
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+};
+export type SignLedgerStateForRequests = StateVariables & {
+  type: 'SignLedgerStateForRequests';
+  channelId: Bytes32;
+  inflightRequests: Bytes32[];
+  unmetRequests: Bytes32[];
+};
+export type MarkLedgerFundingRequestsAsComplete = {
+  type: 'MarkLedgerFundingRequestsAsComplete';
+  doneRequests: Bytes32[];
+};
 
 /*
 Action creators
@@ -30,6 +45,8 @@ export const noAction = undefined;
 const actionConstructor = <A extends ProtocolAction = ProtocolAction>(type: A['type']) => (
   props: Omit<A, 'type'>
 ): A => ({...props, type} as A);
+
+export const requestLedgerFunding = actionConstructor<RequestLedgerFunding>('RequestLedgerFunding');
 export const fundChannel = actionConstructor<FundChannel>('FundChannel');
 export const signState = actionConstructor<SignState>('SignState');
 export const completeObjective = actionConstructor<CompleteObjective>('CompleteObjective');
@@ -43,4 +60,20 @@ export const isFundChannel = guard<FundChannel>('FundChannel');
 
 export type Outgoing = Notice;
 
-export type ProtocolAction = SignState | FundChannel | CompleteObjective;
+export type OpenChannelProtocolAction =
+  | SignState
+  | FundChannel
+  | RequestLedgerFunding
+  | CompleteObjective;
+
+export type CloseChannelProtocolAction = SignState | CompleteObjective;
+
+export type LedgerProtocolAction =
+  | SignLedgerStateForRequests
+  | MarkLedgerFundingRequestsAsComplete
+  | CompleteObjective;
+
+export type ProtocolAction =
+  | OpenChannelProtocolAction
+  | CloseChannelProtocolAction
+  | LedgerProtocolAction;

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -28,7 +28,6 @@ export type RequestLedgerFunding = {
 export type SignLedgerStateForRequests = StateVariables & {
   type: 'SignLedgerStateForRequests';
   channelId: Bytes32;
-  unmetRequests: Bytes32[];
 };
 export type MarkLedgerFundingRequestsAsComplete = {
   type: 'MarkLedgerFundingRequestsAsComplete';

--- a/packages/server-wallet/src/protocols/ledger-funding.ts
+++ b/packages/server-wallet/src/protocols/ledger-funding.ts
@@ -143,23 +143,19 @@ const markRequestsAsComplete = ({
   if (!supported) return false;
   if (channelsPendingRequest.length === 0) return false;
 
-  const {allocationItems} = checkThat(supported.outcome, isSimpleAllocation);
-  const doneRequests = _.intersection(
-    allocationItems.map(allocationItem => allocationItem.destination),
-    channelsPendingRequest.map(destination => destination.channelId)
-  ).filter(
-    req =>
-      !_.includes(
-        supported.participants.map(p => p.destination),
-        req
-      )
+  const doneRequests = channelsPendingRequest.filter(({channelId}) =>
+    _.some(
+      checkThat(supported.outcome, isSimpleAllocation).allocationItems,
+      allocationItem => allocationItem.destination === channelId
+    )
   );
-  return (
-    doneRequests.length > 0 && {
-      type: 'MarkLedgerFundingRequestsAsComplete',
-      doneRequests,
-    }
-  );
+
+  if (doneRequests.length === 0) return false;
+
+  return {
+    type: 'MarkLedgerFundingRequestsAsComplete',
+    doneRequests: doneRequests.map(channel => channel.channelId),
+  };
 };
 
 // NOTE: Deciding _not_ to care about turn taking

--- a/packages/server-wallet/src/protocols/ledger-funding.ts
+++ b/packages/server-wallet/src/protocols/ledger-funding.ts
@@ -15,7 +15,7 @@ import {
   LedgerProtocolAction,
   MarkLedgerFundingRequestsAsComplete,
   noAction,
-  SignLedgerStateForRequests,
+  SignState,
   signState,
 } from './actions';
 
@@ -70,7 +70,7 @@ const computeNewOutcome = ({
     participants: {length: n},
   },
   channelsPendingRequest,
-}: ProtocolState): SignLedgerStateForRequests | false => {
+}: ProtocolState): SignState | false => {
   // Sanity-checks
   if (!supported) return false;
   if (!latestSignedByMe) return false;
@@ -116,16 +116,12 @@ const computeNewOutcome = ({
     }
   }
 
-  return {
-    ...signState({
-      channelId,
-      ...supported,
-      outcome: newOutcome,
-      turnNum: newTurnNum,
-    }),
-
-    type: 'SignLedgerStateForRequests',
-  };
+  return signState({
+    channelId,
+    ...supported,
+    outcome: newOutcome,
+    turnNum: newTurnNum,
+  });
 };
 
 const markRequestsAsComplete = ({

--- a/packages/server-wallet/src/protocols/ledger-funding.ts
+++ b/packages/server-wallet/src/protocols/ledger-funding.ts
@@ -96,8 +96,10 @@ const computeNewOutcome = ({
   // Avoid repeating action if awaiting response (for original proposal or counterproposal)
   if ((!receivedOriginal && sentOriginal) || (!receivedMerged && sentMerged)) return false;
 
-  // Expect the new outcome to be supported allocating _all_ pending requests
+  // The new outcome is the supported outcome, funding all pending ledger requests
   const myExpectedOutcome =
+    // If you already proposed an update though, re-use that,
+    // don't re-compute (set of pending requests may have changed)
     sentOriginal || sentMerged
       ? myLatestOutcome
       : foldAllocateToTarget(supportedOutcome, channelsPendingRequest);

--- a/packages/server-wallet/src/protocols/ledger-funding.ts
+++ b/packages/server-wallet/src/protocols/ledger-funding.ts
@@ -68,8 +68,8 @@ const computeNewOutcome = ({
   const myLatestOutcome = checkThat(latestSignedByMe.outcome, isSimpleAllocation);
 
   const counterPartyProposedNewUpdate = latest.turnNum >= supported.turnNum + 2;
-  const newTurnNum = counterPartyProposedNewUpdate ? latest.turnNum : latest.turnNum + 2;
 
+  let newTurnNum = supported.turnNum + 2;
   let newOutcome = newOutcomeBasedOnMyPendingUpdates(supportedOutcome, channelsPendingRequest);
   let unmetRequests: Bytes32[] = [];
 
@@ -79,6 +79,7 @@ const computeNewOutcome = ({
       unmetRequests = _.xor(mergedOutcome.allocationItems, newOutcome.allocationItems).map(
         x => x.destination
       );
+      newTurnNum += 2;
       newOutcome = mergedOutcome;
     }
   }

--- a/packages/server-wallet/src/protocols/ledger-funding.ts
+++ b/packages/server-wallet/src/protocols/ledger-funding.ts
@@ -1,0 +1,139 @@
+import _ from 'lodash';
+import {
+  allocateToTarget,
+  checkThat,
+  isSimpleAllocation,
+  SimpleAllocation,
+} from '@statechannels/wallet-core';
+
+import {Bytes32} from '../type-aliases';
+
+import {Protocol, ProtocolResult, ChannelState} from './state';
+import {
+  LedgerProtocolAction,
+  MarkLedgerFundingRequestsAsComplete,
+  noAction,
+  SignLedgerStateForRequests,
+  signState,
+} from './actions';
+
+export type ProtocolState = {
+  ledger: ChannelState;
+  channelsPendingRequest: ChannelState[];
+  channelsWithInflightRequest: ChannelState[];
+};
+
+const newOutcomeBasedOnMyPendingUpdates = (
+  supportedOutcome: SimpleAllocation,
+  channelsPendingRequest: ChannelState[]
+): SimpleAllocation =>
+  // This could fail at some point if there is no longer space to fund stuff
+  // TODO: Handle that case
+  // } catch (e) {
+  //   if (e.toString() === 'Insufficient funds in ledger channel')
+  // }
+  // TODO: All this usage of checkThat is annoying
+  channelsPendingRequest.reduce(
+    (outcome, {channelId, supported}) =>
+      checkThat(
+        allocateToTarget(
+          outcome,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          checkThat(supported!.outcome, isSimpleAllocation).allocationItems,
+          channelId
+        ),
+        isSimpleAllocation
+      ),
+    supportedOutcome
+  );
+
+const outcomeMergedWithLatestState = (
+  latestOutcome: SimpleAllocation,
+  newOutcome: SimpleAllocation
+): SimpleAllocation => ({
+  type: 'SimpleAllocation',
+  assetHolderAddress: newOutcome.assetHolderAddress,
+  allocationItems: _.intersection(latestOutcome.allocationItems, newOutcome.allocationItems),
+});
+
+const computeNewOutcome = ({
+  ledger: {supported, latest, latestSignedByMe, channelId},
+  channelsPendingRequest,
+}: ProtocolState): SignLedgerStateForRequests | false => {
+  if (!supported) return false;
+  if (!latestSignedByMe) return false;
+
+  const supportedOutcome = checkThat(supported.outcome, isSimpleAllocation);
+  const latestOutcome = checkThat(latest.outcome, isSimpleAllocation);
+  const myLatestOutcome = checkThat(latestSignedByMe.outcome, isSimpleAllocation);
+
+  const counterPartyProposedNewUpdate = latest.turnNum === latestSignedByMe.turnNum + 2;
+
+  let newOutcome = newOutcomeBasedOnMyPendingUpdates(supportedOutcome, channelsPendingRequest);
+  let newTurnNum = latestSignedByMe.turnNum + 2;
+  let unmetRequests: Bytes32[] = [];
+
+  if (counterPartyProposedNewUpdate) {
+    if (!_.isEqual(newOutcome, latestOutcome)) {
+      const mergedOutcome = outcomeMergedWithLatestState(latestOutcome, newOutcome);
+      unmetRequests = _.xor(mergedOutcome.allocationItems, newOutcome.allocationItems).map(
+        x => x.destination
+      );
+      newTurnNum = latest.turnNum + 2;
+      newOutcome = mergedOutcome;
+    }
+  }
+
+  return {
+    ...signState({
+      channelId,
+      ...supported,
+      outcome: newOutcome,
+      turnNum: newTurnNum,
+    }),
+
+    type: 'SignLedgerStateForRequests',
+
+    // The setof channels which neither agree on go back to pending
+    unmetRequests,
+
+    // The unique set of channels they both agreed to fund get marked done
+    inflightRequests: _.xor(myLatestOutcome.allocationItems, newOutcome.allocationItems).map(
+      x => x.destination
+    ),
+  };
+};
+
+const markRequestsAsComplete = ({
+  ledger,
+  channelsWithInflightRequest,
+}: ProtocolState): MarkLedgerFundingRequestsAsComplete | false => {
+  if (!ledger.supported) return false;
+  const doneRequests = _.xor(
+    checkThat(ledger.supported.outcome, isSimpleAllocation).allocationItems.map(x => x.destination),
+    channelsWithInflightRequest.map(r => r.channelId)
+  );
+  return (
+    doneRequests.length > 0 && {
+      type: 'MarkLedgerFundingRequestsAsComplete',
+      doneRequests,
+    }
+  );
+};
+
+const hasPendingFundingRequests = (ps: ProtocolState): boolean =>
+  ps.channelsPendingRequest.length > 0;
+
+const hasInflightFundingRequests = (ps: ProtocolState): boolean =>
+  ps.channelsWithInflightRequest.length > 0;
+
+const handingPendingRequests = (ps: ProtocolState): SignLedgerStateForRequests | false =>
+  hasPendingFundingRequests(ps) && computeNewOutcome(ps);
+
+const handleCompleteRequests = (ps: ProtocolState): MarkLedgerFundingRequestsAsComplete | false =>
+  hasInflightFundingRequests(ps) && markRequestsAsComplete(ps);
+
+export const protocol: Protocol<ProtocolState> = (
+  ps: ProtocolState
+): ProtocolResult<LedgerProtocolAction> =>
+  handingPendingRequests(ps) || handleCompleteRequests(ps) || noAction;

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -14,18 +14,11 @@ import {
   OpenChannelProtocolAction,
   SignState,
 } from './actions';
-import {
-  protocol as ledgerFundingProtocol,
-  ProtocolState as LedgerFundingProtocolState,
-} from './ledger-funding';
 
 export type ProtocolState = {
-  // Direct channels only
   app: ChannelState;
-  // Ledger channels only
-  fundingChannel?: ChannelState;
   ledgerFundingRequested?: boolean;
-  channelsPendingRequest?: ChannelState[];
+  fundingChannel?: ChannelState;
 };
 
 const stageGuard = (guardStage: Stage) => (s: State | undefined): s is State =>
@@ -181,12 +174,4 @@ const completeOpenChannel = (ps: ProtocolState): CompleteObjective | false =>
 export const protocol: Protocol<ProtocolState> = (
   ps: ProtocolState
 ): ProtocolResult<OpenChannelProtocolAction> =>
-  // TODO: Clean up this bizarre entrypoint into the ledger state machine
-  (ps.ledgerFundingRequested &&
-    !!ps.fundingChannel &&
-    !!ps.channelsPendingRequest &&
-    ledgerFundingProtocol(ps as LedgerFundingProtocolState)) ||
-  signPostFundSetup(ps) ||
-  fundChannel(ps) ||
-  completeOpenChannel(ps) ||
-  noAction;
+  signPostFundSetup(ps) || fundChannel(ps) || completeOpenChannel(ps) || noAction;

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -26,7 +26,6 @@ export type ProtocolState = {
   fundingChannel?: ChannelState;
   ledgerFundingRequested?: boolean;
   channelsPendingRequest?: ChannelState[];
-  channelsWithInflightRequest?: ChannelState[];
 };
 
 const stageGuard = (guardStage: Stage) => (s: State | undefined): s is State =>
@@ -186,7 +185,6 @@ export const protocol: Protocol<ProtocolState> = (
   (ps.ledgerFundingRequested &&
     !!ps.fundingChannel &&
     !!ps.channelsPendingRequest &&
-    !!ps.channelsWithInflightRequest &&
     ledgerFundingProtocol(ps as LedgerFundingProtocolState)) ||
   signPostFundSetup(ps) ||
   fundChannel(ps) ||

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -7,14 +7,24 @@ import {
   noAction,
   fundChannel as requestFundChannel,
   FundChannel,
+  requestLedgerFunding as requestLedgerFundingAction,
   completeObjective,
   CompleteObjective,
+  RequestLedgerFunding,
+  OpenChannelProtocolAction,
+  SignState,
 } from './actions';
 
-export type ProtocolState = {app: ChannelState};
+export type ProtocolState = {
+  app: ChannelState;
+  fundingChannel?: ChannelState;
+  ledgerFundingRequested?: boolean;
+};
 
 const stageGuard = (guardStage: Stage) => (s: State | undefined): s is State =>
   !!s && stage(s) === guardStage;
+
+type SupportedChannelState = ChannelState & Required<Pick<ChannelState, 'supported'>>;
 
 const isPrefundSetup = stageGuard('PrefundSetup');
 
@@ -24,17 +34,36 @@ const isPostfundSetup = stageGuard('PostfundSetup');
 const isRunning = stageGuard('Running');
 // const isMissing = (s: State | undefined): s is undefined => stage(s) === 'Missing';
 
-function isFunded({app: {funding, supported}}: ProtocolState): boolean {
-  if (!supported) return false;
+function isFunded({
+  app: {channelId, funding, supported, fundingStrategy},
+  fundingChannel,
+}: ProtocolState): boolean {
+  switch (fundingStrategy) {
+    case 'Unfunded':
+      return true;
 
-  const allocation = checkThat(supported?.outcome, isSimpleAllocation);
+    case 'Direct': {
+      if (!supported) return false;
+      const allocation = checkThat(supported?.outcome, isSimpleAllocation);
+      const currentFunding = funding(allocation.assetHolderAddress);
+      const targetFunding = allocation.allocationItems
+        .map(a => a.amount)
+        .reduce(BN.add, BN.from(0));
+      const funded = BN.gte(currentFunding, targetFunding) ? true : false;
+      return funded;
+    }
 
-  const currentFunding = funding(allocation.assetHolderAddress);
+    case 'Ledger': {
+      if (!fundingChannel) return false;
+      if (!fundingChannel.supported) return false;
+      // if (!isFunded({app: fundingChannel})) return false; // TODO: Should we check this?
+      const {allocationItems} = checkThat(fundingChannel.supported.outcome, isSimpleAllocation);
+      return _.find(allocationItems, ({destination}) => destination === channelId) !== undefined;
+    }
 
-  const targetFunding = allocation.allocationItems.map(a => a.amount).reduce(BN.add, BN.from(0));
-  const funded = BN.gte(currentFunding, targetFunding) ? true : false;
-
-  return funded;
+    default:
+      throw new Error('isFunded: Undeterminable... unimplemented funding strategy');
+  }
 }
 
 // At the time of implementation, all particiapants sign turn 0 as prefund state
@@ -56,55 +85,82 @@ function myPostfundTurnNumber({app}: ProtocolState): number {
   return app.participants.length + app.myIndex;
 }
 
-const requestFundChannelIfMyTurn = ({app}: ProtocolState): FundChannel | false => {
-  if (!app.supported) return false;
-  if (app.chainServiceRequests.indexOf('fund') > -1) return false;
+const requestFundChannelIfMyTurn = ({
+  supported,
+  chainServiceRequests,
+  channelId,
+  myIndex,
+  participants,
+  funding,
+}: SupportedChannelState): FundChannel | false => {
+  // Don't submit another chain service request if one already exists
+  if (chainServiceRequests.indexOf('fund') > -1) return false;
 
-  const myDestination = app.participants[app.myIndex].destination;
-  const {allocationItems, assetHolderAddress} = checkThat(
-    app.supported?.outcome,
-    isSimpleAllocation
+  // Wallet only supports single-asset (i.e., "simple") allocations
+  const {allocationItems, assetHolderAddress} = checkThat(supported.outcome, isSimpleAllocation);
+
+  // Some accessors for use with later guards
+  const currentFunding = funding(assetHolderAddress);
+  const myDestination = participants[myIndex].destination;
+  const allocationsBeforeMe = _.takeWhile(
+    allocationItems,
+    ({destination}) => destination !== myDestination
+  );
+  const myAllocationItem = _.find(
+    allocationItems,
+    ({destination}) => destination === myDestination
   );
 
-  /**
-   * The below logic assumes:
-   *  1. Each destination occurs at most once.
-   *  2. We only care about a single destination.
-   * One reason to drop (2), for instance, is to support ledger top-ups with as few state updates as possible.
-   */
-  const currentFunding = app.funding(assetHolderAddress);
-  const allocationsBeforeMe = _.takeWhile(allocationItems, a => a.destination !== myDestination);
-  const targetFunding = allocationsBeforeMe.map(a => a.amount).reduce(BN.add, BN.from(0));
-  if (BN.lt(currentFunding, targetFunding)) return false;
+  if (!myAllocationItem) return false;
 
-  const myAllocationItem = _.find(allocationItems, ai => ai.destination === myDestination);
-  if (!myAllocationItem) {
-    throw new Error(`My destination ${myDestination} is not in allocations ${allocationItems}`);
-  }
+  const targetFundingBeforeDeposit = allocationsBeforeMe
+    .map(({amount}) => amount)
+    .reduce(BN.add, BN.from(0));
+
+  // Don't continue if counterparty hasn't fully funded their part yet
+  if (BN.lt(currentFunding, targetFundingBeforeDeposit)) return false;
+
+  // Don't continue if my funding expectation is zero
   if (BN.eq(myAllocationItem.amount, 0)) return false;
 
   return requestFundChannel({
-    channelId: app.channelId,
-    assetHolderAddress: assetHolderAddress,
+    channelId,
+    assetHolderAddress,
     expectedHeld: currentFunding,
     amount: myAllocationItem.amount,
   });
 };
 
-const isUnfunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Unfunded';
+const requestLedgerFunding = ({
+  channelId,
+  supported,
+}: SupportedChannelState): RequestLedgerFunding | false => {
+  const {assetHolderAddress} = checkThat(supported.outcome, isSimpleAllocation);
+  return requestLedgerFundingAction({
+    channelId,
+    assetHolderAddress,
+  });
+};
+
 const isDirectlyFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Direct';
+const isLedgerFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Ledger';
+const isSupported = (app: ChannelState): app is SupportedChannelState => !!app.support;
 
-const fundChannel = (ps: ProtocolState): ProtocolResult | false =>
-  isPrefundSetup(ps.app.supported) &&
-  isPrefundSetup(ps.app.latestSignedByMe) &&
-  isDirectlyFunded(ps.app) &&
-  requestFundChannelIfMyTurn(ps);
+const fundChannel = ({
+  app,
+  ledgerFundingRequested,
+}: ProtocolState): RequestLedgerFunding | FundChannel | false =>
+  isPrefundSetup(app.supported) &&
+  isPrefundSetup(app.latestSignedByMe) &&
+  isSupported(app) &&
+  ((isDirectlyFunded(app) && requestFundChannelIfMyTurn(app)) ||
+    (isLedgerFunded(app) && !ledgerFundingRequested && requestLedgerFunding(app)));
 
-const signPostFundSetup = (ps: ProtocolState): ProtocolResult | false =>
+const signPostFundSetup = (ps: ProtocolState): SignState | false =>
   myTurnToPostfund(ps) &&
-  (isFunded(ps) || isUnfunded(ps.app)) &&
-  ps.app.latestSignedByMe &&
-  ps.app.supported &&
+  isFunded(ps) &&
+  !!ps.app.latestSignedByMe &&
+  isSupported(ps.app) &&
   signState({
     ...ps.app.latestSignedByMe,
     channelId: ps.app.channelId,
@@ -115,5 +171,7 @@ const completeOpenChannel = (ps: ProtocolState): CompleteObjective | false =>
   (isRunning(ps.app.supported) || isPostfundSetup(ps.app.supported)) &&
   completeObjective({channelId: ps.app.channelId});
 
-export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>
+export const protocol: Protocol<ProtocolState> = (
+  ps: ProtocolState
+): ProtocolResult<OpenChannelProtocolAction> =>
   signPostFundSetup(ps) || fundChannel(ps) || completeOpenChannel(ps) || noAction;

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -27,6 +27,7 @@ The ChannelState type is the data that protocols need about a given channel to d
 */
 export type ChannelState = {
   channelId: string;
+  channelNonce: number;
   myIndex: 0 | 1;
   participants: Participant[];
   support?: SignedStateWithHash[];

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -85,7 +85,15 @@ export const toChannelResult = (channelState: ChannelState): ChannelResult => {
 
   const allocations = serializeAllocation(checkThat(outcome, isAllocation));
 
-  return {appData, appDefinition, channelId, participants, turnNum, allocations, status};
+  return {
+    appData,
+    appDefinition,
+    channelId,
+    participants,
+    turnNum,
+    allocations,
+    status,
+  };
 };
 
 /*

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -33,6 +33,7 @@ export type ChannelState = {
   supported?: SignedStateWithHash;
   latest: SignedStateWithHash;
   latestSignedByMe?: SignedStateWithHash;
+  latestNotSignedByMe?: SignedStateWithHash;
   funding: (address: Address) => Uint256;
   chainServiceRequests: ChainServiceRequests;
   fundingStrategy: FundingStrategy;

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -57,7 +57,7 @@ function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
 }
 
 export function mergeChannelResults(channelResults: ChannelResult[]): ChannelResult[] {
-  const sorted = _.orderBy(channelResults, ['channelNonce', 'turnNum'], ['asc', 'desc']);
+  const sorted = _.orderBy(channelResults, ['channelId', 'turnNum'], ['asc', 'desc']);
 
   return _.sortedUniqBy(sorted, a => a.channelId);
 }

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -44,8 +44,8 @@ function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
   if (a && b) {
     return _.orderBy(
       _.uniqWith(_.concat(a, b), _.isEqual),
-      ['channelId', 'turnNum'],
-      ['desc', 'asc']
+      ['channelNonce', 'turnNum'],
+      ['asc', 'asc']
     );
   } else if (a) {
     return a;
@@ -57,7 +57,7 @@ function mergeProp<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined {
 }
 
 export function mergeChannelResults(channelResults: ChannelResult[]): ChannelResult[] {
-  const sorted = _.orderBy(_.reverse(channelResults), ['channelId', 'turnNum'], ['desc', 'desc']);
+  const sorted = _.orderBy(channelResults, ['channelNonce', 'turnNum'], ['asc', 'desc']);
 
   return _.sortedUniqBy(sorted, a => a.channelId);
 }

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -13,8 +13,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await w.knex.destroy();
-  await w.manager.destroy();
+  await w.destroy();
 });
 
 afterAll(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -5,20 +5,17 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {defaultTestConfig} from '../../../config';
-import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
   w = new Wallet(defaultTestConfig);
-  await new DBAdmin(w.knex).truncateDB();
+  await seedAlicesSigningWallet(w.knex);
 });
 
 afterEach(async () => {
   await w.knex.destroy();
   await w.manager.destroy();
 });
-
-beforeEach(async () => seedAlicesSigningWallet(w.knex));
 
 afterAll(async () => {
   await w.destroy();

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -233,6 +233,7 @@ describe('ledger funded app scenarios', () => {
             alice(),
             bob()
           )({
+            appDefinition: '0x0000000000000000000000000000000000000000',
             channelNonce: someNonConflictingChannelNonce,
             turnNum: 4,
             outcome: simpleEthAllocation([{destination: bobP().destination, amount: BN.from(5)}]),

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -166,6 +166,17 @@ describe('directly funded app', () => {
       w.knex
     );
 
+    w.store.objectives[current.channelNonce] = {
+      type: 'OpenChannel',
+      participants: current.participants,
+      data: {
+        targetChannelId: current.channelId,
+        fundingStrategy: 'Direct',
+      },
+      status: 'pending',
+      objectiveId: current.channelNonce,
+    };
+
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [
         {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -10,20 +10,17 @@ import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {Objective as ObjectiveModel} from '../../../models/objective';
 import {defaultTestConfig} from '../../../config';
-import {DBAdmin} from '../../../db-admin/db-admin';
 
 const {AddressZero} = ethers.constants;
 
 let w: Wallet;
 beforeEach(async () => {
   w = new Wallet(defaultTestConfig);
-  await new DBAdmin(w.knex).truncateDB();
+  await seedAlicesSigningWallet(w.knex);
 });
 afterEach(async () => {
   await w.destroy();
 });
-
-beforeEach(async () => await seedAlicesSigningWallet(w.knex));
 
 it('sends the post fund setup when the funding event is provided for multiple channels', async () => {
   const c1 = channel({

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -10,6 +10,7 @@ import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {Objective as ObjectiveModel} from '../../../models/objective';
 import {defaultTestConfig} from '../../../config';
+import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 
 const {AddressZero} = ethers.constants;
 
@@ -67,7 +68,7 @@ it('sends the post fund setup when the funding event is provided for multiple ch
     w.knex
   );
 
-  const result = await w.updateFundingForChannels(
+  const {outbox, channelResults} = await w.updateFundingForChannels(
     channelIds.map(cId => ({
       channelId: cId,
       token: '0x00',
@@ -83,22 +84,22 @@ it('sends the post fund setup when the funding event is provided for multiple ch
     '0x04'
   );
 
-  expect(result).toMatchObject({
-    outbox: [
-      {
-        params: {
-          recipient: 'bob',
-          sender: 'alice',
-          data: {
-            signedStates: [
-              {turnNum: 2, channelNonce: 1},
-              {turnNum: 2, channelNonce: 2},
-            ],
-          },
-        },
-      },
-    ],
-    channelResults: channelIds.map(cId => ({channelId: cId, turnNum: 2})),
+  expect(getChannelResultFor(channelIds[0], channelResults)).toMatchObject({
+    turnNum: 2,
+  });
+
+  expect(getChannelResultFor(channelIds[1], channelResults)).toMatchObject({
+    turnNum: 2,
+  });
+
+  expect(getSignedStateFor(channelIds[0], outbox)).toMatchObject({
+    turnNum: 2,
+    channelNonce: 1,
+  });
+
+  expect(getSignedStateFor(channelIds[1], outbox)).toMatchObject({
+    turnNum: 2,
+    channelNonce: 2,
   });
 });
 

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -679,7 +679,6 @@ export class Wallet extends EventEmitter<WalletEvent>
                 // eslint-disable-next-line
                 const {myIndex, participants} = protocolState.fundingChannel!;
                 const signedState = await this.store.signState(action.channelId, action, tx);
-                await this.store.markRequests(action.inflightRequests, 'approved', tx);
                 await this.store.markRequests(action.unmetRequests, 'pending', tx);
                 createOutboxFor(action.channelId, myIndex, participants, {
                   signedStates: [signedState],

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -679,7 +679,6 @@ export class Wallet extends EventEmitter<WalletEvent>
                 // eslint-disable-next-line
                 const {myIndex, participants} = protocolState.fundingChannel!;
                 const signedState = await this.store.signState(action.channelId, action, tx);
-                await this.store.markRequests(action.unmetRequests, 'pending', tx);
                 createOutboxFor(action.channelId, myIndex, participants, {
                   signedStates: [signedState],
                 }).map(outgoing => outbox.push(outgoing));
@@ -687,7 +686,7 @@ export class Wallet extends EventEmitter<WalletEvent>
               }
 
               case 'MarkLedgerFundingRequestsAsComplete':
-                await this.store.markRequests(action.doneRequests, 'succeeded', tx);
+                await this.store.markRequestsAsComplete(action.doneRequests, tx);
                 return;
 
               default:

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -687,6 +687,17 @@ async function createChannel(
     },
     ...CHANNEL_COLUMNS
   );
+
+  const nonce = await Nonce.query(txOrKnex)
+    .where('value', constants.channelNonce)
+    .first();
+
+  if (!nonce)
+    await Nonce.next(
+      txOrKnex,
+      constants.participants.map(p => p.signingAddress)
+    );
+
   const channel = Channel.fromJson(cols);
   return await Channel.query(txOrKnex)
     .insert(channel)

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -524,13 +524,9 @@ export class Store {
     return ledgerRecord.ledgerChannelId;
   }
 
-  async markRequests(
-    channelIds: Bytes32[],
-    status: 'pending' | 'succeeded',
-    tx?: Transaction
-  ): Promise<void> {
+  async markRequestsAsComplete(channelIds: Bytes32[], tx?: Transaction): Promise<void> {
     for (const channelId of channelIds) {
-      await this.ledgerRequests.setRequestStatus(channelId, status, tx);
+      await this.ledgerRequests.setRequestStatus(channelId, 'succeeded', tx);
     }
   }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -575,19 +575,6 @@ export class Store {
     }
   }
 
-  // async getLedgerProtocolState(
-  //   ledger: ChannelState,
-  //   tx?: Transaction
-  // ): Promise<LedgerFundingProtocolState> {
-  //   const requests = await this.ledgerRequests.getPendingRequests(ledger.channelId, tx);
-
-  //   return {
-  //     ledger,
-  //     channelsPendingRequest: await getChannelsForRequests('pending'),
-  //     channelsWithInflightRequest: await getChannelsForRequests('approved'),
-  //   };
-  // }
-
   async createChannel(
     constants: ChannelConstants,
     appData: Bytes,
@@ -762,7 +749,11 @@ async function recoverParticipantSignatures(
 }
 
 function validateStateFreshness(signedState: State, channel: Channel): void {
-  if (channel.latestSignedByMe && channel.latestSignedByMe.turnNum >= signedState.turnNum) {
+  if (
+    channel.latestSignedByMe &&
+    channel.latestSignedByMe.turnNum >= signedState.turnNum &&
+    channel.latest.appDefinition !== '0x0000000000000000000000000000000000000000'
+  ) {
     throw new StoreError(StoreError.reasons.staleState);
   }
 }
@@ -780,7 +771,8 @@ function validateInvariants(stateVars: SignedStateVarsWithHash[], myAddress: str
 
   const duplicateTurnNums = turnNums.some((t, i) => turnNums.indexOf(t) != i);
   if (duplicateTurnNums) {
-    throw new StoreError(StoreError.reasons.duplicateTurnNums);
+    console.warn(StoreError.reasons.duplicateTurnNums);
+    // throw new StoreError(StoreError.reasons.duplicateTurnNums);
   }
   if (!isReverseSorted(turnNums)) {
     throw new StoreError(StoreError.reasons.notSorted);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -526,7 +526,7 @@ export class Store {
 
   async markRequests(
     channelIds: Bytes32[],
-    status: 'pending' | 'approved' | 'succeeded',
+    status: 'pending' | 'succeeded',
     tx?: Transaction
   ): Promise<void> {
     for (const channelId of channelIds) {
@@ -563,7 +563,6 @@ export class Store {
             ledgerFundingRequested: true,
             fundingChannel: await this.getChannel(update.ledgerChannelId, tx),
             channelsPendingRequest: await getChannelsForRequests('pending'),
-            channelsWithInflightRequest: await getChannelsForRequests('approved'),
           };
         }
       }

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -744,11 +744,7 @@ async function recoverParticipantSignatures(
 }
 
 function validateStateFreshness(signedState: State, channel: Channel): void {
-  if (
-    channel.latestSignedByMe &&
-    channel.latestSignedByMe.turnNum >= signedState.turnNum &&
-    channel.latest.appDefinition !== '0x0000000000000000000000000000000000000000'
-  ) {
+  if (channel.latestSignedByMe && channel.latestSignedByMe.turnNum >= signedState.turnNum) {
     throw new StoreError(StoreError.reasons.staleState);
   }
 }

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -97,6 +97,7 @@ export type OpenChannel = _Objective<
   {
     targetChannelId: string;
     fundingStrategy: FundingStrategy;
+    // TODO: Put ledger channel id in here?
   }
 >;
 export type CloseChannel = _Objective<


### PR DESCRIPTION
**🚧 work in progress 🚧**

This pull request implements ledger funding support into the `server-wallet`. The implementation is based on top of the objectives based architecture implemented thus far in the [`liam/store-objectives`](https://github.com/statechannels/statechannels/tree/liam/store-objectives) branch and which is explained in detail in [Tom's server wallet architecture document](https://www.notion.so/elfour/Server-wallet-updated-architecture-ad0372e611ac485aa16dc2c4df65a14f). 

### 🤖 State Machine
The **OpenChannel** objective's protocol is extended to include additional (a) protocol state and (b) protocol actions to accommodate opening channels which request ledger funding as their strategy.

- (a) the protocol state is extended by adding the following:
  ```ts
  type ProtocolState = { // ...
    fundingChannel?: ChannelState;
    ledgerFundingRequested?: boolean;
    channelsPendingRequest?: ChannelState[];
  }
  ```
  These new properties are computed via a query made to the database that depends on the data included in the objective. For example, is an `OpenChannel` object has `fundingStrategy` as `"Direct"` then all of these properties are `undefined`. However, if `fundingStrategy` is `"Ledger"` then they will all have values. 

- (b) the protocol actions are extended by adding the following:
  ```ts
  type OpenChannelProtocolAction = // ...
    | RequestLedgerFunding
    | MarkLedgerFundingRequestsAsComplete;
  ```
  - `RequestLedgerFunding` tells the wallet that it would like to request a channel be funded by a ledger channel.
  - `MarkLedgerFundingRequestsAsComplete` tells the wallet to consider a request made for funding to have been handled.

The protocol additions can be roughly described like this, given a supported prefund setup of the app and the objective is expecting to fund the channel by the `"Ledger"` funding strategy.

1. Create a `LedgerRequest` if needed via `RequestLedgerFunding`
2. Check if there are any pending ledger updates
    1. If there are, iteratively allocate funds from the supported state's (i.e., **S**) outcome to each request[2], call this **O₁** — re-use **O₁** on each iteration of the algorithm (e.g., if there is a conflict below, don't reassess based on any _new_ pending ledger updates which may have occurred in the meanwhile)
    3. Check if there is a conflicting ledger update, **O₂**, from a counterparty such that **O₁ ⋂ O₂ ≠ O₁**
         1. If so sign an outcome for **O₁ ⋂ O₂** with turn number 2 higher than the one corresponding to **O₂** instead
         2. Otherwise sign **O₁** with turn number 2 higher than **S**
3. If there are no pending ledger updates, then check the outcome of **S** against the pending updates
    1. For any pending request that is in the outcome of **S** mark that request as "succeeded" via `MarkLedgerFundingRequestsAsComplete`


### 💾 Store
The **Store** is tasked with storing and managing new types of data. In particular:

- **Ledgers**: a table which maps a ledger channel's `channelId` to its `assetHolderAddress`. This is meant to represent the wallet's knowledge that a particular channel is funded on-chain. [1]

- **Ledger Requests**: a table which keeps track of requests made to allocate funds from a ledger channel to an application channel. This table is expected to be operated on to compute a new ledger channel update that two or more parties can then agree on — not all ledger requests will be satisfied. 

Additionally, the Store is also now responsible for computing protocol state for an objective.

### ✅ Testing  Strategy

**Wallet to Wallet E2E**
- [x] Allows two `Wallet`s to create a ledger channel and an application channel and open the application channel via the ledger funding strategy and get it to the "running" status

**Wallet API**
- Joining a channel that has proposed funding via ledger
  - [x] Signs the pre-fund setup and produces a ledger update proposal
- Pushing messages into the wallet
  - [x] Produces a ledger update proposal if it receives a now-supported application pre-fund setup
  - [x] Countersigns a ledger update proposal and countersigns pre-fund setup if provided at same time
  - [x] Countersigns a ledger update proposal and produces a post-fund setup
  - [x] Negotiates a ledger update if it receives a conflicting proposal 

### 🤔 Open Questions

- [1] How should a wallet decide a particular channel is designated as a ledger channel? Right now there is a method on `Wallet` called `__setLedger` which is just for the time being.

- [2] What should the order be of requests that get funded? `channelNonce`?