### PR TITLE
Minor fix to use the same alreadyHaveState check when validating transitions

### DIFF
--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -24,7 +24,6 @@ import {
   SignedState,
   objectiveId,
   deserializeState,
-  statesEqual,
   isSimpleAllocation,
   checkThat,
 } from '@statechannels/wallet-core';
@@ -180,11 +179,10 @@ export class Store {
       channel.signingWallet.signState(state)
     );
     const signedState = {...state, signatures: [signatureEntry]};
-
+    const alreadyHaveState = channel.sortedStates.some(s => s.stateHash === state.stateHash);
     if (
       supported &&
-      // If the state is the same as the support state then its not a transition just adding signatures
-      !statesEqual(supported, state) &&
+      !alreadyHaveState &&
       !(await this.isLedger(channelId, tx)) &&
       !(await timer('validating transition', async () =>
         this.validateTransition(supported, signedState, tx)


### PR DESCRIPTION
I don't think this was actively causing any issues but we should be using the same [check](https://github.com/statechannels/statechannels/blob/9c59e0683de67cdfa567302d52bed16e55bda080/packages/server-wallet/src/wallet/store.ts#L591) in both places we validate state transitions.