### PR TITLE
A few refactors to the Objective model

### DIFF
--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -8,7 +8,7 @@ import Knex from 'knex';
 import {SigningWallet} from '../models/signing-wallet';
 import {Channel} from '../models/channel';
 import {Nonce} from '../models/nonce';
-import {Objective, ObjectiveChannel} from '../models/objective';
+import {ObjectiveModel, ObjectiveChannel} from '../models/objective';
 import {Funding} from '../models/funding';
 import {AppBytecode} from '../models/app-bytecode';
 
@@ -39,7 +39,7 @@ export class DBAdmin {
       SigningWallet.tableName,
       Channel.tableName,
       Nonce.tableName,
-      Objective.tableName,
+      ObjectiveModel.tableName,
       ObjectiveChannel.tableName,
       Funding.tableName,
       AppBytecode.tableName,

--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -8,7 +8,7 @@ import Knex from 'knex';
 import {SigningWallet} from '../models/signing-wallet';
 import {Channel} from '../models/channel';
 import {Nonce} from '../models/nonce';
-import {ObjectiveModel, ObjectiveChannel} from '../models/objective';
+import {ObjectiveModel, ObjectiveChannelModel} from '../models/objective';
 import {Funding} from '../models/funding';
 import {AppBytecode} from '../models/app-bytecode';
 
@@ -40,7 +40,7 @@ export class DBAdmin {
       Channel.tableName,
       Nonce.tableName,
       ObjectiveModel.tableName,
-      ObjectiveChannel.tableName,
+      ObjectiveChannelModel.tableName,
       Funding.tableName,
       AppBytecode.tableName,
     ]

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -3,7 +3,7 @@ import {OpenChannel} from '@statechannels/wallet-core';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../channel';
-import {ObjectiveModel, ObjectiveChannel} from '../objective';
+import {ObjectiveModel, ObjectiveChannelModel} from '../objective';
 
 import {channel} from './fixtures/channel';
 
@@ -27,7 +27,7 @@ describe('Objective > insert', () => {
 
     expect(await ObjectiveModel.query(knex).select()).toMatchObject([]);
 
-    expect(await ObjectiveChannel.query(knex).select()).toMatchObject([]);
+    expect(await ObjectiveChannelModel.query(knex).select()).toMatchObject([]);
   });
 
   it('inserts and associates an objective with all channels that it references (channels exist)', async () => {
@@ -41,7 +41,7 @@ describe('Objective > insert', () => {
       {objectiveId: `OpenChannel-${c.channelId}`},
     ]);
 
-    expect(await ObjectiveChannel.query(knex).select()).toMatchObject([
+    expect(await ObjectiveChannelModel.query(knex).select()).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`, channelId: c.channelId},
     ]);
   });

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -3,7 +3,7 @@ import {OpenChannel} from '@statechannels/wallet-core';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../channel';
-import {Objective, ObjectiveChannel} from '../objective';
+import {ObjectiveModel, ObjectiveChannel} from '../objective';
 
 import {channel} from './fixtures/channel';
 
@@ -23,9 +23,9 @@ beforeEach(async () => {
 describe('Objective > insert', () => {
   it('fails to insert / associate an objective when it references a channel that does not exist', async () => {
     // For some reason this does not catch the error :/
-    await expect(Objective.insert({...objective, status: 'pending'}, knex)).rejects.toThrow();
+    await expect(ObjectiveModel.insert({...objective, status: 'pending'}, knex)).rejects.toThrow();
 
-    expect(await Objective.query(knex).select()).toMatchObject([]);
+    expect(await ObjectiveModel.query(knex).select()).toMatchObject([]);
 
     expect(await ObjectiveChannel.query(knex).select()).toMatchObject([]);
   });
@@ -35,9 +35,9 @@ describe('Objective > insert', () => {
       .withGraphFetched('signingWallet')
       .insert(c);
 
-    await Objective.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
 
-    expect(await Objective.query(knex).select()).toMatchObject([
+    expect(await ObjectiveModel.query(knex).select()).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},
     ]);
 
@@ -53,9 +53,9 @@ describe('Objective > forChannelIds', () => {
       .withGraphFetched('signingWallet')
       .insert(c);
 
-    await Objective.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
 
-    expect(await Objective.forChannelIds([c.channelId], knex)).toMatchObject([
+    expect(await ObjectiveModel.forChannelIds([c.channelId], knex)).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},
     ]);
   });

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -19,7 +19,7 @@ import {WalletError, Values} from '../errors/wallet-error';
 
 import {SigningWallet} from './signing-wallet';
 import {Funding} from './funding';
-import {Objective} from './objective';
+import {ObjectiveModel} from './objective';
 
 export const REQUIRED_COLUMNS = [
   'chainId',
@@ -102,7 +102,7 @@ export class Channel extends Model implements RequiredColumns {
     },
     objectivesChannels: {
       relation: Model.ManyToManyRelation,
-      modelClass: Objective,
+      modelClass: ObjectiveModel,
       join: {
         from: 'channels.channelId',
         through: {

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -27,7 +27,7 @@ function extractReferencedChannels(objective: ObjectiveType): string[] {
   }
 }
 
-export class ObjectiveChannel extends Model {
+export class ObjectiveChannelModel extends Model {
   readonly objectiveId!: ObjectiveStoredInDB['objectiveId'];
   readonly channelId!: string;
 
@@ -92,7 +92,7 @@ export class ObjectiveModel extends Model {
       // Requires objective and channels to exist
       await Promise.all(
         extractReferencedChannels(objectiveToBeStored).map(async value =>
-          ObjectiveChannel.query(trx).insert({objectiveId: id, channelId: value})
+          ObjectiveChannelModel.query(trx).insert({objectiveId: id, channelId: value})
         )
       );
       return objective;
@@ -121,7 +121,7 @@ export class ObjectiveModel extends Model {
     tx: TransactionOrKnex
   ): Promise<ObjectiveStoredInDB[]> {
     const objectiveIds = (
-      await ObjectiveChannel.query(tx)
+      await ObjectiveChannelModel.query(tx)
         .column('objectiveId')
         .select()
         .whereIn('channelId', targetChannelIds)

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -3,7 +3,7 @@ import {Model, TransactionOrKnex} from 'objection';
 
 import {ObjectiveStoredInDB} from '../wallet/store';
 
-function extract(objective: Objective): ObjectiveStoredInDB {
+function extract(objective: ObjectiveModel): ObjectiveStoredInDB {
   return {
     ...objective,
     participants: [],
@@ -37,7 +37,7 @@ export class ObjectiveChannel extends Model {
   }
 }
 
-export class Objective extends Model {
+export class ObjectiveModel extends Model {
   readonly objectiveId!: ObjectiveStoredInDB['objectiveId'];
   readonly status!: ObjectiveStoredInDB['status'];
   readonly type!: ObjectiveStoredInDB['type'];
@@ -76,11 +76,11 @@ export class Objective extends Model {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
     },
     tx: TransactionOrKnex
-  ): Promise<Objective> {
+  ): Promise<ObjectiveModel> {
     const id: string = objectiveId(objectiveToBeStored);
 
     return tx.transaction(async trx => {
-      const objective = await Objective.query(trx).insert({
+      const objective = await ObjectiveModel.query(trx).insert({
         objectiveId: id,
         status: objectiveToBeStored.status,
         type: objectiveToBeStored.type,
@@ -100,18 +100,18 @@ export class Objective extends Model {
   }
 
   static async forId(objectiveId: string, tx: TransactionOrKnex): Promise<ObjectiveStoredInDB> {
-    const objective = await Objective.query(tx).findById(objectiveId);
+    const objective = await ObjectiveModel.query(tx).findById(objectiveId);
     return extract(objective);
   }
 
   static async approve(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await Objective.query(tx)
+    await ObjectiveModel.query(tx)
       .findById(objectiveId)
       .patch({status: 'approved'});
   }
 
   static async succeed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await Objective.query(tx)
+    await ObjectiveModel.query(tx)
       .findById(objectiveId)
       .patch({status: 'succeeded'});
   }
@@ -127,6 +127,6 @@ export class Objective extends Model {
         .whereIn('channelId', targetChannelIds)
     ).map(oc => oc.objectiveId);
 
-    return (await Objective.query(tx).findByIds(objectiveIds)).map(extract);
+    return (await ObjectiveModel.query(tx).findByIds(objectiveIds)).map(extract);
   }
 }

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -10,7 +10,7 @@ import {channel} from '../../../models/__test__/fixtures/channel';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
-import {Objective as ObjectiveModel} from '../../../models/objective';
+import {ObjectiveModel} from '../../../models/objective';
 
 let w: Wallet;
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -10,7 +10,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {stateSignedBy} from '../fixtures/states';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
-import {Objective as ObjectiveModel} from '../../../models/objective';
+import {ObjectiveModel} from '../../../models/objective';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -8,7 +8,7 @@ import {Wallet} from '../..';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
-import {Objective as ObjectiveModel} from '../../../models/objective';
+import {ObjectiveModel} from '../../../models/objective';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -51,8 +51,9 @@ import {
   MockChainService,
 } from '../chain-service';
 import {DBAdmin} from '../db-admin/db-admin';
+import {DBObjective} from '../models/objective';
 
-import {Store, AppHandler, MissingAppHandler, ObjectiveStoredInDB} from './store';
+import {Store, AppHandler, MissingAppHandler} from './store';
 
 // TODO: The client-api does not currently allow for outgoing messages to be
 // declared as the result of a wallet API call.
@@ -60,12 +61,12 @@ import {Store, AppHandler, MissingAppHandler, ObjectiveStoredInDB} from './store
 export type SingleChannelOutput = {
   outbox: Outgoing[];
   channelResult: ChannelResult;
-  objectivesToApprove?: Omit<ObjectiveStoredInDB, 'status'>[];
+  objectivesToApprove?: Omit<DBObjective, 'status'>[];
 };
 export type MultipleChannelOutput = {
   outbox: Outgoing[];
   channelResults: ChannelResult[];
-  objectivesToApprove?: Omit<ObjectiveStoredInDB, 'status'>[];
+  objectivesToApprove?: Omit<DBObjective, 'status'>[];
 };
 type Message = SingleChannelOutput | MultipleChannelOutput;
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -52,7 +52,7 @@ import {Funding} from '../models/funding';
 import {Nonce} from '../models/nonce';
 import {recoverAddress} from '../utilities/signatures';
 import {Outgoing} from '../protocols/actions';
-import {Objective as ObjectiveModel} from '../models/objective';
+import {ObjectiveModel} from '../models/objective';
 import {logger} from '../logger';
 import {AppBytecode} from '../models/app-bytecode';
 


### PR DESCRIPTION
This PR:

* Renames `Objective -> ObjectiveModel` and `ObjectiveChannel -> ObjectiveChannelModel` to make the different types more explicit.
* Changes `extract` from being a standalone function that took an `ObjectiveModel` to being an instance method, `toObjective` on the `ObjectiveModel`.
* Moves and renames the `ObjectiveStoredInDB` model to `DBObjective` and adds a brief description.

These changes should hopefully make it less confusing to work with objectives 🤞 .