### PR TITLE
Switch PrefundSetup turrnnum to be index of participant

### DIFF
--- a/packages/server-wallet/src/__chain-test__/direct-funding.test.ts
+++ b/packages/server-wallet/src/__chain-test__/direct-funding.test.ts
@@ -92,21 +92,21 @@ it('Create a directly funded channel between two wallets ', async () => {
   const prefundB = await b.joinChannel({channelId});
   expect(getChannelResultFor(channelId, [prefundB.channelResult])).toMatchObject({
     status: 'opening',
-    turnNum: 0,
+    turnNum: 1,
   });
 
   const resultA0 = await a.pushMessage(getPayloadFor(participantA.participantId, prefundB.outbox));
 
   expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
     status: 'opening',
-    turnNum: 0,
+    turnNum: 1,
   });
 
   const postFundA = await postFundAPromise;
   await channelFundedBPromise;
   expect(getChannelResultFor(channelId, [postFundA.channelResult])).toMatchObject({
-    status: 'opening', // Still opening because turnNum 3 is not supported yet, but is signed by A
-    turnNum: 0,
+    status: 'running',
+    turnNum: 2,
   });
 
   const postFundB = await b.pushMessage(

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -91,7 +91,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
   const resultB1 = await b.joinChannel({channelId});
   expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
     status: 'opening',
-    turnNum: 0,
+    turnNum: 1,
   });
 
   //  PreFund0B <
@@ -106,7 +106,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
     status: 'opening',
