### PR TITLE
Ignore older states when validating

### DIFF
--- a/packages/server-wallet/src/utilities/validate-transition.ts
+++ b/packages/server-wallet/src/utilities/validate-transition.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import {SignedState, StateWithHash, toNitroState} from '@statechannels/wallet-core';
 import {constants} from 'ethers';
-import {Transaction} from 'knex';
 
 import {logger} from '../logger';
 import {validateTransitionWithEVM} from '../evm-validator';
@@ -10,20 +9,15 @@ import {Channel} from '../models/channel';
 
 export async function shouldValidateTransition(
   incomingState: StateWithHash,
-  channel: Channel,
-  tx: Transaction
+  channel: Channel
 ): Promise<boolean> {
-  const {channelId} = channel;
+  const {supported, isLedger} = channel;
 
   // If we already have the state we should of already validated it
   const alreadyHaveState = _.some(channel.sortedStates, ['stateHash', incomingState.stateHash]);
 
-  const {supported} = channel;
-
   // Ignore older states that may be added via syncing
   const isOldState = incomingState.turnNum < (supported?.turnNum || 0);
-
-  const isLedger = await Channel.isLedger(channelId, tx);
 
   return !!supported && !isOldState && !alreadyHaveState && !isLedger;
 }

--- a/packages/server-wallet/src/utilities/validate-transition.ts
+++ b/packages/server-wallet/src/utilities/validate-transition.ts
@@ -7,12 +7,8 @@ import {validateTransitionWithEVM} from '../evm-validator';
 import {Bytes} from '../type-aliases';
 import {Channel} from '../models/channel';
 
-export async function shouldValidateTransition(
-  incomingState: StateWithHash,
-  channel: Channel
-): Promise<boolean> {
+export function shouldValidateTransition(incomingState: StateWithHash, channel: Channel): boolean {
   const {supported, isLedger} = channel;
-
   // If we already have the state we should of already validated it
   const alreadyHaveState = _.some(channel.sortedStates, ['stateHash', incomingState.stateHash]);
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -165,7 +165,7 @@ export class Store {
     );
     const signedState = {...state, signatures: [signatureEntry]};
 
-    if (supported && shouldValidateTransition(state, channel, tx)) {
+    if (supported && shouldValidateTransition(state, channel)) {
       const bytecode = await this.getBytecode(supported.appDefinition, tx);
 
       if (!this.skipEvmValidation && !bytecode)
@@ -475,7 +475,7 @@ export class Store {
       (await createChannel(state, 'Unknown', undefined, tx));
 
     const {supported} = channel;
-    if (supported && shouldValidateTransition(state, channel, tx)) {
+    if (supported && shouldValidateTransition(state, channel)) {
       const bytecode = await this.getBytecode(supported.appDefinition, tx);
 
       if (!this.skipEvmValidation && !bytecode)


### PR DESCRIPTION
Ignore old states that may be received from syncing when validating. Also moves the shouldValidate logic into it's own function for clarity.

I'll be adding tests but this can be done in a separate PR to prevent blocking @snario .