### PR TITLE
feat: wallet emits channel ready events

### DIFF
--- a/packages/server-wallet/src/__chain-test__/direct-funding.test.ts
+++ b/packages/server-wallet/src/__chain-test__/direct-funding.test.ts
@@ -62,11 +62,11 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   // the type assertion is due to
   // https://github.com/devanshj/rxjs-from-emitter/blob/master/docs/solving-some-from-event-flaws.md#the-way-fromevent-checks-if-the-first-argument-passed-is-an-emitter-or-not-is-incorrect
-  const postFundAPromise = fromEvent<SingleChannelOutput>(a as any, 'singleChannelOutput')
+  const postFundAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdate')
     .pipe(take(2))
     .toPromise();
 
-  const channelFundedBPromise = fromEvent<SingleChannelOutput>(b as any, 'singleChannelOutput')
+  const channelFundedBPromise = fromEvent<SingleChannelOutput>(b as any, 'channelUpdate')
     .pipe(take(2))
     .toPromise();
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -150,7 +150,7 @@ describe('registerChannel', () => {
     let resolve: () => void;
     const p = new Promise(r => (resolve = r));
 
-    const onHoldingUpdated = (arg: HoldingUpdatedArg): void => {
+    const holdingUpdated = (arg: HoldingUpdatedArg): void => {
       switch (counter) {
         case 0:
           expect(arg).toMatchObject({
@@ -178,7 +178,7 @@ describe('registerChannel', () => {
     };
 
     chainService.registerChannel(channelId, [ethAssetHolderAddress], {
-      onHoldingUpdated,
+      holdingUpdated,
       onAssetTransferred: _.noop,
     });
     await p;
@@ -190,7 +190,7 @@ describe('registerChannel', () => {
 
     await new Promise(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
-        onHoldingUpdated: arg => {
+        holdingUpdated: arg => {
           expect(arg).toMatchObject({
             channelId,
             assetHolderAddress: ethAssetHolderAddress,
@@ -217,7 +217,7 @@ describe('registerChannel', () => {
       )
     );
 
-    const onHoldingUpdated = (arg: HoldingUpdatedArg): void => {
+    const holdingUpdated = (arg: HoldingUpdatedArg): void => {
       const index = objectsToMatch.findIndex(
         predicate =>
           predicate.channelId === arg.channelId &&
@@ -230,7 +230,7 @@ describe('registerChannel', () => {
       if (!objectsToMatch.length) resolve();
     };
     chainService.registerChannel(channelId, [ethAssetHolderAddress, erc20AssetHolderAddress], {
-      onHoldingUpdated,
+      holdingUpdated,
       onAssetTransferred: _.noop,
     });
     fundChannel(0, 5, channelId, ethAssetHolderAddress);
@@ -246,7 +246,7 @@ describe('concludeAndWithdraw', () => {
     let counter = 0;
     const p = new Promise(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
-        onHoldingUpdated: _.noop,
+        holdingUpdated: _.noop,
         onAssetTransferred: (arg: AssetTransferredArg) => {
           switch (counter) {
             case 0:
@@ -285,7 +285,7 @@ describe('concludeAndWithdraw', () => {
     let counter = 0;
     const p = new Promise(resolve =>
       chainService.registerChannel(channelId, [erc20AssetHolderAddress], {
-        onHoldingUpdated: _.noop,
+        holdingUpdated: _.noop,
         onAssetTransferred: (arg: AssetTransferredArg) => {
           switch (counter) {
             case 0:

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -40,7 +40,7 @@ export type FundChannelArg = {
 };
 
 export interface ChainEventSubscriberInterface {
-  onHoldingUpdated(arg: HoldingUpdatedArg): void;
+  holdingUpdated(arg: HoldingUpdatedArg): void;
   onAssetTransferred(arg: AssetTransferredArg): void;
 }
 
@@ -237,7 +237,7 @@ export class ChainService implements ChainServiceInterface {
         next: event => {
           switch (event.type) {
             case Deposited:
-              subscriber.onHoldingUpdated(event);
+              subscriber.holdingUpdated(event);
               break;
             case AssetTransferred:
               subscriber.onAssetTransferred(event);

--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -9,6 +9,8 @@ import {SigningWallet} from '../models/signing-wallet';
 import {Channel} from '../models/channel';
 import {Nonce} from '../models/nonce';
 import {Objective, ObjectiveChannel} from '../models/objective';
+import {Funding} from '../models/funding';
+import {AppBytecode} from '../models/app-bytecode';
 
 export class DBAdmin {
   knex: Knex;
@@ -39,6 +41,8 @@ export class DBAdmin {
       Nonce.tableName,
       Objective.tableName,
       ObjectiveChannel.tableName,
+      Funding.tableName,
+      AppBytecode.tableName,
     ]
   ): Promise<void> {
     // eslint-disable-next-line no-process-env

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -1,6 +1,4 @@
-import {Payload} from '@statechannels/wallet-core';
+export {Payload as Message} from '@statechannels/wallet-core';
 
-import {Wallet} from './wallet';
-import {Outgoing} from './protocols/actions';
-
-export {Wallet, Payload as Message, Outgoing};
+export {Wallet, SingleChannelOutput} from './wallet';
+export {Outgoing} from './protocols/actions';

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -645,7 +645,7 @@ export class Wallet extends EventEmitter<WalletEvent>
   };
 
   // ChainEventSubscriberInterface implementation
-  onHoldingUpdated(arg: HoldingUpdatedArg): void {
+  holdingUpdated(arg: HoldingUpdatedArg): void {
     const channelUpdate: WalletEventName = 'channelUpdate';
     this.updateChannelFundingForAssetHolder(arg).then(singleChannelOutput =>
       this.emit(channelUpdate, singleChannelOutput)

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -72,7 +72,9 @@ export type MultipleChannelOutput = {
   objectivesToApprove?: Omit<ObjectiveStoredInDB, 'status'>[];
 };
 type Message = SingleChannelOutput | MultipleChannelOutput;
-type WalletEvent = {singleChannelOutput: SingleChannelOutput};
+
+export type WalletEventName = 'channelUpdate' | 'channelReady';
+type WalletEvent = {[key in WalletEventName]: SingleChannelOutput};
 
 const isSingleChannelMessage = (message: Message): message is SingleChannelOutput =>
   'channelResult' in message;
@@ -617,8 +619,18 @@ export class Wallet extends EventEmitter<WalletEvent>
           this.walletConfig.timingMetrics
         );
 
-        if (!nextAction) markObjectiveAsDone();
-        else {
+        if (!nextAction) {
+          markObjectiveAsDone();
+          // todo: is there a better check for "has the final postfund state been signed"?
+          if (app.supported?.turnNum === app.participants.length * 2 - 1) {
+            const toEmit: SingleChannelOutput = {
+              channelResult: ChannelState.toChannelResult(app),
+              outbox: [],
+            };
+            const channelReady: WalletEventName = 'channelReady';
+            this.emit(channelReady, toEmit);
+          }
+        } else {
           try {
             await doAction(nextAction);
           } catch (err) {
@@ -634,7 +646,10 @@ export class Wallet extends EventEmitter<WalletEvent>
 
   // ChainEventSubscriberInterface implementation
   onHoldingUpdated(arg: HoldingUpdatedArg): void {
-    this.updateChannelFundingForAssetHolder(arg).then(arg => this.emit('singleChannelOutput', arg));
+    const channelUpdate: WalletEventName = 'channelUpdate';
+    this.updateChannelFundingForAssetHolder(arg).then(singleChannelOutput =>
+      this.emit(channelUpdate, singleChannelOutput)
+    );
   }
 
   onAssetTransferred(_arg: AssetTransferredArg): void {


### PR DESCRIPTION
Also contains changes from https://github.com/statechannels/statechannels/pull/2725.

Consider the following scenario. A channel manager **CM** is trying to open one channel with a receipt manager **RM**. How does this work with fake funded channels? CM creates prefund 1 state and sends the state to RM. CM creates a promise **P** that resolves when:
1. A response is received from RM.
1. AND CM has no more messages to send to RM.

In practice, the promise P resolves when CM receives postfund2 from RM. This poses a problem for directly funded channels. Consider the following scenario.
1. CM sends prefund1 to RM.
1. CM receives prefund2 from RM.
1. CM triggers the chain deposit transaction.
1. CM has no more states to send to RM.
1. Promise P resolves.

There are several strategies for CM to block on a channel progressing to a ready state (aka last prefund has been signed). In this PR we chose to implement a wallet event that notifies any wallet consumer when a channel is ready.