### PR TITLE
fix: use knex whereComposite instead of where for composite index

### DIFF
--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -152,7 +152,10 @@ export class Channel extends Model implements RequiredColumns {
   ): Promise<Channel[]> {
     return Channel.query(txOrKnex)
       .select()
-      .where({assetHolderAddress, participants: JSON.stringify(participants)});
+      .whereComposite(
+        ['assetHolderAddress', 'participants'],
+        [assetHolderAddress, JSON.stringify(participants)]
+      );
   }
 
   static allChannelsWithPendingLedgerRequests(txOrKnex: TransactionOrKnex): Promise<Channel[]> {


### PR DESCRIPTION
For future consideration. I'm not totally sure if this is right or not. A good analysis might review the raw SQL that gets generated between the two approaches.

The [docs](https://vincit.github.io/objection.js/api/query-builder/find-methods.html#wherecomposite) seem to indicate this is at least in theory meant for composite indexes which this is one.

Also, I'm not sure we can get around stringifying the participants. It could be that a composite index in PostgreSQL between a `jsonb` and a `string` must be a `string`...?
