### PR TITLE
[server-wallet] Ensure Nonce gets bumped on reception of new signed states

### DIFF
--- a/packages/server-wallet/src/models/__test__/nonces.test.ts
+++ b/packages/server-wallet/src/models/__test__/nonces.test.ts
@@ -42,7 +42,7 @@ describe('using a given nonce', () => {
 
   it('rejects when the value does not exceed the existing nonce', async () => {
     await expect(nonce({value: 3}).use(knex)).resolves.toEqual(3);
-    await expect(nonce({value: 1}).use(knex)).rejects.toThrow('Nonce too low');
+    await expect(nonce({value: 1}).use(knex)).resolves.toEqual(3);
     await expect(nonce({value: 4}).use(knex)).resolves.toEqual(4);
   });
 });

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -278,8 +278,13 @@ export class Store {
 
   async pushMessage(message: WirePayload): Promise<Bytes32[]> {
     return this.knex.transaction(async tx => {
+      // Sorted to ensure channel nonces arrive in ascending order
+      const sortedSignedStates = (message.signedStates || []).sort(
+        (a, b) => a.channelNonce - b.channelNonce
+      );
+
       const stateChannelIds = message.signedStates?.map(ss => ss.channelId) || [];
-      for (const ss of message.signedStates || []) {
+      for (const ss of sortedSignedStates || []) {
         await this.addSignedState(ss.channelId, undefined, ss, tx);
       }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -341,9 +341,19 @@ export class Store {
         )
     );
 
+    maybeChannel =
+      maybeChannel || (await timer('get channel', async () => getChannel(channelId, tx)));
+
+    if (!maybeChannel) {
+      // TODO: Discuss where to put the code that bumps a channel nonce (is here ok?)
+      await Nonce.fromJson({
+        value: wireSignedState.channelNonce,
+        addresses: wireSignedState.participants.map(p => p.signingAddress),
+      }).use(tx);
+    }
+
     const channel =
       maybeChannel ||
-      (await timer('get channel', async () => getChannel(channelId, tx))) ||
       (await createChannel(
         {
           ...wireSignedState,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -349,13 +349,13 @@ export class Store {
     maybeChannel =
       maybeChannel || (await timer('get channel', async () => getChannel(channelId, tx)));
 
-    if (!maybeChannel) {
-      // TODO: Discuss where to put the code that bumps a channel nonce (is here ok?)
-      await Nonce.fromJson({
-        value: wireSignedState.channelNonce,
-        addresses: wireSignedState.participants.map(p => p.signingAddress),
-      }).use(tx);
-    }
+    if (!maybeChannel)
+      (
+        await Nonce.fromJson({
+          value: wireSignedState.channelNonce,
+          addresses: wireSignedState.participants.map(p => p.signingAddress),
+        })
+      ).use(tx);
 
     const channel =
       maybeChannel ||


### PR DESCRIPTION
The `Nonce` is currently not bumped on the receiving end and this can lead to issues when a party who has received many states decides to create a channel with an existing counterparty.
