### PR TITLE
Add workaround for noisy log message

### DIFF
--- a/packages/server-wallet/src/utilities/validate-transition.ts
+++ b/packages/server-wallet/src/utilities/validate-transition.ts
@@ -8,7 +8,13 @@ import {Bytes} from '../type-aliases';
 import {Channel} from '../models/channel';
 
 export function shouldValidateTransition(incomingState: StateWithHash, channel: Channel): boolean {
-  const {supported, isLedger} = channel;
+  const {supported, isLedger, fundingStrategy} = channel;
+  // TODO: This is a temporary workaround for https://github.com/statechannels/statechannels/issues/2842
+  // We should figure out a smarter way of handling this
+  if (fundingStrategy == 'Fake' && incomingState.turnNum === 3) {
+    return false;
+  }
+
   // If we already have the state we should of already validated it
   const alreadyHaveState = _.some(channel.sortedStates, ['stateHash', incomingState.stateHash]);
 


### PR DESCRIPTION
Adds a workaround for #2842 by skipping validation when fake funding and receiving a post fund setup. 

This should solve the immediate issue while we think of a proper solution for handling this.