### PR TITLE
Add networkChainId to store

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -12,7 +12,12 @@ import {alice, bob} from './fixtures/signing-wallets';
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
+  store = new Store(
+    knex,
+    defaultTestConfig.timingMetrics,
+    defaultTestConfig.skipEvmValidation,
+    '0'
+  );
 });
 
 describe('addSignedState', () => {

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -9,7 +9,12 @@ import {defaultTestConfig} from '../../config';
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
+  store = new Store(
+    knex,
+    defaultTestConfig.timingMetrics,
+    defaultTestConfig.skipEvmValidation,
+    '0'
+  );
 });
 
 describe('addSignedState', () => {

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -12,7 +12,12 @@ import {alice} from './fixtures/participants';
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
+  store = new Store(
+    knex,
+    defaultTestConfig.timingMetrics,
+    defaultTestConfig.skipEvmValidation,
+    '0'
+  );
 });
 
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -15,7 +15,12 @@ jest.setTimeout(10_000);
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
+  store = new Store(
+    knex,
+    defaultTestConfig.timingMetrics,
+    defaultTestConfig.skipEvmValidation,
+    '0'
+  );
 });
 
 it('works', async () => {

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -16,7 +16,12 @@ let tx: Objection.Transaction;
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
+  store = new Store(
+    knex,
+    defaultTestConfig.timingMetrics,
+    defaultTestConfig.skipEvmValidation,
+    '0'
+  );
 });
 
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -11,7 +11,12 @@ import {alice} from './fixtures/participants';
 let store: Store;
 
 beforeAll(async () => {
-  store = new Store(knex, defaultTestConfig.timingMetrics, defaultTestConfig.skipEvmValidation);
+  store = new Store(
+    knex,
+    defaultTestConfig.timingMetrics,
+    defaultTestConfig.skipEvmValidation,
+    '0'
+  );
 });
 
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -121,7 +121,8 @@ export class Wallet extends EventEmitter<WalletEvent>
     this.store = new Store(
       this.knex,
       this.walletConfig.timingMetrics,
-      this.walletConfig.skipEvmValidation
+      this.walletConfig.skipEvmValidation,
+      this.walletConfig.chainNetworkID
     );
 
     // Bind methods to class instance

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -80,7 +80,8 @@ export class Store {
   constructor(
     public readonly knex: Knex,
     readonly timingMetrics: boolean,
-    readonly skipEvmValidation: boolean
+    readonly skipEvmValidation: boolean,
+    readonly chainNetworkID: string
   ) {
     if (timingMetrics) {
       this.getFirstParticipant = recordFunctionMetrics(this.getFirstParticipant);


### PR DESCRIPTION
The `networkChainId` is wallet-wide, so there's no reason not to have it on the store too. If we put it on the store, that's one less thing we need to provide when creating channels. (Will be used in an upcoming PR).