-    turnNum: 0,
+    turnNum: 1,
   });
 
   const depositByA = {
@@ -131,13 +131,13 @@ it('Create a fake-funded channel between two wallets ', async () => {
   const resultB2 = await b.updateFundingForChannels([depositByB]);
 
   expect(getChannelResultFor(channelId, resultA2.channelResults)).toMatchObject({
-    status: 'opening', // Still opening because turnNum 3 is not supported yet, but is signed by A
-    turnNum: 0,
+    status: 'running',
+    turnNum: 2,
   });
 
   expect(getChannelResultFor(channelId, resultB2.channelResults)).toMatchObject({
-    status: 'opening', // Still opening because turnNum 3 is not supported yet, but is signed by B
-    turnNum: 0,
+    status: 'opening',
+    turnNum: 1,
   });
 
   //  > PostFund3A

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -83,20 +83,20 @@ it('Create a fake-funded channel between two wallets ', async () => {
     turnNum: 0,
   });
 
-  // after joinChannel, B double-signs PreFund0
+  // after joinChannel, B signs PreFund1
   const bJoinChannelOutput = await b.joinChannel({channelId});
   expect(getChannelResultFor(channelId, [bJoinChannelOutput.channelResult])).toMatchObject({
     status: 'opening',
-    turnNum: 0,
+    turnNum: 1,
   });
 
-  // B sends countersigned PreFund0 to A
+  // B sends signed PreFund1 to A
   const aPushJoinChannelOutput = await a.pushMessage(
     getPayloadFor(participantA.participantId, bJoinChannelOutput.outbox)
   );
   expect(getChannelResultFor(channelId, aPushJoinChannelOutput.channelResults)).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
+    status: 'running',
+    turnNum: 2,
   });
 
   // A sends PostFund3 to B

--- a/packages/server-wallet/src/db/seeds/1_signing_wallet_seeds.ts
+++ b/packages/server-wallet/src/db/seeds/1_signing_wallet_seeds.ts
@@ -2,14 +2,16 @@ import Knex from 'knex';
 
 import {DBAdmin} from '../../db-admin/db-admin';
 import {SigningWallet} from '../../models/signing-wallet';
-import {alice} from '../../wallet/__test__/fixtures/signing-wallets';
-
-const seeds = [alice()];
+import {alice, bob} from '../../wallet/__test__/fixtures/signing-wallets';
 
 export async function seedAlicesSigningWallet(knex: Knex): Promise<void> {
   await new DBAdmin(knex).truncateDB();
-  await SigningWallet.query(knex).insert(seeds);
+  await SigningWallet.query(knex).insert(alice());
 }
 
+export async function seedBobsSigningWallet(knex: Knex): Promise<void> {
+  await new DBAdmin(knex).truncateDB();
+  await SigningWallet.query(knex).insert([bob()]);
+}
 // This is the function that `yarn knex seed` executes
 export const seed = seedAlicesSigningWallet;

--- a/packages/server-wallet/src/handlers/__test__/join-channel.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/join-channel.test.ts
@@ -13,9 +13,9 @@ const prefundVars = {turnNum: 0, appData: '0x0f00'};
 const runningVars = {turnNum: 7, appData: '0x0f00'};
 
 test.each`
-  input                                                                        | result
-  ${channel({vars: [stateSignedBy([bob()])(prefundVars)]}).protocolState}      | ${{type: 'SignState', ...prefundVars}}
-  ${channelStateFixture({latest: prefundVars}, {latestSignedByMe: undefined})} | ${{type: 'SignState', ...prefundVars}}
+  input                                                                                                    | result
+  ${channel({signingAddress: bob().address, vars: [stateSignedBy([alice()])(prefundVars)]}).protocolState} | ${{type: 'SignState', ...prefundVars, turnNum: 1}}
+  ${channelStateFixture({myIndex: 1, latest: prefundVars}, {latestSignedByMe: undefined})}                 | ${{type: 'SignState', ...prefundVars, turnNum: 1}}
 `('happy path', ({input, result}) => {
   expect(joinChannel(joinChannelFixture(), input)).toMatchObject(right(result));
 });

--- a/packages/server-wallet/src/handlers/join-channel.ts
+++ b/packages/server-wallet/src/handlers/join-channel.ts
@@ -43,8 +43,8 @@ function ensureLatestStateIsPrefundSetup(cs: ChannelState): StepResult {
   return left(new JoinChannelError(JoinChannelError.reasons.invalidTurnNum));
 }
 
-function latest(cs: ChannelState): StateVariables {
-  return cs.latest;
+function nextState(cs: ChannelState): StateVariables {
+  return {...cs.latest, turnNum: cs.myIndex};
 }
 // End helpers
 
@@ -53,17 +53,19 @@ export function joinChannel(
   channelState: ChannelState
 ): HandlerResult {
   // TODO: use Action creator from another branch
-  const signStateAction = (sv: StateVariables): SignState => ({
-    type: 'SignState',
-    channelId: args.channelId,
-    ...sv,
-  });
+  const signStateAction = (sv: StateVariables): SignState => {
+    return {
+      type: 'SignState',
+      channelId: args.channelId,
+      ...sv,
+    };
+  };
 
   return pipe(
     channelState,
     ensureNotSignedByMe,
     chain(ensureLatestStateIsPrefundSetup),
-    map(latest),
+    map(nextState),
     map(signStateAction)
   );
 }

--- a/packages/server-wallet/src/handlers/join-channel.ts
+++ b/packages/server-wallet/src/handlers/join-channel.ts
@@ -43,7 +43,7 @@ function ensureLatestStateIsPrefundSetup(cs: ChannelState): StepResult {
   return left(new JoinChannelError(JoinChannelError.reasons.invalidTurnNum));
 }
 
-function nextState(cs: ChannelState): StateVariables {
+function myPrefundState(cs: ChannelState): StateVariables {
   return {...cs.latest, turnNum: cs.myIndex};
 }
 // End helpers

--- a/packages/server-wallet/src/handlers/join-channel.ts
+++ b/packages/server-wallet/src/handlers/join-channel.ts
@@ -65,7 +65,7 @@ export function joinChannel(
     channelState,
     ensureNotSignedByMe,
     chain(ensureLatestStateIsPrefundSetup),
-    map(nextState),
+    map(myPrefundState),
     map(signStateAction)
   );
 }

--- a/packages/server-wallet/src/handlers/join-channel.ts
+++ b/packages/server-wallet/src/handlers/join-channel.ts
@@ -55,9 +55,9 @@ export function joinChannel(
   // TODO: use Action creator from another branch
   const signStateAction = (sv: StateVariables): SignState => {
     return {
+      ...sv,
       type: 'SignState',
       channelId: args.channelId,
-      ...sv,
     };
   };
 

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -192,8 +192,10 @@ export class Channel extends Model implements RequiredColumns {
     };
   }
 
-  public get sortedStates(): SignedStateVarsWithHash[] {
-    return this.vars.map(s => ({...this.channelConstants, ...s}));
+  public get sortedStates(): Array<SignedStateWithHash> {
+    return this.vars
+      .map(s => ({...this.channelConstants, ...s}))
+      .sort((s1, s2) => s2.turnNum - s1.turnNum);
   }
 
   public get myAddress(): Address {
@@ -271,7 +273,7 @@ export class Channel extends Model implements RequiredColumns {
     let participantsWhoHaveNotSigned = new Set(this.participants.map(p => p.signingAddress));
     let previousState;
 
-    for (const signedState of this.signedStates) {
+    for (const signedState of this.sortedStates) {
       // If there is not a valid transition we know there cannot be a valid support
       // so we clear out what we have and start at the current signed state
       if (previousState && !this.validChain(signedState, previousState)) {

--- a/packages/server-wallet/src/protocols/__test__/application.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/application.test.ts
@@ -16,10 +16,11 @@ const outcome2 = simpleEthAllocation([
   {amount: BN.from(5), destination: bob().destination},
   {amount: BN.from(5), destination: alice().destination},
 ]);
-const prefundState = {outcome, turnNum: 0, participants: [alice(), bob()]};
-const prefundState2 = {outcome: outcome2, turnNum: 0, participants: [alice(), bob()]};
-const postFundState = {outcome, turnNum: 2, participants: [alice(), bob()]};
-const closingState = {outcome, turnNum: 4, isFinal: true, participants: [alice(), bob()]};
+const participants = [alice(), bob()];
+const prefundState = {outcome, turnNum: 0, participants};
+const prefundState2 = {outcome: outcome2, turnNum: 0, participants};
+const postFundState = {outcome, turnNum: 2, participants};
+const closingState = {outcome, turnNum: 4, isFinal: true, participants};
 
 const runningState = {outcome, turnNum: 7, participants: [alice(), bob()]};
 const closingState2 = {outcome, turnNum: 8, isFinal: true, participants: [alice(), bob()]};

--- a/packages/server-wallet/src/protocols/__test__/application.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/application.test.ts
@@ -16,13 +16,13 @@ const outcome2 = simpleEthAllocation([
   {amount: BN.from(5), destination: bob().destination},
   {amount: BN.from(5), destination: alice().destination},
 ]);
-const prefundState = {outcome, turnNum: 0};
-const prefundState2 = {outcome: outcome2, turnNum: 0};
-const postFundState = {outcome, turnNum: 2};
-const closingState = {outcome, turnNum: 4, isFinal: true};
+const prefundState = {outcome, turnNum: 0, participants: [alice(), bob()]};
+const prefundState2 = {outcome: outcome2, turnNum: 0, participants: [alice(), bob()]};
+const postFundState = {outcome, turnNum: 2, participants: [alice(), bob()]};
+const closingState = {outcome, turnNum: 4, isFinal: true, participants: [alice(), bob()]};
 
-const runningState = {outcome, turnNum: 7};
-const closingState2 = {outcome, turnNum: 8, isFinal: true};
+const runningState = {outcome, turnNum: 7, participants: [alice(), bob()]};
+const closingState2 = {outcome, turnNum: 8, isFinal: true, participants: [alice(), bob()]};
 
 const funded = (): Uint256 => BN.from(5);
 const notFunded = (): Uint256 => BN.from(0);

--- a/packages/server-wallet/src/protocols/__test__/application.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/application.test.ts
@@ -22,8 +22,8 @@ const prefundState2 = {outcome: outcome2, turnNum: 0, participants};
 const postFundState = {outcome, turnNum: 2, participants};
 const closingState = {outcome, turnNum: 4, isFinal: true, participants};
 
-const runningState = {outcome, turnNum: 7, participants: [alice(), bob()]};
-const closingState2 = {outcome, turnNum: 8, isFinal: true, participants: [alice(), bob()]};
+const runningState = {outcome, turnNum: 7, participants};
+const closingState2 = {outcome, turnNum: 8, isFinal: true, participants};
 
 const funded = (): Uint256 => BN.from(5);
 const notFunded = (): Uint256 => BN.from(0);

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -57,9 +57,9 @@ export const stage = (state: State | undefined): Stage =>
     ? 'Missing'
     : state.isFinal
     ? 'Final'
-    : state.turnNum === 0
+    : state.turnNum <= state.participants.length - 1
     ? 'PrefundSetup'
-    : state.turnNum === 3
+    : state.turnNum <= state.participants.length * 2 - 1
     ? 'PostfundSetup'
     : 'Running';
 

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -1,12 +1,9 @@
-import {simpleEthAllocation, serializeOutcome, BN} from '@statechannels/wallet-core';
-
 import {Channel} from '../../../models/channel';
 import {Wallet} from '../..';
-import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
+import {seedBobsSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {stateWithHashSignedBy} from '../fixtures/states';
-import {bob} from '../fixtures/signing-wallets';
+import {bob, alice} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {alice} from '../fixtures/participants';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 
@@ -14,13 +11,12 @@ let w: Wallet;
 beforeEach(async () => {
   w = new Wallet(defaultTestConfig);
   await new DBAdmin(w.knex).truncateDB();
+  await seedBobsSigningWallet(w.knex);
 });
 
 afterEach(async () => {
   await w.destroy();
 });
-
-beforeEach(async () => seedAlicesSigningWallet(w.knex));
 
 describe('directly funded app', () => {
   it('signs multiple prefund setups when joining multiple channels', async () => {
@@ -29,17 +25,36 @@ describe('directly funded app', () => {
     const state1 = {...preFS, channelNonce: 1};
     const state2 = {...preFS, channelNonce: 2};
 
-    const c1 = channel({channelNonce: 1, vars: [stateWithHashSignedBy(bob())(state1)]});
+    const c1 = channel({
+      signingAddress: bob().address,
+      channelNonce: 1,
+      vars: [stateWithHashSignedBy(alice())(state1)],
+    });
 
     await Channel.query(w.knex).insert(c1);
-    const c2 = channel({channelNonce: 2, vars: [stateWithHashSignedBy(bob())(state2)]});
+    const c2 = channel({
+      signingAddress: bob().address,
+      channelNonce: 2,
+      vars: [stateWithHashSignedBy(alice())(state2)],
+    });
 
     await Channel.query(w.knex).insert(c2);
     const channelIds = [c1, c2].map(c => c.channelId);
     const result = await w.joinChannels(channelIds);
     expect(result).toMatchObject({
       outbox: [
-        {params: {recipient: 'bob', sender: 'alice', data: {signedStates: [state1, state2]}}},
+        {
+          params: {
+            recipient: 'alice',
+            sender: 'bob',
+            data: {
+              signedStates: [
+                {...state1, turnNum: 1},
+                {...state2, turnNum: 1},
+              ],
+            },
+          },
+        },
       ],
       channelResults: [{channelId: c1.channelId}, {channelId: c2.channelId}],
     });
@@ -47,92 +62,34 @@ describe('directly funded app', () => {
     await Promise.all(
       channelIds.map(async c => {
         const updated = await Channel.forId(c, w.knex);
-        expect(updated.protocolState).toMatchObject({latest: preFS, supported: preFS});
+        expect(updated.protocolState).toMatchObject({
+          latest: {turnNum: 1},
+          supported: {turnNum: 1},
+        });
       })
     );
   });
 
   it('signs the prefund setup ', async () => {
     const appData = '0x0f00';
-    const preFS = {turnNum: 0, appData};
-
-    const c = channel({vars: [stateWithHashSignedBy(bob())(preFS)]});
+    const preFS0 = {turnNum: 0, appData};
+    const preFS1 = {turnNum: 1, appData};
+    const c = channel({
+      signingAddress: bob().address,
+      vars: [stateWithHashSignedBy(alice())(preFS0)],
+    });
     await Channel.query(w.knex).insert(c);
-
-    const channelId = c.channelId;
+    const {channelId} = c;
     const current = await Channel.forId(channelId, w.knex);
-    expect(current.protocolState).toMatchObject({latest: preFS, supported: undefined});
 
+    expect(current.protocolState).toMatchObject({latest: preFS0, supported: undefined});
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
-      outbox: [{params: {recipient: 'bob', sender: 'alice', data: {signedStates: [preFS]}}}],
-      channelResult: {channelId, turnNum: 0, appData, status: 'opening'},
+      outbox: [{params: {recipient: 'alice', sender: 'bob', data: {signedStates: [preFS1]}}}],
+      channelResult: {channelId, turnNum: 1, appData, status: 'opening'},
     });
 
     const updated = await Channel.forId(channelId, w.knex);
-    expect(updated.protocolState).toMatchObject({latest: preFS, supported: preFS});
-  });
 
-  it('signs the prefund setup and postfund setup, when there are no deposits to make', async () => {
-    const outcome = simpleEthAllocation([]);
-    const preFS = {turnNum: 0, outcome};
-    const postFS = {turnNum: 2, outcome};
-    const c = channel({vars: [stateWithHashSignedBy(bob())(preFS)]});
-    await Channel.query(w.knex).insert(c);
-
-    const outcomeWire = serializeOutcome(outcome);
-    const preFSWire = {turnNum: 0, outcome: outcomeWire};
-    const postFSWire = {turnNum: 2, outcome: outcomeWire};
-
-    const channelId = c.channelId;
-    const current = await Channel.forId(channelId, w.knex);
-    expect(current.latest).toMatchObject(preFS);
-
-    await expect(w.joinChannel({channelId})).resolves.toMatchObject({
-      outbox: [
-        {
-          params: {
-            recipient: 'bob',
-            sender: 'alice',
-            data: {signedStates: [preFSWire, postFSWire]},
-          },
-        },
-      ],
-      channelResult: {channelId, turnNum: 0, status: 'opening'}, // The latest supported state still has turnnum: 0
-    });
-
-    const updated = await Channel.forId(channelId, w.knex);
-    expect(updated.protocolState).toMatchObject({latest: postFS, supported: preFS});
-  });
-
-  it('signs the prefund setup and makes a deposit, when I am first to deposit in a directly funded app', async () => {
-    const outcome = simpleEthAllocation([{destination: alice().destination, amount: BN.from(5)}]);
-    const preFS = {turnNum: 0, outcome};
-    const c = channel({vars: [stateWithHashSignedBy(bob())(preFS)]});
-    await Channel.query(w.knex).insert(c);
-
-    const channelId = c.channelId;
-    const current = await Channel.forId(channelId, w.knex);
-    expect(current.latest).toMatchObject(preFS);
-
-    await expect(w.joinChannel({channelId})).resolves.toMatchObject({
-      outbox: [
-        {
-          method: 'MessageQueued',
-          params: {
-            recipient: 'bob',
-            sender: 'alice',
-            data: {signedStates: [{...preFS, outcome: serializeOutcome(preFS.outcome)}]},
-          },
-        },
-      ],
-      channelResult: {channelId, turnNum: 0, status: 'opening'},
-    });
-
-    const updated = await Channel.forId(channelId, w.knex);
-    expect(updated.protocolState).toMatchObject({
-      latest: preFS,
-      supported: preFS,
-      chainServiceRequests: ['fund'],
-    });
+    expect(updated.protocolState).toMatchObject({latest: preFS1, supported: preFS1});
   });
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -27,11 +27,17 @@ beforeEach(async () => await seedAlicesSigningWallet(w.knex));
 it('sends the post fund setup when the funding event is provided for multiple channels', async () => {
   const c1 = channel({
     channelNonce: 1,
-    vars: [stateWithHashSignedBy(alice(), bob())({turnNum: 0, channelNonce: 1})],
+    vars: [
+      stateWithHashSignedBy(alice())({turnNum: 0, channelNonce: 1}),
+      stateWithHashSignedBy(bob())({turnNum: 1, channelNonce: 1}),
+    ],
   });
   const c2 = channel({
     channelNonce: 2,
-    vars: [stateWithHashSignedBy(alice(), bob())({turnNum: 0, channelNonce: 2})],
+    vars: [
+      stateWithHashSignedBy(alice())({turnNum: 0, channelNonce: 2}),
+      stateWithHashSignedBy(bob())({turnNum: 1, channelNonce: 2}),
+    ],
   });
   await Channel.query(w.knex).insert(c1);
   await Channel.query(w.knex).insert(c2);
@@ -67,12 +73,17 @@ it('sends the post fund setup when the funding event is provided for multiple ch
         },
       },
     ],
-    channelResults: channelIds.map(cId => ({channelId: cId, turnNum: 0})),
+    channelResults: channelIds.map(cId => ({channelId: cId, turnNum: 2})),
   });
 });
 
 it('sends the post fund setup when the funding event is provided', async () => {
-  const c = channel({vars: [stateWithHashSignedBy(alice(), bob())({turnNum: 0})]});
+  const c = channel({
+    vars: [
+      stateWithHashSignedBy(alice())({turnNum: 0}),
+      stateWithHashSignedBy(bob())({turnNum: 1}),
+    ],
+  });
   await Channel.query(w.knex).insert(c);
   const {channelId} = c;
   const result = await w.updateFundingForChannels([
@@ -95,6 +106,6 @@ it('sends the post fund setup when the funding event is provided', async () => {
         },
       },
     ],
-    channelResults: [{channelId: c.channelId, turnNum: 0}], // The turnNum is coming from the supported state so we expect it be 0 still
+    channelResults: [{channelId: c.channelId, turnNum: 2}],
   });
 });


### PR DESCRIPTION
This PR switches the turn number on prefund setups to be the index of the participant.

This allows for the supported turn during prefund/postfund to be the latest state signed by a participant.