### PR TITLE
[nitro-protocol] Redeclare SafeMath in extending contracts

### DIFF
--- a/packages/docs-website/docs/contract-api/contract-inheritance.mdx
+++ b/packages/docs-website/docs/contract-api/contract-inheritance.mdx
@@ -17,11 +17,13 @@ SafeMath([SafeMath])
 Outcome([Outcome])
 IAssetHolder
 AssetHolder
+IERC20
 ERC20AssetHolder
 ETHAssetHolder
 TESTAssetHolder
 IAssetHolder--> AssetHolder
 SafeMath-.-> AssetHolder
+IERC20-.-> ERC20AssetHolder
 Outcome-.-> AssetHolder
 AssetHolder-->ETHAssetHolder
 AssetHolder-->ERC20AssetHolder
@@ -33,7 +35,7 @@ classDef Abstraction fill:#ffffff,stroke:#8dc404,stroke-dasharray: 5 5;
 classDef Interface fill:#ffffff,stroke:#de1065,stroke-dasharray: 5 5;
 classDef TestContract fill:#fafe4f,stroke-width:0px
 class SafeMath,Outcome Library;
-class IAssetHolder Interface;
+class IAssetHolder,IERC20 Interface;
 class AssetHolder,ETHAssetHolder,ERC20AssetHolder Contract;
 class TESTAssetHolder TestContract;
 class ETHAssetHolder,ERC20AssetHolder DeployedContract;
@@ -44,6 +46,7 @@ click ERC20AssetHolder "/contract-api/natspec/ERC20AssetHolder";
 click ETHAssetHolder "/contract-api/natspec/ETHAssetHolder";
 click IAssetHolder "/contract-api/natspec/IAssetHolder";
 click TESTAssetHolder "/contract-api/natspec/TESTAssetHolder";
+click IERC20 "/contract-api/natspec/IERC20";
 '
 />
 

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -8,8 +8,10 @@ import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
  * @dev Ther ERC20AssetHolder contract extends the AssetHolder contract, and adds the following functionality: it allows ERC20 tokens to be escrowed against a state channelId and to be transferred to external destinations.
  */
 contract ERC20AssetHolder is AssetHolder {
-    IERC20 public Token;
+    using SafeMath for uint256;
 
+    IERC20 public Token;
+    
     /**
      * @notice Constructor function storing the AdjudicatorAddress and instantiating an interface to an ERC20 Token contract.
      * @dev Constructor function storing the AdjudicatorAddress and instantiating an interface to an ERC20 Token contract.

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -11,7 +11,7 @@ contract ERC20AssetHolder is AssetHolder {
     using SafeMath for uint256;
 
     IERC20 public Token;
-    
+
     /**
      * @notice Constructor function storing the AdjudicatorAddress and instantiating an interface to an ERC20 Token contract.
      * @dev Constructor function storing the AdjudicatorAddress and instantiating an interface to an ERC20 Token contract.

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -7,6 +7,9 @@ import './AssetHolder.sol';
  * @dev Ther ETHAssetHolder contract extends the AssetHolder contract, and adds the following functionality: it allows ETH to be escrowed against a state channelId and to be transferred to external destinations.
  */
 contract ETHAssetHolder is AssetHolder {
+
+    using SafeMath for uint256;
+
     /**
      * @notice Constructor function storing the AdjudicatorAddress.
      * @dev Constructor function storing the AdjudicatorAddress.

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -7,7 +7,6 @@ import './AssetHolder.sol';
  * @dev Ther ETHAssetHolder contract extends the AssetHolder contract, and adds the following functionality: it allows ETH to be escrowed against a state channelId and to be transferred to external destinations.
  */
 contract ETHAssetHolder is AssetHolder {
-
     using SafeMath for uint256;
 
     /**

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -84,7 +84,7 @@ contract ForceMove is IForceMove {
         emit ChallengeRegistered(
             channelId,
             largestTurnNum,
-            uint48(now) + fixedPart.challengeDuration,
+            uint48(now) + fixedPart.challengeDuration, // This could overflow, so don't join a channel with a huge challengeDuration
             challenger,
             isFinalCount > 0,
             fixedPart,


### PR DESCRIPTION
This is required in solidity 0.7