### PR TITLE
chore: remove "conflicting" dev dependency

### DIFF
--- a/packages/iframe-channel-provider/package.json
+++ b/packages/iframe-channel-provider/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "7.10.1",
-    "@statechannels/client-api-schema": "^0.3.10",
     "@types/debug": "4.1.5",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",


### PR DESCRIPTION
When publishing a canary build, a conflicting dependency version warning
clued me into this issue