### PR TITLE
fix: fix broken query on ledger channels in DB

### DIFF
--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -152,7 +152,7 @@ export class Channel extends Model implements RequiredColumns {
   ): Promise<Channel[]> {
     return Channel.query(txOrKnex)
       .select()
-      .where({assetHolderAddress, participants});
+      .where({assetHolderAddress, participants: JSON.stringify(participants)});
   }
 
   static allChannelsWithPendingLedgerRequests(txOrKnex: TransactionOrKnex): Promise<Channel[]> {

--- a/packages/server-wallet/src/wallet/__test__/fixtures/create-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/create-channel.ts
@@ -12,7 +12,7 @@ const defaultVars: CreateChannelParams = {
   fundingStrategy: 'Direct',
   allocations: [
     {
-      token: '0x00',
+      token: constants.AddressZero,
       allocationItems: [
         {destination: alice().destination, amount: BN.from(1)},
         {destination: bob().destination, amount: BN.from(3)},

--- a/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
@@ -1,0 +1,80 @@
+import {constants} from 'ethers';
+
+import {Channel} from '../../../models/channel';
+import {Wallet} from '../..';
+import {createChannelArgs} from '../fixtures/create-channel';
+import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
+import {defaultTestConfig} from '../../../config';
+import {alice, bob} from '../fixtures/participants';
+import {DBAdmin} from '../../../db-admin/db-admin';
+
+let w: Wallet;
+beforeEach(async () => {
+  w = new Wallet(defaultTestConfig);
+  await new DBAdmin(w.knex).truncateDB();
+});
+
+afterEach(async () => {
+  await w.destroy();
+});
+
+describe('happy path', () => {
+  beforeEach(async () => seedAlicesSigningWallet(w.knex));
+
+  it('creates a ledger channel', async () => {
+    expect(await Channel.query(w.knex).resultSize()).toEqual(0);
+
+    const {participants, allocations} = createChannelArgs();
+
+    const createPromise = w.createLedgerChannel({participants, allocations});
+
+    await expect(createPromise).resolves.toMatchObject({
+      outbox: [
+        {
+          params: {
+            recipient: 'bob',
+            sender: 'alice',
+            data: {
+              signedStates: [{turnNum: 0}],
+              objectives: [
+                {
+                  participants: [alice(), bob()],
+                  data: {
+                    fundingStrategy: 'Direct',
+                  },
+                  type: 'OpenChannel',
+                },
+              ],
+            },
+          },
+        },
+      ],
+      channelResult: {channelId: expect.any(String), turnNum: 0},
+    });
+
+    const {channelId} = (await createPromise).channelResult;
+
+    expect(await Channel.query(w.knex).resultSize()).toEqual(1);
+
+    const updated = await Channel.forId(channelId, w.knex);
+    const expectedState = {
+      turnNum: 0,
+      appData: '0x00',
+      appDefinition: constants.AddressZero,
+    };
+
+    expect(updated).toMatchObject({
+      latest: expectedState,
+      latestSignedByMe: expectedState,
+      supported: undefined,
+    });
+
+    await expect(w.getLedgerChannels(allocations[0].token, participants)).resolves.toMatchObject({
+      channelResults: [
+        {
+          channelId,
+        },
+      ],
+    });
+  });
+});

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -263,10 +263,10 @@ export class Store {
   }
 
   async getLedgerChannels(
-    addressHolderAddress: string,
+    assetHolderAddress: string,
     participants: Participant[]
   ): Promise<ChannelState[]> {
-    const ledgers = await Channel.getLedgerChannels(addressHolderAddress, participants, this.knex);
+    const ledgers = await Channel.getLedgerChannels(assetHolderAddress, participants, this.knex);
     return ledgers.map(c => c.protocolState);
   }
 


### PR DESCRIPTION
I observed this error:

```
[1604329033593] ERROR (7338): [] PaymentServer - DataError: select "channels".* from "channels" where "asset_holder_address" = $1 and "participants" = $2 - invalid input syntax for type json
    at wrapError (/node_modules/db-errors/lib/dbErrors.js:19:14)
    at handleExecuteError (/node_modules/objection/lib/queryBuilder/QueryBuilder.js:1506:32)
    at QueryBuilder.execute (/node_modules/objection/lib/queryBuilder/QueryBuilder.js:687:20) {
  nativeError: error: invalid input syntax for type json
      at Parser.parseErrorMessage (/node_modules/pg-protocol/src/parser.ts:357:11)
      at Parser.handlePacket (/node_modules/pg-protocol/src/parser.ts:186:21)
      at Parser.parse (/node_modules/pg-protocol/src/parser.ts:101:30)
      at Socket.<anonymous> (/node_modules/pg-protocol/src/index.ts:7:48)
      at Socket.emit (events.js:310:20)
      at Socket.EventEmitter.emit (domain.js:482:12)
      at addChunk (_stream_readable.js:286:12)
      at readableAddChunk (_stream_readable.js:268:9)
      at Socket.Readable.push (_stream_readable.js:209:10)
      at TCP.onStreamRead (internal/stream_base_commons.js:186:23) {
```

And found [this solution](https://github.com/brianc/node-postgres/issues/442#issuecomment-24496481).

This applies that solution and adds a test to find this in the future.