### PR TITLE
fix: ensure prefund setup is signed if turnNum < participants.length

### DIFF
--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -103,7 +103,7 @@ const fundChannel = (ps: ProtocolState): ProtocolResult | false =>
 const signPreFundSetup = (ps: ProtocolState): ProtocolResult | false =>
   !ps.app.latestSignedByMe &&
   !!ps.app.latest &&
-  ps.app.latest.turnNum < ps.app.participants.length - 1 &&
+  ps.app.latest.turnNum < ps.app.participants.length &&
   signState({
     ...ps.app.latest,
     channelId: ps.app.channelId,


### PR DESCRIPTION
I believe this is an off by one error. If your turn number is 0, and you have not signed anything yet, you want to sign the prefund setup if the latest turnNum is less than 2 
