### PR TITLE
Make sender and objective.participants optional in wire-format

### DIFF
--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -468,7 +468,7 @@ export interface JsonRpcResponse<ResponseType = object> {
 export interface Message {
     data: unknown;
     recipient: string;
-    sender: string;
+    sender?: string;
 }
 
 // Warning: (ae-incompatible-release-tags) The symbol "MessageQueuedNotification" is marked as @public, but its signature references "JsonRpcNotification" which is marked as @beta
@@ -543,7 +543,9 @@ export type StateChannelsNotification = ChannelProposedNotification | ChannelUpd
 //
 // @public (undocumented)
 export type StateChannelsNotificationType = {
-    [T in StateChannelsNotification['method']]: [FilterByMethod<StateChannelsNotification, T>['params']];
+    [T in StateChannelsNotification['method']]: [
+        FilterByMethod<StateChannelsNotification, T>['params']
+    ];
 };
 
 // @public (undocumented)

--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -543,9 +543,7 @@ export type StateChannelsNotification = ChannelProposedNotification | ChannelUpd
 //
 // @public (undocumented)
 export type StateChannelsNotificationType = {
-    [T in StateChannelsNotification['method']]: [
-        FilterByMethod<StateChannelsNotification, T>['params']
-    ];
+    [T in StateChannelsNotification['method']]: [FilterByMethod<StateChannelsNotification, T>['params']];
 };
 
 // @public (undocumented)

--- a/packages/client-api-schema/src/data-types.ts
+++ b/packages/client-api-schema/src/data-types.ts
@@ -137,7 +137,7 @@ export interface Message {
   /**
    * Identifier of user that the message is from
    */
-  sender: string;
+  sender?: string;
   /**
    * Message payload. Format defined by wallet and opaque to app.
    */

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -373,7 +373,7 @@
       "$ref": "#/definitions/JsonRpcRequest%3C%22GetChannels%22%2Cstructure-1978982097-247-273-1978982097-217-274-1978982097-184-275-1978982097-0-344%3E"
     },
     "GetChannelsResponse": {
-      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src_data-types.ts-2747-3043-src_data-types.ts-0-3460%5B%5D%3E"
+      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src_data-types.ts-2747-3043-src_data-types.ts-0-3461%5B%5D%3E"
     },
     "GetStateError": {
       "$ref": "#/definitions/JsonRpcError%3C1200%2C%22Could%20not%20find%20channel%22%3E"
@@ -1691,7 +1691,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcResponse<def-interface-src_data-types.ts-2747-3043-src_data-types.ts-0-3460[]>": {
+    "JsonRpcResponse<def-interface-src_data-types.ts-2747-3043-src_data-types.ts-0-3461[]>": {
       "additionalProperties": false,
       "description": "Specifies response headers as per {@link https://www.jsonrpc.org/specification | JSON-RPC 2.0 Specification }",
       "properties": {
@@ -1880,7 +1880,6 @@
       },
       "required": [
         "recipient",
-        "sender",
         "data"
       ],
       "type": "object"

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -89,7 +89,7 @@ export function deserializeState(state: SignedStateWire): SignedState {
 }
 
 export function deserializeObjective(objective: ObjectiveWire): Objective {
-  const participants = objective.participants.map(p => ({
+  const participants = objective.participants?.map(p => ({
     ...p,
     destination: makeDestination(p.destination)
   }));

--- a/packages/wallet-core/src/serde/wire-format/serialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/serialize.ts
@@ -22,7 +22,7 @@ export function serializeMessage(
   walletVersion: string,
   message: Payload,
   recipient: string,
-  sender: string,
+  sender?: string,
   channelId?: string
 ): WireMessage {
   const signedStates = (message.signedStates || []).map(s => serializeState(s, channelId));

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -88,7 +88,7 @@ export type SignedStateVariables = StateVariables & Signed;
 export type SignedStateVarsWithHash = SignedStateVariables & Hashed;
 
 type _Objective<Name, Data> = {
-  participants: Participant[];
+  participants?: Participant[];
   type: Name;
   data: Data;
 };

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -112,7 +112,6 @@
         }
       },
       "required": [
-        "participants",
         "type",
         "data"
       ],
@@ -145,7 +144,6 @@
         }
       },
       "required": [
-        "participants",
         "type",
         "data"
       ],
@@ -186,7 +184,6 @@
         }
       },
       "required": [
-        "participants",
         "type",
         "data"
       ],
@@ -219,7 +216,6 @@
         }
       },
       "required": [
-        "participants",
         "type",
         "data"
       ],
@@ -269,7 +265,6 @@
       },
       "required": [
         "recipient",
-        "sender",
         "data"
       ],
       "type": "object"
@@ -344,7 +339,6 @@
         }
       },
       "required": [
-        "participants",
         "type",
         "data"
       ],
@@ -507,7 +501,6 @@
         }
       },
       "required": [
-        "participants",
         "type",
         "data"
       ],

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -154,6 +154,6 @@ export interface Payload {
 
 export interface Message {
   recipient: string; // Identifier of user that the message should be relayed to
-  sender: string; // Identifier of user that the message is from
+  sender?: string; // Identifier of user that the message is from
   data: Payload;
 }

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -76,7 +76,7 @@ export interface SignedState {
 }
 
 type _Objective<Name, Data> = {
-  participants: Participant[];
+  participants?: Participant[];
   type: Name;
   data: Data;
 };


### PR DESCRIPTION
We currently have a couple of properties on the wire-format that we're not using, and probably won't use, but make it harder to write wallet code because the wallet needs them available when constructing messages. This PR removes those properties.

The properties are:
* `participants` on the objective
   * objectives always reference one or more channels, which can provide the participants
   * we originally had participants on objectives because there was a thought that objectives could exist before the channels. This is no-longer the case in any of the current objectives, and I can't see it happening in the future.
* `sender` on the message
    * we don't use this in the wallet, and shouldn't need to, as the wallet is deliberately agnostic to how messages arrived
    * as messaging is handled by the app, it's more appropriate for the app to handle this. For example, the ongoing http request essentially does this in the indexer.

The plan for deploying is:
1. make the properties optional, but still provide them (this PR), so that the wire-format is backwards compatible
2. wait for wallets to upgrade
3. simultaneously with 2, we can start providing fake values for these properties (they aren't used for anything, so this should be ok)
4. once wallets have upgraded, we can remove the properties from the api altogether 

