### PR TITLE
Fix: Do not evm validate final states

### DIFF
--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -330,8 +330,8 @@ export class Store {
     }
 
     // Validates app specific rules by running the app rules contract in the EVM
-    // We only want to run the validation for states not in the funding stage per the force move contract
-    if (!this.skipEvmValidation && !isInFundingStage) {
+    // We only want to run the validation for states not in a funding or final stage per the force move contract
+    if (!this.skipEvmValidation && !isInFundingStage && !toState.isFinal) {
       const evmValidation = await validateTransitionWithEVM(
         toNitroState(fromState),
         toNitroState(toState),


### PR DESCRIPTION
Following the force move contracts we should not be calling `validTransition` when transitioning to a `isFinal` state. 

This fixes the validation logic to respect that.