### PR TITLE
[nitro-protocol] post-audit changes

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16-slim
+FROM node:12.18-slim
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -17,6 +17,6 @@ RUN apt-get install -y \
     tar \
     zlib1g-dev
 
-RUN curl -o /usr/bin/solc -fL https://github.com/ethereum/solidity/releases/download/v0.6.2/solc-static-linux \
+RUN curl -o /usr/bin/solc -fL https://github.com/ethereum/solidity/releases/download/v0.6.12/solc-static-linux \
     && chmod u+x /usr/bin/solc
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
   working_directory: /home/circleci/project
   resource_class: medium
   docker:
-    - image: geoknee/statechannels:node12.18-solc0.6.9 # Fast contract compilation with solc installed
+    - image: geoknee/statechannels:12.18-solc0.6.12 # Fast contract compilation with solc installed
     - image: circleci/postgres:12-alpine-ram # server-wallet uses a postgresql DB. alpine-ram is a minimal installation that runs in memory (ie. faster tests!)
       environment:
         POSTGRES_USER: root

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -20,7 +20,7 @@
     "lockfile": "1.0.4",
     "pino": "6.2.0",
     "pino-pretty": "4.0.0",
-    "solc": "0.6.1",
+    "solc": "0.6.12",
     "tcp-port-used": "1.0.1",
     "tree-kill": "1.2.2",
     "write-json-file": "4.2.0",

