### PR TITLE
refactor: rename Unfunded -> Fake funding

### DIFF
--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -288,7 +288,7 @@ export type ErrorCodes = {
 export type ExternalDestination = string;
 
 // @public (undocumented)
-export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
+export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Fake' | 'Unknown';
 
 // @public (undocumented)
 export interface Funds {

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -346,7 +346,7 @@
         "Direct",
         "Ledger",
         "Virtual",
-        "Unfunded",
+        "Fake",
         "Unknown"
       ],
       "type": "string"

--- a/packages/client-api-schema/src/methods/CreateChannel.ts
+++ b/packages/client-api-schema/src/methods/CreateChannel.ts
@@ -2,7 +2,7 @@ import {Participant, Allocation, Address, ChannelResult} from '../data-types';
 import {JsonRpcRequest, JsonRpcResponse, JsonRpcError} from '../jsonrpc-header-types';
 import {ErrorCodes as AllErrors} from '../error-codes';
 
-export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
+export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Fake' | 'Unknown';
 
 export interface CreateChannelParams {
   participants: Participant[];

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -58,7 +58,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
     allocations: [allocation],
     appDefinition: ethers.constants.AddressZero,
     appData: '0x00', // must be even length
-    fundingStrategy: 'Unfunded',
+    fundingStrategy: 'Fake',
   };
 
   //        A <> B

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -45,7 +45,7 @@ test('when I have signed a final state, unfunded', () => {
   const ps = applicationProtocolState({
     app: {supported: closingState, latest: closingState, latestSignedByMe: closingState},
   });
-  ps.app.fundingStrategy = 'Unfunded';
+  ps.app.fundingStrategy = 'Fake';
   expect(protocol(ps)).toMatchObject({
     type: 'CompleteObjective',
     channelId: ps.app.channelId,

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -87,7 +87,7 @@ export const getCloseChannelProtocolState = async (
   const app = await store.getChannel(channelId, tx);
   switch (app.fundingStrategy) {
     case 'Direct':
-    case 'Unfunded':
+    case 'Fake':
       return {app};
     case 'Ledger': {
       const req = await store.getLedgerRequest(app.channelId, 'defund', tx);

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -62,7 +62,7 @@ function isFunded(ps: ProtocolState): boolean {
   const {funding, supported, fundingStrategy} = ps.app;
 
   switch (fundingStrategy) {
-    case 'Unfunded':
+    case 'Fake':
       return true;
 
     case 'Direct': {
@@ -154,7 +154,7 @@ const requestLedgerFunding = ({app}: ProtocolState): RequestLedgerFunding | fals
   });
 };
 
-const isUnfunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Unfunded';
+const isFakeFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Fake';
 const isDirectlyFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Direct';
 const isLedgerFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Ledger';
 
@@ -192,7 +192,7 @@ const signPreFundSetup = (ps: ProtocolState): ProtocolResult | false =>
 
 const signPostFundSetup = (ps: ProtocolState): ProtocolResult | false =>
   myTurnToPostfund(ps) &&
-  (isFunded(ps) || isUnfunded(ps.app)) &&
+  (isFunded(ps) || isFakeFunded(ps.app)) &&
   ps.app.latestSignedByMe &&
   ps.app.supported &&
   signState({
@@ -224,7 +224,7 @@ export const getOpenChannelProtocolState = async (
   const app = await store.getChannel(channelId, tx);
   switch (app.fundingStrategy) {
     case 'Direct':
-    case 'Unfunded':
+    case 'Fake':
       return {type: 'DirectFundingProtocolState', app};
     case 'Ledger': {
       const req = await store.getLedgerRequest(app.channelId, 'fund', tx);

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -249,7 +249,7 @@ describe('when the application protocol returns an action', () => {
         participants: c.participants,
         data: {
           targetChannelId: c.channelId,
-          fundingStrategy: 'Unfunded', // Could also be Direct, funding is empty
+          fundingStrategy: 'Fake', // Could also be Direct, funding is empty
           role: 'app',
         },
       },

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -262,7 +262,7 @@ export class Wallet extends EventEmitter<WalletEvent>
 
   async createLedgerChannel(
     args: Pick<CreateChannelParams, 'participants' | 'allocations'>,
-    fundingStrategy: 'Direct' | 'Unfunded' = 'Direct'
+    fundingStrategy: 'Direct' | 'Fake' = 'Direct'
   ): Promise<SingleChannelOutput> {
     const {participants, allocations} = args;
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -443,7 +443,7 @@ export class Store {
         throw new StoreError(StoreError.reasons.channelMissing, {channelId});
       }
 
-      if (!_.includes(['Ledger', 'Direct', 'Unfunded'], objective.data.fundingStrategy))
+      if (!_.includes(['Ledger', 'Direct', 'Fake'], objective.data.fundingStrategy))
         throw new StoreError(StoreError.reasons.unimplementedFundingStrategy, {fundingStrategy});
 
       const objectiveToBeStored: DBObjective = {

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -85,7 +85,7 @@
                 "Direct",
                 "Ledger",
                 "Virtual",
-                "Unfunded",
+                "Fake",
                 "Unknown"
               ],
               "type": "string"
@@ -310,7 +310,7 @@
                 "Direct",
                 "Ledger",
                 "Virtual",
-                "Unfunded",
+                "Fake",
                 "Unknown"
               ],
               "type": "string"

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -80,7 +80,7 @@ type _Objective<Name, Data> = {
   type: Name;
   data: Data;
 };
-type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Unfunded' | 'Unknown';
+type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Fake' | 'Unknown';
 export type OpenChannel = _Objective<
   'OpenChannel',
   {

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -356,9 +356,9 @@ async function convertToInternalEvent(
   }
 }
 
-export type SupportedFundingStrategy = Exclude<FundingStrategy, 'Unknown' | 'Unfunded'>;
+export type SupportedFundingStrategy = Exclude<FundingStrategy, 'Unknown' | 'Fake'>;
 function isSupportedFundingStrategy(fs: FundingStrategy): fs is SupportedFundingStrategy {
-  return fs !== 'Unfunded' && fs !== 'Unknown';
+  return fs !== 'Fake' && fs !== 'Unknown';
 }
 export function supportedFundingStrategyOrThrow(fs: FundingStrategy): SupportedFundingStrategy {
   if (!isSupportedFundingStrategy(fs)) {


### PR DESCRIPTION
We've discussed this a few times, and I think the consensus was that "fake funding" is more descriptive than "unfunded". 

Related changes in the-graph: https://github.com/statechannels/the-graph/pull/254
