### PR TITLE
fix: fix bug in allocateToTarget preventing funding with amount 0x00

### DIFF
--- a/packages/wallet-core/src/utils/outcome.ts
+++ b/packages/wallet-core/src/utils/outcome.ts
@@ -73,17 +73,19 @@ export function allocateToTarget(
   let total = Zero;
   let currentItems = currentOutcome.allocationItems;
 
-  deductions.forEach(targetItem => {
-    const ledgerItem = currentItems.find(i => i.destination === targetItem.destination);
-    if (!ledgerItem) {
-      throw new Error(Errors.DestinationMissing);
-    }
+  deductions
+    .filter(i => BN.gt(i.amount, 0))
+    .forEach(targetItem => {
+      const ledgerItem = currentItems.find(i => i.destination === targetItem.destination);
+      if (!ledgerItem) {
+        throw new Error(Errors.DestinationMissing);
+      }
 
-    total = BN.add(total, targetItem.amount);
-    ledgerItem.amount = BN.sub(ledgerItem.amount, targetItem.amount);
+      total = BN.add(total, targetItem.amount);
+      ledgerItem.amount = BN.sub(ledgerItem.amount, targetItem.amount);
 
-    if (BN.lt(ledgerItem.amount, 0)) throw new Error(Errors.InsufficientFunds);
-  });
+      if (BN.lt(ledgerItem.amount, 0)) throw new Error(Errors.InsufficientFunds);
+    });
 
   currentItems.push({destination: makeDestination(targetChannelId), amount: total});
   currentItems = currentItems.filter(i => BN.gt(i.amount, 0));


### PR DESCRIPTION
If I had an outcome {A: 2, B: 0} and I wanted to fund (C1) {A: 1, B: 0} and (C2) {A: 1, B 0} then I would make two calls to `allocateToTarget`. The first would have produced {A: 0, C1: 1} and the second would have thrown an error (since B was not in this result and the destination was missing. With this change, the second call will produce {C1: 1, C2: 1} and each channel would be funded as needed.
