### PR TITLE
chore: add new database indexes for channels table

### DIFF
--- a/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
+++ b/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
@@ -1,15 +1,15 @@
 import * as Knex from 'knex';
 
+const COLUMNS = ['assetHolderAddress', 'participants'];
+
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.alterTable('channels', function(t) {
-    t.index('assetHolderAddress');
-    t.index('participants');
+    t.index(COLUMNS);
   });
 }
 
 export async function down(knex: Knex): Promise<any> {
   await knex.schema.alterTable('channels', function(t) {
-    t.dropIndex('assetHolderAddress');
-    t.dropIndex('participants');
+    t.dropIndex(COLUMNS);
   });
 }

--- a/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
+++ b/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
@@ -1,0 +1,15 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.alterTable('channels', function(t) {
+    t.index('assetHolderAddress');
+    t.index('participants');
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.alterTable('channels', function(t) {
+    t.dropIndex('assetHolderAddress');
+    t.dropIndex('participants');
+  });
+}

--- a/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
+++ b/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
@@ -1,6 +1,6 @@
 import * as Knex from 'knex';
 
-const COLUMNS = ['assetHolderAddress', 'participants'];
+const COLUMNS = ['asset_holder_address', 'participants'];
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.alterTable('channels', function(t) {


### PR DESCRIPTION
[Direct quote]

> I propose we add an index in the server-wallet’s PostgreSQL channels table — in addition to channelId — on participants.
> Then, we can do this.wallet.getChannels(participants). If we also index on assetHolderAddress then we can make this.wallet.getLedgerChannel(assetHolderAddress, participants) and O(1) call. Which is an alias for getLedgerChannelForAllocation (since participants is [gateway,allocation.id]).