### PR TITLE
[nitro-protocol] Do not require external calls to succeed

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -61,6 +61,8 @@ contract AssetHolder is IAssetHolder {
             }
         }
 
+        require(affordsForDestination > 0, '_transfer fromChannel allocates 0 to destination');
+        
         // effects
         holdings[fromChannelId] -= affordsForDestination;
 

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -430,13 +430,13 @@ contract AssetHolder is IAssetHolder {
                 } else {
                     holdings[allocation[j].destination] += payouts[j];
                 }
-            }
             // Event emitted regardless of success of external calls
             emit AssetTransferred(
                         guarantorChannelId,
                         allocation[j].destination,
                         payouts[j]
                     );
+            }
         }
     }
 

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -18,8 +18,8 @@ contract AssetHolder is IAssetHolder {
     mapping(bytes32 => bytes32) public assetOutcomeHashes;
 
     /**
-     * @notice Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries. Performs no checks.
-     * @dev Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries. Performs no checks.
+     * @notice Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries. Does not check allocationBytes against on chain storage.
+     * @dev Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries. Does not check allocationBytes against on chain storage.
      * @param fromChannelId Unique identifier for state channel to transfer funds *from*.
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
      * @param destination External destination or channel to transfer funds *to*.
@@ -130,8 +130,8 @@ contract AssetHolder is IAssetHolder {
     }
 
     /**
-     * @notice Transfers the funds escrowed against `channelId` to the beneficiaries of that channel. No checks performed.
-     * @dev Transfers the funds escrowed against `channelId` and transfers them to the beneficiaries of that channel. No checks performed.
+     * @notice Transfers the funds escrowed against `channelId` to the beneficiaries of that channel. Does not check allocationBytes against on chain storage.
+     * @dev Transfers the funds escrowed against `channelId` and transfers them to the beneficiaries of that channel. Does not check allocationBytes against on chain storage.
      * @param channelId Unique identifier for a state channel.
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
      */

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -113,14 +113,17 @@ contract AssetHolder is IAssetHolder {
             );
         } 
 
-        // storage updated BEFORE asset transferred (prevent reentrancy)
 
+        // Event emitted regardless of success of external calls
+        emit AssetTransferred(fromChannelId, destination, affordsForDestination);
+
+        // storage updated BEFORE asset transferred (prevent reentrancy)
         if (_isExternalDestination(destination)) {
-            _transferAsset(_bytes32ToAddress(destination), affordsForDestination);
-            emit AssetTransferred(fromChannelId, destination, affordsForDestination);
+            _transferAsset(_bytes32ToAddress(destination), affordsForDestination);    
         } else {
             holdings[destination] += affordsForDestination;
         }
+
         
     }
 
@@ -192,6 +195,8 @@ contract AssetHolder is IAssetHolder {
         } else {
             delete assetOutcomeHashes[channelId];
         }
+
+
         // holdings updated BEFORE asset transferred (prevent reentrancy)
         uint256 payoutAmount;
         for (uint256 m = 0; m < numPayouts; m++) {
@@ -202,10 +207,11 @@ contract AssetHolder is IAssetHolder {
             }
             if (_isExternalDestination(allocation[m].destination)) {
                 _transferAsset(_bytes32ToAddress(allocation[m].destination), payoutAmount);
-                emit AssetTransferred(channelId, allocation[m].destination, payoutAmount);
             } else {
                 holdings[allocation[m].destination] += payoutAmount;
             }
+            // Event emitted regardless of success of external calls
+            emit AssetTransferred(channelId, allocation[m].destination, payoutAmount);
         }
     }
 
@@ -421,15 +427,16 @@ contract AssetHolder is IAssetHolder {
             if (payouts[j] > 0) {
                 if (_isExternalDestination(allocation[j].destination)) {
                     _transferAsset(_bytes32ToAddress(allocation[j].destination), payouts[j]);
-                    emit AssetTransferred(
-                        guarantorChannelId,
-                        allocation[j].destination,
-                        payouts[j]
-                    );
                 } else {
                     holdings[allocation[j].destination] += payouts[j];
                 }
             }
+            // Event emitted regardless of success of external calls
+            emit AssetTransferred(
+                        guarantorChannelId,
+                        allocation[j].destination,
+                        payouts[j]
+                    );
         }
     }
 

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -116,15 +116,14 @@ contract AssetHolder is IAssetHolder {
         } 
 
 
-        // Event emitted regardless of success of external calls
-        emit AssetTransferred(fromChannelId, destination, affordsForDestination);
-
-        // storage updated BEFORE asset transferred (prevent reentrancy)
+        // storage updated BEFORE external contracts called (prevent reentrancy attacks)
         if (_isExternalDestination(destination)) {
             _transferAsset(_bytes32ToAddress(destination), affordsForDestination);    
         } else {
             holdings[destination] += affordsForDestination;
         }
