### PR TITLE
fix: remove subtely introduced additional JS ecrecover call (via deserialization fn)

### DIFF
--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -23,7 +23,6 @@ import {
   convertToParticipant,
   SignedState,
   objectiveId,
-  deserializeState,
   isSimpleAllocation,
   checkThat,
 } from '@statechannels/wallet-core';
@@ -573,8 +572,6 @@ export class Store {
         tx
       ));
 
-    const incomingState = deserializeState(wireSignedState);
-
     const sswh: SignedStateWithHash = addHash({
       chainId: wireSignedState.chainId,
       channelNonce: wireSignedState.channelNonce,
@@ -594,7 +591,7 @@ export class Store {
 
       if (
         !(await timer('validating transition', async () =>
-          this.validateTransition(supported, incomingState, tx)
+          this.validateTransition(supported, sswh, tx)
         ))
       ) {
         throw new StoreError('Invalid state transition', {


### PR DESCRIPTION
Calling `deserializeState` triggered an additional call to `getStateSignerAddress` which does `ethers.utils.keccak256` and `ethers.utils.verifyMessage` in JS

1. https://github.com/statechannels/statechannels/blob/6aa64ccdb346722a40e1412df907d08f20ef7f60/packages/server-wallet/src/wallet/store.ts#L576-L576

2. https://github.com/statechannels/statechannels/blob/6aa64ccdb346722a40e1412df907d08f20ef7f60/packages/wallet-core/src/serde/wire-format/deserialize.ts#L84-L84

3. https://github.com/statechannels/statechannels/blob/6aa64ccdb346722a40e1412df907d08f20ef7f60/packages/wallet-core/src/state-utils.ts#L95-L98

4. https://github.com/statechannels/statechannels/blob/6aa64ccdb346722a40e1412df907d08f20ef7f60/packages/nitro-protocol/src/signatures.ts#L12-L14