### PR TITLE
ci: use git diff --exit-code in GH actions

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -20,15 +20,15 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache-v0-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-cache-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-cache-v0-
+            ${{ runner.os }}-yarn-cache-v1-
 
-      - name: yarn install
+      - name: yarn install 
         # skip the prepare step here, as lerna publish will run prepare before publishing
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-          SKIP_PREPARE=true yarn install
+          SKIP_PREPARE=true yarn install && git diff --exit-code
 
       - name: Configure CI Git User
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         # skip the prepare step here, as lerna publish will run prepare before publishing
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-          SKIP_PREPARE=true yarn install
+          SKIP_PREPARE=true yarn install && git diff --exit-code
 
       - name: Configure CI Git User
         run: |


### PR DESCRIPTION
Provides the same protection as we enjoy on circle -- namely, that the action will fail out if changes to `yarn.lock` were not committed. 

