### PR TITLE
📝💬🔏 Add two phase commit for ledger channel updates

### DIFF
--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -444,8 +444,9 @@ describe('Funding multiple channels syncronously (in bulk)', () => {
     } = ledger;
 
     expect(ledger).toMatchObject({
-      // 11 because there is a conflicting back-and-forth due to concurrent messages
-      turnNum: 11,
+      // The ordering of the concurrent messages leads to closing one
+      // channel on turn 7 then the remaining N - 1 others on turn 9
+      turnNum: 9,
       status: 'running',
     });
 

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -22,7 +22,7 @@ let b = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_B'});
 let participantA: Participant;
 let participantB: Participant;
 
-jest.setTimeout(100_000);
+jest.setTimeout(15_000);
 
 beforeAll(async () => {
   await a.dbAdmin().createDB();

--- a/packages/server-wallet/src/__test__/test-helpers.ts
+++ b/packages/server-wallet/src/__test__/test-helpers.ts
@@ -1,5 +1,5 @@
 import {ChannelResult} from '@statechannels/client-api-schema';
-import {Payload, SignedState} from '@statechannels/wire-format';
+import {ChannelRequest, Payload, SignedState} from '@statechannels/wire-format';
 
 import {Wallet} from '../wallet';
 
@@ -38,4 +38,13 @@ export async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
   const config = wallet.walletConfig;
   await wallet.destroy();
   return new Wallet(config); // Wallet that will "restart"
+}
+
+export function getRequestFor(channelId: string, outbox: Outgoing[]): ChannelRequest {
+  // eslint-disable-next-line
+  const requests = (outbox[0]!.params.data as Payload).requests!.filter(
+    req => req.channelId === channelId
+  );
+  if (requests.length != 1) throw Error(`Expected exactly one request found ${requests.length}`);
+  return requests[0];
 }

--- a/packages/server-wallet/src/db/migrations/20201014174041_ledgers.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174041_ledgers.ts
@@ -3,6 +3,8 @@ import * as Knex from 'knex';
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.table('channels', function(table) {
     table.string('asset_holder_address');
+    table.jsonb('my_unsigned_commitment');
+    table.jsonb('their_unsigned_commitment');
   });
 }
 

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -9,6 +9,7 @@ import {
   hashState,
   outcomesEqual,
   Zero,
+  Outcome,
 } from '@statechannels/wallet-core';
 import {JSONSchema, Model, Pojo, QueryContext, ModelOptions, TransactionOrKnex} from 'objection';
 import {ChannelResult, FundingStrategy} from '@statechannels/client-api-schema';
@@ -71,6 +72,8 @@ export class Channel extends Model implements RequiredColumns {
   readonly fundingStrategy!: FundingStrategy;
 
   readonly assetHolderAddress: string | undefined; // only Ledger channels have this
+  readonly myUnsignedCommitment: Outcome | undefined; // only Ledger channels have this
+  readonly theirUnsignedCommitment: Outcome | undefined; // only Ledger channels have this
 
   static get jsonSchema(): JSONSchema {
     return {
@@ -198,7 +201,6 @@ export class Channel extends Model implements RequiredColumns {
       supported,
       latest,
       latestSignedByMe,
-      latestNotSignedByMe,
       support,
       participants,
       chainServiceRequests,
@@ -216,7 +218,6 @@ export class Channel extends Model implements RequiredColumns {
       support,
       latest,
       latestSignedByMe,
-      latestNotSignedByMe,
       funding,
       chainServiceRequests,
       fundingStrategy,
@@ -291,12 +292,6 @@ export class Channel extends Model implements RequiredColumns {
 
   get latest(): SignedStateWithHash {
     return {...this.channelConstants, ...this.signedStates[0]};
-  }
-
-  get latestNotSignedByMe(): SignedStateWithHash | undefined {
-    const signed = this.signedStates.find(s => !this.mySignature(s.signatures));
-    if (!signed) return undefined;
-    return {...this.channelConstants, ...signed};
   }
 
   private get _supported(): SignedStateWithHash | undefined {

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -120,7 +120,12 @@ export class Channel extends Model implements RequiredColumns {
     },
   };
 
-  static jsonAttributes = ['vars', 'participants'];
+  static jsonAttributes = [
+    'vars',
+    'participants',
+    'myUnsignedCommitment',
+    'theirUnsignedCommitment',
+  ];
 
   static async forId(channelId: Bytes32, txOrKnex: TransactionOrKnex): Promise<Channel> {
     return Channel.query(txOrKnex)

--- a/packages/server-wallet/src/protocols/actions.ts
+++ b/packages/server-wallet/src/protocols/actions.ts
@@ -1,5 +1,5 @@
 import {MessageQueuedNotification, Address} from '@statechannels/client-api-schema';
-import {StateVariables} from '@statechannels/wallet-core';
+import {SimpleAllocation, StateVariables} from '@statechannels/wallet-core';
 
 import {Bytes32, Uint256} from '../type-aliases';
 
@@ -34,6 +34,13 @@ export type MarkLedgerFundingRequestsAsComplete = {
   type: 'MarkLedgerFundingRequestsAsComplete';
   fundedChannels: Bytes32[];
   defundedChannels: Bytes32[];
+  ledgerChannelId: Bytes32;
+};
+export type ProposeLedgerState = {
+  type: 'ProposeLedgerState';
+  channelId: Bytes32;
+  outcome: SimpleAllocation;
+  channelsNotFunded: Bytes32[];
 };
 export type SignLedgerState = {
   type: 'SignLedgerState';
@@ -70,6 +77,7 @@ export type Outgoing = Notice;
 
 export type ProtocolAction =
   | SignState
+  | ProposeLedgerState
   | SignLedgerState
   | FundChannel
   | CompleteObjective

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -33,7 +33,6 @@ export type ChannelState = {
   supported?: SignedStateWithHash;
   latest: SignedStateWithHash;
   latestSignedByMe?: SignedStateWithHash;
-  latestNotSignedByMe?: SignedStateWithHash;
   funding: (address: Address) => Uint256;
   chainServiceRequests: ChainServiceRequests;
   fundingStrategy: FundingStrategy;

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -6,6 +6,7 @@ import {
   makeDestination,
   SignedStateWithHash,
   serializeOutcome,
+  serializeRequest,
 } from '@statechannels/wallet-core';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
 import Objection from 'objection';
@@ -269,7 +270,7 @@ describe('ledger funded app scenarios', () => {
     return channel;
   };
 
-  it('countersigns a prefund setup and automatically creates a ledger update', async () => {
+  it('countersigns a prefund setup and automatically proposes a ledger update', async () => {
     const outcome = simpleEthAllocation([{destination: bobP().destination, amount: BN.from(5)}]);
     const preFS0 = {turnNum: 0, outcome};
     const preFS1 = {turnNum: 1, outcome};
@@ -290,9 +291,13 @@ describe('ledger funded app scenarios', () => {
             recipient: 'alice',
             sender: 'bob',
             data: {
-              signedStates: [
-                serializeState(stateWithHashSignedBy(bob())(signedPreFS1)),
-                serializeState(stateWithHashSignedBy(bob())(expectedUpdatedLedgerState)),
+              signedStates: [serializeState(stateWithHashSignedBy(bob())(signedPreFS1))],
+              requests: [
+                serializeRequest({
+                  type: 'ProposeLedger',
+                  channelId: ledger.channelId,
+                  outcome: expectedUpdatedLedgerState.outcome,
+                }),
               ],
             },
           },

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -485,7 +485,7 @@ export class Wallet extends EventEmitter<WalletEvent>
             outbox.push(outgoing)
           );
         } else if (req.type === 'ProposeLedger') {
-          await store.storeTheirLedgerCommit(channelId, req.outcome);
+          await store.storeTheirLedgerCommit(channelId, checkThat(req.outcome, isSimpleAllocation));
         }
       };
     }

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -548,14 +548,14 @@ export class Store {
     await Channel.query(tx)
       .where({channelId})
       .whereNotNull('myUnsignedCommitment')
-      .patch({myUnsignedCommitment: null});
+      .patch({myUnsignedCommitment: this.knex.raw('NULL')});
   }
 
   async removeTheirLedgerCommit(channelId: Bytes32, tx: Transaction): Promise<void> {
     await Channel.query(tx)
       .where({channelId})
       .whereNotNull('theirUnsignedCommitment')
-      .patch({theirUnsignedCommitment: null});
+      .patch({theirUnsignedCommitment: this.knex.raw('NULL')});
   }
 
   async addSignedState(

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -101,20 +101,13 @@ export function deserializeObjective(objective: ObjectiveWire): Objective {
 // I don't want asset holders in the json rpc layer, as the client shouldn't care
 
 export function deserializeRequest(request: ChannelRequestWire): ChannelRequest {
-  if (request.type === 'GetChannel') return request;
   if (request.type === 'ProposeLedger')
     return {
       ...request,
-      outcome: {
-        ...request.outcome,
-        type: 'SimpleAllocation',
-        allocationItems: request.outcome.allocationItems.map(item => ({
-          amount: BN.from(item.amount),
-          destination: makeDestination(item.destination)
-        }))
-      }
+      outcome: deserializeOutcome(request.outcome)
     };
-  throw new Error(`unreachable: unknown channel request ${request}`);
+
+  return request;
 }
 
 export function deserializeOutcome(outcome: OutcomeWire): Outcome {

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -1,6 +1,7 @@
 import {
   SignedState as SignedStateWire,
   Outcome as OutcomeWire,
+  ChannelRequest as ChannelRequestWire,
   AllocationItem as AllocationItemWire,
   Allocation as AllocationWire,
   Guarantee as GuaranteeWire,
@@ -13,7 +14,8 @@ import {
   AllocationItem,
   SimpleAllocation,
   Payload,
-  SimpleGuarantee
+  SimpleGuarantee,
+  ChannelRequest
 } from '../../types';
 import {calculateChannelId} from '../../state-utils';
 import {formatAmount} from '../../utils';
@@ -26,7 +28,7 @@ export function serializeMessage(
 ): WireMessage {
   const signedStates = (message.signedStates || []).map(s => serializeState(s, channelId));
   const objectives = message.objectives;
-  const {requests} = message;
+  const requests = message.requests?.map(serializeRequest);
   return {
     recipient,
     sender,
@@ -59,6 +61,13 @@ export function serializeState(state: SignedState, channelId?: string): SignedSt
     channelId: channelId || calculateChannelId(state),
     signatures: state.signatures.map(s => s.signature)
   };
+}
+
+function serializeRequest(request: ChannelRequest): ChannelRequestWire {
+  if (request.type === 'ProposeLedger') {
+    return {...request, outcome: serializeSimpleAllocation(request.outcome)};
+  }
+  return request;
 }
 
 export function serializeOutcome(outcome: Outcome): OutcomeWire {

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -63,9 +63,9 @@ export function serializeState(state: SignedState, channelId?: string): SignedSt
   };
 }
 
-function serializeRequest(request: ChannelRequest): ChannelRequestWire {
+export function serializeRequest(request: ChannelRequest): ChannelRequestWire {
   if (request.type === 'ProposeLedger') {
-    return {...request, outcome: serializeSimpleAllocation(request.outcome)};
+    return {...request, outcome: serializeOutcome(request.outcome)};
   }
   return request;
 }

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -165,7 +165,7 @@ export function objectiveId(objective: Objective): string {
 }
 
 type GetChannel = {type: 'GetChannel'; channelId: string};
-type ProposeLedger = {type: 'ProposeLedger'; channelId: string; outcome: SimpleAllocation};
+type ProposeLedger = {type: 'ProposeLedger'; channelId: string; outcome: Outcome};
 export type ChannelRequest = GetChannel | ProposeLedger;
 
 export interface Payload {

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -165,7 +165,8 @@ export function objectiveId(objective: Objective): string {
 }
 
 type GetChannel = {type: 'GetChannel'; channelId: string};
-export type ChannelRequest = GetChannel;
+type ProposeLedger = {type: 'ProposeLedger'; channelId: string; outcome: SimpleAllocation};
+export type ChannelRequest = GetChannel | ProposeLedger;
 
 export interface Payload {
   signedStates?: SignedState[];

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -83,7 +83,7 @@
               "type": "string"
             },
             "outcome": {
-              "$ref": "#/definitions/Allocation"
+              "$ref": "#/definitions/Outcome"
             },
             "type": {
               "const": "ProposeLedger",

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -58,21 +58,46 @@
       "type": "string"
     },
     "ChannelRequest": {
-      "additionalProperties": false,
-      "properties": {
-        "channelId": {
-          "$ref": "#/definitions/Bytes32"
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "channelId": {
+              "type": "string"
+            },
+            "type": {
+              "const": "GetChannel",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "channelId"
+          ],
+          "type": "object"
         },
-        "type": {
-          "const": "GetChannel",
-          "type": "string"
+        {
+          "additionalProperties": false,
+          "properties": {
+            "channelId": {
+              "type": "string"
+            },
+            "outcome": {
+              "$ref": "#/definitions/Allocation"
+            },
+            "type": {
+              "const": "ProposeLedger",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "channelId",
+            "outcome"
+          ],
+          "type": "object"
         }
-      },
-      "required": [
-        "type",
-        "channelId"
-      ],
-      "type": "object"
+      ]
     },
     "CloseChannel": {
       "additionalProperties": false,

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -141,7 +141,7 @@ export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');
 
 // channel requests
 type GetChannel = {type: 'GetChannel'; channelId: string};
-type ProposeLedger = {type: 'ProposeLedger'; channelId: string; outcome: Allocation};
+type ProposeLedger = {type: 'ProposeLedger'; channelId: string; outcome: Outcome};
 export type ChannelRequest = GetChannel | ProposeLedger;
 
 export interface Payload {

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -140,8 +140,9 @@ export const isVirtuallyFund = guard<VirtuallyFund>('VirtuallyFund');
 export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');
 
 // channel requests
-type GetChannel = {type: 'GetChannel'; channelId: Bytes32};
-export type ChannelRequest = GetChannel;
+type GetChannel = {type: 'GetChannel'; channelId: string};
+type ProposeLedger = {type: 'ProposeLedger'; channelId: string; outcome: Allocation};
+export type ChannelRequest = GetChannel | ProposeLedger;
 
 export interface Payload {
   signedStates?: SignedState[];


### PR DESCRIPTION
Changes the implementation in #2715, which has each part sign a state of its proposed update immediately, this PR first ensures the two parties exchange a sequence of "commits", sharing what they propose the next ledger update be before actually signing it (or the intersection of it and the others commit). This implementation uses "requests", but it might be argued that it should be an objective instead.

### Pros
- Maintains that a Store need only store a single state per turn number

### Cons
- This adds networking overhead