### PR TITLE
fix: disable validTransition check for ledger channels

### DIFF
--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -189,6 +189,7 @@ export class Store {
       supported &&
       // If the state is the same as the support state then its not a transition just adding signatures
       !statesEqual(supported, state) &&
+      !(await this.isLedger(channelId)) &&
       !(await timer('validating transition', async () =>
         this.validateTransition(supported, signedState, tx)
       ))
@@ -515,7 +516,8 @@ export class Store {
     if (
       channel.supported &&
       // If the state is the same as the support state then its not a transition just adding signatures
-      !statesEqual(channel.supported, incomingState)
+      !statesEqual(channel.supported, incomingState) &&
+      !(await this.isLedger(channelId))
     ) {
       const {supported} = channel;
 
@@ -524,7 +526,7 @@ export class Store {
           this.validateTransition(supported, incomingState, tx)
         ))
       ) {
-        logger.error('Invalid state transition — state is stored but not supported', {
+        throw new StoreError('Invalid state transition', {
           from: channel.supported,
           to: wireSignedState,
         });


### PR DESCRIPTION
Following the approach outlined [here](https://github.com/statechannels/statechannels/pull/2728#issuecomment-715311687):

* it's too restrictive to check all state transitions for valid transitions, because new ledger states will always fail this check
* in the longer term we probably want to think more carefully about where we do this check
* but for now, we just turn it off for ledger channels