### PR TITLE
refactor: log level of debug for mock chain service warning

### DIFF
--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -148,7 +148,7 @@ export class Wallet extends EventEmitter<WalletEvent>
     if (walletConfig?.rpcEndpoint && walletConfig.serverPrivateKey) {
       this.chainService = new ChainService(walletConfig.rpcEndpoint, walletConfig.serverPrivateKey);
     } else {
-      logger.warn(
+      logger.debug(
         'rpcEndpoint and serverPrivateKey must be defined for the wallet to use chain service'
       );
       this.chainService = new MockChainService();

--- a/yarn.lock
+++ b/yarn.lock
@@ -26769,7 +26769,7 @@ rxjs@6.5.5:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.6.0, rxjs@^6.6.2, rxjs@^6.6.3:
+rxjs@6.6.3, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.6.0, rxjs@^6.6.2:
   version "6.6.3"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==


### PR DESCRIPTION
Most unit tests use a mock chain service. This reduces logging noise for unit tests.