### PR TITLE
ci: bump canary publish cache

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache-v0-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-cache-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-cache-v0-
+            ${{ runner.os }}-yarn-cache-v1-
 
       - name: yarn install
         # skip the prepare step here, as lerna publish will run prepare before publishing


### PR DESCRIPTION
This seems to fix the issue that @andrewgordstewart where [his canary publish](https://github.com/statechannels/statechannels/actions/runs/336021827) failed. I have verified this by making the same change on the regular publish, and observing the publish succeed (where it also previously failed with the [same error](https://github.com/statechannels/statechannels/actions/runs/336247661)). I made that change in the actions editor on github, which ended up pushing the change directly to master 😳 .

The fact that this works seems to imply that the github actions cache became corrupted somehow. Both the failed builds had an exact cache hit. That cache would presumably have been written @snario's [canary publish](https://github.com/statechannels/statechannels/actions/runs/334809751) from a non-master branch.

I suggest we merge this fix and see if the problem re-occurs in the future.