### PR TITLE
[nitro-protocol] Enhance testing of ERC20 deposits and withdrawals

### DIFF
--- a/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import '../ERC20AssetHolder.sol';
+import './TESTAssetHolder.sol';
 
 /**
  * @dev This contract is a clone of the ERC20AssetHolder contract. It will be initialized to point to the TestNitroAdjudicator.
@@ -10,4 +11,26 @@ contract TestErc20AssetHolder is ERC20AssetHolder {
         public
         ERC20AssetHolder(_AdjudicatorAddress, _TokenAddress)
     {}
+
+    /**
+     * @dev Manually set the holdings mapping to a given amount for a given channelId.  Shortcuts the deposit workflow (ONLY USE IN A TESTING ENVIRONMENT)
+     * @param channelId Unique identifier for a state channel.
+     * @param amount The number of assets that should now be "escrowed: against channelId
+     */
+    function setHoldings(bytes32 channelId, uint256 amount) external {
+        holdings[channelId] = amount;
+    }
+
+    /**
+     * @dev Sets the given assetOutcomeHash for the given channelId in the assetOutcomeHashes storage mapping, but circumvents the AdjudicatorOnly modifier (thereby allowing externally owned accounts to call the method).
+     * @param channelId Unique identifier for a state channel.
+     * @param assetOutcomeHash The keccak256 of the abi.encode of the Outcome.
+     */
+    function setAssetOutcomeHashPermissionless(bytes32 channelId, bytes32 assetOutcomeHash)
+        external
+        returns (bool success)
+    {
+        _setAssetOutcomeHash(channelId, assetOutcomeHash);
+        return true;
+    }
 }

--- a/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
@@ -6,7 +6,7 @@ const {AddressZero} = ethers.constants;
 import ERC20AssetHolderArtifact from '../../../build/contracts/TestErc20AssetHolder.json';
 import TokenArtifact from '../../../build/contracts/Token.json';
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {getTestProvider, setupContracts} from '../../test-helpers';
+import {getTestProvider, setupContracts, writeGasConsumption} from '../../test-helpers';
 
 const provider = getTestProvider();
 const signer0 = provider.getSigner(0); // Convention matches setupContracts function
@@ -32,78 +32,84 @@ beforeAll(async () => {
 });
 
 const description0 = 'Deposits Tokens (expectedHeld = 0)';
