### PR TITLE
Add walletVersion as a required string on wire-format.message.payload

### DIFF
--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -137,6 +137,7 @@ export default class PayerClient {
 
   public emptyMessage(): Promise<unknown> {
     return this.messageReceiverAndExpectReply({
+      walletVersion: '',
       signedStates: [],
       objectives: [],
     });

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -6,6 +6,7 @@ import {Wallet, Message as Payload} from '../../src';
 import {timerFactory, recordFunctionMetrics} from '../../src/metrics';
 import {receiverConfig} from '../e2e-utils';
 import {defaultConfig} from '../../src/config';
+import {WALLET_VERSION} from '../../src/version';
 
 export default class ReceiverController {
   private readonly wallet: Wallet = recordFunctionMetrics(
@@ -29,6 +30,7 @@ export default class ReceiverController {
 
   public async acceptMessageAndReturnReplies(message: unknown): Promise<unknown> {
     const reply: Payload = {
+      walletVersion: WALLET_VERSION,
       signedStates: [],
       objectives: [],
     };

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -84,7 +84,7 @@
     "lint:check": "eslint \"*/**/*.{js,ts}\" --cache",
     "lint:write": "eslint \"*/**/*.{js,ts}\" --fix",
     "precommit": "lint-staged --quiet",
-    "prepare": "rm -rf lib; tsc -b .",
+    "prepare": "rm -rf lib; tsc -b . && node ./scripts/inject-wallet-version.js",
     "prestart": "yarn prepare && npm run db:rollback && npm run db:migrate && npm run db:seed",
     "prettier:check": "npx prettier --check 'src/**/*.{ts,tsx}'",
     "prettier:write": "npx prettier --write 'src/**/*.{ts,tsx}'",

--- a/packages/server-wallet/scripts/inject-wallet-version.js
+++ b/packages/server-wallet/scripts/inject-wallet-version.js
@@ -1,0 +1,10 @@
+var fs = require('fs');
+
+fs.writeFileSync(
+  'lib/src/version.js',
+  `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.WALLET_VERSION = void 0;
+exports.WALLET_VERSION = '${process.env.npm_package_name}@${process.env.npm_package_version}';
+//# sourceMappingURL=version.js.map`
+);

--- a/packages/server-wallet/src/errors/wallet-error.ts
+++ b/packages/server-wallet/src/errors/wallet-error.ts
@@ -41,7 +41,7 @@ export class PushMessageError extends WalletError {
   readonly type = WalletError.errors.PushMessageError;
 
   static readonly reasons = {
-    objectiveNotFound: 'Error during pushMessage',
+    genericPushMessageError: 'Error during pushMessage',
   } as const;
 
   constructor(

--- a/packages/server-wallet/src/errors/wallet-error.ts
+++ b/packages/server-wallet/src/errors/wallet-error.ts
@@ -9,6 +9,7 @@ export abstract class WalletError extends Error {
     NonceError: 'NonceError',
     StoreError: 'StoreError',
     OnchainError: 'OnchainError',
+    PushMessageError: 'PushMessageError',
   } as const;
 
   abstract readonly type: Values<typeof WalletError.errors>;
@@ -34,4 +35,19 @@ export function isWalletError(error: any): error is WalletError {
   if (!error?.type) return false;
   if (!(typeof error.type === 'string' || error.type instanceof String)) return false;
   return hasOwnProperty(WalletError.errors, error.type);
+}
+
+export class PushMessageError extends WalletError {
+  readonly type = WalletError.errors.PushMessageError;
+
+  static readonly reasons = {
+    objectiveNotFound: 'Error during pushMessage',
+  } as const;
+
+  constructor(
+    reason: Values<typeof PushMessageError.reasons>,
+    public readonly data: {thisWalletVersion: string; payloadWalletVersion: string; cause: Error}
+  ) {
+    super(reason);
+  }
 }

--- a/packages/server-wallet/src/logger.ts
+++ b/packages/server-wallet/src/logger.ts
@@ -9,15 +9,13 @@ export function createLogger(config: ServerWalletConfig): pino.Logger {
     config.logDestination && config.logDestination.toLocaleLowerCase() !== 'console'
       ? pino.destination(config.logDestination)
       : undefined;
-  return destination
-    ? pino({level: config.logLevel}, destination).child({
-        dbName: config.postgresDBName,
-        walletVersion: WALLET_VERSION,
-      })
-    : pino({level: config.logLevel}).child({
-        dbName: config.postgresDBName,
-        walletVersion: WALLET_VERSION,
-      });
+  return (destination
+    ? pino({level: config.logLevel}, destination)
+    : pino({level: config.logLevel})
+  ).child({
+    dbName: config.postgresDBName,
+    walletVersion: WALLET_VERSION,
+  });
 }
 
 export const logger = createLogger(defaultConfig);

--- a/packages/server-wallet/src/logger.ts
+++ b/packages/server-wallet/src/logger.ts
@@ -1,6 +1,7 @@
 import pino from 'pino';
 
 import {defaultConfig, ServerWalletConfig} from './config';
+import {WALLET_VERSION} from './version';
 
 export function createLogger(config: ServerWalletConfig): pino.Logger {
   // eslint-disable-next-line no-process-env
@@ -8,7 +9,15 @@ export function createLogger(config: ServerWalletConfig): pino.Logger {
     config.logDestination && config.logDestination.toLocaleLowerCase() !== 'console'
       ? pino.destination(config.logDestination)
       : undefined;
-  return destination ? pino({level: config.logLevel}, destination) : pino({level: config.logLevel});
+  return destination
+    ? pino({level: config.logLevel}, destination).child({
+        dbName: config.postgresDBName,
+        walletVersion: WALLET_VERSION,
+      })
+    : pino({level: config.logLevel}).child({
+        dbName: config.postgresDBName,
+        walletVersion: WALLET_VERSION,
+      });
 }
 
 export const logger = createLogger(defaultConfig);

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -11,6 +11,7 @@ import {LedgerRequest} from '../models/ledger-request';
 import {ChainServiceInterface} from '../chain-service';
 import {Outgoing, ProtocolAction} from '../protocols/actions';
 import {recordFunctionMetrics} from '../metrics';
+import {WALLET_VERSION} from '../version';
 
 import {ObjectiveManagerParams, ExecutionResult} from './types';
 
@@ -77,6 +78,7 @@ export class ObjectiveManager {
               const {myIndex, participants, channelId} = protocolState.app;
               const signedState = await this.store.signState(action.channelId, action, tx);
               createOutboxFor(channelId, myIndex, participants, {
+                walletVersion: WALLET_VERSION,
                 signedStates: [signedState],
               }).map(outgoing => outbox.push(outgoing));
               return;
@@ -154,5 +156,11 @@ const createOutboxFor = (
     .filter((_p, i: number): boolean => i !== myIndex)
     .map(({participantId: recipient}) => ({
       method: 'MessageQueued' as const,
-      params: serializeMessage(data, recipient, participants[myIndex].participantId, channelId),
+      params: serializeMessage(
+        WALLET_VERSION,
+        data,
+        recipient,
+        participants[myIndex].participantId,
+        channelId
+      ),
     }));

--- a/packages/server-wallet/src/utilities/messaging.ts
+++ b/packages/server-wallet/src/utilities/messaging.ts
@@ -3,6 +3,7 @@ import {Payload} from '@statechannels/wallet-core';
 import _ from 'lodash';
 
 import {Notice} from '../protocols/actions';
+import {WALLET_VERSION} from '../version';
 
 // Merges any messages to the same recipient into one message
 // This makes message delivery less painful with the request/response model
@@ -23,12 +24,13 @@ export function mergeOutgoing(outgoing: Notice[]): Notice[] {
   for (const notice of outgoing) {
     const {recipient, data} = notice.params as {recipient: string; data: Payload};
     if (!mergedOutgoing[recipient]) {
-      mergedOutgoing[recipient] = {};
+      mergedOutgoing[recipient] = {walletVersion: WALLET_VERSION};
     }
 
     const {signedStates, requests, objectives} = mergedOutgoing[recipient];
 
     mergedOutgoing[recipient] = {
+      walletVersion: WALLET_VERSION,
       signedStates: mergeProp(signedStates, data.signedStates),
       requests: mergeProp(requests, data.requests),
       objectives: mergeProp(objectives, data.objectives),

--- a/packages/server-wallet/src/version.ts
+++ b/packages/server-wallet/src/version.ts
@@ -1,0 +1,1 @@
+export const WALLET_VERSION = ''; // Will be overwritten during npm's 'prepare' lifecycle script

--- a/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/messages.ts
@@ -1,9 +1,11 @@
 import {SignedState, Payload} from '@statechannels/wallet-core';
 import _ from 'lodash';
 
+import {WALLET_VERSION} from '../../../version';
+
 import {createState} from './states';
 
-const emptyMessage = {};
+const emptyMessage = {walletVersion: WALLET_VERSION};
 
 type WithState = {signedStates: SignedState[]};
 export function messageWithState(props?: Partial<Payload>): Payload & WithState {

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -27,6 +27,7 @@ import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {LedgerRequest} from '../../../models/ledger-request';
 import {WALLET_VERSION} from '../../../version';
+import {PushMessageError} from '../../../errors/wallet-error';
 
 jest.setTimeout(20_000);
 
@@ -259,7 +260,7 @@ it("doesn't store states for unknown signing addresses", async () => {
 
   const signedStates = [serializeState(stateSignedBy([alice(), bob()])({turnNum: five}))];
   return expect(wallet.pushMessage({walletVersion: WALLET_VERSION, signedStates})).rejects.toThrow(
-    Error('Not in channel')
+    PushMessageError
   );
 });
 

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -15,9 +15,9 @@ import {
   Outcome,
   AllocationItem,
   SimpleAllocation,
-  Payload,
   Objective,
-  Participant
+  Participant,
+  Payload
 } from '../../types';
 import {BN} from '../../bignumber';
 import {makeDestination} from '../../utils';
@@ -39,11 +39,13 @@ export function validatePayload(rawPayload: unknown): WirePayload {
 }
 
 export function deserializeMessage(message: WireMessage): Payload {
-  const signedStates = message?.data?.signedStates?.map(ss => deserializeState(ss));
-  const objectives = message?.data?.objectives?.map(objective => deserializeObjective(objective));
-  const requests = message?.data?.requests;
+  const signedStates = message.data.signedStates?.map(ss => deserializeState(ss));
+  const objectives = message.data.objectives?.map(objective => deserializeObjective(objective));
+  const requests = message.data.requests;
+  const walletVersion = message.data.walletVersion;
 
   return {
+    walletVersion,
     signedStates,
     objectives,
     requests

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -5,6 +5,8 @@ import {Payload, SignedState} from '../../types';
 import {makeDestination} from '../../utils';
 import {calculateChannelId} from '../../state-utils';
 
+export const walletVersion = 'someWalletVersion';
+
 export const wireStateFormat: WireState = {
   participants: [
     {
@@ -125,6 +127,7 @@ export const wireMessageFormat: WireMessage = {
   recipient: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf',
   sender: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
   data: {
+    walletVersion,
     signedStates: [wireStateFormat, wireStateFormat2],
     objectives: [
       {
@@ -158,6 +161,7 @@ export const wireMessageFormat: WireMessage = {
 };
 
 export const internalMessageFormat: Payload = {
+  walletVersion,
   signedStates: [internalStateFormat, internalStateFormat2],
   objectives: [
     {

--- a/packages/wallet-core/src/serde/wire-format/serde.test.ts
+++ b/packages/wallet-core/src/serde/wire-format/serde.test.ts
@@ -5,7 +5,8 @@ import {
   wireStateFormat,
   internalStateFormat,
   internalMessageFormat,
-  wireMessageFormat
+  wireMessageFormat,
+  walletVersion
 } from './example';
 import {serializeState, serializeMessage} from './serialize';
 import {deserializeState, deserializeMessage} from './deserialize';
@@ -17,7 +18,9 @@ it('works for states', () => {
 
 it('works for a message', () => {
   const {recipient, sender} = wireMessageFormat;
-  expect(serializeMessage(internalMessageFormat, recipient, sender)).toEqual(wireMessageFormat);
+  expect(serializeMessage(walletVersion, internalMessageFormat, recipient, sender)).toEqual(
+    wireMessageFormat
+  );
   expect(deserializeMessage(wireMessageFormat)).toEqual(internalMessageFormat);
 });
 

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -19,6 +19,7 @@ import {calculateChannelId} from '../../state-utils';
 import {formatAmount} from '../../utils';
 
 export function serializeMessage(
+  walletVersion: string,
   message: Payload,
   recipient: string,
   sender: string,
@@ -30,7 +31,7 @@ export function serializeMessage(
   return {
     recipient,
     sender,
-    data: {signedStates, objectives, requests}
+    data: {walletVersion, signedStates, objectives, requests}
   };
 }
 

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -170,6 +170,7 @@ type GetChannel = {type: 'GetChannel'; channelId: string};
 export type ChannelRequest = GetChannel;
 
 export interface Payload {
+  walletVersion: string;
   signedStates?: SignedState[];
   objectives?: Objective[];
   requests?: ChannelRequest[];

--- a/packages/wire-format/src/__tests__/good_sample_messages.ts
+++ b/packages/wire-format/src/__tests__/good_sample_messages.ts
@@ -2,6 +2,7 @@ export const goodMessage = {
   recipient: 'Alice',
   sender: 'Bob',
   data: {
+    walletVersion: 'someWalletVersion',
     signedStates: [
       {
         participants: [
@@ -51,11 +52,12 @@ export const undefinedObjectives1 = {
   recipient: 'alice',
   sender: 'bob',
   data: {
+    walletVersion: 'someWalletVersion',
     objectives: undefined
   }
 };
 export const undefinedObjectives2 = {
   recipient: 'alice',
   sender: 'bob',
-  data: {}
+  data: {walletVersion: 'someWalletVersion'}
 };

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -400,8 +400,14 @@
             "$ref": "#/definitions/SignedState"
           },
           "type": "array"
+        },
+        "walletVersion": {
+          "type": "string"
         }
       },
+      "required": [
+        "walletVersion"
+      ],
       "type": "object"
     },
     "SignedState": {

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -146,6 +146,7 @@ type GetChannel = {type: 'GetChannel'; channelId: Bytes32};
 export type ChannelRequest = GetChannel;
 
 export interface Payload {
+  walletVersion: string; // e.g. @statechannels/server-wallet@1.4.0
   signedStates?: SignedState[];
   objectives?: Objective[];
   requests?: ChannelRequest[];

--- a/packages/xstate-wallet/src/config.ts
+++ b/packages/xstate-wallet/src/config.ts
@@ -18,6 +18,8 @@ function getBool(val: string | undefined): boolean {
 
 export const GIT_VERSION = process.env.GIT_VERSION;
 
+export const WALLET_VERSION = '@statechannels/xstate-wallet@' + GIT_VERSION;
+
 export const NODE_ENV: string = process.env.NODE_ENV as string;
 
 export const CHAIN_NETWORK_ID: string = process.env.CHAIN_NETWORK_ID || '0';

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -42,7 +42,8 @@ import {
   CHAIN_NETWORK_ID,
   HUB_PARTICIPANT_ID,
   HUB_ADDRESS,
-  HUB_DESTINATION
+  HUB_DESTINATION,
+  WALLET_VERSION
 } from './config';
 import {Store} from './store';
 
@@ -160,7 +161,7 @@ export class MessagingService implements MessagingServiceInterface {
       const notification: StateChannelsNotification = {
         jsonrpc: '2.0',
         method: 'MessageQueued',
-        params: validateMessage(serializeMessage(message, recipient, sender))
+        params: validateMessage(serializeMessage(WALLET_VERSION, message, recipient, sender))
       };
       this.eventEmitter.emit('SendMessage', notification);
     });

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -24,7 +24,7 @@ import {
 } from '@statechannels/wallet-core';
 
 import {Chain, FakeChain} from '../chain';
-import {CHAIN_NETWORK_ID, HUB} from '../config';
+import {CHAIN_NETWORK_ID, HUB, WALLET_VERSION} from '../config';
 import {checkThat, recordToArray} from '../utils';
 import {logger} from '../logger';
 import {DB_NAME} from '../constants';
@@ -325,7 +325,11 @@ export class Store {
     if (this.backend.transactionOngoing) throw Error(Errors.emittingDuringTransaction);
 
     this._eventEmitter.emit('channelUpdated', entry);
-    if (signedState) this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
+    if (signedState)
+      this._eventEmitter.emit('addToOutbox', {
+        walletVersion: WALLET_VERSION,
+        signedStates: [signedState]
+      });
 
     return entry;
   }
@@ -378,7 +382,11 @@ export class Store {
     const objectives = this.objectives;
     if (!_.find(objectives, o => _.isEqual(o, objective))) {
       this.objectives.push(objective);
-      addToOutbox && this._eventEmitter.emit('addToOutbox', {objectives: [objective]});
+      addToOutbox &&
+        this._eventEmitter.emit('addToOutbox', {
+          walletVersion: WALLET_VERSION,
+          objectives: [objective]
+        });
       this._eventEmitter.emit('newObjective', objective);
     }
   }

--- a/packages/xstate-wallet/src/store/tests/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/memory-store.test.ts
@@ -11,7 +11,7 @@ import {Wallet} from 'ethers';
 
 import {ChannelStoreEntry} from '../channel-store-entry';
 import {MemoryBackend as Backend} from '../memory-backend';
-import {CHAIN_NETWORK_ID, CHALLENGE_DURATION} from '../../config';
+import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, WALLET_VERSION} from '../../config';
 import {Errors} from '..';
 
 import {Store} from './../store';
@@ -72,7 +72,7 @@ describe('channelUpdatedFeed', () => {
     store.channelUpdatedFeed(channelId).subscribe(x => {
       outputs.push(x);
     });
-    await store.pushMessage({signedStates});
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
 
     expect(outputs[0].latest).toMatchObject(state);
   });
@@ -82,7 +82,7 @@ describe('channelUpdatedFeed', () => {
 
     const outputs: ChannelStoreEntry[] = [];
     store.channelUpdatedFeed('a-different-channel-id').subscribe(x => outputs.push(x));
-    await store.pushMessage({signedStates});
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
 
     expect(outputs).toEqual([]);
   });
@@ -100,11 +100,11 @@ test('newObjectiveFeed', async () => {
   const outputs: Objective[] = [];
   store.objectiveFeed.subscribe(x => outputs.push(x));
 
-  await store.pushMessage({objectives: [objective]});
+  await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
   expect(outputs).toEqual([objective]);
 
   // doing it twice doesn't change anything
-  await store.pushMessage({objectives: [objective]});
+  await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
   expect(outputs).toEqual([objective]);
 });
 
@@ -152,6 +152,7 @@ describe('pushMessage', () => {
 
     const nextState = {...state, turnNum: state.turnNum + 2};
     await store.pushMessage({
+      walletVersion: WALLET_VERSION,
       signedStates: [{...nextState, signatures: [createSignatureEntry(nextState, bPrivateKey)]}]
     });
     expect((await store.getEntry(channelId)).latest).toMatchObject(nextState);
@@ -159,7 +160,7 @@ describe('pushMessage', () => {
 
   it('creates a channel if it receives states for a new channel', async () => {
     const store = await aStore();
-    await store.pushMessage({signedStates});
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
     expect(await store.getEntry(channelId)).not.toBeUndefined();
   });
 });

--- a/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@statechannels/wallet-core';
 import {constants} from 'ethers';
 
+import {WALLET_VERSION} from '../../config';
 import {FakeChain} from '../../chain';
 import {TestStore} from '../../test-store';
 import {ParticipantIdx} from '../virtual-funding-as-leaf';
@@ -263,6 +264,7 @@ test('invalid joint state', async () => {
   };
 
   await store.pushMessage({
+    walletVersion: WALLET_VERSION,
     signedStates: [
       {
         ...invalidState,


### PR DESCRIPTION
_In the xstate wallet:_ populate this string using the githash (which we are already using and is injected during the webpack build). 

_In the server wallet:_ write the package version number into the compiled javascript before publishing. Use an empty string otherwise (e.g. with ts-node). 

Also throw an error if we got a message from a wallet at a different `walletVersion`.
