### PR TITLE
fetchBytecode rejects when bytecode is missing

### DIFF
--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -334,4 +334,10 @@ describe('getBytecode', () => {
     const bytecode = await chainService.fetchBytecode(ethAssetHolderAddress);
     expect(bytecode).toMatch(/^0x[A-Fa-f0-9]{64,}$/);
   });
+
+  it('rejects when there is no bytecode deployed at the address', async () => {
+    await expect(chainService.fetchBytecode(constants.AddressZero)).rejects.toThrow(
+      'Bytecode missing'
+    );
+  });
 });

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -309,7 +309,17 @@ export class ChainService implements ChainServiceInterface {
     return obs.pipe(share());
   }
 
+  /**
+   *
+   * @param appDefinition Address of state channels app
+   *
+   * Rejects with 'Bytecode missint' if there is no contract deployed at `appDefinition`.
+   */
   public async fetchBytecode(appDefinition: string): Promise<string> {
-    return this.provider.getCode(appDefinition);
+    const result = await this.provider.getCode(appDefinition);
+
+    if (result === '0x') throw new Error('Bytecode missing');
+
+    return result;
   }
 }

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -85,7 +85,7 @@ export interface UpdateChannelFundingParams {
 export type WalletInterface = {
   // App utilities
   getParticipant(): Promise<Participant | undefined>;
-  registerAppDefintion(appDefinition: string): Promise<void>;
+  registerAppDefinition(appDefinition: string): Promise<void>;
   // App channel management
   createChannels(
     args: CreateChannelParams,
@@ -146,7 +146,7 @@ export class Wallet extends EventEmitter<WalletEvent>
     this.mergeMessages = this.mergeMessages.bind(this);
     this.registerChannelWithChainService = this.registerChannelWithChainService.bind(this);
     this.destroy = this.destroy.bind(this);
-    this.registerAppDefintion = this.registerAppDefintion.bind(this);
+    this.registerAppDefinition = this.registerAppDefinition.bind(this);
 
     // set up timing metrics
     if (this.walletConfig.timingMetrics) {
@@ -166,7 +166,7 @@ export class Wallet extends EventEmitter<WalletEvent>
     }
   }
 
-  public async registerAppDefintion(appDefinition: string): Promise<void> {
+  public async registerAppDefinition(appDefinition: string): Promise<void> {
     const bytecode = await this.chainService.fetchBytecode(appDefinition);
     await this.store.upsertBytecode(this.walletConfig.chainNetworkID, appDefinition, bytecode);
   }

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -168,10 +168,6 @@ export class Wallet extends EventEmitter<WalletEvent>
 
   public async registerAppDefintion(appDefinition: string): Promise<void> {
     const bytecode = await this.chainService.fetchBytecode(appDefinition);
-    if (!bytecode) {
-      throw Error(`Could not fetch bytecode for ${appDefinition}`);
-    }
-
     await this.store.upsertBytecode(this.walletConfig.chainNetworkID, appDefinition, bytecode);
   }
 


### PR DESCRIPTION
Either `fetchBytecode` or `registerAppDefinition` should reject when no contract is deployed at the target address.

This rules out applications using a "null app" for application rules.
However, it is more important for applications to not accidentally use a null app than it is to support null app applications.
If an application explicitly wants to use a null app, they can deploy an explicit version where `validTransition` returns `false`.