### PR TITLE
refactor: encapsulate AppBytecode inside Store

### DIFF
--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -51,7 +51,6 @@ import {
   MockChainService,
 } from '../chain-service';
 import {DBAdmin} from '../db-admin/db-admin';
-import {AppBytecode} from '../models/app-bytecode';
 
 import {Store, AppHandler, MissingAppHandler, ObjectiveStoredInDB} from './store';
 
@@ -171,12 +170,7 @@ export class Wallet extends EventEmitter<WalletEvent>
       throw Error(`Could not fetch bytecode for ${appDefinition}`);
     }
 
-    await AppBytecode.upsertBytecode(
-      this.walletConfig.chainNetworkID,
-      appDefinition,
-      bytecode,
-      this.knex
-    );
+    await this.store.upsertBytecode(this.walletConfig.chainNetworkID, appDefinition, bytecode);
   }
 
   public mergeMessages(messages: Message[]): MultipleChannelOutput {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -54,6 +54,7 @@ import {recoverAddress} from '../utilities/signatures';
 import {Outgoing} from '../protocols/actions';
 import {Objective as ObjectiveModel} from '../models/objective';
 import {logger} from '../logger';
+import {AppBytecode} from '../models/app-bytecode';
 
 export type AppHandler<T> = (tx: Transaction, channel: ChannelState) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;
@@ -414,6 +415,14 @@ export class Store {
 
   async markObjectiveAsSucceeded(objective: ObjectiveStoredInDB, tx?: Transaction): Promise<void> {
     await ObjectiveModel.succeed(objective.objectiveId, tx || this.knex);
+  }
+
+  async upsertBytecode(
+    chainNetworkId: string,
+    appDefinition: Address,
+    bytecode: Bytes
+  ): Promise<void> {
+    await AppBytecode.upsertBytecode(chainNetworkId, appDefinition, bytecode, this.knex);
   }
 
   async addObjective(objective: Objective, tx: Transaction): Promise<ObjectiveStoredInDB> {


### PR DESCRIPTION
The Wallet should not need to know about or care which models the Store relies on
