### PR TITLE
fix: ensure pushMessage returns latest channelResults

### DIFF
--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -563,7 +563,7 @@ export class Wallet extends EventEmitter<WalletEvent>
 
     const {channelResults, outbox} = await this.takeActions(channelIds);
 
-    for (const channel of fromStoring) {
+    for (const channel of mergeChannelResults(fromStoring)) {
       if (!_.some(channelResults, c => c.channelId === channel.channelId))
         channelResults.push(channel);
     }


### PR DESCRIPTION
While debugging I noticed that when you call `syncChannel` and provide the outbox to a wallet, let's say you provide `[3, 4]` being the latest turn numbers, then `this.store.pushMessage` will return `[3, 4]` and then the for loop this PR modifies would loop over `[3, 4]` and insert the `3` into the channel results and discard the `4`.
