### PR TITLE
Set max of one connection in test knex config

### DIFF
--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -13,7 +13,6 @@ beforeAll(async () => {
   await new DBAdmin(testKnex).truncateDB();
 });
 
-afterEach(async () => {});
 afterAll(async () => {
   // We need to close the db connection after the test suite has run.
   // Otherwise, jest will not exit within the required one second after the test

--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -63,6 +63,7 @@ export const defaultConfig: ServerWalletConfig = {
 export const defaultTestConfig = {
   ...defaultConfig,
   skipEvmValidation: (process.env.SKIP_EVM_VALIDATION || 'true').toLowerCase() === 'true',
+  postgresPoolSize: {max: 1, min: 0},
 };
 
 export function extractDBConfigFromServerWalletConfig(

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -562,7 +562,7 @@ export class Wallet extends EventEmitter<WalletEvent>
               });
               return;
             case 'CompleteObjective':
-              await this.store.markObjectiveAsSucceeded(objective);
+              await this.store.markObjectiveAsSucceeded(objective, tx);
               markObjectiveAsDone(); // TODO: Awkward to use this for undefined and CompleteObjective
               return;
             default:


### PR DESCRIPTION
If you
1. starting a transaction (acquires a connection)
2. executing a query (acquires a connection)
3. committing the transaction

Then at (2), there are no connections available, you are blocked

If the entire connection pool is at (1), every transaction is blocked and none of them proceed.

This detects this behaviour by setting the maximum size of the connection pool to be 1.

This change detects https://github.com/statechannels/statechannels/issues/2748 (and hopefully not other deadlocks!)