### PR TITLE
fix: completeOpenChannel uses turn number

### DIFF
--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -18,8 +18,9 @@ const outcome2 = simpleEthAllocation([
 ]);
 const participants = [alice(), bob()];
 const prefundState = {outcome, turnNum: 0, participants};
-const prefundState2 = {outcome: outcome2, turnNum: 0, participants};
-const postFundState = {outcome, turnNum: 2, participants};
+const prefundState1 = {outcome: outcome2, turnNum: 0, participants};
+const postfundState2 = {outcome, turnNum: 2, participants};
+const postfundState3 = {outcome, turnNum: 3, participants};
 
 const funded = (): Uint256 => BN.from(5);
 const notFunded = (): Uint256 => BN.from(0);
@@ -35,30 +36,31 @@ const fundChannelAction1 = fundChannel({
 const fundChannelAction2 = {...fundChannelAction1, expectedHeld: BN.from(5)};
 
 test.each`
-  supported        | latestSignedByMe | latest           | funding      | action                      | cond                                                                     | result
-  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${funded}    | ${signState(postFundState)} | ${'when the prefund state is supported, and the channel is funded'}      | ${'signs the postfund state'}
-  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${notFunded} | ${fundChannelAction1}       | ${'when the prefund state is supported, and alice is first to deposit'}  | ${'submits transaction'}
-  ${prefundState2} | ${prefundState2} | ${prefundState2} | ${funded}    | ${fundChannelAction2}       | ${'when the prefund state is supported, and alice is secont to deposit'} | ${'submits transaction'}
+  supported        | latestSignedByMe | latest           | funding      | action                       | cond                                                                     | result
+  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${funded}    | ${signState(postfundState2)} | ${'when the prefund state is supported, and the channel is funded'}      | ${'signs the postfund state'}
+  ${prefundState}  | ${prefundState}  | ${prefundState}  | ${notFunded} | ${fundChannelAction1}        | ${'when the prefund state is supported, and alice is first to deposit'}  | ${'submits transaction'}
+  ${prefundState1} | ${prefundState1} | ${prefundState1} | ${funded}    | ${fundChannelAction2}        | ${'when the prefund state is supported, and alice is secont to deposit'} | ${'submits transaction'}
 `('$result $cond', ({supported, latest, latestSignedByMe, funding, action}) => {
   const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe, funding}});
   expect(protocol(ps)).toMatchObject(action);
 });
 
 test.each`
-  supported        | latestSignedByMe | latest           | funding      | cond
-  ${undefined}     | ${prefundState}  | ${prefundState}  | ${funded}    | ${'when I have signed the prefund state, but it is not supported'}
-  ${undefined}     | ${undefined}     | ${undefined}     | ${funded}    | ${'when there is no state'}
-  ${prefundState}  | ${postFundState} | ${postFundState} | ${funded}    | ${'when the prefund state is supported, and I have signed the postfund state'}
-  ${prefundState2} | ${prefundState2} | ${prefundState2} | ${notFunded} | ${'when the prefund state is supported, and alice is second to deposit'}
+  supported         | latestSignedByMe  | latest            | funding      | cond
+  ${undefined}      | ${prefundState}   | ${prefundState}   | ${funded}    | ${'when I have signed the prefund state, but it is not supported'}
+  ${undefined}      | ${undefined}      | ${undefined}      | ${funded}    | ${'when there is no state'}
+  ${prefundState}   | ${postfundState2} | ${postfundState2} | ${funded}    | ${'when the prefund state is supported, and I have signed the postfund state'}
+  ${prefundState1}  | ${prefundState1}  | ${prefundState1}  | ${notFunded} | ${'when the prefund state is supported, and alice is second to deposit'}
+  ${postfundState2} | ${postfundState2} | ${postfundState2} | ${funded}    | ${'when the first postfund state is supported'}
 `('takes no action $cond', ({supported, latest, latestSignedByMe, funding}) => {
   const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe, funding}});
   expect(protocol(ps)).toBeUndefined();
 });
 
 test.each`
-  supported        | latestSignedByMe | latest           | funding   | cond
-  ${postFundState} | ${postFundState} | ${postFundState} | ${funded} | ${'when the postfund state is supported'}
-`('takes no action $cond', ({supported, latest, latestSignedByMe, funding}) => {
+  supported         | latestSignedByMe  | latest            | funding   | cond
+  ${postfundState3} | ${postfundState3} | ${postfundState3} | ${funded} | ${'when the last postfund state is supported'}
+`('completes the objective $cond', ({supported, latest, latestSignedByMe, funding}) => {
   const ps = applicationProtocolState({app: {supported, latest, latestSignedByMe, funding}});
   expect(protocol(ps)).toMatchObject({channelId: ps.app.channelId, type: 'CompleteObjective'});
 });

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -20,7 +20,7 @@ const isPrefundSetup = stageGuard('PrefundSetup');
 
 // These are currently unused, but will be used
 // const isRunning = stageGuard('Running');
-const isPostfundSetup = stageGuard('PostfundSetup');
+// const isPostfundSetup = stageGuard('PostfundSetup');
 const isRunning = stageGuard('Running');
 // const isMissing = (s: State | undefined): s is undefined => stage(s) === 'Missing';
 
@@ -122,7 +122,7 @@ const signPostFundSetup = (ps: ProtocolState): ProtocolResult | false =>
   });
 
 const completeOpenChannel = (ps: ProtocolState): CompleteObjective | false =>
-  (isRunning(ps.app.supported) || isPostfundSetup(ps.app.supported)) &&
+  (isRunning(ps.app.supported) || ps.app.supported === ps.app.participants.length * 2 - 1) &&
   completeObjective({channelId: ps.app.channelId});
 
 export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -122,7 +122,7 @@ const signPostFundSetup = (ps: ProtocolState): ProtocolResult | false =>
   });
 
 const completeOpenChannel = (ps: ProtocolState): CompleteObjective | false =>
-  (isRunning(ps.app.supported) || ps.app.supported === ps.app.participants.length * 2 - 1) &&
+  (isRunning(ps.app.supported) || ps.app.supported.turnNum === ps.app.participants.length * 2 - 1) &&
   completeObjective({channelId: ps.app.channelId});
 
 export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -122,7 +122,8 @@ const signPostFundSetup = (ps: ProtocolState): ProtocolResult | false =>
   });
 
 const completeOpenChannel = (ps: ProtocolState): CompleteObjective | false =>
-  (isRunning(ps.app.supported) || ps.app.supported.turnNum === ps.app.participants.length * 2 - 1) &&
+  (ps.app.supported?.turnNum === ps.app.participants.length * 2 - 1 ||
+    isRunning(ps.app.supported)) &&
   completeObjective({channelId: ps.app.channelId});
 
 export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>


### PR DESCRIPTION
`completeOpenChannel` should only generate the `completeObjective` after the last `postfund` state has been signed, NOT any postfund state.

After this is fixed and new server wallet package is published, the direct funding e2e test can be commented back in in the-graph repo: https://github.com/statechannels/the-graph/commit/6184cf377c4ae8069a34a5ffd8778f74c0275a81