### PR TITLE
ci: pin to exact versions when canary publishing

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -29,4 +29,4 @@ jobs:
           git config --global user.email "github-actions@users.noreply.github.com"
 
       - name: publish packages to npm
-        run: yarn run lerna publish --canary --force-publish --preid next.$(git rev-parse --short HEAD) --dist-tag next --yes
+        run: yarn run lerna publish --canary --force-publish --exact --preid next.$(git rev-parse --short HEAD) --dist-tag next --yes


### PR DESCRIPTION
Without this, you can get surprising package resolution such as https://jubianchi.github.io/semver-check/#/%5E0.0.5-next.1805b9a.155%2B1805b9a/%220.0.5-next.f526a89.85%2Bf526a89%22