### PR TITLE
[server-wallet] iteration on conclude and withdraw

### DIFF
--- a/packages/server-wallet/jest/chain-setup.ts
+++ b/packages/server-wallet/jest/chain-setup.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-process-env */
-import {GanacheServer} from '@statechannels/devtools';
+import {ETHERLIME_ACCOUNTS, GanacheServer} from '@statechannels/devtools';
 import {utils} from 'ethers';
 
 import {defaultConfig} from '../src/config';
@@ -13,14 +13,15 @@ export default async function setup(): Promise<void> {
     'RPC_ENDPOINT'
   ] = `http://${process.env['GANACHE_HOST']}:${process.env['GANACHE_PORT']}`;
 
-  const account = {
-    privateKey: defaultConfig.serverPrivateKey,
+  const accounts = ETHERLIME_ACCOUNTS.map(account => ({
+    ...account,
     amount: utils.parseEther('100').toString(),
-  };
+  }));
+
   if (!process.env.GANACHE_PORT) {
     throw new Error('process.env.GANACHE_PORT must be defined');
   }
-  const ganacheServer = new GanacheServer(parseInt(process.env.GANACHE_PORT), 1337, [account]);
+  const ganacheServer = new GanacheServer(parseInt(process.env.GANACHE_PORT), 1337, accounts);
   await ganacheServer.ready();
 
   const deployedArtifacts = await deploy();

--- a/packages/server-wallet/jest/chain-setup.ts
+++ b/packages/server-wallet/jest/chain-setup.ts
@@ -2,7 +2,6 @@
 import {ETHERLIME_ACCOUNTS, GanacheServer} from '@statechannels/devtools';
 import {utils} from 'ethers';
 
