### PR TITLE
chore: disable server-wallet-profiling step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,9 +452,9 @@ workflows:
           requires:
             - prepare
 
-      - server-wallet-profiling:
-          requires:
-            - prepare
+      # - server-wallet-profiling:
+      #     requires:
+      #       - prepare
       - server-wallet-stress-test:
           requires:
             - prepare


### PR DESCRIPTION
Reason: It still flickers