### PR TITLE
fix: log error on invalid state transition of received state instead of throwing

### DIFF
--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -520,7 +520,7 @@ export class Store {
           this.validateTransition(supported, incomingState, tx)
         ))
       ) {
-        throw new StoreError('Invalid state transition', {
+        logger.error('Invalid state transition — state is stored but not supported', {
           from: channel.supported,
           to: wireSignedState,
         });


### PR DESCRIPTION
You may want to store a state that is not a valid transition from a previously supported one (e.g., a new ledger update) but not consider it supported. In that case, you still want to check if a valid transition is there to determine if it is in fact supported but you don't want to discard the new state entirely.