-import {defaultConfig} from '../src/config';
 import {deploy} from '../deployment/deploy';
 
 export default async function setup(): Promise<void> {

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -1,4 +1,5 @@
 import {CreateChannelParams, Participant, Allocation} from '@statechannels/client-api-schema';
+import {ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
 import {BN, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, constants, ethers, providers} from 'ethers';
 import {fromEvent} from 'rxjs';
@@ -12,7 +13,11 @@ if (!defaultTestConfig.rpcEndpoint) throw new Error('rpc endpoint must be define
 const rpcEndpoint = defaultTestConfig.rpcEndpoint;
 let provider: providers.JsonRpcProvider;
 const b = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_B'});
-const a = new Wallet({...defaultTestConfig, postgresDBName: 'TEST_A'});
+const a = new Wallet({
+  ...defaultTestConfig,
+  postgresDBName: 'TEST_A',
+  serverPrivateKey: ETHERLIME_ACCOUNTS[1].privateKey,
+});
 
 const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';
 const bAddress = '0x632d0b05c78A83cEd439D3bd6C710c4814D3a6db';
@@ -156,11 +161,11 @@ it('Create a directly funded channel between two wallets ', async () => {
     turnNum: 4,
   });
 
-  const aBalanceFinal = await getBalance(aAddress);
-  const bBalanceFinal = await getBalance(bAddress);
-
   // A fragile way to wait for the conclude and withdraw to complete
   await new Promise(r => setTimeout(r, 1_000));
+
+  const aBalanceFinal = await getBalance(aAddress);
+  const bBalanceFinal = await getBalance(bAddress);
 
   expect(BN.sub(aBalanceFinal, aBalanceInit)).toEqual(aFunding);
   expect(BN.sub(bBalanceFinal, bBalanceInit)).toEqual(bFunding);

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -272,7 +272,9 @@ describe('concludeAndWithdraw', () => {
       })
     );
 
-    await (await chainService.concludeAndWithdraw([{...state, signatures}])).wait();
+    const transactionResponse = await chainService.concludeAndWithdraw([{...state, signatures}]);
+    if (!transactionResponse) throw 'Expected transaction response';
+    await transactionResponse.wait();
 
     expect(await provider.getBalance(aAddress)).toEqual(BigNumber.from(1));
     expect(await provider.getBalance(bAddress)).toEqual(BigNumber.from(3));
@@ -311,7 +313,9 @@ describe('concludeAndWithdraw', () => {
       })
     );
 
-    await (await chainService.concludeAndWithdraw([{...state, signatures}])).wait();
+    const transactionResponse = await chainService.concludeAndWithdraw([{...state, signatures}]);
+    if (!transactionResponse) throw 'Expected transaction response';
+    await transactionResponse.wait();
 
     const erc20Contract: Contract = new Contract(
       erc20Address,

--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -42,10 +42,10 @@ export const defaultConfig: ServerWalletConfig = {
   postgresDBPassword: process.env.SERVER_DB_PASSWORD,
   serverSignerPrivateKey:
     process.env.SERVER_SIGNER_PRIVATE_KEY ||
-    '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
+    '0x1b427b7ab88e2e10674b5aa92bb63c0ca26aa0b5a858e1d17295db6ad91c049b',
   serverPrivateKey:
     process.env.SERVER_PRIVATE_KEY ||
-    '0x1b427b7ab88e2e10674b5aa92bb63c0ca26aa0b5a858e1d17295db6ad91c049b',
+    '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
   rpcEndpoint: process.env.RPC_ENDPOINT,
   chainNetworkID: process.env.CHAIN_NETWORK_ID || '0x00',
   ethAssetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -39,7 +39,6 @@ function chainWithdraw(ps: ProtocolState): Withdraw | false {
     everyoneSignedFinalState(ps) &&
     ps.app.fundingStrategy === 'Direct' &&
     ps.app.chainServiceRequests.indexOf('withdraw') === -1 &&
-    ps.app.myIndex === 0 &&
     withdraw(ps.app)
   );
 }

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -565,6 +565,7 @@ export class Wallet extends EventEmitter<WalletEvent>
             case 'Withdraw':
               await this.store.addChainServiceRequest(action.channelId, 'withdraw', tx);
               // Note, this returns a promise. We are NOT waiting on the promise
+              // app.supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
               this.chainService.concludeAndWithdraw(app.supported ? [app.supported] : []);
               return;
             default:

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -551,8 +551,7 @@ export class Wallet extends EventEmitter<WalletEvent>
             }
             case 'FundChannel':
               await this.store.addChainServiceRequest(action.channelId, 'fund', tx);
-              // Note, this returns a promise. We are NOT waiting on the promise
-              this.chainService.fundChannel({
+              await this.chainService.fundChannel({
                 ...action,
                 expectedHeld: BN.from(action.expectedHeld),
                 amount: BN.from(action.amount),
@@ -564,9 +563,9 @@ export class Wallet extends EventEmitter<WalletEvent>
               return;
             case 'Withdraw':
               await this.store.addChainServiceRequest(action.channelId, 'withdraw', tx);
-              // Note, this returns a promise. We are NOT waiting on the promise
               // app.supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
-              this.chainService.concludeAndWithdraw([app.supported!]);
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              await this.chainService.concludeAndWithdraw([app.supported!]);
               return;
             default:
               throw 'Unimplemented';

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -566,7 +566,7 @@ export class Wallet extends EventEmitter<WalletEvent>
               await this.store.addChainServiceRequest(action.channelId, 'withdraw', tx);
               // Note, this returns a promise. We are NOT waiting on the promise
               // app.supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
-              this.chainService.concludeAndWithdraw(app.supported ? [app.supported] : []);
+              this.chainService.concludeAndWithdraw([app.supported!]);
               return;
             default:
               throw 'Unimplemented';

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -551,7 +551,8 @@ export class Wallet extends EventEmitter<WalletEvent>
             }
             case 'FundChannel':
               await this.store.addChainServiceRequest(action.channelId, 'fund', tx);
-              await this.chainService.fundChannel({
+              // Note, this returns a promise. We are NOT waiting on the promise
+              this.chainService.fundChannel({
                 ...action,
                 expectedHeld: BN.from(action.expectedHeld),
                 amount: BN.from(action.amount),
@@ -563,7 +564,8 @@ export class Wallet extends EventEmitter<WalletEvent>
               return;
             case 'Withdraw':
               await this.store.addChainServiceRequest(action.channelId, 'withdraw', tx);
-              await this.chainService.concludeAndWithdraw(app.supported ? [app.supported] : []);
+              // Note, this returns a promise. We are NOT waiting on the promise
+              this.chainService.concludeAndWithdraw(app.supported ? [app.supported] : []);
               return;
             default:
               throw 'Unimplemented';


### PR DESCRIPTION
The two major changes are:
1. The server wallet runloop does not wait for chain service calls. See https://github.com/statechannels/statechannels/commit/e68ea1596b5da9d122c3cef4c3a65d7df172a464 for reasoning.
1. all participants submit conclude and withdraw transactions. Addresses https://github.com/statechannels/statechannels/pull/2753#issuecomment-717302221