### PR TITLE
chore: upgrade api-extractor

### DIFF
--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -11,7 +11,7 @@
     "loglevel": "1.6.8"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.10.1",
+    "@microsoft/api-extractor": "7.11.2",
     "@types/eslint": "7.2.3",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/jest": "26.0.14",

--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -543,7 +543,9 @@ export type StateChannelsNotification = ChannelProposedNotification | ChannelUpd
 //
 // @public (undocumented)
 export type StateChannelsNotificationType = {
-    [T in StateChannelsNotification['method']]: [FilterByMethod<StateChannelsNotification, T>['params']];
+    [T in StateChannelsNotification['method']]: [
+        FilterByMethod<StateChannelsNotification, T>['params']
+    ];
 };
 
 // @public (undocumented)

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -11,7 +11,7 @@
     "ajv": "6.11.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.10.1",
+    "@microsoft/api-extractor": "7.11.2",
     "@types/eslint": "7.2.3",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/jest": "26.0.14",

--- a/packages/iframe-channel-provider/package.json
+++ b/packages/iframe-channel-provider/package.json
@@ -23,7 +23,7 @@
     "pino": "6.2.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.10.1",
+    "@microsoft/api-extractor": "7.11.2",
     "@types/debug": "4.1.5",
     "@types/eslint": "7.2.3",
     "@types/eslint-plugin-prettier": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,13 +3899,13 @@
     js-yaml "~3.13.1"
     resolve "~1.17.0"
 
-"@microsoft/api-extractor-model@7.10.1":
-  version "7.10.1"
-  resolved "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.10.1.tgz#7e86fa5507f03951482239baa9fd761e9767837b"
-  integrity sha512-9LpG6ICn7yfFMALOL0BjPwG8o7itb4MnIDn5OYYYU2qQOmMsX+B9ZcJ+VfUIUdCqhvEjoAiIO6qGT6xUFOazBA==
+"@microsoft/api-extractor-model@7.10.8":
+  version "7.10.8"
+  resolved "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.10.8.tgz#12fa3c25f26b5eb1f4799270bf0df12d4113f16e"
+  integrity sha512-9TfiCTPnkUeLaYywZeg9rYbVPX9Tj6AAkO6ThnjSE0tTPLjMcL3RiHkqn0BJ4+aGcl56APwo32zj5+kG+NqxYA==
   dependencies:
     "@microsoft/tsdoc" "0.12.19"
-    "@rushstack/node-core-library" "3.34.1"
+    "@rushstack/node-core-library" "3.34.7"
 
 "@microsoft/api-extractor-model@7.8.12":
   version "7.8.12"
@@ -3915,22 +3915,22 @@
     "@microsoft/tsdoc" "0.12.19"
     "@rushstack/node-core-library" "3.25.0"
 
-"@microsoft/api-extractor@7.10.1":
-  version "7.10.1"
-  resolved "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.10.1.tgz#6b5b293c59a94b5b4516a8e3c8fb8ac31fb0e4fd"
-  integrity sha512-hJfwdaLXI/Crq4gH9yzLFwOY/uCwdXerqp3cBq27zxb773LXv88mhnhCehnce7eHMqhKXgPSPgVBf/Zfla9skw==
+"@microsoft/api-extractor@7.11.2":
+  version "7.11.2"
+  resolved "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.11.2.tgz#7f90e39294d16a18bb00883e9462242dc1646efe"
+  integrity sha512-iZPv22j9K02cbwIDblOgF1MxZG+KWovp3CQpWCD6UC/+YYO4DfLxX5uZYVNzfgT4vU8fN0rugJmGm85rHX6Ouw==
   dependencies:
-    "@microsoft/api-extractor-model" "7.10.1"
+    "@microsoft/api-extractor-model" "7.10.8"
     "@microsoft/tsdoc" "0.12.19"
