### PR TITLE
Close channel objective only completes when funds have been transferred

### DIFF
--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -92,11 +92,11 @@ it('Create a directly funded channel between two wallets ', async () => {
     .toPromise();
 
   const closeCompletedA = fromEvent<ObjectiveSucceededValue>(a as any, 'objectiveSucceeded')
-    .pipe(take(1))
+    .pipe(take(2))
     .toPromise();
 
   const closeCompletedB = fromEvent<ObjectiveSucceededValue>(b as any, 'objectiveSucceeded')
-    .pipe(take(1))
+    .pipe(take(2))
     .toPromise();
 
   //        A <> B
@@ -180,8 +180,8 @@ it('Create a directly funded channel between two wallets ', async () => {
     turnNum: 4,
   });
 
-  await closeCompletedA;
-  await closeCompletedB;
+  expect(await closeCompletedA).toMatchObject({channelId, objectiveType: 'CloseChannel'});
+  expect(await closeCompletedB).toMatchObject({channelId, objectiveType: 'CloseChannel'});
 
   const aBalanceFinal = await getBalance(aAddress);
   const bBalanceFinal = await getBalance(bAddress);

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -83,11 +83,11 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   // the type assertion is due to
   // https://github.com/devanshj/rxjs-from-emitter/blob/master/docs/solving-some-from-event-flaws.md#the-way-fromevent-checks-if-the-first-argument-passed-is-an-emitter-or-not-is-incorrect
-  const postFundAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdate')
+  const postFundAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
     .pipe(take(2))
     .toPromise();
 
-  const postFundBPromise = fromEvent<SingleChannelOutput>(b as any, 'channelUpdate')
+  const postFundBPromise = fromEvent<SingleChannelOutput>(b as any, 'channelUpdated')
     .pipe(take(2))
     .toPromise();
 

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -174,7 +174,6 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   // A fragile way to wait for the conclude and withdraw to complete
   await new Promise(r => setTimeout(r, 1_000));
-
   const aBalanceFinal = await getBalance(aAddress);
   const bBalanceFinal = await getBalance(bAddress);
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -184,7 +184,7 @@ describe('registerChannel', () => {
 
     chainService.registerChannel(channelId, [ethAssetHolderAddress], {
       holdingUpdated,
-      onAssetTransferred: _.noop,
+      assetTransferred: _.noop,
     });
     await p;
   });
@@ -203,7 +203,7 @@ describe('registerChannel', () => {
           });
           resolve();
         },
-        onAssetTransferred: _.noop,
+        assetTransferred: _.noop,
       })
     );
   });