+        // Event emitted regardless of success of external calls
+        emit AssetTransferred(fromChannelId, destination, affordsForDestination);
 
         
     }
@@ -199,7 +198,7 @@ contract AssetHolder is IAssetHolder {
         }
 
 
-        // holdings updated BEFORE asset transferred (prevent reentrancy)
+        // holdings updated BEFORE asset transferred (prevent reentrancy attacks)
         uint256 payoutAmount;
         for (uint256 m = 0; m < numPayouts; m++) {
             if (overlap && m == numPayouts.sub(1)) {

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -58,7 +58,7 @@ contract ETHAssetHolder is AssetHolder {
 
         // refund whatever wasn't deposited.
         uint256 refund = amount.sub(amountDeposited);
-        msg.sender.send(refund); // forwards a stipend of only 2300 gas, will not revert on failure 
+        msg.sender.send(refund); // forwards a stipend of only 2300 gas, will not revert on failure
         // We do not require success here, to block a griefing vector
     }
 

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -58,8 +58,7 @@ contract ETHAssetHolder is AssetHolder {
 
         // refund whatever wasn't deposited.
         uint256 refund = amount.sub(amountDeposited);
-        (bool success, ) = msg.sender.call{value: refund}('');
-        require(success, 'Could not refund excess funds');
+        msg.sender.call{value: refund}(''); // We do not require success here, to block a griefing vector
     }
 
     /**

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -58,7 +58,8 @@ contract ETHAssetHolder is AssetHolder {
 
         // refund whatever wasn't deposited.
         uint256 refund = amount.sub(amountDeposited);
-        msg.sender.call{value: refund}(''); // We do not require success here, to block a griefing vector
+        msg.sender.send(refund); // forwards a stipend of only 2300 gas, will not revert on failure 
+        // We do not require success here, to block a griefing vector
     }
 
     /**
@@ -68,7 +69,7 @@ contract ETHAssetHolder is AssetHolder {
      * @param amount Quantity of wei to be transferred.
      */
     function _transferAsset(address payable destination, uint256 amount) internal override {
-        (bool success, ) = destination.call{value: amount}('');
-        require(success, 'Could not transfer asset');
+        destination.send(amount); // forwards a stipend of only 2300 gas, will not revert on failure
+        // We do not require success here, to block a griefing vector
     }
 }

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -40,9 +40,9 @@ interface IAssetHolder {
     );
 
     /**
-     * @dev Indicates that `amount` assets have been transferred to the external destination denoted by `destination`.
+     * @dev Indicates that `amount` assets have been transferred (internally or externally) to the destination denoted by `destination`.
      * @param channelId The channelId of the funds being withdrawn.
-     * @param destination An external destination, left-padded with zeros.
+     * @param destination An internal destination (channelId) of external destination (padded ethereum address)
      * @param amount Number of assets transferred (wei or tokens).
      */
     event AssetTransferred(bytes32 indexed channelId, bytes32 indexed destination, uint256 amount);

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -51,15 +51,15 @@ const reason6 =
 // Amounts are valueString representations of wei
 describe('claimAll', () => {
   it.each`
-    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter   | heldAfter | payouts         | reason
-    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason6}
-    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
+    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter   | heldAfter | payouts         | events          | reason
+    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${{I: 5}}       | ${undefined}
+    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${{B: 5}}       | ${undefined}
+    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${{I: 5}}       | ${undefined}
+    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${{A: 5}}       | ${undefined}
+    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${{}}           | ${reason5}
+    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${{}}           | ${reason6}
+    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${{A: 5, B: 5}} | ${undefined}
   `(
     '$name',
     async ({
@@ -70,6 +70,7 @@ describe('claimAll', () => {
       tOutcomeAfter,
       heldAfter,
       payouts,
+      events,
       reason,
     }: {
       name;
@@ -79,6 +80,7 @@ describe('claimAll', () => {
       tOutcomeAfter: AssetOutcomeShortHand;
       heldAfter: AssetOutcomeShortHand;
       payouts: AssetOutcomeShortHand;
+      events: AssetOutcomeShortHand;
       reason;
     }) => {
       // Compute channelIds
@@ -90,12 +92,13 @@ describe('claimAll', () => {
       addresses.g = guarantorId;
 
       // Transform input data (unpack addresses and BigNumber amounts)
-      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [
+      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts, events] = [
         heldBefore,
         tOutcomeBefore,
         tOutcomeAfter,
         heldAfter,
         payouts,
+        events,
       ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
       guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
 
@@ -142,26 +145,21 @@ describe('claimAll', () => {
         await expectRevert(() => tx, reason);
       } else {
         // Compile event expectations
-        let expectedEvents = [];
-
-        // Add AssetTransferred events to expectations
-        Object.keys(payouts).forEach(assetHolder => {
-          expectedEvents = assetTransferredEventsFromPayouts(
-            guarantorId,
-            payouts,
-            AssetHolder.address
-          );
-        });
+        const expectedEvents = assetTransferredEventsFromPayouts(
+          guarantorId,
+          events,
+          AssetHolder.address
+        );
 
         // Extract logs
         const {logs, gasUsed} = await (await tx).wait();
         await writeGasConsumption('./claimAll.gas.md', name, gasUsed);
 
         // Compile events from logs
-        const events = compileEventsFromLogs(logs, [AssetHolder]);
+        const eventsFromLogs = compileEventsFromLogs(logs, [AssetHolder]);
 
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!
-        expect(events).toMatchObject(expectedEvents);
+        expect(eventsFromLogs).toMatchObject(expectedEvents);
 
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -41,23 +41,33 @@ const reason1 = '_transfer | fromChannel affords 0 for destination';
 // c is the channel we are transferring from.
 describe('transferAll', () => {
   it.each`
-    name                              | heldBefore | setOutcome      | destination | newOutcome      | heldAfter       | payouts   | reason
-    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${'A'}      | ${{}}           | ${{}}           | ${{A: 1}} | ${reason0}
-    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${'A'}      | ${{}}           | ${{}}           | ${{A: 1}} | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${'A'}      | ${{}}           | ${{c: 1}}       | ${{A: 1}} | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${'A'}      | ${{A: 1}}       | ${{}}           | ${{A: 1}} | ${undefined}
-    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${'C'}      | ${{}}           | ${{c: 0, C: 1}} | ${{}}     | ${undefined}
-    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${'C'}      | ${{}}           | ${{c: 1, C: 1}} | ${{}}     | ${undefined}
-    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${'C'}      | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}     | ${undefined}
-    ${' 7. -> 2 EOA            full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${'A'}      | ${{B: 1}}       | ${{c: 1}}       | ${{A: 1}} | ${undefined}
-    ${' 8. -> 2 EOA            full'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${'A'}      | ${{B: 1}}       | ${{c: 0}}       | ${{A: 1}} | ${undefined}
-    ${' 9. -> 2 EOA         partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${'B'}      | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}} | ${undefined}
-    ${'10. -> 2 chan             no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${'X'}      | ${{C: 1, X: 1}} | ${{c: 0}}       | ${{}}     | ${reason1}
-    ${'11. -> 2 chan           full'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${'C'}      | ${{X: 1}}       | ${{c: 0, C: 1}} | ${{}}     | ${undefined}
-    ${'12. -> 2 chan        partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${'X'}      | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}     | ${undefined}
+    name                              | heldBefore | setOutcome      | destination | newOutcome      | heldAfter       | payouts   | events    | reason
+    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${'A'}      | ${{}}           | ${{}}           | ${{A: 1}} | ${{A: 1}} | ${reason0}
+    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${'A'}      | ${{}}           | ${{}}           | ${{A: 1}} | ${{A: 1}} | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${'A'}      | ${{}}           | ${{c: 1}}       | ${{A: 1}} | ${{A: 1}} | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${'A'}      | ${{A: 1}}       | ${{}}           | ${{A: 1}} | ${{A: 1}} | ${undefined}
+    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${'C'}      | ${{}}           | ${{c: 0, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
+    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${'C'}      | ${{}}           | ${{c: 1, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
+    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${'C'}      | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
+    ${' 7. -> 2 EOA            full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${'A'}      | ${{B: 1}}       | ${{c: 1}}       | ${{A: 1}} | ${{A: 1}} | ${undefined}
+    ${' 8. -> 2 EOA            full'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${'A'}      | ${{B: 1}}       | ${{c: 0}}       | ${{A: 1}} | ${{A: 1}} | ${undefined}
+    ${' 9. -> 2 EOA         partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${'B'}      | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}} | ${{B: 1}} | ${undefined}
+    ${'10. -> 2 chan             no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${'X'}      | ${{C: 1, X: 1}} | ${{c: 0}}       | ${{}}     | ${{}}     | ${reason1}
+    ${'11. -> 2 chan           full'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${'C'}      | ${{X: 1}}       | ${{c: 0, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
+    ${'12. -> 2 chan        partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${'X'}      | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}     | ${{X: 1}} | ${undefined}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
-    async ({name, heldBefore, setOutcome, destination, newOutcome, heldAfter, payouts, reason}) => {
+    async ({
+      name,
+      heldBefore,
+      setOutcome,
+      destination,
+      newOutcome,
+      heldAfter,
+      payouts,
+      events,
+      reason,
+    }) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -69,6 +79,7 @@ describe('transferAll', () => {
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
       payouts = replaceAddressesAndBigNumberify(payouts, addresses);
+      events = replaceAddressesAndBigNumberify(events, addresses);
       destination = addresses[destination];
 
       // Reset the holdings (only works on test contract)
@@ -98,17 +109,17 @@ describe('transferAll', () => {
       if (reason) {
         await expectRevert(() => tx, reason);
       } else {
-        const {events} = await (await tx).wait();
         const expectedEvents = [];
-        Object.keys(payouts).forEach(destination => {
-          if (payouts[destination] && payouts[destination].gt(0)) {
+        Object.keys(events).forEach(destination => {
+          if (events[destination] && events[destination].gt(0)) {
             expectedEvents.push({
               event: 'AssetTransferred',
-              args: {channelId, destination, amount: payouts[destination]},
+              args: {channelId, destination, amount: events[destination]},
             });
           }
         });
-        expect(events).toMatchObject(expectedEvents);
+        const {events: eventsFromTx} = await (await tx).wait();
+        expect(eventsFromTx).toMatchObject(expectedEvents);
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>
           expect(await AssetHolder.holdings(key)).toEqual(heldAfter[key])

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -40,23 +40,23 @@ const reason0 = 'transferAll | submitted data does not match stored assetOutcome
 // c is the channel we are transferring from.
 describe('transferAll', () => {
   it.each`
-    name                              | heldBefore | setOutcome      | newOutcome | heldAfter             | payouts         | reason
-    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}      | ${{}}                 | ${{A: 1}}       | ${reason0}
-    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}      | ${{}}                 | ${{A: 1}}       | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}      | ${{c: 1}}             | ${{A: 1}}       | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}  | ${{}}                 | ${{A: 1}}       | ${undefined}
-    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}      | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
-    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}      | ${{c: 1, C: 1}}       | ${{}}           | ${undefined}
-    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}  | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
-    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}      | ${{c: 0}}             | ${{A: 1, B: 1}} | ${undefined}
-    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 1}}       | ${undefined}
-    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 2, B: 1}} | ${undefined}
-    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}      | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${undefined}
-    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{X: 1}}  | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${undefined}
-    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{X: 1}}  | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${undefined}
+    name                              | heldBefore | setOutcome      | newOutcome | heldAfter             | payouts         | events          | reason
+    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}      | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${reason0}
+    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}      | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}      | ${{c: 1}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}  | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}      | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}      | ${{c: 1, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}  | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}      | ${{c: 0}}             | ${{A: 1, B: 1}} | ${{A: 1, B: 1}} | ${undefined}
+    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 2, B: 1}} | ${{A: 2, B: 1}} | ${undefined}
+    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}      | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${{C: 1, X: 1}} | ${undefined}
+    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{X: 1}}  | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{X: 1}}  | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${{C: 2, X: 1}} | ${undefined}
   `(
-    `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
-    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, reason}) => {
+    `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts, events: $events`,
+    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, events, reason}) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -68,6 +68,7 @@ describe('transferAll', () => {
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
       payouts = replaceAddressesAndBigNumberify(payouts, addresses);
+      events = replaceAddressesAndBigNumberify(events, addresses);
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
@@ -96,17 +97,17 @@ describe('transferAll', () => {
       if (reason) {
         await expectRevert(() => tx, reason);
       } else {
-        const {events} = await (await tx).wait();
+        const {events: eventsFromLogs} = await (await tx).wait();
         const expectedEvents = [];
-        Object.keys(payouts).forEach(destination => {
-          if (payouts[destination] && payouts[destination].gt(0)) {
+        Object.keys(events).forEach(destination => {
+          if (events[destination] && events[destination].gt(0)) {
             expectedEvents.push({
               event: 'AssetTransferred',
-              args: {channelId, destination, amount: payouts[destination]},
+              args: {channelId, destination, amount: events[destination]},
             });
           }
         });
-        expect(events).toMatchObject(expectedEvents);
+        expect(eventsFromLogs).toMatchObject(expectedEvents);
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>
           expect(await AssetHolder.holdings(key)).toEqual(heldAfter[key])


### PR DESCRIPTION
- Limit gas forwarded when making external calls (using `.send`)
- emit AssetTransferred unconditionally, even for internal updates to `holdings`.