-    "@rushstack/node-core-library" "3.34.1"
-    "@rushstack/rig-package" "0.2.1"
-    "@rushstack/ts-command-line" "4.7.1"
+    "@rushstack/node-core-library" "3.34.7"
+    "@rushstack/rig-package" "0.2.7"
+    "@rushstack/ts-command-line" "4.7.6"
     colors "~1.2.1"
     lodash "~4.17.15"
     resolve "~1.17.0"
     semver "~7.3.0"
     source-map "~0.6.1"
-    typescript "~3.9.7"
+    typescript "~4.0.5"
 
 "@microsoft/tsdoc-config@0.13.5":
   version "0.13.5"
@@ -4705,10 +4705,10 @@
     timsort "~0.3.0"
     z-schema "~3.18.3"
 
-"@rushstack/node-core-library@3.34.1":
-  version "3.34.1"
-  resolved "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.34.1.tgz#36368179bb7a80afced4c3bb68387b7fc5381b3a"
-  integrity sha512-DX1xB9E2Xmi5auFxacftUXVuI2DUUyKrlGaecjesiS2YmV6pBnKzHHAaxWOQF2ajFNhXY2I1cGvDp45z3aJv5g==
+"@rushstack/node-core-library@3.34.7":
+  version "3.34.7"
+  resolved "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.34.7.tgz#864c773212ec0fc158576fec0b5ae0535a246886"
+  integrity sha512-7FwJ0jmZsh7bDIZ1IqDNphY9Kc6aAi1D2K8jiq+da4flMyL84HNeq2KxvwFLzjLwu3eMr88X+oBpgxCTD5Y57Q==
   dependencies:
     "@types/node" "10.17.13"
     colors "~1.2.1"
@@ -4720,10 +4720,10 @@
     timsort "~0.3.0"
     z-schema "~3.18.3"
 
-"@rushstack/rig-package@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.1.tgz#45437a88444eb65a825f9cc93f3cd228d4b47934"
-  integrity sha512-B1JQ6lF8mg8MfRCki8XML6bs2qPCS0AX83enEZ3lSZdI8nVdFe7PumS03dpN3MXElbNiuqlJpECXo9sSKEzcyg==
+"@rushstack/rig-package@0.2.7":
+  version "0.2.7"
+  resolved "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.7.tgz#42b1ed2cfd73d4fc50a119e74a236aacb70d2125"
+  integrity sha512-hI1L0IIzCHqH/uW64mKqEQ0/MANA/IklVId3jGpj1kt9RJcBdeNUIlzDtHl437LZRAuEA8CyotRHzG6YDgWlTw==
   dependencies:
     "@types/node" "10.17.13"
     resolve "~1.17.0"
@@ -4738,10 +4738,10 @@
     argparse "~1.0.9"
     colors "~1.2.1"
 
-"@rushstack/ts-command-line@4.7.1":
-  version "4.7.1"
-  resolved "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.1.tgz#05ca90825239029065304efaf340c89e076a19c9"
-  integrity sha512-bpBByIKH1t3g2uCXspr5wsA2/XGA9qAaKVYkUnSVheAyH9OmAiUzgpcVswTnYrM3zEhIxGmo9Giqx/FCKubW0g==
+"@rushstack/ts-command-line@4.7.6":
+  version "4.7.6"
+  resolved "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.6.tgz#ce509855b507863ed5e2a9ced8451774b6bfd359"
+  integrity sha512-falJVNfpJtsL3gJaY77JXXycfzhzB9VkKhqEfjRWD69/f6ezMUorPR6Nc90MnIaWgePTcdTJPZibxOQrNpu1Uw==
   dependencies:
     "@types/argparse" "1.0.38"
     argparse "~1.0.9"
@@ -29169,10 +29169,15 @@ typescript@4.0.3, typescript@~4.0.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
-typescript@^3.5.1, typescript@^3.8.3, typescript@~3.9.7:
+typescript@^3.5.1, typescript@^3.8.3:
   version "3.9.7"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@~4.0.5:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.38"


### PR DESCRIPTION
quiets warnings about TS version