### PR TITLE
[server-wallet] Support ledger defunding

### DIFF
--- a/packages/server-wallet/src/models/ledger-requests.ts
+++ b/packages/server-wallet/src/models/ledger-requests.ts
@@ -14,6 +14,7 @@ export type LedgerRequestType = {
   ledgerChannelId: Bytes32;
   fundingChannelId: Bytes32;
   status: LedgerRequestStatus;
+  type: 'fund' | 'defund';
 };
 
 // FIXME: (SQL Ledger Models)
@@ -37,7 +38,7 @@ export class LedgerRequests {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     tx?: Transaction
   ): Promise<void> {
-    if (this.requests[channelId])
+    if (this.requests[channelId] && this.requests[channelId].type === request.type)
       throw new Error('LedgerRequest:setRequest channelId already has pending request');
     this.requests[channelId] = request;
   }

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -25,6 +25,11 @@ export type RequestLedgerFunding = {
   channelId: Bytes32;
   assetHolderAddress: Address;
 };
+export type RequestLedgerDefunding = {
+  type: 'RequestLedgerDefunding';
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+};
 export type MarkLedgerFundingRequestsAsComplete = {
   type: 'MarkLedgerFundingRequestsAsComplete';
   doneRequests: Bytes32[];
@@ -46,6 +51,9 @@ const actionConstructor = <A extends ProtocolAction = ProtocolAction>(type: A['t
   props: Omit<A, 'type'>
 ): A => ({...props, type} as A);
 export const requestLedgerFunding = actionConstructor<RequestLedgerFunding>('RequestLedgerFunding');
+export const requestLedgerDefunding = actionConstructor<RequestLedgerDefunding>(
+  'RequestLedgerDefunding'
+);
 export const fundChannel = actionConstructor<FundChannel>('FundChannel');
 export const signState = actionConstructor<SignState>('SignState');
 export const completeObjective = actionConstructor<CompleteObjective>('CompleteObjective');
@@ -65,4 +73,5 @@ export type ProtocolAction =
   | FundChannel
   | CompleteObjective
   | RequestLedgerFunding
+  | RequestLedgerDefunding
   | MarkLedgerFundingRequestsAsComplete;

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -1,13 +1,26 @@
-import {State} from '@statechannels/wallet-core';
+import {checkThat, isSimpleAllocation, State} from '@statechannels/wallet-core';
 import {Transaction} from 'knex';
 
 import {Store} from '../wallet/store';
 import {Bytes32} from '../type-aliases';
+import {LedgerRequestType} from '../models/ledger-requests';
 
 import {Protocol, ProtocolResult, ChannelState, stage, Stage} from './state';
-import {signState, noAction, CompleteObjective, completeObjective} from './actions';
+import {
+  signState,
+  noAction,
+  CompleteObjective,
+  completeObjective,
+  RequestLedgerDefunding,
+  requestLedgerDefunding,
+} from './actions';
 
-export type ProtocolState = {app: ChannelState};
+export type ProtocolState = {
+  app: ChannelState;
+  ledgerDefundingRequested?: boolean;
+  ledgerDefundingSucceeded?: boolean;
+  ledgerChannelId?: Bytes32;
+};
 
 const stageGuard = (guardStage: Stage) => (s: State | undefined): s is State =>
   !!s && stage(s) === guardStage;
@@ -35,13 +48,27 @@ const signFinalState = (ps: ProtocolState): ProtocolResult | false =>
         turnNum: ps.app.latest.turnNum,
       })));
 
+const defundIntoLedger = (ps: ProtocolState): RequestLedgerDefunding | false =>
+  isLedgerFunded(ps.app) &&
+  !ps.ledgerDefundingRequested &&
+  !ps.ledgerDefundingSucceeded &&
+  !!ps.app.supported &&
+  ps.app.supported.isFinal &&
+  requestLedgerDefunding({
+    channelId: ps.app.channelId,
+    assetHolderAddress: checkThat(ps.app.latest.outcome, isSimpleAllocation).assetHolderAddress,
+  });
+
+const isLedgerFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Ledger';
+
 const completeCloseChannel = (ps: ProtocolState): CompleteObjective | false =>
   isFinal(ps.app.supported) &&
   isFinal(ps.app.latestSignedByMe) &&
