### PR TITLE
[nitro-protocol] Run chain tests concurrently

### DIFF
--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -78,9 +78,9 @@
     "prettier:write": "prettier --write './contracts/**/*.sol'",
     "test": "run-s test:contracts 'test:app --all'",
     "test:app": "jest -c ./config/jest/jest.config.js",
-    "test:ci": "yarn run-p 'test:ci:contracts --runInBand' 'test:ci:app --runInBand'",
-    "test:ci:app": "yarn test:app --all --ci --runInBand --bail",
-    "test:ci:contracts": "yarn test:contracts --all --ci --runInBand --bail",
+    "test:ci": "yarn test:ci:app && yarn test:ci:contracts",
+    "test:ci:app": "yarn test:app --all --ci --bail",
+    "test:ci:contracts": "yarn test:contracts --all --ci --bail",
     "test:contracts": "jest -c ./config/jest/jest.contracts.config.js"
   },
   "types": "lib/src/index.d.ts"

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -79,8 +79,8 @@
     "test": "run-s test:contracts 'test:app --all'",
     "test:app": "jest -c ./config/jest/jest.config.js",
     "test:ci": "yarn test:ci:app && yarn test:ci:contracts",
-    "test:ci:app": "yarn test:app --all --ci --bail",
-    "test:ci:contracts": "yarn test:contracts --all --ci --bail",
+    "test:ci:app": "yarn test:app --all --ci --bail --maxWorkers=4",
+    "test:ci:contracts": "yarn test:contracts --all --ci --bail --maxWorkers=4",
     "test:contracts": "jest -c ./config/jest/jest.contracts.config.js"
   },
   "types": "lib/src/index.d.ts"

