### PR TITLE
ci: don't cache node_modules on the publish workflows

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -17,13 +17,6 @@ jobs:
         with:
           node-version: 12.16.3
 
-      - uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache-v1-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-cache-v1-
-
       - name: yarn install 
         # skip the prepare step here, as lerna publish will run prepare before publishing
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,6 @@ jobs:
         with:
           node-version: 12.16.3
 
-      - uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache-v1-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-cache-v1-
-
       - name: yarn install
         # skip the prepare step here, as lerna publish will run prepare before publishing
         run: |


### PR DESCRIPTION
For reasons not fully understood, we occasionally run into build failures such as:
```
@statechannels/client-api-schema: ERROR: Internal Error: The referenced path was not found:
/home/runner/work/statechannels/statechannels/packages/client-api-schema/lib/src/notifications.d.ts
```

Resetting the cache fixes the problem, so it seems like it might be cache related.

We don't publish very often, so the advantage to having the cache is minimal.