### PR TITLE
chore: remove duplicate implementation of stateWithHashSignedBy

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -6,7 +6,7 @@ import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
 import {channel} from '../../models/__test__/fixtures/channel';
 
-import {stateWithHashSignedBy2} from './fixtures/states';
+import {stateWithHashSignedBy} from './fixtures/states';
 import {alice, bob} from './fixtures/signing-wallets';
 
 let store: Store;
@@ -30,7 +30,7 @@ describe('addSignedState', () => {
   });
 
   it('throws when the signer is not me', async () => {
-    const stateSignedByBob = stateWithHashSignedBy2([bob()])();
+    const stateSignedByBob = stateWithHashSignedBy([bob()])();
     const channelWithAliceAsSigner = channel();
     await expect(
       store.addMyState(channelWithAliceAsSigner, stateSignedByBob, knex as any)
@@ -39,7 +39,7 @@ describe('addSignedState', () => {
 
   it('throws when there are multiple signers (me and someone else)', async () => {
     // This is bad since the other person's signature will not be validated
-    const stateSignedByBob = stateWithHashSignedBy2([bob(), alice()])();
+    const stateSignedByBob = stateWithHashSignedBy([bob(), alice()])();
     const channelWithAliceAsSigner = channel();
     await expect(
       store.addMyState(channelWithAliceAsSigner, stateSignedByBob, knex as any)
@@ -47,7 +47,7 @@ describe('addSignedState', () => {
   });
 
   it('does not throw when the signer is me', async () => {
-    const stateSignedByAlice = stateWithHashSignedBy2([alice()])();
+    const stateSignedByAlice = stateWithHashSignedBy([alice()])();
     const channelWithAliceAsSigner = channel();
     await expect(
       store.addMyState(channelWithAliceAsSigner, stateSignedByAlice, knex as any)

--- a/packages/server-wallet/src/wallet/__test__/fixtures/states.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/states.ts
@@ -53,19 +53,7 @@ export const stateSignedBy = (signingWallets = [aliceWallet()]): Fixture<SignedS
     flow(overwriteOutcome, addSignatures(signingWallets))
   );
 
-// TODO: This should be replaced with stateWithHashSignedBy2.
-// The problem with this version is that it is impossible to get a state
-// signed only by bob.
 export const stateWithHashSignedBy = (
-  pk = aliceWallet(),
-  ...otherWallets: SigningWallet[]
-): Fixture<SignedStateWithHash> =>
-  fixture(
-    createState() as SignedStateWithHash,
-    flow(overwriteOutcome, addSignatures([pk, ...otherWallets]), addHash)
-  );
-
-export const stateWithHashSignedBy2 = (
   signingWallets: SigningWallet[] = [aliceWallet()]
 ): Fixture<SignedStateWithHash> =>
   fixture(

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -21,7 +21,10 @@ it("signs a final state when it's my turn", async () => {
   const turnNum = 7;
   const runningState = {turnNum, appData};
   const closingState = {...runningState, isFinal: true, turnNum: turnNum + 1};
-  const c = channel({channelNonce: 1, vars: [stateWithHashSignedBy(alice(), bob())(runningState)]});
+  const c = channel({
+    channelNonce: 1,
+    vars: [stateWithHashSignedBy([alice(), bob()])(runningState)],
+  });
   await Channel.query(w.knex).insert(c);
 
   const channelId = c.channelId;
@@ -41,7 +44,10 @@ it("reject when it's not my turn", async () => {
   const appData = '0x0f00';
   const turnNum = 8;
   const runningState = {turnNum, appData};
-  const c = channel({channelNonce: 2, vars: [stateWithHashSignedBy(alice(), bob())(runningState)]});
+  const c = channel({
+    channelNonce: 2,
+    vars: [stateWithHashSignedBy([alice(), bob()])(runningState)],
+  });
   await Channel.query(w.knex).insert(c);
 
   const channelId = c.channelId;

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -43,14 +43,14 @@ describe('directly funded app', () => {
     const c1 = channel({
       signingAddress: bob().address,
       channelNonce: 1,
-      vars: [stateWithHashSignedBy(alice())(state1)],
+      vars: [stateWithHashSignedBy([alice()])(state1)],
     });
 
     await Channel.query(w.knex).insert(c1);
     const c2 = channel({
       signingAddress: bob().address,
       channelNonce: 2,
-      vars: [stateWithHashSignedBy(alice())(state2)],
+      vars: [stateWithHashSignedBy([alice()])(state2)],
     });
 
     await Channel.query(w.knex).insert(c2);
@@ -116,7 +116,7 @@ describe('directly funded app', () => {
     const preFS1 = {turnNum: 1, appData};
     const c = channel({
       signingAddress: bob().address,
-      vars: [stateWithHashSignedBy(alice())(preFS0)],
+      vars: [stateWithHashSignedBy([alice()])(preFS0)],
     });
     await Channel.query(w.knex).insert(c);
     const {channelId} = c;
@@ -155,7 +155,7 @@ describe('directly funded app', () => {
 
     const c = channel({
       signingAddress: bob().address,
-      vars: [stateWithHashSignedBy(alice())(preFS0)],
+      vars: [stateWithHashSignedBy([alice()])(preFS0)],
     });
 
     await Channel.query(w.knex).insert(c);
@@ -214,10 +214,7 @@ describe('ledger funded app scenarios', () => {
         signingAddress: bob().address,
         channelNonce: someNonConflictingChannelNonce,
         vars: [
-          stateWithHashSignedBy(
-            alice(),
-            bob()
-          )({
+          stateWithHashSignedBy([alice(), bob()])({
             appDefinition: '0x0000000000000000000000000000000000000000',
             channelNonce: someNonConflictingChannelNonce,
             turnNum: 4,
@@ -282,10 +279,10 @@ describe('ledger funded app scenarios', () => {
     const {channelId} = await putTestChannelInsideWallet({
       ...app,
       signingAddress: bob().address,
-      vars: [stateWithHashSignedBy(alice())(preFS0)],
+      vars: [stateWithHashSignedBy([alice()])(preFS0)],
     });
 
-    const signedPreFS1 = stateWithHashSignedBy(bob())(preFS1);
+    const signedPreFS1 = stateWithHashSignedBy([bob()])(preFS1);
 
     await expect(w.joinChannel({channelId})).resolves.toMatchObject({
       outbox: [
@@ -296,8 +293,8 @@ describe('ledger funded app scenarios', () => {
             sender: 'bob',
             data: {
               signedStates: [
-                serializeState(stateWithHashSignedBy(bob())(signedPreFS1)),
-                serializeState(stateWithHashSignedBy(bob())(expectedUpdatedLedgerState)),
+                serializeState(stateWithHashSignedBy([bob()])(signedPreFS1)),
+                serializeState(stateWithHashSignedBy([bob()])(expectedUpdatedLedgerState)),
               ],
             },
           },

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -392,10 +392,7 @@ describe('ledger funded app scenarios', () => {
       channel({
         channelNonce: someNonConflictingChannelNonce,
         vars: [
-          stateWithHashSignedBy(
-            alice(),
-            bob()
-          )({
+          stateWithHashSignedBy([alice(), bob()])({
             appDefinition: '0x0000000000000000000000000000000000000000',
             channelNonce: someNonConflictingChannelNonce,
             turnNum: 4,
@@ -457,16 +454,16 @@ describe('ledger funded app scenarios', () => {
   it('countersigns a prefund setup and automatically creates a ledger update', async () => {
     const {latest} = await putTestChannelInsideWallet({
       ...app,
-      vars: [stateWithHashSignedBy(alice())(preFS)],
+      vars: [stateWithHashSignedBy([alice()])(preFS)],
     });
 
     const {outbox, channelResults} = await wallet.pushMessage({
-      signedStates: [serializeState(stateWithHashSignedBy(bob())(latest))],
+      signedStates: [serializeState(stateWithHashSignedBy([bob()])(latest))],
     });
 
     expect(getSignedStateFor(ledger.channelId, outbox)).toMatchObject(
       // Serialized ledger update signed _only_ by Alice for wire message
-      serializeState(stateWithHashSignedBy(alice())(expectedUpdatedLedgerState))
+      serializeState(stateWithHashSignedBy([alice()])(expectedUpdatedLedgerState))
     );
 
     expect(getChannelResultFor(app.channelId, channelResults)).toMatchObject({
@@ -479,7 +476,7 @@ describe('ledger funded app scenarios', () => {
     const {protocolState} = await Channel.forId(ledger.channelId, wallet.knex);
 
     expect(protocolState).toMatchObject({
-      latest: stateWithHashSignedBy(alice())(expectedUpdatedLedgerState),
+      latest: stateWithHashSignedBy([alice()])(expectedUpdatedLedgerState),
       supported: ledger.latest, // The original b/c Bob has not signed yet
     });
   });
@@ -487,19 +484,19 @@ describe('ledger funded app scenarios', () => {
   it('countersigns ledger update received _with_ prefund setup in pushMessage call', async () => {
     const {latest} = await putTestChannelInsideWallet({
       ...app,
-      vars: [stateWithHashSignedBy(alice())(preFS)],
+      vars: [stateWithHashSignedBy([alice()])(preFS)],
     });
 
     const {outbox, channelResults} = await wallet.pushMessage({
       signedStates: [
-        serializeState(stateWithHashSignedBy(bob())(latest)),
-        serializeState(stateWithHashSignedBy(bob())(expectedUpdatedLedgerState)),
+        serializeState(stateWithHashSignedBy([bob()])(latest)),
+        serializeState(stateWithHashSignedBy([bob()])(expectedUpdatedLedgerState)),
       ],
     });
 
     expect(getSignedStateFor(ledger.channelId, outbox)).toMatchObject(
       // Countersigned ledger update
-      serializeState(stateWithHashSignedBy(alice())(expectedUpdatedLedgerState))
+      serializeState(stateWithHashSignedBy([alice()])(expectedUpdatedLedgerState))
     );
 
     expect(getChannelResultFor(app.channelId, channelResults)).toMatchObject({
@@ -511,7 +508,7 @@ describe('ledger funded app scenarios', () => {
   it('countersigns standalone ledger update when it already has a prefund setup in store', async () => {
     await putTestChannelInsideWallet({
       ...app,
-      vars: [stateWithHashSignedBy(alice(), bob())(preFS)],
+      vars: [stateWithHashSignedBy([alice(), bob()])(preFS)],
     });
 
     await LedgerRequest.setRequest(
@@ -525,12 +522,12 @@ describe('ledger funded app scenarios', () => {
     );
 
     const {outbox, channelResults} = await wallet.pushMessage({
-      signedStates: [serializeState(stateWithHashSignedBy(bob())(expectedUpdatedLedgerState))],
+      signedStates: [serializeState(stateWithHashSignedBy([bob()])(expectedUpdatedLedgerState))],
     });
 
     expect(getSignedStateFor(ledger.channelId, outbox)).toMatchObject(
       // Countersigned ledger update
-      serializeState(stateWithHashSignedBy(alice())(expectedUpdatedLedgerState))
+      serializeState(stateWithHashSignedBy([alice()])(expectedUpdatedLedgerState))
     );
 
     expect(getChannelResultFor(app.channelId, channelResults)).toMatchObject({
@@ -542,7 +539,7 @@ describe('ledger funded app scenarios', () => {
   it('proposes intersection of a ledger update it received', async () => {
     const {latest} = await putTestChannelInsideWallet({
       ...app,
-      vars: [stateWithHashSignedBy(alice())(preFS)],
+      vars: [stateWithHashSignedBy([alice()])(preFS)],
     });
 
     await LedgerRequest.setRequest(
@@ -559,12 +556,12 @@ describe('ledger funded app scenarios', () => {
       outbox: outboxFromFirstPushMessage,
       channelResults: channelResults1,
     } = await wallet.pushMessage({
-      signedStates: [serializeState(stateWithHashSignedBy(bob())(latest))],
+      signedStates: [serializeState(stateWithHashSignedBy([bob()])(latest))],
     });
 
     expect(getSignedStateFor(ledger.channelId, outboxFromFirstPushMessage)).toMatchObject(
       // Serialized ledger update signed _only_ by Alice for wire message
-      serializeState(stateWithHashSignedBy(alice())(expectedUpdatedLedgerState))
+      serializeState(stateWithHashSignedBy([alice()])(expectedUpdatedLedgerState))
     );
 
     expect(getChannelResultFor(app.channelId, channelResults1)).toMatchObject({
@@ -591,7 +588,7 @@ describe('ledger funded app scenarios', () => {
       outbox: outboxFromSecondPushMessage,
       channelResults: channelResults2,
     } = await wallet.pushMessage({
-      signedStates: [serializeState(stateWithHashSignedBy(bob())(conflictingUpdatedLedgerState))],
+      signedStates: [serializeState(stateWithHashSignedBy([bob()])(conflictingUpdatedLedgerState))],
     });
 
     const expectedResolvedUpdatedLedgerState = {
@@ -601,7 +598,7 @@ describe('ledger funded app scenarios', () => {
 
     expect(getSignedStateFor(ledger.channelId, outboxFromSecondPushMessage)).toMatchObject(
       // Countersigned ledger update
-      serializeState(stateWithHashSignedBy(alice())(expectedResolvedUpdatedLedgerState))
+      serializeState(stateWithHashSignedBy([alice()])(expectedResolvedUpdatedLedgerState))
     );
 
     expect(getChannelResultFor(app.channelId, channelResults2)).toMatchObject({
@@ -613,7 +610,7 @@ describe('ledger funded app scenarios', () => {
   it('handles counterproposal equal to my original proposal', async () => {
     const {latest} = await putTestChannelInsideWallet({
       ...app,
-      vars: [stateWithHashSignedBy(alice())(preFS)],
+      vars: [stateWithHashSignedBy([alice()])(preFS)],
     });
 
     await LedgerRequest.setRequest(
@@ -627,12 +624,12 @@ describe('ledger funded app scenarios', () => {
     );
 
     const {outbox: outboxFromFirstPushMessage} = await wallet.pushMessage({
-      signedStates: [serializeState(stateWithHashSignedBy(bob())(latest))],
+      signedStates: [serializeState(stateWithHashSignedBy([bob()])(latest))],
     });
 
     expect(getSignedStateFor(ledger.channelId, outboxFromFirstPushMessage)).toMatchObject(
       // Serialized ledger update signed _only_ by Alice for wire message
-      serializeState(stateWithHashSignedBy(alice())(expectedUpdatedLedgerState))
+      serializeState(stateWithHashSignedBy([alice()])(expectedUpdatedLedgerState))
     );
 
     // Using spread syntax to do a deep copy essentially
@@ -643,13 +640,13 @@ describe('ledger funded app scenarios', () => {
 
     const {outbox: outboxFromSecondPushMessage, channelResults} = await wallet.pushMessage({
       signedStates: [
-        serializeState(stateWithHashSignedBy(bob())(expectedResolvedUpdatedLedgerState)),
+        serializeState(stateWithHashSignedBy([bob()])(expectedResolvedUpdatedLedgerState)),
       ],
     });
 
     expect(getSignedStateFor(ledger.channelId, outboxFromSecondPushMessage)).toMatchObject(
       // Countersigned ledger update
-      serializeState(stateWithHashSignedBy(alice())(expectedResolvedUpdatedLedgerState))
+      serializeState(stateWithHashSignedBy([alice()])(expectedResolvedUpdatedLedgerState))
     );
 
     expect(getChannelResultFor(ledger.channelId, channelResults)).toMatchObject({

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -39,8 +39,8 @@ it('returns an outgoing message with the latest state', async () => {
   const c = channel({
     participants,
     vars: [
-      stateWithHashSignedBy(alice(), bob(), charlie())(runningState),
-      stateWithHashSignedBy(alice())(nextState),
+      stateWithHashSignedBy([alice(), bob(), charlie()])(runningState),
+      stateWithHashSignedBy([alice()])(nextState),
     ],
   });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -33,10 +33,7 @@ beforeEach(async () => {
 it('updates a channel', async () => {
   const c = channel({
     vars: [
-      stateWithHashSignedBy(
-        alice(),
-        bob()
-      )({
+      stateWithHashSignedBy([alice(), bob()])({
         turnNum: 5,
         appDefinition: COUNTING_APP_DEFINITION,
         appData: appData1,
@@ -68,7 +65,7 @@ it('updates a channel', async () => {
 
 describe('error cases', () => {
   it('throws when it is not my turn', async () => {
-    const c = channel({vars: [stateWithHashSignedBy(alice(), bob())({turnNum: 4})]});
+    const c = channel({vars: [stateWithHashSignedBy([alice(), bob()])({turnNum: 4})]});
     await Channel.query(w.knex).insert(c);
 
     await expect(w.updateChannel(updateChannelArgs())).rejects.toMatchObject(
@@ -85,10 +82,7 @@ describe('error cases', () => {
   it('throws when it is an invalid app transition', async () => {
     const c = channel({
       vars: [
-        stateWithHashSignedBy(
-          alice(),
-          bob()
-        )({
+        stateWithHashSignedBy([alice(), bob()])({
           turnNum: 5,
           appDefinition: COUNTING_APP_DEFINITION,
           appData: appData2,

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -30,15 +30,15 @@ it('sends the post fund setup when the funding event is provided for multiple ch
   const c1 = channel({
     channelNonce: 1,
     vars: [
-      stateWithHashSignedBy(alice())({turnNum: 0, channelNonce: 1}),
-      stateWithHashSignedBy(bob())({turnNum: 1, channelNonce: 1}),
+      stateWithHashSignedBy([alice()])({turnNum: 0, channelNonce: 1}),
+      stateWithHashSignedBy([bob()])({turnNum: 1, channelNonce: 1}),
     ],
   });
   const c2 = channel({
     channelNonce: 2,
     vars: [
-      stateWithHashSignedBy(alice())({turnNum: 0, channelNonce: 2}),
-      stateWithHashSignedBy(bob())({turnNum: 1, channelNonce: 2}),
+      stateWithHashSignedBy([alice()])({turnNum: 0, channelNonce: 2}),
+      stateWithHashSignedBy([bob()])({turnNum: 1, channelNonce: 2}),
     ],
   });
   await Channel.query(w.knex).insert(c1);
@@ -111,8 +111,8 @@ it('sends the post fund setup when the funding event is provided for multiple ch
 it('sends the post fund setup when the funding event is provided', async () => {
   const c = channel({
     vars: [
-      stateWithHashSignedBy(alice())({turnNum: 0}),
-      stateWithHashSignedBy(bob())({turnNum: 1}),
+      stateWithHashSignedBy([alice()])({turnNum: 0}),
+      stateWithHashSignedBy([bob()])({turnNum: 1}),
     ],
   });
   await Channel.query(w.knex).insert(c);

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -37,7 +37,7 @@ describe('signState', () => {
   let c: Channel;
 
   beforeEach(async () => {
-    c = await Channel.query(knex).insert(channel({vars: [stateWithHashSignedBy(bob())()]}));
+    c = await Channel.query(knex).insert(channel({vars: [stateWithHashSignedBy([bob()])()]}));
   });
 
   it('signs the state, returning the signed state', async () => {


### PR DESCRIPTION
Just addressing a FIXME in the code.