-const description1 = 'Reverts deposit of Tokens (expectedHeld > holdings)';
-const description2 = 'Reverts deposit of Tokens (expectedHeld + amount < holdings)';
-const description3 = 'Deposits Tokens (amount < holdings < amount + expectedHeld)';
+const description1 = 'Deposits Tokens (expectedHeld = 1)';
+const description2 = 'Reverts deposit of Tokens (expectedHeld > holdings)';
+const description3 = 'Reverts deposit of Tokens (expectedHeld + amount < holdings)';
+const description4 = 'Deposits Tokens (amount < holdings < amount + expectedHeld)';
 
 describe('deposit', () => {
   it.each`
     description     | channelNonce | held | expectedHeld | amount | heldAfter | reasonString
     ${description0} | ${0}         | ${0} | ${0}         | ${1}   | ${1}      | ${undefined}
-    ${description1} | ${1}         | ${0} | ${1}         | ${2}   | ${0}      | ${'Deposit | holdings[destination] is less than expected'}
-    ${description2} | ${2}         | ${3} | ${1}         | ${1}   | ${3}      | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
-    ${description3} | ${3}         | ${3} | ${2}         | ${2}   | ${4}      | ${undefined}
-  `('$description', async ({channelNonce, held, expectedHeld, amount, reasonString, heldAfter}) => {
-    held = BigNumber.from(held);
-    expectedHeld = BigNumber.from(expectedHeld);
-    amount = BigNumber.from(amount);
-    heldAfter = BigNumber.from(heldAfter);
+    ${description1} | ${1}         | ${1} | ${1}         | ${1}   | ${2}      | ${undefined}
+    ${description2} | ${2}         | ${0} | ${1}         | ${2}   | ${0}      | ${'Deposit | holdings[destination] is less than expected'}
+    ${description3} | ${3}         | ${3} | ${1}         | ${1}   | ${3}      | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
+    ${description4} | ${4}         | ${3} | ${2}         | ${2}   | ${4}      | ${undefined}
+  `(
+    '$description',
+    async ({description, channelNonce, held, expectedHeld, amount, reasonString, heldAfter}) => {
+      held = BigNumber.from(held);
+      expectedHeld = BigNumber.from(expectedHeld);
+      amount = BigNumber.from(amount);
+      heldAfter = BigNumber.from(heldAfter);
 
-    const destinationChannel: Channel = {chainId, channelNonce, participants};
-    const destination = getChannelId(destinationChannel);
+      const destinationChannel: Channel = {chainId, channelNonce, participants};
+      const destination = getChannelId(destinationChannel);
 
-    // Check msg.sender has enough tokens
-    const balance = await Token.balanceOf(signer0Address);
-    await expect(balance.gte(held.add(amount))).toBe(true);
+      // Check msg.sender has enough tokens
+      const balance = await Token.balanceOf(signer0Address);
+      await expect(balance.gte(held.add(amount))).toBe(true);
 
-    // Increase allowance
-    await (await Token.increaseAllowance(ERC20AssetHolder.address, held.add(amount))).wait(); // Approve enough for setup and main test
+      // Increase allowance
+      await (await Token.increaseAllowance(ERC20AssetHolder.address, held.add(amount))).wait(); // Approve enough for setup and main test
 
-    // Check allowance updated
-    const allowance = BigNumber.from(
-      await Token.allowance(signer0Address, ERC20AssetHolder.address)
-    );
-    expect(
-      allowance
-        .sub(amount)
-        .sub(held)
-        .gte(0)
-    ).toBe(true);
+      // Check allowance updated
+      const allowance = BigNumber.from(
+        await Token.allowance(signer0Address, ERC20AssetHolder.address)
+      );
+      expect(
+        allowance
+          .sub(amount)
+          .sub(held)
+          .gte(0)
+      ).toBe(true);
 
-    if (held > 0) {
-      // Set holdings by depositing in the 'safest' way
-      const {events} = await (await ERC20AssetHolder.deposit(destination, 0, held)).wait();
-      expect(await ERC20AssetHolder.holdings(destination)).toEqual(held);
-      const {data: amountTransferred} = getTransferEvent(events);
-      expect(held.eq(amountTransferred)).toBe(true);
+      if (held > 0) {
+        // Set holdings by depositing in the 'safest' way
+        const {events} = await (await ERC20AssetHolder.deposit(destination, 0, held)).wait();
+        expect(await ERC20AssetHolder.holdings(destination)).toEqual(held);
+        const {data: amountTransferred} = getTransferEvent(events);
+        expect(held.eq(amountTransferred)).toBe(true);
+      }
+
+      const balanceBefore = BigNumber.from(await Token.balanceOf(signer0Address));
+      const tx = ERC20AssetHolder.deposit(destination, expectedHeld, amount);
+
+      if (reasonString) {
+        await expectRevert(() => tx, reasonString);
+      } else {
+        const {gasUsed, events} = await (await tx).wait();
+        await writeGasConsumption('./erc20-deposit.gas.md', description, gasUsed);
+
+        const depositedEvent = getDepositedEvent(events);
+        expect(depositedEvent).toMatchObject({
+          destination,
+          amountDeposited: heldAfter.sub(held),
+          destinationHoldings: heldAfter,
+        });
+
+        const amountTransferred = BigNumber.from(getTransferEvent(events).data);
+        expect(heldAfter.sub(held).eq(amountTransferred)).toBe(true);
+
+        const allocatedAmount = await ERC20AssetHolder.holdings(destination);
+        await expect(allocatedAmount).toEqual(heldAfter);
+
+        // Check that the correct number of Tokens were deducted
+        const balanceAfter = BigNumber.from(await Token.balanceOf(signer0Address));
+        expect(balanceAfter.eq(balanceBefore.sub(amountTransferred))).toBe(true);
+      }
     }
-
-    const balanceBefore = BigNumber.from(await Token.balanceOf(signer0Address));
-    const tx = ERC20AssetHolder.deposit(destination, expectedHeld, amount);
-
-    if (reasonString) {
-      await expectRevert(() => tx, reasonString);
-    } else {
-      const {events} = await (await tx).wait();
-
-      const depositedEvent = getDepositedEvent(events);
-      expect(depositedEvent).toMatchObject({
-        destination,
-        amountDeposited: heldAfter.sub(held),
-        destinationHoldings: heldAfter,
-      });
-
-      const amountTransferred = BigNumber.from(getTransferEvent(events).data);
-      expect(heldAfter.sub(held).eq(amountTransferred)).toBe(true);
-
-      const allocatedAmount = await ERC20AssetHolder.holdings(destination);
-      await expect(allocatedAmount).toEqual(heldAfter);
-
-      // Check that the correct number of Tokens were deducted
-      const balanceAfter = BigNumber.from(await Token.balanceOf(signer0Address));
-      expect(balanceAfter.eq(balanceBefore.sub(amountTransferred))).toBe(true);
-    }
-  });
+  );
 });
 
 const getDepositedEvent = events => events.find(({event}) => event === 'Deposited').args;

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -51,8 +51,8 @@ const addresses = {
   A: randomExternalDestination(),
   B: randomExternalDestination(),
   // // Externals preloaded with TOK (cheaper to pay to)
-  // At: randomExternalDestination(),
-  // Bt: randomExternalDestination(),
+  At: randomExternalDestination(),
+  Bt: randomExternalDestination(),
   // Asset Holders
   ETH: undefined,
   ETH2: undefined,
@@ -90,12 +90,16 @@ beforeAll(async () => {
   addresses.ETH2 = AssetHolder2.address;
   addresses.ERC20 = ERC20AssetHolder.address;
   appDefinition = getPlaceHolderContractAddress();
+  // Preload At and Bt with TOK
+  await (await Token.transfer('0x' + addresses.At.slice(26), BigNumber.from(1))).wait();
+  await (await Token.transfer('0x' + addresses.Bt.slice(26), BigNumber.from(1))).wait();
 });
 
 const accepts1 = '{ETH: {A: 1}}';
 const accepts2 = '{ETH: {A: 1}, ETH2: {A: 2}}';
 const accepts3 = '{ETH2: {A: 1, B: 1}}';
 const accepts4 = '{ERC20: {A: 1, B: 1}}';
+const accepts5 = '{ERC20: {At: 1, Bt: 1}} (At and Bt already have some TOK)';
 
 const oneState = {
   whoSignedWhat: [0, 0, 0],
@@ -111,6 +115,7 @@ describe('concludePushOutcomeAndTransferAll', () => {
     ${accepts2} | ${{ETH: {A: 1}, ETH2: {A: 2}}} | ${{ETH: {c: 1}, ETH2: {c: 2}}} | ${{ETH: {c: 0}, ETH2: {c: 0}}} | ${{}}      | ${{ETH: {A: 1}, ETH2: {A: 2}}} | ${undefined}
     ${accepts3} | ${{ETH2: {A: 1, B: 1}}}        | ${{ETH2: {c: 2}}}              | ${{ETH2: {c: 0}}}              | ${{}}      | ${{ETH2: {A: 1, B: 1}}}        | ${undefined}
     ${accepts4} | ${{ERC20: {A: 1, B: 1}}}       | ${{ERC20: {c: 2}}}             | ${{ERC20: {c: 0}}}             | ${{}}      | ${{ERC20: {A: 1, B: 1}}}       | ${undefined}
+    ${accepts5} | ${{ERC20: {At: 1, Bt: 1}}}     | ${{ERC20: {c: 2}}}             | ${{ERC20: {c: 0}}}             | ${{}}      | ${{ERC20: {At: 1, Bt: 1}}}     | ${undefined}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -59,6 +59,18 @@ const addresses = {
   ERC20: undefined,
 };
 
+const tenPayouts = {ERC20: {}};
+const fiftyPayouts = {ERC20: {}};
+const oneHundredPayouts = {ERC20: {}};
+
+for (let i = 0; i < 100; i++) {
+  const destination = randomExternalDestination();
+  addresses[i.toString()] = destination;
+  if (i < 10) tenPayouts.ERC20[i.toString()] = 1;
+  if (i < 50) fiftyPayouts.ERC20[i.toString()] = 1;
+  if (i < 100) oneHundredPayouts.ERC20[i.toString()] = 1;
+}
+
 // Populate wallets and participants array
 for (let i = 0; i < 3; i++) {
   wallets[i] = Wallet.createRandom();
@@ -100,6 +112,9 @@ const accepts2 = '{ETH: {A: 1}, ETH2: {A: 2}}';
 const accepts3 = '{ETH2: {A: 1, B: 1}}';
 const accepts4 = '{ERC20: {A: 1, B: 1}}';
 const accepts5 = '{ERC20: {At: 1, Bt: 1}} (At and Bt already have some TOK)';
+const accepts6 = '10 TOK payouts';
+const accepts7 = '50 TOK payouts';
+const accepts8 = '100 TOK payouts';
 
 const oneState = {
   whoSignedWhat: [0, 0, 0],
@@ -116,6 +131,9 @@ describe('concludePushOutcomeAndTransferAll', () => {
     ${accepts3} | ${{ETH2: {A: 1, B: 1}}}        | ${{ETH2: {c: 2}}}              | ${{ETH2: {c: 0}}}              | ${{}}      | ${{ETH2: {A: 1, B: 1}}}        | ${undefined}
     ${accepts4} | ${{ERC20: {A: 1, B: 1}}}       | ${{ERC20: {c: 2}}}             | ${{ERC20: {c: 0}}}             | ${{}}      | ${{ERC20: {A: 1, B: 1}}}       | ${undefined}
     ${accepts5} | ${{ERC20: {At: 1, Bt: 1}}}     | ${{ERC20: {c: 2}}}             | ${{ERC20: {c: 0}}}             | ${{}}      | ${{ERC20: {At: 1, Bt: 1}}}     | ${undefined}
+    ${accepts6} | ${tenPayouts}                  | ${{ERC20: {c: 10}}}            | ${{ERC20: {c: 0}}}             | ${{}}      | ${tenPayouts}                  | ${undefined}
+    ${accepts7} | ${fiftyPayouts}                | ${{ERC20: {c: 50}}}            | ${{ERC20: {c: 0}}}             | ${{}}      | ${fiftyPayouts}                | ${undefined}
+    ${accepts8} | ${oneHundredPayouts}           | ${{ERC20: {c: 100}}}           | ${{ERC20: {c: 0}}}             | ${{}}      | ${oneHundredPayouts}           | ${undefined}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({
@@ -148,7 +166,6 @@ describe('concludePushOutcomeAndTransferAll', () => {
       // Transfer some tokens into ERC20AssetHolder
       // Do this step before transforming input data (easier)
       if ('ERC20' in heldBefore) {
-        console.log(`transferring some tokens to ${heldBefore.ERC20} `);
         await (
           await Token.transfer(ERC20AssetHolder.address, BigNumber.from(heldBefore.ERC20.c))
         ).wait();

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -47,7 +47,7 @@ const addresses = {
   A: randomExternalDestination(),
   B: randomExternalDestination(),
   ETH: undefined,
-  TOK: undefined,
+  ETH2: undefined,
 };
 
 // Populate wallets and participants array
@@ -72,12 +72,13 @@ beforeAll(async () => {
     process.env.TEST_ASSET_HOLDER2_ADDRESS
   );
   addresses.ETH = AssetHolder1.address;
-  addresses.TOK = AssetHolder2.address;
+  addresses.ETH2 = AssetHolder2.address;
   appDefinition = getPlaceHolderContractAddress();
 });
 
-const accepts1 = '1 Asset Types';
-const accepts2 = '2 Asset Types';
+const accepts1 = '{ETH: {A: 1}}';
+const accepts2 = '{ETH: {A: 1}, ETH2: {A: 2}}';
+const accepts3 = '{ETH2: {A: 1, B: 1}}';
 
 const oneState = {
   whoSignedWhat: [0, 0, 0],
@@ -88,9 +89,10 @@ let channelNonce = 400;
 describe('concludePushOutcomeAndTransferAll', () => {
   beforeEach(() => (channelNonce += 1));
   it.each`
-    description | outcomeShortHand              | heldBefore                    | heldAfter                     | newOutcome | payouts                       | reasonString
-    ${accepts1} | ${{ETH: {A: 1}}}              | ${{ETH: {c: 1}}}              | ${{ETH: {c: 0}}}              | ${{}}      | ${{ETH: {A: 1}}}              | ${undefined}
-    ${accepts2} | ${{ETH: {A: 1}, TOK: {A: 2}}} | ${{ETH: {c: 1}, TOK: {c: 2}}} | ${{ETH: {c: 0}, TOK: {c: 0}}} | ${{}}      | ${{ETH: {A: 1}, TOK: {A: 2}}} | ${undefined}
+    description | outcomeShortHand               | heldBefore                     | heldAfter                      | newOutcome | payouts                        | reasonString
+    ${accepts1} | ${{ETH: {A: 1}}}               | ${{ETH: {c: 1}}}               | ${{ETH: {c: 0}}}               | ${{}}      | ${{ETH: {A: 1}}}               | ${undefined}
+    ${accepts2} | ${{ETH: {A: 1}, ETH2: {A: 2}}} | ${{ETH: {c: 1}, ETH2: {c: 2}}} | ${{ETH: {c: 0}, ETH2: {c: 0}}} | ${{}}      | ${{ETH: {A: 1}, ETH2: {A: 2}}} | ${undefined}
+    ${accepts3} | ${{ETH2: {A: 1, B: 1}}}        | ${{ETH2: {c: 2}}}              | ${{ETH2: {c: 0}}}              | ${{}}      | ${{ETH2: {A: 1, B: 1}}}        | ${undefined}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
@@ -37,7 +37,7 @@ const addresses = {
   A: randomExternalDestination(),
   B: randomExternalDestination(),
   ETH: undefined,
-  TOK: undefined,
+  ETH2: undefined,
 };
 
 // Constants for this test suite
@@ -68,7 +68,7 @@ beforeAll(async () => {
     process.env.TEST_ASSET_HOLDER2_ADDRESS
   );
   addresses.ETH = AssetHolder1.address;
-  addresses.TOK = AssetHolder2.address;
+  addresses.ETH2 = AssetHolder2.address;
 });
 
 // Scenarios are synonymous with channelNonce:
@@ -84,8 +84,8 @@ const finalized = true;
 
 describe('pushOutcomeAndTransferAll', () => {
   it.each`
-    description     | setOutcome                    | heldBefore                    | newOutcome | heldAfter                     | payouts                       | reasonString
-    ${description2} | ${{ETH: {A: 1}, TOK: {A: 2}}} | ${{ETH: {c: 1}, TOK: {c: 2}}} | ${{}}      | ${{ETH: {c: 0}, TOK: {c: 0}}} | ${{ETH: {A: 1}, TOK: {A: 2}}} | ${undefined}
+    description     | setOutcome                     | heldBefore                     | newOutcome | heldAfter                      | payouts                        | reasonString
+    ${description2} | ${{ETH: {A: 1}, ETH2: {A: 2}}} | ${{ETH: {c: 1}, ETH2: {c: 2}}} | ${{}}      | ${{ETH: {c: 0}, ETH2: {c: 0}}} | ${{ETH: {A: 1}, ETH2: {A: 2}}} | ${undefined}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({


### PR DESCRIPTION
Headlines: 

`ERC20AssetHolder.deposit`:
```
Deposits Tokens (expectedHeld = 0):
76024 gas

Deposits Tokens (expectedHeld = 1):
46024 gas
```

Most expensive for first person to deposit, since they must create (instead of modify) a storage slot. Perhaps some interesting game theory there!

`concludePushOutcomeAndTransferAll`:
```
{ERC20: {A: 1, B: 1}}:
140121 gas

{ERC20: {At: 1, Bt: 1}} (At and Bt already have some TOK, so it's cheaper to pay out-- this is probably the norm, though):
110109 gas

10 TOK payouts:
406,543 gas

50 TOK payouts:
1,589,293 gas

100 TOK payouts:
2,656,645 gas

```

Context: that block gas limit of 8million.