@@ -236,7 +236,7 @@ describe('registerChannel', () => {
     };
     chainService.registerChannel(channelId, [ethAssetHolderAddress, erc20AssetHolderAddress], {
       holdingUpdated,
-      onAssetTransferred: _.noop,
+      assetTransferred: _.noop,
     });
     fundChannel(0, 5, channelId, ethAssetHolderAddress);
     fundChannel(0, 5, channelId, erc20AssetHolderAddress);
@@ -252,7 +252,7 @@ describe('concludeAndWithdraw', () => {
     const p = new Promise(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         holdingUpdated: _.noop,
-        onAssetTransferred: (arg: AssetTransferredArg) => {
+        assetTransferred: (arg: AssetTransferredArg) => {
           switch (counter) {
             case 0:
               expect(arg).toMatchObject({
@@ -293,7 +293,7 @@ describe('concludeAndWithdraw', () => {
     const p = new Promise(resolve =>
       chainService.registerChannel(channelId, [erc20AssetHolderAddress], {
         holdingUpdated: _.noop,
-        onAssetTransferred: (arg: AssetTransferredArg) => {
+        assetTransferred: (arg: AssetTransferredArg) => {
           switch (counter) {
             case 0:
               expect(arg).toMatchObject({

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -258,7 +258,7 @@ describe('concludeAndWithdraw', () => {
               expect(arg).toMatchObject({
                 amount: BN.from(1),
                 assetHolderAddress: ethAssetHolderAddress,
-                to: makeDestination(aAddress).toLocaleLowerCase(),
+                to: makeDestination(aAddress).toLowerCase(),
                 channelId,
               });
               counter++;
@@ -267,7 +267,7 @@ describe('concludeAndWithdraw', () => {
               expect(arg).toMatchObject({
                 amount: BN.from(3),
                 assetHolderAddress: ethAssetHolderAddress,
-                to: makeDestination(bAddress).toLocaleLowerCase(),
+                to: makeDestination(bAddress).toLowerCase(),
                 channelId,
               });
               resolve();
@@ -299,7 +299,7 @@ describe('concludeAndWithdraw', () => {
               expect(arg).toMatchObject({
                 amount: BN.from(1),
                 assetHolderAddress: erc20AssetHolderAddress,
-                to: makeDestination(aAddress).toLocaleLowerCase(),
+                to: makeDestination(aAddress).toLowerCase(),
                 channelId,
               });
               counter++;
@@ -308,7 +308,7 @@ describe('concludeAndWithdraw', () => {
               expect(arg).toMatchObject({
                 amount: BN.from(3),
                 assetHolderAddress: erc20AssetHolderAddress,
-                to: makeDestination(bAddress).toLocaleLowerCase(),
+                to: makeDestination(bAddress).toLowerCase(),
                 channelId,
               });
               resolve();

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -42,7 +42,7 @@ export type FundChannelArg = {
 
 export interface ChainEventSubscriberInterface {
   holdingUpdated(arg: HoldingUpdatedArg): void;
-  onAssetTransferred(arg: AssetTransferredArg): void;
+  assetTransferred(arg: AssetTransferredArg): void;
 }
 
 interface ChainEventEmitterInterface {
@@ -223,7 +223,7 @@ export class ChainService implements ChainServiceInterface {
               subscriber.holdingUpdated(event);
               break;
             case AssetTransferred:
-              subscriber.onAssetTransferred(event);
+              subscriber.assetTransferred(event);
               break;
             default:
               throw new Error('Unexpected event from contract observable');

--- a/packages/server-wallet/src/db/migrations/20201029130000_transferred_out.ts
+++ b/packages/server-wallet/src/db/migrations/20201029130000_transferred_out.ts
@@ -1,7 +1,7 @@
 import * as Knex from 'knex';
 
 const funding = 'funding';
-const transferredOut = 'transferredOut';
+const transferredOut = 'transferred_out';
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.alterTable(funding, table => {
     table

--- a/packages/server-wallet/src/db/migrations/20201029130000_transferred_out.ts
+++ b/packages/server-wallet/src/db/migrations/20201029130000_transferred_out.ts
@@ -1,0 +1,16 @@
+import * as Knex from 'knex';
+
+const funding = 'funding';
+const transferredOut = 'transferredOut';
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.alterTable(funding, table => {
+    table
+      .specificType(transferredOut, 'jsonb')
+      .notNullable()
+      .defaultTo('[]');
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable(transferredOut);
+}

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -217,10 +217,10 @@ export class Channel extends Model implements RequiredColumns {
       fundingLedgerChannelId,
     } = this;
     const funding = (assetHolder: Address): ChannelStateFunding => {
+      const noFunding = {amount: Zero, transferredOut: []};
+      if (!this.funding) return noFunding;
       const result = this.funding.find(f => f.assetHolder === assetHolder);
-      return result
-        ? {amount: result.amount, transferredOut: result.transferredOut}
-        : {amount: Zero, transferredOut: []};
+      return result ? {amount: result.amount, transferredOut: result.transferredOut} : noFunding;
     };
     return {
       myIndex: myIndex as 0 | 1,

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -14,7 +14,12 @@ import {JSONSchema, Model, Pojo, QueryContext, ModelOptions, TransactionOrKnex} 
 import {ChannelResult, FundingStrategy} from '@statechannels/client-api-schema';
 
 import {Address, Bytes32, Uint48} from '../type-aliases';
-import {ChannelState, toChannelResult, ChainServiceRequests} from '../protocols/state';
+import {
+  ChannelState,
+  toChannelResult,
+  ChainServiceRequests,
+  ChannelStateFunding,
+} from '../protocols/state';
 import {WalletError, Values} from '../errors/wallet-error';
 
 import {SigningWallet} from './signing-wallet';
@@ -211,9 +216,11 @@ export class Channel extends Model implements RequiredColumns {
       fundingStrategy,
       fundingLedgerChannelId,
     } = this;
-    const funding = (assetHolder: Address): string => {
+    const funding = (assetHolder: Address): ChannelStateFunding => {
       const result = this.funding.find(f => f.assetHolder === assetHolder);
-      return result ? result.amount : Zero;
+      return result
+        ? {amount: result.amount, transferredOut: result.transferredOut}
+        : {amount: Zero, transferredOut: []};
     };
     return {
       myIndex: myIndex as 0 | 1,

--- a/packages/server-wallet/src/models/funding.ts
+++ b/packages/server-wallet/src/models/funding.ts
@@ -3,16 +3,21 @@ import {Zero} from '@statechannels/wallet-core';
 import Knex from 'knex';
 
 import {Uint256, Bytes32, Address} from '../type-aliases';
+import {logger} from '../logger';
+
+type TransferredOutEntry = {toAddress: Address; amount: Uint256};
 
 export const REQUIRED_COLUMNS = {
   channelId: 'channelId',
   amount: 'amount',
   assetHolder: 'assetHolder',
+  transferredOut: 'transferredOut',
 };
 export interface RequiredColumns {
   readonly channelId: Bytes32;
   readonly amount: Uint256;
   readonly assetHolder: Address;
+  readonly transferredOut: TransferredOutEntry[];
 }
 
 export class Funding extends Model implements RequiredColumns {
@@ -23,6 +28,7 @@ export class Funding extends Model implements RequiredColumns {
   readonly channelId!: Bytes32;
   readonly amount!: Uint256;
   readonly assetHolder!: Address;
+  readonly transferredOut!: TransferredOutEntry[];
 
   static async getFundingAmount(
     knex: Knex,
@@ -55,5 +61,32 @@ export class Funding extends Model implements RequiredColumns {
         .returning('*')
         .first();
     }
+  }
+
+  static async updateTransferredOut(
+    knex: Knex,
+    channelId: Bytes32,
+    assetHolder: Address,
+    toAddress: Uint256,
+    amount: Address
+  ): Promise<Funding> {
+    return knex.transaction(async tx => {
+      const existing = await Funding.query(tx)
+        .where({channelId, assetHolder})
+        .first();
+
+      if (!existing) {
+        const errorMessage = `Expected for funding row to exists with channelId ${channelId}, assetHolder ${assetHolder}`;
+        logger.error(errorMessage, {channelId, assetHolder, toAddress, amount});
+        throw new Error(errorMessage);
+      } else {
+        existing.transferredOut;
+        return await Funding.query(tx)
+          .patch({transferredOut: existing.transferredOut.concat({toAddress, amount})})
+          .where({channelId, assetHolder})
+          .returning('*')
+          .first();
+      }
+    });
   }
 }

--- a/packages/server-wallet/src/models/funding.ts
+++ b/packages/server-wallet/src/models/funding.ts
@@ -80,9 +80,9 @@ export class Funding extends Model implements RequiredColumns {
         logger.error(errorMessage, {channelId, assetHolder, toAddress, amount});
         throw new Error(errorMessage);
       } else {
-        existing.transferredOut;
+        const transferredOut = existing.transferredOut.concat({toAddress, amount});
         return await Funding.query(tx)
-          .patch({transferredOut: existing.transferredOut.concat({toAddress, amount})})
+          .patch({transferredOut})
           .where({channelId, assetHolder})
           .returning('*')
           .first();

--- a/packages/server-wallet/src/models/funding.ts
+++ b/packages/server-wallet/src/models/funding.ts
@@ -64,7 +64,7 @@ export class Funding extends Model implements RequiredColumns {
       return await Funding.query(knex).insert({channelId, amount, assetHolder, transferredOut: []});
     } else {
       return await Funding.query(knex)
-        .patch({channelId, amount, assetHolder})
+        .patch({amount})
         .where({channelId, assetHolder})
         .returning('*')
         .first();

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -98,7 +98,8 @@ export class ObjectiveManager {
               await this.store.markObjectiveAsSucceeded(objective, tx);
               channelResults.push(ChannelState.toChannelResult(protocolState.app));
               eventsToEmit.concat({
-                objectiveSucceeded: {
+                type: 'objectiveSucceeded',
+                value: {
                   channelId: objective.data.targetChannelId,
                   objectiveType: objective.type,
                 },

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -37,7 +37,7 @@ export class ObjectiveManager {
     const outbox: Outgoing[] = [];
     const channelResults: ChannelResult[] = [];
     let maybeError: any = undefined;
-    const eventsToEmit: WalletEvent[] = [];
+    let eventsToEmit: WalletEvent[] = [];
 
     const objective = await this.store.getObjective(objectiveId);
 
@@ -97,7 +97,7 @@ export class ObjectiveManager {
             case 'CompleteObjective':
               await this.store.markObjectiveAsSucceeded(objective, tx);
               channelResults.push(ChannelState.toChannelResult(protocolState.app));
-              eventsToEmit.concat({
+              eventsToEmit = eventsToEmit.concat({
                 type: 'objectiveSucceeded',
                 value: {
                   channelId: objective.data.targetChannelId,

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -85,7 +85,8 @@ export class ObjectiveManager {
             }
             case 'FundChannel':
               await this.store.addChainServiceRequest(action.channelId, 'fund', tx);
-              await this.chainService.fundChannel({
+              // Note, we are not awaiting transaction submission
+              this.chainService.fundChannel({
                 ...action,
                 expectedHeld: BN.from(action.expectedHeld),
                 amount: BN.from(action.amount),
@@ -99,6 +100,7 @@ export class ObjectiveManager {
             case 'Withdraw':
               await this.store.addChainServiceRequest(action.channelId, 'withdraw', tx);
               // app.supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
+              // Note, we are not awaiting transaction submission
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               await this.chainService.concludeAndWithdraw([protocolState.app.supported!]);
               return;

--- a/packages/server-wallet/src/objectives/types.ts
+++ b/packages/server-wallet/src/objectives/types.ts
@@ -4,6 +4,7 @@ import {ChannelResult} from '@statechannels/client-api-schema';
 import {Store} from '../wallet/store';
 import {ChainServiceInterface} from '../chain-service';
 import {Outgoing} from '../protocols/actions';
+import {WalletEvent} from '../wallet';
 
 export interface ObjectiveManagerParams {
   store: Store;
@@ -16,5 +17,6 @@ export interface ObjectiveManagerParams {
 export type ExecutionResult = {
   outbox: Outgoing[];
   channelResults: ChannelResult[];
+  events?: WalletEvent[];
   error?: any;
 };

--- a/packages/server-wallet/src/protocols/__test__/fixtures/channel-state.ts
+++ b/packages/server-wallet/src/protocols/__test__/fixtures/channel-state.ts
@@ -1,6 +1,5 @@
-import {ChannelStateWithSupported} from '../../state';
+import {ChannelStateFunding, ChannelStateWithSupported} from '../../state';
 import {stateWithHashSignedBy} from '../../../wallet/__test__/fixtures/states';
-import {Uint256} from '../../../type-aliases';
 import {fixture} from '../../../wallet/__test__/fixtures/utils';
 import {alice, bob} from '../../../wallet/__test__/fixtures/participants';
 
@@ -11,7 +10,7 @@ const defaultChannelState: ChannelStateWithSupported = {
   supported: stateWithHashSignedBy()({turnNum: 3}),
   latest: stateWithHashSignedBy()({turnNum: 3}),
   latestSignedByMe: stateWithHashSignedBy()({turnNum: 3}),
-  funding: (): Uint256 => '0x00',
+  funding: (): ChannelStateFunding => ({amount: '0x00', transferredOut: []}),
   chainServiceRequests: [],
   fundingStrategy: 'Direct',
 };

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -1,4 +1,4 @@
-import {simpleEthAllocation, BN, Uint256, State} from '@statechannels/wallet-core';
+import {simpleEthAllocation, BN, State} from '@statechannels/wallet-core';
 import matchers from '@pacote/jest-either';
 import {ethers} from 'ethers';
 
@@ -28,8 +28,10 @@ const altPrefundState0 = {outcome: outcome2, turnNum: 0, participants};
 const reversedPFState0 = {outcome, turnNum: 0, participants: [bob(), alice()]};
 const reversedPFState1 = {outcome, turnNum: 1, participants: [bob(), alice()]};
 
-const funded = (): Uint256 => BN.from(5);
-const notFunded = (): Uint256 => BN.from(0);
+const funded = () => ({
+  amount: BN.from(5),
+});
+const notFunded = () => ({amount: BN.from(0)});
 
 const signState = (state: Partial<State>): Partial<SignState> => ({type: 'SignState', ...state});
 const fundChannelAction1 = fundChannel({

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -33,7 +33,9 @@ function everyoneSignedFinalState(ps: ProtocolState): boolean {
 }
 
 function successfulWithdraw({app}: ProtocolState): boolean {
+  if (app.fundingStrategy !== 'Direct') return true;
   if (!app.supported) return false;
+
   const {allocationItems, assetHolderAddress} = checkThat(
     app.supported.outcome,
     isSimpleAllocation

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -32,6 +32,10 @@ function everyoneSignedFinalState(ps: ProtocolState): boolean {
   return (ps.app.support || []).every(isFinal) && isFinal(ps.app.latestSignedByMe);
 }
 
+function successfulWithdraw(_ps: ProtocolState): boolean {
+  return true;
+}
+
 const signFinalState = (ps: ProtocolState): ProtocolResult | false =>
   !!ps.app.supported &&
   !isFinal(ps.app.latestSignedByMe) &&
@@ -58,6 +62,7 @@ const isLedgerFunded = ({fundingStrategy}: ChannelState): boolean => fundingStra
 const completeCloseChannel = (ps: ProtocolState): CompleteObjective | false =>
   everyoneSignedFinalState(ps) &&
   ((isLedgerFunded(ps.app) && ps.ledgerDefundingSucceeded) || !isLedgerFunded(ps.app)) &&
+  successfulWithdraw(ps) &&
   completeObjective({channelId: ps.app.channelId});
 
 function chainWithdraw(ps: ProtocolState): Withdraw | false {

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -32,6 +32,8 @@ function everyoneSignedFinalState(ps: ProtocolState): boolean {
   return (ps.app.support || []).every(isFinal) && isFinal(ps.app.latestSignedByMe);
 }
 
+// todo: where is the corresponding logic for ledger channels?
+//       should there be a generic logic for computing whether a channel is defunded regardless of funding type?
 function successfulWithdraw({app}: ProtocolState): boolean {
   if (app.fundingStrategy !== 'Direct') return true;
   if (!app.supported) return false;

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -46,7 +46,8 @@ function successfulWithdraw({app}: ProtocolState): boolean {
     .reduce((soFar, currentAi) => BN.add(soFar, currentAi.amount), BN.from(0));
   const amountTransferredToMe = app
     .funding(assetHolderAddress)
-    .transferredOut.filter(tf => tf.toAddress === myDestination)
+    // todo: figure out why destination in emitted events are lower case
+    .transferredOut.filter(tf => tf.toAddress === myDestination.toLocaleLowerCase())
     .reduce((soFar, currentAi) => BN.add(soFar, currentAi.amount), BN.from(0));
   return BN.eq(amountOwedToMe, amountTransferredToMe);
 }

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -49,7 +49,7 @@ function successfulWithdraw({app}: ProtocolState): boolean {
   const amountTransferredToMe = app
     .funding(assetHolderAddress)
     // todo: figure out why destination in emitted events are lower case
-    .transferredOut.filter(tf => tf.toAddress === myDestination.toLocaleLowerCase())
+    .transferredOut.filter(tf => tf.toAddress === myDestination.toLowerCase())
     .reduce((soFar, currentAi) => BN.add(soFar, currentAi.amount), BN.from(0));
   return BN.eq(amountOwedToMe, amountTransferredToMe);
 }

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -68,7 +68,7 @@ function isFunded(ps: ProtocolState): boolean {
     case 'Direct': {
       if (!supported) return false;
       const allocation = checkThat(supported?.outcome, isSimpleAllocation);
-      const currentFunding = funding(allocation.assetHolderAddress);
+      const currentFunding = funding(allocation.assetHolderAddress).amount;
       const targetFunding = allocation.allocationItems
         .map(a => a.amount)
         .reduce(BN.add, BN.from(0));
@@ -109,7 +109,7 @@ const requestFundChannelIfMyTurn = ({app}: ProtocolState): FundChannel | false =
    *  2. We only care about a single destination.
    * One reason to drop (2), for instance, is to support ledger top-ups with as few state updates as possible.
    */
-  const currentFunding = app.funding(assetHolderAddress);
+  const currentFunding = app.funding(assetHolderAddress).amount;
   const allocationsBeforeMe = _.takeWhile(allocationItems, a => a.destination !== myDestination);
   const targetFunding = allocationsBeforeMe.map(a => a.amount).reduce(BN.add, BN.from(0));
   if (BN.lt(currentFunding, targetFunding)) return false;

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -21,6 +21,10 @@ export type ChainServiceApi = 'fund' | 'withdraw' | 'challenge';
  * - challenge: the value is the state with which challenge is called.
  */
 export type ChainServiceRequests = ChainServiceApi[];
+export type ChannelStateFunding = {
+  amount: Uint256;
+  transferredOut: {toAddress: Address; amount: Uint256}[];
+};
 
 /*
 The ChannelState type is the data that protocols need about a given channel to decide what to do next.
@@ -34,7 +38,7 @@ export type ChannelState = {
   latest: SignedStateWithHash;
   latestSignedByMe?: SignedStateWithHash;
   latestNotSignedByMe?: SignedStateWithHash;
-  funding: (address: Address) => Uint256;
+  funding: (address: Address) => ChannelStateFunding;
   chainServiceRequests: ChainServiceRequests;
   fundingStrategy: FundingStrategy;
   fundingLedgerChannelId?: Address; // only present if funding strategy is Ledger

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -763,7 +763,7 @@ export class Wallet extends EventEmitter<EventEmitterType>
       try {
         events?.map(event => this.emit(event.type, event.value));
       } catch (error) {
-        logger.error('Unable to emit events', {error, events});
+        this.logger.error('Unable to emit events', {error, events});
       }
 
       // todo(tom): this how the code behaved previously. Is it actually what we want?

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -760,7 +760,11 @@ export class Wallet extends EventEmitter<EventEmitterType>
       channelResults.push(...newChannelResults);
       outbox.push(...newOutbox);
 
-      events?.map(e => this.emit(e.type, e.value));
+      try {
+        events?.map(event => this.emit(event.type, event.value));
+      } catch (error) {
+        logger.error('Unable to emit events', {error, events});
+      }
 
       // todo(tom): this how the code behaved previously. Is it actually what we want?
       error = newError;
@@ -785,6 +789,7 @@ export class Wallet extends EventEmitter<EventEmitterType>
       arg.to,
       arg.amount
     );
+    await this.takeActions([arg.channelId]);
   }
 
   private registerChannelWithChainService(cr: ChannelResult): void {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -755,8 +755,13 @@ export class Wallet extends EventEmitter<WalletEvent>
     );
   }
 
-  onAssetTransferred(_arg: AssetTransferredArg): void {
-    // todo: implement me
+  async assetTransferred(arg: AssetTransferredArg): Promise<void> {
+    await this.store.updateTransferredOut(
+      arg.channelId,
+      arg.assetHolderAddress,
+      arg.to,
+      arg.amount
+    );
   }
 
   private registerChannelWithChainService(cr: ChannelResult): void {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -83,12 +83,13 @@ type ChannelUpdateEvent = {
   type: ChannelUpdateEventName;
   value: SingleChannelOutput;
 };
+export type ObjectiveSucceededValue = {
+  channelId: string;
+  objectiveType: 'OpenChannel' | 'CloseChannel';
+};
 type ObjectiveSucceededEvent = {
   type: ObjectiveSucceededEventName;
-  value: {
-    channelId: string;
-    objectiveType: 'OpenChannel' | 'CloseChannel';
-  };
+  value: ObjectiveSucceededValue;
 };
 export type WalletEvent = ChannelUpdateEvent | ObjectiveSucceededEvent;
 type EventEmitterType =

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -77,10 +77,10 @@ export type MultipleChannelOutput = {
 };
 type Message = SingleChannelOutput | MultipleChannelOutput;
 
-type ChannelUpdateEventName = 'channelUpdate';
+type ChannelUpdatedEventName = 'channelUpdated';
 type ObjectiveSucceededEventName = 'objectiveSucceeded';
-type ChannelUpdateEvent = {
-  type: ChannelUpdateEventName;
+type ChannelUpdatedEvent = {
+  type: ChannelUpdatedEventName;
   value: SingleChannelOutput;
 };
 export type ObjectiveSucceededValue = {
@@ -91,10 +91,10 @@ type ObjectiveSucceededEvent = {
   type: ObjectiveSucceededEventName;
   value: ObjectiveSucceededValue;
 };
-export type WalletEvent = ChannelUpdateEvent | ObjectiveSucceededEvent;
+export type WalletEvent = ChannelUpdatedEvent | ObjectiveSucceededEvent;
 type EventEmitterType =
   | {
-      [key in ChannelUpdateEvent['type']]: ChannelUpdateEvent['value'];
+      [key in ChannelUpdatedEvent['type']]: ChannelUpdatedEvent['value'];
     }
   | {
       [key in ObjectiveSucceededEvent['type']]: ObjectiveSucceededEvent['value'];
@@ -776,9 +776,9 @@ export class Wallet extends EventEmitter<EventEmitterType>
 
   // ChainEventSubscriberInterface implementation
   holdingUpdated(arg: HoldingUpdatedArg): void {
-    const channelUpdate: ChannelUpdateEventName = 'channelUpdate';
+    const channelUpdated: ChannelUpdatedEventName = 'channelUpdated';
     this.updateChannelFundingForAssetHolder(arg).then(singleChannelOutput =>
-      this.emit(channelUpdate, singleChannelOutput)
+      this.emit(channelUpdated, singleChannelOutput)
     );
   }
 

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -783,6 +783,7 @@ export class Wallet extends EventEmitter<EventEmitterType>
   }
 
   async assetTransferred(arg: AssetTransferredArg): Promise<void> {
+    // todo: make sure that arg.to is checksummed
     await this.store.updateTransferredOut(
       arg.channelId,
       arg.assetHolderAddress,

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -404,7 +404,9 @@ export class Store {
       // fetch the channel to make sure the channel exists
       const channel = await Channel.forId(targetChannelId, tx);
       if (!channel) {
-        throw new StoreError(StoreError.reasons.channelMissing, {channelId: targetChannelId});
+        throw new StoreError(StoreError.reasons.channelMissing, {
+          channelId: targetChannelId,
+        });
       }
 
       const objectiveToBeStored: DBObjective = {
@@ -573,6 +575,15 @@ export class Store {
     assetHolderAddress: Address
   ): Promise<void> {
     await Funding.updateFunding(this.knex, channelId, fromAmount, assetHolderAddress);
+  }
+
+  async updateTransferredOut(
+    channelId: string,
+    assetHolder: Address,
+    toAddress: Address,
+    amount: Uint256
+  ): Promise<void> {
+    await Funding.updateTransferredOut(this.knex, channelId, assetHolder, toAddress, amount);
   }
 
   async nextNonce(signingAddresses: Address[]): Promise<number> {


### PR DESCRIPTION
This work only impacts directly funded channels.

How it works before this PR: when processing the close channel objective, the wallet submits a `concludeAndWithdraw` transaction. If the transaction is successfully submitted or fails for an accepted reason (regardless of what happens during mining), the wallet allows the close channel objective to succeed.

How it works after this PR: the wallet only allows the close channel objective to succeed if the wallet has been notified of `AssetTransferred` events that show that all of the assets for the participant have been transferred out of the channel.

Follow up work includes the wallet emitting an event when the close channel objective succeeds. At the moment, the tests do not verify that the close channel objective succeeds for directly funded channels.