### PR TITLE
style: remove eslint rule disabling and add type information to utils

### DIFF
--- a/packages/nitro-protocol/.eslintrc.js
+++ b/packages/nitro-protocol/.eslintrc.js
@@ -20,9 +20,5 @@ module.exports = {
   extends: ['../../.eslintrc.js', 'plugin:jest/recommended', 'plugin:jest/style'],
   rules: {
     ...leftoverTsLintRules,
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    // TODO remove this ^^^
-    '@typescript-eslint/ban-types': 'off',
-    // TODO remove this ^^^
   },
 };

--- a/packages/nitro-protocol/src/contract/challenge.ts
+++ b/packages/nitro-protocol/src/contract/challenge.ts
@@ -31,7 +31,7 @@ export interface ChallengeRegisteredStruct {
   sigs: Signature[];
   whoSignedWhat: Uint8[];
 }
-export function getChallengeRegisteredEvent(eventResult): ChallengeRegisteredEvent {
+export function getChallengeRegisteredEvent(eventResult: any[]): ChallengeRegisteredEvent {
   const {
     turnNumRecord,
     finalizesAt,
@@ -92,7 +92,7 @@ export interface RespondTransactionArguments {
 }
 export function getChallengeClearedEvent(
   tx: ethers.Transaction,
-  eventResult
+  eventResult: any[]
 ): ChallengeClearedEvent {
   const {newTurnNumRecord}: ChallengeClearedStruct = eventResult.slice(-1)[0].args;
 

--- a/packages/nitro-protocol/src/contract/channel-storage.ts
+++ b/packages/nitro-protocol/src/contract/channel-storage.ts
@@ -11,6 +11,13 @@ export interface ChannelData {
   challengerAddress?: Address;
   outcome?: Outcome;
 }
+interface CompactChannelData {
+  turnNumRecord: Uint48;
+  finalizesAt: Uint48;
+  stateHash: Bytes32;
+  challengerAddress: Address;
+  outcomeHash: Bytes32;
+}
 const CHANNEL_DATA_TYPE = `tuple(
   uint256 turnNumRecord,
   uint256 finalizesAt,
@@ -24,6 +31,12 @@ export interface ChannelDataLite {
   state: State;
   challengerAddress: Address;
   outcome: Outcome;
+}
+interface CompactChannelDataLite {
+  finalizesAt: Uint48;
+  stateHash: Bytes32;
+  challengerAddress: Address;
+  outcomeHash: Bytes32;
 }
 const CHANNEL_DATA_LITE_TYPE = `tuple(
   uint256 finalizesAt,
@@ -71,7 +84,7 @@ export function channelDataStruct({
   challengerAddress,
   turnNumRecord,
   outcome,
-}: ChannelData) {
+}: ChannelData): CompactChannelData {
   /*
   When the channel is not open, it is still possible for the state and
   challengerAddress to be missing. They should either both be present, or
@@ -102,7 +115,7 @@ export function channelDataLiteStruct({
   challengerAddress,
   state,
   outcome,
-}: ChannelDataLite) {
+}: ChannelDataLite): CompactChannelDataLite {
   return {
     finalizesAt,
     challengerAddress,

--- a/packages/nitro-protocol/src/hex-utils.ts
+++ b/packages/nitro-protocol/src/hex-utils.ts
@@ -11,7 +11,7 @@ export function subHex(a: string, b: string): string {
     .toHexString();
 }
 
-export function eqHex(a: string, b: string) {
+export function eqHex(a: string, b: string): boolean {
   return BigNumber.from(a).eq(b);
 }
 

--- a/packages/nitro-protocol/src/signatures.ts
+++ b/packages/nitro-protocol/src/signatures.ts
@@ -37,7 +37,7 @@ export function signState(state: State, privateKey: string): SignedState {
   return {state, signature};
 }
 
-export async function sign(wallet: Wallet, msgHash: string | Uint8Array) {
+export async function sign(wallet: Wallet, msgHash: string | Uint8Array): Promise<Signature> {
   // MsgHash is a hex string
   // Returns an object with v, r, and s properties.
   return utils.splitSignature(await wallet.signMessage(utils.arrayify(msgHash)));

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -1,11 +1,16 @@
 import {Contract, providers, Signature} from 'ethers';
 
+import {Uint256} from './contract/types';
 import {State} from './contract/state';
 import * as forceMoveTrans from './contract/transaction-creators/force-move';
 import * as nitroAdjudicatorTrans from './contract/transaction-creators/nitro-adjudicator';
 import {getStateSignerAddress, SignedState} from './signatures';
 
-export async function getChannelStorage(provider, contractAddress: string, channelId: string) {
+export async function getChannelStorage(
+  provider: providers.Provider,
+  contractAddress: string,
+  channelId: string
+): Promise<[Uint256, Uint256, Uint256]> {
   const forceMove = new Contract(
     contractAddress,
     forceMoveTrans.ForceMoveContractInterface,

--- a/packages/wallet-core/.eslintrc.js
+++ b/packages/wallet-core/.eslintrc.js
@@ -11,11 +11,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     'no-restricted-imports': ['error', {patterns: ['**/lib', '**/src']}],
-    'arrow-body-style': 'error',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    // TODO remove this ^^^
-    '@typescript-eslint/ban-types': 'off'
-    // TODO remove this ^^^
+    'arrow-body-style': 'error'
   },
   overrides: [
     {

--- a/packages/wallet-core/src/bignumber.ts
+++ b/packages/wallet-core/src/bignumber.ts
@@ -50,7 +50,8 @@ export class BN {
   static toHexString = unaryOperator('toHexString');
 
   static from = (n: BigNumberish | BN): Uint256 => EthersBigNumber.from(n).toHexString() as Uint256;
-  static isUint256 = (val: any) => typeof val === 'string' && !!val.match(/^0x[0-9A-Fa-f]{0,64}$/);
+  static isUint256 = (val: unknown): val is Uint256 =>
+    typeof val === 'string' && !!val.match(/^0x[0-9A-Fa-f]{0,64}$/);
 }
 
 export const Zero = BN.from(0);

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -67,7 +67,7 @@ export function wireStateToNitroState(state: SignedStateWire): NitroState {
     appData: state.appData
   };
 }
-export function hashWireState(state: SignedStateWire) {
+export function hashWireState(state: SignedStateWire): string {
   return hashState(wireStateToNitroState(state));
 }
 

--- a/packages/wallet-core/src/state-utils.ts
+++ b/packages/wallet-core/src/state-utils.ts
@@ -97,7 +97,7 @@ export function getSignerAddress(state: State, signature: string): string {
   return getNitroSignerAddress({state: nitroState, signature: utils.splitSignature(signature)});
 }
 
-export function statesEqual(left: State, right: State) {
+export function statesEqual(left: State, right: State): boolean {
   return hashState(left) === hashState(right);
 }
 
@@ -114,7 +114,7 @@ function simpleAllocationsEqual(left: SimpleAllocation, right: SimpleAllocation)
   );
 }
 
-export function outcomesEqual(left: Outcome, right?: Outcome) {
+export function outcomesEqual(left: Outcome, right?: Outcome): boolean {
   if (left.type === 'SimpleAllocation' && right?.type === 'SimpleAllocation') {
     return simpleAllocationsEqual(left, right);
   }
@@ -220,7 +220,7 @@ export function fromNitroOutcome(outcome: NitroOutcome): Outcome {
   };
 }
 
-export function nextState(state: State, outcome: Outcome) {
+export function nextState(state: State, outcome: Outcome): State {
   if (state.outcome.type !== outcome.type) {
     throw new Error('Attempting to change outcome type');
   }

--- a/packages/wallet-core/src/utils/helpers.ts
+++ b/packages/wallet-core/src/utils/helpers.ts
@@ -2,7 +2,7 @@ import {utils} from 'ethers';
 
 import {BN} from '../bignumber';
 import {Uint256} from '../types';
-export function unreachable(x: never) {
+export function unreachable(x: never): never {
   return x;
 }
 


### PR DESCRIPTION
This removes four TODOs from the codebase. Some eslint rules were disabled which allowed a lack of return values on functions and other basic typing related information.

We should periodically do this kind of work to keep the codebase clean