--- a/packages/nitro-protocol/test/contracts/AssetHolder/adjudicatorAddress.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/adjudicatorAddress.test.ts
@@ -1,4 +1,3 @@
-import {expectRevert} from '@statechannels/devtools';
 import {Contract} from 'ethers';
 
 import AssetHolderArtifact from '../../../build/contracts/TESTAssetHolder.json';

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -8,6 +8,7 @@ import {
   AssetOutcomeShortHand,
   assetTransferredEventsFromPayouts,
   compileEventsFromLogs,
+  getRandomNonce,
   getTestProvider,
   guaranteeToParams,
   randomChannelId,
@@ -81,12 +82,8 @@ describe('claimAll', () => {
       reason;
     }) => {
       // Compute channelIds
-      const tNonce = BigNumber.from(utils.id(name))
-        .mask(30)
-        .toNumber();
-      const gNonce = BigNumber.from(utils.id(name + 'g'))
-        .mask(30)
-        .toNumber();
+      const tNonce = getRandomNonce(name);
+      const gNonce = getRandomNonce(name + 'g');
       const targetId = randomChannelId(tNonce);
       const guarantorId = randomChannelId(gNonce);
       addresses.t = targetId;

--- a/packages/nitro-protocol/test/contracts/AssetHolder/setOutcome.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/setOutcome.test.ts
@@ -1,10 +1,9 @@
-import {expectRevert} from '@statechannels/devtools';
 import {Contract, Wallet, utils} from 'ethers';
 const {id, keccak256} = utils;
 
 import AssetHolderArtifact from '../../../build/contracts/TestEthAssetHolder.json';
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {getTestProvider, setupContracts} from '../../test-helpers';
+import {getRandomNonce, getTestProvider, setupContracts} from '../../test-helpers';
 
 const provider = getTestProvider();
 let AssetHolder: Contract;
@@ -13,7 +12,7 @@ let channelId;
 const participants = ['', '', ''];
 const wallets = new Array(3);
 const chainId = '0x1234';
-const channelNonce = 0x9999;
+const channelNonce = getRandomNonce('setOutcome');
 const outcomeContent = id('some outcome data');
 
 // Populate wallets and participants array

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -4,6 +4,7 @@ import {Contract, BigNumber, utils} from 'ethers';
 import AssetHolderArtifact from '../../../build/contracts/TESTAssetHolder.json';
 import {
   allocationToParams,
+  getRandomNonce,
   getTestProvider,
   randomChannelId,
   randomExternalDestination,
@@ -58,9 +59,7 @@ describe('transferAll', () => {
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
     async ({name, heldBefore, setOutcome, destination, newOutcome, heldAfter, payouts, reason}) => {
       // Compute channelId
-      const nonce = BigNumber.from(utils.id(name))
-        .mask(30)
-        .toNumber();
+      const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
       addresses.c = channelId;
 

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -4,6 +4,7 @@ import {Contract, BigNumber, utils} from 'ethers';
 import AssetHolderArtifact from '../../../build/contracts/TESTAssetHolder.json';
 import {
   allocationToParams,
+  getRandomNonce,
   getTestProvider,
   randomChannelId,
   randomExternalDestination,
@@ -57,9 +58,7 @@ describe('transferAll', () => {
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
     async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, reason}) => {
       // Compute channelId
-      const nonce = BigNumber.from(utils.id(name))
-        .mask(30)
-        .toNumber();
+      const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
       addresses.c = channelId;
 

--- a/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
@@ -4,7 +4,12 @@ const {parseUnits} = ethers.utils;
 
 import ETHAssetHolderArtifact from '../../../build/contracts/TestEthAssetHolder.json';
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {getTestProvider, setupContracts, writeGasConsumption} from '../../test-helpers';
+import {
+  getRandomNonce,
+  getTestProvider,
+  setupContracts,
+  writeGasConsumption,
+} from '../../test-helpers';
 
 const provider = getTestProvider();
 let ETHAssetHolder: Contract;
@@ -32,24 +37,19 @@ const description3 =
 
 // Amounts are valueString represenationa of wei
 describe('deposit', () => {
+  let channelNonce = getRandomNonce('deposit');
+  afterEach(() => {
+    channelNonce++;
+  });
   it.each`
-    description     | channelNonce | held   | expectedHeld | amount | msgValue | heldAfterString | reasonString
-    ${description0} | ${0}         | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}          | ${undefined}
-    ${description1} | ${1}         | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}          | ${'Deposit | holdings[destination] is less than expected'}
-    ${description2} | ${2}         | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}          | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
-    ${description3} | ${3}         | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}          | ${undefined}
+    description     | held   | expectedHeld | amount | msgValue | heldAfterString | reasonString
+    ${description0} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}          | ${undefined}
+    ${description1} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}          | ${'Deposit | holdings[destination] is less than expected'}
+    ${description2} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}          | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
+    ${description3} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}          | ${undefined}
   `(
     '$description',
-    async ({
-      description,
-      channelNonce,
-      held,
-      expectedHeld,
-      amount,
-      msgValue,
-      reasonString,
-      heldAfterString,
-    }) => {
+    async ({description, held, expectedHeld, amount, msgValue, reasonString, heldAfterString}) => {
       held = parseUnits(held, 'wei');
       expectedHeld = parseUnits(expectedHeld, 'wei');
       amount = parseUnits(amount, 'wei');

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -21,6 +21,7 @@ import {
   clearedChallengeHash,
   finalizedOutcomeHash,
   getPlaceHolderContractAddress,
+  getRandomNonce,
   getTestProvider,
   ongoingChallengeHash,
   setupContracts,
@@ -117,7 +118,7 @@ describe('forceMove', () => {
   const challengeAtTwenty = ongoingChallengeHash(20);
   const finalizedAtFive = finalizedOutcomeHash(5);
 
-  let channelNonce = 200;
+  let channelNonce = getRandomNonce('challenge');
   beforeEach(() => (channelNonce += 1));
   it.each`
     description | initialChannelStorageHash    | stateData      | challengeSignature | reasonString

--- a/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
@@ -17,7 +17,12 @@ import {
   UNACCEPTABLE_WHO_SIGNED_WHAT,
 } from '../../../src/contract/transaction-creators/revert-reasons';
 import {COUNTING_APP_INVALID_TRANSITION} from '../../revert-reasons';
-import {getPlaceHolderContractAddress, getTestProvider, setupContracts} from '../../test-helpers';
+import {
+  getPlaceHolderContractAddress,
+  getRandomNonce,
+  getTestProvider,
+  setupContracts,
+} from '../../test-helpers';
 import {signStates} from '../../../src';
 
 const provider = getTestProvider();
@@ -82,7 +87,7 @@ const never = '0x00';
 const turnNumRecord = 7;
 
 describe('checkpoint', () => {
-  let channelNonce = 300;
+  let channelNonce = getRandomNonce('checkpoint');
   beforeEach(() => (channelNonce += 1));
   it.each`
     description | largestTurnNum       | support              | challenger    | finalizesAt  | reason

--- a/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -16,6 +16,7 @@ import {
   clearedChallengeHash,
   finalizedOutcomeHash,
   getPlaceHolderContractAddress,
+  getRandomNonce,
   getTestProvider,
   ongoingChallengeHash,
   setupContracts,
@@ -83,7 +84,7 @@ const channelOpen = clearedChallengeHash(turnNumRecord);
 const challengeOngoing = ongoingChallengeHash(turnNumRecord);
 const finalized = finalizedOutcomeHash(turnNumRecord);
 
-let channelNonce = 400;
+let channelNonce = getRandomNonce('conclude');
 describe('conclude', () => {
   beforeEach(() => (channelNonce += 1));
   it.each`

--- a/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../src/contract/transaction-creators/revert-reasons';
 import {
   getPlaceHolderContractAddress,
+  getRandomNonce,
   getTestProvider,
   setupContracts,
   writeGasConsumption,
@@ -56,7 +57,7 @@ const description5 =
   'It reverts a respond tx if the response state is not a validTransition from the challenge state';
 
 describe('respond', () => {
-  let channelNonce = 1000;
+  let channelNonce = getRandomNonce('respond');
   const future = 1e12;
   const past = 1;
   beforeEach(() => (channelNonce += 1));

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -169,10 +169,7 @@ describe('concludePushOutcomeAndTransferAll', () => {
       if ('ERC20' in heldBefore) {
         await (
           await Token.transfer(ERC20AssetHolder.address, BigNumber.from(heldBefore.ERC20.c))
-        ).wait();
-        expect(await Token.balanceOf(ERC20AssetHolder.address)).toStrictEqual(
-          BigNumber.from(heldBefore.ERC20.c)
-        );
+        ).wait(); // if the tx is mined, we know we the transfer succeeded
       }
 
       // Transform input data (unpack addresses and BigNumberify amounts)

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -18,6 +18,7 @@ import {
   compileEventsFromLogs,
   computeOutcome,
   getPlaceHolderContractAddress,
+  getRandomNonce,
   getTestProvider,
   OutcomeShortHand,
   randomChannelId,
@@ -121,7 +122,7 @@ const oneState = {
   appData: [ethers.constants.HashZero],
 };
 const turnNumRecord = 5;
-let channelNonce = 400;
+let channelNonce = getRandomNonce('concludePushOutcomeAndTransferAll');
 describe('concludePushOutcomeAndTransferAll', () => {
   beforeEach(() => (channelNonce += 1));
   it.each`

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../src/contract/transaction-creators/revert-reasons';
 import {
   finalizedOutcomeHash,
+  getRandomNonce,
   getTestProvider,
   randomExternalDestination,
   sendTransaction,
@@ -64,16 +65,19 @@ const description3 =
 const description4 = 'AssetHolders reject a setOutcome when outcomeHash already exists';
 
 describe('pushOutcome', () => {
+  let channelNonce = getRandomNonce('pushOutcome');
+  afterEach(() => {
+    channelNonce++;
+  });
   it.each`
-    description     | channelNonce | storedTurnNumRecord | declaredTurnNumRecord | finalized | outcomeHashExits | reasonString
-    ${description1} | ${1101}      | ${5}                | ${5}                  | ${true}   | ${false}         | ${undefined}
-    ${description2} | ${1102}      | ${5}                | ${5}                  | ${false}  | ${false}         | ${CHANNEL_NOT_FINALIZED}
-    ${description3} | ${1103}      | ${4}                | ${5}                  | ${true}   | ${false}         | ${WRONG_CHANNEL_STORAGE}
-    ${description4} | ${1104}      | ${5}                | ${5}                  | ${true}   | ${true}          | ${'Outcome hash already exists'}
+    description     | storedTurnNumRecord | declaredTurnNumRecord | finalized | outcomeHashExits | reasonString
+    ${description1} | ${5}                | ${5}                  | ${true}   | ${false}         | ${undefined}
+    ${description2} | ${5}                | ${5}                  | ${false}  | ${false}         | ${CHANNEL_NOT_FINALIZED}
+    ${description3} | ${4}                | ${5}                  | ${true}   | ${false}         | ${WRONG_CHANNEL_STORAGE}
+    ${description4} | ${5}                | ${5}                  | ${true}   | ${true}          | ${'Outcome hash already exists'}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({
-      channelNonce,
       storedTurnNumRecord,
       declaredTurnNumRecord,
       finalized,

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
@@ -14,6 +14,7 @@ import {
   compileEventsFromLogs,
   computeOutcome,
   finalizedOutcomeHash,
+  getRandomNonce,
   getTestProvider,
   OutcomeShortHand,
   randomChannelId,
@@ -77,7 +78,7 @@ beforeAll(async () => {
 //   'NitroAdjudicator accepts a pushOutcomeAndTransferAll tx for a finalized channel, and 1x Asset types transferred';
 const description2 =
   'NitroAdjudicator accepts a pushOutcomeAndTransferAll tx for a finalized channel, and 2x Asset types transferred';
-const channelNonce = 1101;
+const channelNonce = getRandomNonce('pushOutcomeAndTransferAll');
 const storedTurnNumRecord = 5;
 const declaredTurnNumRecord = storedTurnNumRecord;
 const finalized = true;

--- a/packages/nitro-protocol/test/contracts/NullApp/nullApp.test.ts
+++ b/packages/nitro-protocol/test/contracts/NullApp/nullApp.test.ts
@@ -1,7 +1,7 @@
 import {expectRevert} from '@statechannels/devtools';
 import {Contract, Wallet, ethers} from 'ethers';
 
-import {getTestProvider, setupContracts} from '../../test-helpers';
+import {getRandomNonce, getTestProvider, setupContracts} from '../../test-helpers';
 import NitroAdjudicatorArtifact from '../../../build/contracts/TESTNitroAdjudicator.json';
 import {getVariablePart, State, Channel} from '../../../src';
 
@@ -22,7 +22,7 @@ describe('null app', () => {
     const channel: Channel = {
       participants: [Wallet.createRandom().address, Wallet.createRandom().address],
       chainId: '0x1',
-      channelNonce: 0x1,
+      channelNonce: getRandomNonce('nullApp'),
     };
     const fromState: State = {
       channel,

--- a/packages/nitro-protocol/test/contracts/TrivalApp/validTransition.test.ts
+++ b/packages/nitro-protocol/test/contracts/TrivalApp/validTransition.test.ts
@@ -4,7 +4,7 @@ import TrivialAppArtifact from '../../../build/contracts/TrivialApp.json';
 import {Channel} from '../../../src/contract/channel';
 import {validTransition} from '../../../src/contract/force-move-app';
 import {State, VariablePart} from '../../../src/contract/state';
-import {getTestProvider, setupContracts} from '../../test-helpers';
+import {getRandomNonce, getTestProvider, setupContracts} from '../../test-helpers';
 
 const provider = getTestProvider();
 let trivialApp: Contract;
@@ -44,7 +44,7 @@ describe('validTransition', () => {
     const channel: Channel = {
       participants: [Wallet.createRandom().address, Wallet.createRandom().address],
       chainId: '0x1',
-      channelNonce: 0x01,
+      channelNonce: getRandomNonce('trivialApp'),
     };
     const fromState: State = {
       channel,

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -385,3 +385,7 @@ export async function writeGasConsumption(
     if (err) throw err;
   });
 }
+
+export function getRandomNonce(seed: string): number {
+  return Number.parseInt(ethers.utils.keccak256(seed).slice(2, 15), 16);
+}

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -387,5 +387,5 @@ export async function writeGasConsumption(
 }
 
 export function getRandomNonce(seed: string): number {
-  return Number.parseInt(ethers.utils.keccak256(seed).slice(2, 15), 16);
+  return Number.parseInt(ethers.utils.id(seed).slice(2, 11), 16);
 }


### PR DESCRIPTION
This cuts down nitro test run time by about a half (10 mins to about 5) on circle. 

It also closes the gap between local development (where tests will run concurrently, and *fail* some of the time because of that) and circle (where they do not). 

The key fix was not asserting on the balance of one of our test accounts (e.g. one that deploys contracts). 

Other fixes that I put in to avoid interference between tests: 

- generate a psuedorandom nonce for each channel used in each test, using the hash of the test name as a seed.