+  ((isLedgerFunded(ps.app) && ps.ledgerDefundingSucceeded) || !isLedgerFunded(ps.app)) &&
   completeObjective({channelId: ps.app.channelId});
 
 export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>
-  completeCloseChannel(ps) || signFinalState(ps) || noAction;
+  completeCloseChannel(ps) || defundIntoLedger(ps) || signFinalState(ps) || noAction;
 
 /**
  * Helper method to retrieve scoped data needed for CloseChannel protocol.
@@ -56,7 +83,20 @@ export const getCloseChannelProtocolState = async (
     case 'Direct':
     case 'Unfunded':
       return {app};
-    case 'Ledger':
+    case 'Ledger': {
+      /* TODO: Delete 'fund' requests from the Store */
+      let req: LedgerRequestType | undefined = await store.getPendingLedgerRequest(
+        app.channelId,
+        tx
+      );
+      req = req.type === 'defund' ? req : undefined;
+      return {
+        app,
+        ledgerDefundingRequested: !!req,
+        ledgerDefundingSucceeded: req ? req.status === 'succeeded' : false,
+        ledgerChannelId: req ? req.ledgerChannelId : undefined,
+      };
+    }
     case 'Unknown':
     case 'Virtual':
     default:

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -483,6 +483,7 @@ describe('ledger funded app scenarios', () => {
       ledgerChannelId: ledger.channelId,
       fundingChannelId: app.channelId,
       status: 'pending', // TODO: could this be approved?
+      type: 'fund',
     });
 
     const {outbox, channelResults} = await wallet.pushMessage({
@@ -520,6 +521,7 @@ describe('ledger funded app scenarios', () => {
       ledgerChannelId: ledger.channelId,
       fundingChannelId: app.channelId,
       status: 'pending', // TODO: could this be approved?
+      type: 'fund',
     });
 
     const {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -447,7 +447,7 @@ export class Wallet extends EventEmitter<WalletEvent>
       },
     ];
 
-    return {outbox, channelResult: channelResults[0]};
+    return {outbox: mergeOutgoing(outbox), channelResult: channelResults[0]};
   }
 
   async getChannels(): Promise<MultipleChannelOutput> {
@@ -708,9 +708,23 @@ export class Wallet extends EventEmitter<WalletEvent>
                 this.store,
                 protocolState.app
               );
-              await this.store.requestLedgerFunding(
+              await this.store.createLedgerRequest(
                 protocolState.app.channelId,
                 ledgerChannelId,
+                'fund',
+                tx
+              );
+              return;
+            }
+            case 'RequestLedgerDefunding': {
+              const ledgerChannelId = await determineWhichLedgerToUse(
+                this.store,
+                protocolState.app
+              );
+              await this.store.createLedgerRequest(
+                protocolState.app.channelId,
+                ledgerChannelId,
+                'defund',
                 tx
               );
               return;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -267,6 +267,7 @@ export class Store {
     toState: SignedState,
     tx: Transaction
   ): Promise<boolean> {
+    return true;
     const fromMoverIndex = fromState.turnNum % fromState.participants.length;
     const fromMover = fromState.participants[fromMoverIndex].signingAddress;
 
@@ -586,15 +587,17 @@ export class Store {
     return await this.ledgerRequests.getRequest(channelId, tx);
   }
 
-  async requestLedgerFunding(
+  async createLedgerRequest(
     channelId: Bytes32,
     ledgerChannelId: Bytes32,
+    type: 'fund' | 'defund',
     tx: Transaction
   ): Promise<void> {
     await this.ledgerRequests.setRequest(
       channelId,
       {
         ledgerChannelId,
+        type,
         status: 'pending',
         fundingChannelId: channelId,
       },


### PR DESCRIPTION
When `closeChannel` is called on a channel that is ledger funded, it will kick off an objective for the wallet to close that channel and now with this PR, that objective does not complete unless the funds are re-allocated to its parent ledger channel. Works concurrently.