### PR TITLE
[nitro-protocol] Protect against reentrancy during claimAll

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -381,6 +381,7 @@ contract AssetHolder is IAssetHolder {
 
         // EFFECTS
         holdings[guarantorChannelId] = balance;
+       
 
         // at this point have payouts array of uint256s, each corresponding to original destinations
         // and allocations has some zero amounts which we want to prune
@@ -410,6 +411,7 @@ contract AssetHolder is IAssetHolder {
                 )
             );
         } else {
+            delete assetOutcomeHashes[guarantorChannelId];
             delete assetOutcomeHashes[guarantee.targetChannelId];
         }
 

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -288,8 +288,8 @@ contract AssetHolder is IAssetHolder {
         bytes memory guaranteeBytes,
         bytes memory allocationBytes
     ) public override {
-        // checks
-
+        
+        // CHECKS
         require(
             assetOutcomeHashes[guarantorChannelId] ==
                 keccak256(
@@ -379,7 +379,7 @@ contract AssetHolder is IAssetHolder {
             }
         }
 
-        // effects
+        // EFFECTS
         holdings[guarantorChannelId] = balance;
 
         // at this point have payouts array of uint256s, each corresponding to original destinations
@@ -396,18 +396,6 @@ contract AssetHolder is IAssetHolder {
                 newAllocation[k] = allocation[j];
                 k++;
             }
-            if (payouts[j] > 0) {
-                if (_isExternalDestination(allocation[j].destination)) {
-                    _transferAsset(_bytes32ToAddress(allocation[j].destination), payouts[j]);
-                    emit AssetTransferred(
-                        guarantorChannelId,
-                        allocation[j].destination,
-                        payouts[j]
-                    );
-                } else {
-                    holdings[allocation[j].destination] += payouts[j];
-                }
-            }
         }
         assert(k == newAllocationLength);
 
@@ -423,6 +411,23 @@ contract AssetHolder is IAssetHolder {
             );
         } else {
             delete assetOutcomeHashes[guarantee.targetChannelId];
+        }
+
+        // INTERACTIONS
+        for (uint256 j = 0; j < allocation.length; j++) {
+            // for each destination in the target channel's allocation
+            if (payouts[j] > 0) {
+                if (_isExternalDestination(allocation[j].destination)) {
+                    _transferAsset(_bytes32ToAddress(allocation[j].destination), payouts[j]);
+                    emit AssetTransferred(
+                        guarantorChannelId,
+                        allocation[j].destination,
+                        payouts[j]
+                    );
+                } else {
+                    holdings[allocation[j].destination] += payouts[j];
+                }
+            }
         }
     }
 

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -14,6 +14,7 @@ import {
   randomExternalDestination,
   replaceAddressesAndBigNumberify,
   setupContracts,
+  writeGasConsumption,
 } from '../../test-helpers';
 
 const provider = getTestProvider();
@@ -156,7 +157,8 @@ describe('claimAll', () => {
         });
 
         // Extract logs
-        const {logs} = await (await tx).wait();
+        const {logs, gasUsed} = await (await tx).wait();
+        await writeGasConsumption('./claimAll.gas.md', name, gasUsed);
 
         // Compile events from logs
         const events = compileEventsFromLogs(logs, [AssetHolder]);


### PR DESCRIPTION
...by using a checks/effects/interactions pattern. 

Currently, we call out to external contracts _before_ modifying the `assetOutcomeHash` for the target channel*: those external contracts could call back into `claimAll` or another `AssetHolder` function and try to exploit the unmodified storage. I can't think of an actual exploit RN because the `holdings` _has_ been updated by this point. 

In any case it seems worth a "modest" (~ 200 for our test cases) increase in gas to restore a safer pattern.

```
1. straight-through guarantee, 3 destinations:
40939 gas

2. swap guarantee,             2 destinations:
37771 gas

3. swap guarantee,             3 destinations:
40939 gas

4. straight-through guarantee, 2 destinations:
37602 gas

7. swap guarantee, overfunded, 2 destinations:
38850 gas

8. underspecified guarantee, overfunded      :
37759 gas

------- changes made to contract

1. straight-through guarantee, 3 destinations:
41155 gas

2. swap guarantee,             2 destinations:
37915 gas

3. swap guarantee,             3 destinations:
41143 gas

4. straight-through guarantee, 2 destinations:
37758 gas

7. swap guarantee, overfunded, 2 destinations:
39003 gas

8. underspecified guarantee, overfunded      :
37924 gas

```

* the guarantor channel `assetOutcomeHash` is **not** currently modified. 
