### PR TITLE
Validate ForceMove transition rules in typescript

### DIFF
--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -44,7 +44,18 @@ export const validateTransitionWithEVM = async (
     Uint8Array.from(Buffer.from(bytecode.substr(2), 'hex')),
     Uint8Array.from(Buffer.from(data ? data.toString().substr(2) : '0x00', 'hex'))
   );
-
   // We need to ensure the result is the correct length otherwise we might be interpreting a failed assertion
-  return result.length === 32 && (utils.defaultAbiCoder.decode(['bool'], result)[0] as boolean);
+  const transitionPassed =
+    result.length === 32 && (utils.defaultAbiCoder.decode(['bool'], result)[0] as boolean);
+
+  if (!transitionPassed) {
+    // TODO: Figure out the proper encoding.
+    // Right now the revert reason is readable but slightly garbled
+    logger.error(`Call to ValidTransition failed in the EVM`, {
+      result: new TextDecoder().decode(result),
+    });
+    return false;
+  }
+
+  return true;
 };

--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -49,13 +49,17 @@ export const validateTransitionWithEVM = async (
     result.length === 32 && (utils.defaultAbiCoder.decode(['bool'], result)[0] as boolean);
 
   if (!transitionPassed) {
-    // TODO: Figure out the proper encoding.
-    // Right now the revert reason is readable but slightly garbled
-    logger.error(`Call to ValidTransition failed in the EVM`, {
-      result: new TextDecoder().decode(result),
+    logger.error(`Call to ValidTransition failed in the EVM ${parseRevertReason(result)}`, {
+      result: parseRevertReason(result),
     });
     return false;
   }
 
   return true;
 };
+
+function parseRevertReason(result: Uint8Array) {
+  // TODO: Figure out the proper encoding.
+  // Right now the revert reason is readable but slightly garbled
+  return new TextDecoder().decode(result.filter(r => r !== 0));
+}

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -253,6 +253,8 @@ export class Store {
     )?.protocolState;
   }
 
+  // Port of the following solidity code
+  // https://github.com/statechannels/statechannels/blob/a3d21827e340c0cc086f1abad7685345885bf245/packages/nitro-protocol/contracts/ForceMove.sol#L492-L534
   async validateTransition(
     fromState: SignedState,
     toState: SignedState,
@@ -275,13 +277,15 @@ export class Store {
       toState.signatures.some(s => s.signer === toMover);
 
     if (!basicValidation) {
-      logger.error('Basic ForceMove transition validation failed.', {fromState, toState});
+      const VALIDATION_ERROR = 'Basic ForceMove transition validation failed.';
+      logger.error(VALIDATION_ERROR, {fromState, toState, error: Error(VALIDATION_ERROR)});
       return false;
     }
 
     // Final state specific validation
     if (toState.isFinal && fromState.outcome !== toState.outcome) {
-      logger.error('Outcome changed on a final state', {fromState, toState});
+      const VALIDATION_ERROR = 'Outcome changed on a final state.';
+      logger.error(VALIDATION_ERROR, {fromState, toState, error: Error(VALIDATION_ERROR)});
       return false;
     }
 
@@ -293,10 +297,10 @@ export class Store {
       toState.appData === fromState.appData;
 
     if (isInFundingStage && !fundingStageValidation) {
-      logger.error(
-        'Invalid setup state transition. The outcome, appData have changed or the state is final',
-        {fromState, toState}
-      );
+      const VALIDATION_ERROR =
+        'Invalid setup state transition. The outcome, appData have changed or the state is final';
+      logger.error(VALIDATION_ERROR, {fromState, toState, error: Error(VALIDATION_ERROR)});
+
       return false;
     }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -182,7 +182,7 @@ export class Store {
 
     if (
       supported &&
-      (await timer('validating transition', async () =>
+      !(await timer('validating transition', async () =>
         this.validateTransition(supported, signedState, tx)
       ))
     ) {
@@ -508,9 +508,9 @@ export class Store {
       const {supported} = channel;
 
       if (
-        await timer('validating transition', async () =>
+        !(await timer('validating transition', async () =>
           this.validateTransition(supported, deserializeState(wireSignedState), tx)
-        )
+        ))
       ) {
         throw new StoreError('Invalid state transition', {
           from: channel.supported,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -266,17 +266,18 @@ export class Store {
     const toMoverIndex = toState.turnNum % toState.participants.length;
     const toMover = toState.participants[toMoverIndex].signingAddress;
 
-    const turnNumCheck = toState.turnNum === fromState.turnNum + 1;
+    const turnNumCheck = _.isEqual(toState.turnNum, fromState.turnNum + 1);
     if (!turnNumCheck) {
       const VALIDATION_ERROR = `Turn number check failed.`;
       logger.error(VALIDATION_ERROR, {fromState, toState, error: Error(VALIDATION_ERROR)});
     }
 
     const constantsCheck =
-      toState.chainId === fromState.chainId &&
-      toState.participants === fromState.participants &&
-      toState.appDefinition === fromState.appDefinition &&
-      toState.challengeDuration === fromState.challengeDuration;
+      _.isEqual(toState.chainId, fromState.chainId) &&
+      _.isEqual(toState.participants, fromState.participants) &&
+      _.isEqual(toState.appDefinition, fromState.appDefinition) &&
+      _.isEqual(toState.challengeDuration, fromState.challengeDuration);
+
     if (!constantsCheck) {
       const VALIDATION_ERROR = `Constants check failed.
       )}
@@ -300,7 +301,7 @@ export class Store {
     }
 
     // Final state specific validation
-    if (toState.isFinal && fromState.outcome !== toState.outcome) {
+    if (toState.isFinal && !_.isEqual(fromState.outcome, toState.outcome)) {
       const VALIDATION_ERROR = `Outcome changed on a final state.`;
       logger.error(VALIDATION_ERROR, {fromState, toState, error: Error(VALIDATION_ERROR)});
       return false;
@@ -309,9 +310,9 @@ export class Store {
     // Funding stage specific validation
     const isInFundingStage = toState.turnNum < 2 * toState.participants.length;
     const fundingStageValidation =
-      fromState.isFinal === false &&
-      toState.outcome === fromState.outcome &&
-      toState.appData === fromState.appData;
+      _.isEqual(fromState.isFinal, false) &&
+      _.isEqual(toState.outcome, fromState.outcome) &&
+      _.isEqual(toState.appData, fromState.appData);
 
     if (isInFundingStage && !fundingStageValidation) {
       const VALIDATION_ERROR = `Invalid setup state transition.`;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -286,12 +286,13 @@ export class Store {
     }
 
     // Funding stage specific validation
+    const isInFundingStage = toState.turnNum < 2 * toState.participants.length;
     const fundingStageValidation =
       fromState.isFinal === false &&
       toState.outcome === fromState.outcome &&
       toState.appData === fromState.appData;
 
-    if (toState.turnNum < 2 * toState.participants.length && !fundingStageValidation) {
+    if (isInFundingStage && !fundingStageValidation) {
       logger.error(
         'Invalid setup state transition. The outcome, appData have changed or the state is final',
         {fromState, toState}
@@ -300,7 +301,8 @@ export class Store {
     }
 
     // Validates app specific rules by running the app rules contract in the EVM
-    if (!this.skipEvmValidation) {
+    // We only want to run the validation for states not in the funding stage per the force move contract
+    if (!this.skipEvmValidation && !isInFundingStage) {
       const evmValidation = await validateTransitionWithEVM(
         toNitroState(fromState),
         toNitroState(fromState),


### PR DESCRIPTION
Performs the validation done by the `validTransition`in the ForceMove contract in typescript. This allows us to validate the basic transition rules without using  the `EVM`.

Also we no longer try to validate `Prefund/postfundSetup`  state transitions in the `EVM`. 