--- a/packages/docs-website/docs/protocol-tutorial/clear-a-challenge.md
+++ b/packages/docs-website/docs/protocol-tutorial/clear-a-challenge.md
@@ -108,9 +108,9 @@ You may have noticed that to respond, the challenge state itself must be (re)sub
 ```typescript
 // In lesson10.test.ts
 
-// Prepare a forceMove transaction as above, and store the transaction receipt
+// Prepare a challenge transaction as above, and store the transaction receipt
 const receipt = await(
-  await NitroAdjudicator.forceMove(
+  await NitroAdjudicator.challenge(
     fixedPart,
     largestTurnNum,
     variableParts,
@@ -121,7 +121,7 @@ const receipt = await(
   )
 ).wait();
 
-// Extract the information out of the ForceMove event
+// Extract the information out of the ChallengeRegistered event
 const event = receipt.events.pop();
 const {
   channelId: eventChannelId,

--- a/packages/docs-website/docs/protocol-tutorial/finalize-a-channel-sad.md
+++ b/packages/docs-website/docs/protocol-tutorial/finalize-a-channel-sad.md
@@ -66,11 +66,11 @@ const challengeSignedState: SignedState = signState(
 );
 const challengeSignature = signChallengeMessage([challengeSignedState], challenger.privateKey);
 
-/* Submit the forceMove transaction */
+/* Submit the challenge transaction */
 const variableParts = states.map(state => getVariablePart(state));
 const fixedPart = getFixedPart(states[0]);
 
-const tx = NitroAdjudicator.forceMove(
+const tx = NitroAdjudicator.challenge(
   fixedPart,
   largestTurnNum,
   variableParts,

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -8,7 +8,7 @@
     "easy-table": "1.1.1",
     "eslint-plugin-import": "^2.22.1",
     "ethers": "5.0.12",
-    "solc": "0.6.1",
+    "solc": "0.6.12",
     "typescript": "4.0.3"
   },
   "devDependencies": {

--- a/packages/nitro-protocol/bin/compile.js
+++ b/packages/nitro-protocol/bin/compile.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Compilation with js config
-const {compileAndSave, compile} = require('@ethereum-waffle/compiler');
+const {compileAndSave} = require('@ethereum-waffle/compiler');
 
 async function main() {
   let compilerType = 'solcjs';

--- a/packages/nitro-protocol/bin/compile.js
+++ b/packages/nitro-protocol/bin/compile.js
@@ -15,7 +15,7 @@ async function main() {
 
   const config = {
     compilerType,
-    compilerVersion: '0.6.2',
+    compilerVersion: '0.6.12',
     sourceDirectory: './contracts',
     outputDirectory: './build/contracts',
     outputType: 'multiple',

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -36,7 +36,7 @@ contract AssetHolder is IAssetHolder {
         uint256 finalPayoutAmount;
         uint256 firstNewAllocationItemAmount;
 
-        for (uint256 i = 0; i < allocation.length; i++) {
+        for (uint256 i = 0; i < allocation.length; i = i.add(1)) {
             if (balance == 0) {
                 // if funds are completely depleted, keep the allocationItem and do not pay out
             } else {
@@ -44,15 +44,15 @@ contract AssetHolder is IAssetHolder {
                 if (balance < _amount) {
                     // if funds still exist but are insufficient for this allocationItem, payout what's available and keep the allocationItem (but reduce the amount allocated)
                     // this block is never executed more than once
-                    numPayouts++;
+                    numPayouts = numPayouts.add(1);
                     overlap = true;
                     finalPayoutAmount = balance;
-                    firstNewAllocationItemAmount = _amount - balance;
+                    firstNewAllocationItemAmount = _amount.sub(balance);
                     balance = 0;
                 } else {
                     // if ample funds still exist, pay them out and discard the allocationItem
-                    numPayouts++;
-                    numNewAllocationItems--;
+                    numPayouts = numPayouts.add(1);
+                    numNewAllocationItems = numNewAllocationItems.sub(1);
                     balance = balance.sub(_amount);
                 }
             }
@@ -66,8 +66,8 @@ contract AssetHolder is IAssetHolder {
             Outcome.AllocationItem[] memory newAllocation = new Outcome.AllocationItem[](
                 numNewAllocationItems
             );
-            for (uint256 k = 0; k < numNewAllocationItems; k++) {
-                newAllocation[k] = allocation[allocation.length - numNewAllocationItems + k];
+            for (uint256 k = 0; k < numNewAllocationItems; k = k.add(1)) {
+                newAllocation[k] = allocation[allocation.length.sub(numNewAllocationItems).add(k)];
                 if (overlap && k == 0) {
                     newAllocation[k].amount = firstNewAllocationItemAmount;
                 }
@@ -87,8 +87,8 @@ contract AssetHolder is IAssetHolder {
         }
         // holdings updated BEFORE asset transferred (prevent reentrancy)
         uint256 payoutAmount;
-        for (uint256 m = 0; m < numPayouts; m++) {
-            if (overlap && m == numPayouts - 1) {
+        for (uint256 m = 0; m < numPayouts; m = m.add(1)) {
+            if (overlap && m == numPayouts.sub(1)) {
                 payoutAmount = finalPayoutAmount;
             } else {
                 payoutAmount = allocation[m].amount;
@@ -97,7 +97,7 @@ contract AssetHolder is IAssetHolder {
                 _transferAsset(_bytes32ToAddress(allocation[m].destination), payoutAmount);
                 emit AssetTransferred(channelId, allocation[m].destination, payoutAmount);
             } else {
-                holdings[allocation[m].destination] += payoutAmount;
+                holdings[allocation[m].destination] = holdings[allocation[m].destination].add(payoutAmount);
             }
         }
     }
@@ -196,10 +196,10 @@ contract AssetHolder is IAssetHolder {
         uint256 newAllocationLength = allocation.length;
 
         // first increase payouts according to guarantee
-        for (uint256 i = 0; i < guarantee.destinations.length; i++) {
+        for (uint256 i = 0; i < guarantee.destinations.length; i = i.add(1)) {
             // for each destination in the guarantee
             bytes32 _destination = guarantee.destinations[i];
-            for (uint256 j = 0; j < allocation.length; j++) {
+            for (uint256 j = 0; j < allocation.length; j = j.add(1)) {
                 if (balance == 0) {
                     break;
                 }
@@ -208,14 +208,14 @@ contract AssetHolder is IAssetHolder {
                     uint256 _amount = allocation[j].amount;
                     if (_amount > 0) {
                         if (balance >= _amount) {
-                            balance -= _amount;
+                            balance = balance.sub(_amount);
                             allocation[j].amount = 0; // subtract _amount;
-                            newAllocationLength--;
-                            payouts[j] += _amount;
+                            newAllocationLength = newAllocationLength.sub(1);
+                            payouts[j] = payouts[j].add(_amount);
                             break;
                         } else {
-                            allocation[j].amount = _amount - balance;
-                            payouts[j] += balance;
+                            allocation[j].amount = _amount.sub(balance);
+                            payouts[j] = payouts[j].add(balance);
                             balance = 0;
                             break;
                         }
@@ -226,7 +226,7 @@ contract AssetHolder is IAssetHolder {
 
         // next, increase payouts according to original allocation order
         // this block only has an effect if balance > 0
-        for (uint256 j = 0; j < allocation.length; j++) {
+        for (uint256 j = 0; j < allocation.length; j = j.add(1)) {
             // for each entry in the target channel's outcome
             if (balance == 0) {
                 break;
@@ -234,13 +234,13 @@ contract AssetHolder is IAssetHolder {
             uint256 _amount = allocation[j].amount;
             if (_amount > 0) {
                 if (balance >= _amount) {
-                    balance -= _amount;
+                    balance = balance.sub(_amount);
                     allocation[j].amount = 0; // subtract _amount;
-                    newAllocationLength--;
-                    payouts[j] += _amount;
+                    newAllocationLength = newAllocationLength.sub(1);
+                    payouts[j]  = payouts[j].add(_amount);
                 } else {
-                    allocation[j].amount = _amount - balance;
-                    payouts[j] += balance;
+                    allocation[j].amount = _amount.sub(balance);
+                    payouts[j] = payouts[j].add(balance);
                     balance = 0;
                 }
             }
@@ -257,11 +257,11 @@ contract AssetHolder is IAssetHolder {
         }
 
         uint256 k = 0;
-        for (uint256 j = 0; j < allocation.length; j++) {
+        for (uint256 j = 0; j < allocation.length; j = j.add(1)) {
             // for each destination in the target channel's allocation
             if (allocation[j].amount > 0) {
                 newAllocation[k] = allocation[j];
-                k++;
+                k = k.add(1);
             }
             if (payouts[j] > 0) {
                 if (_isExternalDestination(allocation[j].destination)) {
@@ -272,7 +272,7 @@ contract AssetHolder is IAssetHolder {
                         payouts[j]
                     );
                 } else {
-                    holdings[allocation[j].destination] += payouts[j];
+                    holdings[allocation[j].destination] = holdings[allocation[j].destination].add(payouts[j]);
                 }
             }
         }

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './Outcome.sol';
 import '@openzeppelin/contracts/math/SafeMath.sol';

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './Outcome.sol';

--- a/packages/nitro-protocol/contracts/CountingApp.sol
+++ b/packages/nitro-protocol/contracts/CountingApp.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/CountingApp.sol
+++ b/packages/nitro-protocol/contracts/CountingApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/ForceMoveApp.sol';

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './AssetHolder.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './AssetHolder.sol';

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './AssetHolder.sol';
 

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -56,8 +56,8 @@ contract ETHAssetHolder is AssetHolder {
 
         // refund whatever wasn't deposited.
         uint256 refund = amount.sub(amountDeposited);
-        (bool success, ) = msg.sender.call{value: refund}("");
-        require(success, "Could not refund excess funds");
+        (bool success, ) = msg.sender.call{value: refund}('');
+        require(success, 'Could not refund excess funds');
     }
 
     /**
@@ -67,7 +67,7 @@ contract ETHAssetHolder is AssetHolder {
      * @param amount Quantity of wei to be transferred.
      */
     function _transferAsset(address payable destination, uint256 amount) internal override {
-        (bool success, ) = destination.call{value: amount}("");
-        require(success, "Could not transfer asset");
+        (bool success, ) = destination.call{value: amount}('');
+        require(success, 'Could not transfer asset');
     }
 }

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -56,7 +56,7 @@ contract ETHAssetHolder is AssetHolder {
 
         // refund whatever wasn't deposited.
         uint256 refund = amount.sub(amountDeposited);
-        (bool success, ) = msg.sender.call.value(refund)("");
+        (bool success, ) = msg.sender.call{value: refund}("");
         require(success, "Could not refund excess funds");
     }
 
@@ -67,7 +67,7 @@ contract ETHAssetHolder is AssetHolder {
      * @param amount Quantity of wei to be transferred.
      */
     function _transferAsset(address payable destination, uint256 amount) internal override {
-        (bool success, ) = destination.call.value(amount)("");
+        (bool success, ) = destination.call{value: amount}("");
         require(success, "Could not transfer asset");
     }
 }

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './AssetHolder.sol';

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -236,6 +236,9 @@ contract ForceMove is IForceMove {
         bytes32 channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 
+        require(largestTurnNum + 1 >= numStates, "largestTurnNum + 1 must be greater than or equal to numStates");
+        // ^^ SW-C101: prevent underflow
+
         // By construction, the following states form a valid transition
         bytes32[] memory stateHashes = new bytes32[](numStates);
         for (uint48 i = 0; i < numStates; i++) {
@@ -243,6 +246,8 @@ contract ForceMove is IForceMove {
                 abi.encode(
                     State(
                         largestTurnNum + (i + 1) - numStates, // turnNum
+                        // ^^ SW-C101: It is not easy to use SafeMath here, since we are not using uint256s
+                        // Instead, we are protected by the require statement above
                         true, // isFinal
                         channelId,
                         appPartHash,

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/IForceMove.sol';

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -369,12 +369,11 @@ contract ForceMove is IForceMove {
             whoSignedWhat.length == nParticipants,
             '_validSignatures: whoSignedWhat must be the same length as participants'
         );
-        require(nStates > 0, 'At least one stateHash is required');
         for (uint256 i = 0; i < nParticipants; i++) {
             uint256 offset = (nParticipants + largestTurnNum - i) % nParticipants;
             // offset is the difference between the index of participant[i] and the index of the participant who owns the largesTurnNum state
             // the additional nParticipants in the dividend ensures offset always positive
-            if (whoSignedWhat[i] + offset  < nStates - 1) {
+            if (whoSignedWhat[i] + offset + 1 < nStates) {
                 return false;
             }
         }

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -44,7 +44,7 @@ contract ForceMove is IForceMove {
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
      */
-    function forceMove(
+    function challenge(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
         ForceMoveApp.VariablePart[] memory variableParts,

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -236,7 +236,10 @@ contract ForceMove is IForceMove {
         bytes32 channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 
-        require(largestTurnNum + 1 >= numStates, "largestTurnNum + 1 must be greater than or equal to numStates");
+        require(
+            largestTurnNum + 1 >= numStates,
+            'largestTurnNum + 1 must be greater than or equal to numStates'
+        );
         // ^^ SW-C101: prevent underflow
 
         // By construction, the following states form a valid transition

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -369,11 +369,12 @@ contract ForceMove is IForceMove {
             whoSignedWhat.length == nParticipants,
             '_validSignatures: whoSignedWhat must be the same length as participants'
         );
+        require(nStates > 0, 'At least one stateHash is required');
         for (uint256 i = 0; i < nParticipants; i++) {
             uint256 offset = (nParticipants + largestTurnNum - i) % nParticipants;
             // offset is the difference between the index of participant[i] and the index of the participant who owns the largesTurnNum state
             // the additional nParticipants in the dividend ensures offset always positive
-            if (whoSignedWhat[i] + offset < nStates - 1) {
+            if (whoSignedWhat[i] + offset  < nStates - 1) {
                 return false;
             }
         }

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/Adjudicator.sol';

--- a/packages/nitro-protocol/contracts/Outcome.sol
+++ b/packages/nitro-protocol/contracts/Outcome.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/Outcome.sol
+++ b/packages/nitro-protocol/contracts/Outcome.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 library Outcome {

--- a/packages/nitro-protocol/contracts/Token.sol
+++ b/packages/nitro-protocol/contracts/Token.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 

--- a/packages/nitro-protocol/contracts/Token.sol
+++ b/packages/nitro-protocol/contracts/Token.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 /**

--- a/packages/nitro-protocol/contracts/TrivialApp.sol
+++ b/packages/nitro-protocol/contracts/TrivialApp.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/TrivialApp.sol
+++ b/packages/nitro-protocol/contracts/TrivialApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/ForceMoveApp.sol';

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import '../interfaces/ForceMoveApp.sol';

--- a/packages/nitro-protocol/contracts/interfaces/Adjudicator.sol
+++ b/packages/nitro-protocol/contracts/interfaces/Adjudicator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/interfaces/Adjudicator.sol
+++ b/packages/nitro-protocol/contracts/interfaces/Adjudicator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/packages/nitro-protocol/contracts/interfaces/ForceMoveApp.sol
+++ b/packages/nitro-protocol/contracts/interfaces/ForceMoveApp.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/interfaces/ForceMoveApp.sol
+++ b/packages/nitro-protocol/contracts/interfaces/ForceMoveApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import './ForceMoveApp.sol';

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -58,7 +58,7 @@ abstract contract IForceMove {
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
      */
-    function forceMove(
+    function challenge(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
         ForceMoveApp.VariablePart[] memory variableParts,

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../AssetHolder.sol';

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../AssetHolder.sol';
 

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './TESTAssetHolder.sol';
 

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import './TESTAssetHolder.sol';

--- a/packages/nitro-protocol/contracts/test/TESTForceMove.sol
+++ b/packages/nitro-protocol/contracts/test/TESTForceMove.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../ForceMove.sol';
 

--- a/packages/nitro-protocol/contracts/test/TESTForceMove.sol
+++ b/packages/nitro-protocol/contracts/test/TESTForceMove.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../ForceMove.sol';

--- a/packages/nitro-protocol/contracts/test/TESTNitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/test/TESTNitroAdjudicator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../NitroAdjudicator.sol';

--- a/packages/nitro-protocol/contracts/test/TESTNitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/test/TESTNitroAdjudicator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../NitroAdjudicator.sol';
 

--- a/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../ERC20AssetHolder.sol';
 import './TESTAssetHolder.sol';

--- a/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../ERC20AssetHolder.sol';

--- a/packages/nitro-protocol/contracts/test/TestEthAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TestEthAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.0;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../ETHAssetHolder.sol';
 

--- a/packages/nitro-protocol/contracts/test/TestEthAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TestEthAssetHolder.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import '../ETHAssetHolder.sol';

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -32,6 +32,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "1.19.1",
     "prettier-plugin-solidity": "1.0.0-alpha.58",
+    "solc": "0.6.12",
     "solidoc": "https://github.com/statechannels/solidoc.git#a4d4d244e367c6cf654079d1f157d5eb5903b9af",
     "ts-jest": "26.4.1",
     "typescript": "4.0.3",

--- a/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
@@ -48,7 +48,7 @@ export function createChallengeTransaction(
   }));
   const challengerSignature = signChallengeMessage(signedStates, challengerPrivateKey);
 
-  const data = ForceMoveContractInterface.encodeFunctionData('forceMove', [
+  const data = ForceMoveContractInterface.encodeFunctionData('challenge', [
     fixedPart,
     largestTurnNum,
     variableParts,

--- a/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
@@ -15,7 +15,7 @@ interface CheckpointData {
   whoSignedWhat: number[];
 }
 
-export function createForceMoveTransaction(
+export function createChallengeTransaction(
   states: State[], // in turnNum order [..,state-with-largestTurnNum]
   signatures: Signature[], // in participant order: [sig-from-p0, sig-from-p1, ...]
   whoSignedWhat: number[],

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -20,7 +20,7 @@ export function createForceMoveTransaction(
 ): providers.TransactionRequest {
   const {states, signatures, whoSignedWhat} = createSignatureArguments(signedStates);
 
-  return forceMoveTrans.createForceMoveTransaction(
+  return forceMoveTrans.createChallengeTransaction(
     states,
     signatures,
     whoSignedWhat,

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test..ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test..ts
@@ -176,7 +176,7 @@ describe('forceMove', () => {
       // Set current channelStorageHashes value
       await (await ForceMove.setChannelStorageHash(channelId, initialChannelStorageHash)).wait();
 
-      const tx = ForceMove.forceMove(
+      const tx = ForceMove.challenge(
         fixedPart,
         largestTurnNum,
         variableParts,
@@ -189,7 +189,7 @@ describe('forceMove', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const receipt = await (await tx).wait();
-        await writeGasConsumption('./forceMove.gas.md', description, receipt.gasUsed);
+        await writeGasConsumption('./challenge.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
 
         // Catch ForceMove event

--- a/yarn.lock
+++ b/yarn.lock
@@ -27516,21 +27516,7 @@ socks@~2.3.2:
     ip "1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.npmjs.org/solc/-/solc-0.6.1.tgz#9a5080dd4106e37a87f84e6b355d4478e1ea5832"
-  integrity sha512-iKqNYps2p++x8L9sBg7JeAJb7EmW8VJ/2asAzwlLYcUhj86AzuWLe94UTSQHv1SSCCj/x6lya8twvXkZtlTbIQ==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "3.0.2"
-    fs-extra "^0.30.0"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.0"
-    semver "^5.5.0"
-    tmp "0.0.33"
-
-solc@^0.6.3:
+solc@0.6.12, solc@^0.6.3:
   version "0.6.12"
   resolved "https://registry.npmjs.org/solc/-/solc-0.6.12.tgz#48ac854e0c729361b22a7483645077f58cba080e"
   integrity sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==


### PR DESCRIPTION

Mostly straightforward things, apart from:
- changing name of `forceMove` method to `challenge` (recommended to avoid confusion). Note that I marked this as a **breaking change**
- [ ] SafeMath-ifying `ForceMove.sol` -- still to be done, but not straightforward because we use a lot of `uint48` and `uint8` which I don't think work straightforwardly with `SafeMath`. Workaround might involve a bunch of casting (yuk), extending the SafeMath library, or relying on our own `require()` statements. I did a few of those already.

### Rejected suggestions
---
- `_recoverSigner` should not be `pure`. It depends on a constant defined in the scope of the contract (not the function), which is why I think it may have been flagged. But I think it is still pure.
- arithmetic functions flagged inside of `SafeMath` (these are obviously necessary)
- unused function params in virtual functions (will be overriden, so OK to have empty function body)


### Punted suggestions that require more thought
--- 
- looping over unbounded data structures
