### PR TITLE
refactor: migrate chain-service into its own package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ save_dep: &save_dep
     paths:
       - node_modules
       - packages/client-api-schema/node_modules
+      - packages/chain-service/node_modules
       - packages/devtools/node_modules
       - packages/docs-website/node_modules
       - packages/jest-gas-reporter/node_modules
@@ -52,6 +53,7 @@ save_built_artifacts: &save_built_artifacts
     paths:
       # Various TypeScript emissions
       - packages/channel-client/lib
+      - packages/chain-service/lib
       - packages/client-api-schema/lib
       - packages/devtools/lib
       - packages/jest-gas-reporter/lib

--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@
 !./packages/client-api-schema
 !./packages/nitro-protocol
 !./packages/simple-hub/
+!./packages/chain-service/
 !./packages/wire-format
 # Then ignore node_modules
 **/node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "eslint.workingDirectories": [
     {"directory": "packages/benchmarking", "changeProcessCWD": true },
     {"directory": "packages/channel-client", "changeProcessCWD": true },
+    {"directory": "packages/chain-service", "changeProcessCWD": true },
     {"directory": "packages/client-api-schema", "changeProcessCWD": true },
     {"directory": "packages/devtools", "changeProcessCWD": true },
     {"directory": "packages/docs-website", "changeProcessCWD": true },

--- a/packages/chain-service/.eslintignore
+++ b/packages/chain-service/.eslintignore
@@ -1,0 +1,5 @@
+/node_modules/
+/lib/
+/dist/
+/jest/
+/deployment/

--- a/packages/chain-service/.eslintrc.js
+++ b/packages/chain-service/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../server-wallet/.eslintrc.js'],
+};

--- a/packages/chain-service/.gitignore
+++ b/packages/chain-service/.gitignore
@@ -1,0 +1,16 @@
+# dependencies
+/node_modules
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+**/*.log
+build
+lib
+
+tsconfig.tsbuildinfo
+.eslintcache

--- a/packages/chain-service/.prettierrc.js
+++ b/packages/chain-service/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('../server-wallet/.prettierrc.js')
+};

--- a/packages/chain-service/README.md
+++ b/packages/chain-service/README.md
@@ -1,0 +1,51 @@
+# ⛓ Chain Service
+
+The `chain-service` is a standalone component that enables a State Channels wallet to communicate to an ethereum-based blockchain. It's primary responsibilities are:
+
+- Relay transactions to the chain for channel deposits and withdrawals
+- Watch for events related to channels such as those related to deposits and withdrawals
+- Fetch bytecode for existing on-chain contracts that channels may use as their app definition
+
+## Usage
+
+You can use the `chain-service` by requiring it in a file and attaching it to the `chainService` property of a [`@statechannels/server-wallet`](https://github.com/statechannels/statechannels/tree/master/packages/server-wallet/) like so:
+
+```ts
+import { ChainService } from "@statechannels/chain-service";
+
+const chainService = new ChainService(rpcEndpoint, privateKey);
+
+const wallet = new Wallet({...config, chainService});
+```
+
+You must provide an RPC Endpoint (e.g., `http://localhost:8545`) and a private key for an Ethereum account with some ETH that can send transactions.
+
+## Features
+
+### Calls
+- [x] Triggering a call to `deposit`
+- [x] Triggering a call to `concludeAndWithdraw`
+- [ ] Triggering a call to `forceMove`
+- [ ] Triggering a call to `checkpoint`
+- [ ] Triggering a call to `respond`
+
+### Monitoring
+- [x] Monitoring for `Deposit` events
+- [x] Monitoring for `AssetTransferred` events
+- [ ] Monitoring for `ChallengeRegistered` events
+- [ ] Monitoring for `ChallengeCleared` events
+- [ ] Monitoring for `Concluded` events
+
+### Communication
+- [x] Same-process
+- [ ] Cross-process
+
+## FAQ
+
+### Why is this a separate package?
+
+1. At the moment, the `chain-service` is tightly coupled to the `server-wallet` codebase but not to the `server-wallet` _process_. In production scenarios the `server-wallet` might be horizontally scaled to support several concurrent updates to a large number of channels, but you might only want a single connection to a blockchain monitoring and managing all of these channels.
+
+2. We expect that other wallets in the future (e.g., a browser-based wallet) may want to re-use this same service and plug it in to that environment similarly to how the `server-wallet` does now.
+
+3. The set of responsibilities this package controls are actually the only things which link a state channels wallet to a particular blockchain. In the future we may want to write a version of this package that connects to alternative blockchain-like backends such as [Optimism](http://optimism.io/) or [zkSync](https://zksync.io/) which would have different implementations for relaying transactions and monitoring the movement of funds. This package being de-coupled helps development move forward with less potential for unnecessary coupling to the implementation of the `server-wallet`, or any other wallet.

--- a/packages/chain-service/deployment/deploy.ts
+++ b/packages/chain-service/deployment/deploy.ts
@@ -1,0 +1,47 @@
+import {Address} from '@statechannels/client-api-schema';
+import {ContractArtifacts} from '@statechannels/nitro-protocol';
+import {GanacheDeployer} from '@statechannels/devtools';
+
+import defaultConfig from '../src/config';
+
+// NOTE: deploying contracts like this allows the onchain service package to
+// be easily extracted
+
+export type TestNetworkContext = {
+  ETH_ASSET_HOLDER_ADDRESS: Address;
+  ERC20_ADDRESS: Address;
+  ERC20_ASSET_HOLDER_ADDRESS: Address;
+  NITRO_ADJUDICATOR_ADDRESS: Address;
+};
+
+export async function deploy(): Promise<TestNetworkContext> {
+  // TODO: best way to configure this?
+  const deployer = new GanacheDeployer(8545, defaultConfig.serverPrivateKey);
+  const {
+    EthAssetHolderArtifact,
+    TokenArtifact,
+    Erc20AssetHolderArtifact,
+    NitroAdjudicatorArtifact,
+  } = ContractArtifacts;
+
+  const NITRO_ADJUDICATOR_ADDRESS = await deployer.deploy(NitroAdjudicatorArtifact);
+  const ERC20_ADDRESS = await deployer.deploy(TokenArtifact, {}, 0);
+  const ERC20_ASSET_HOLDER_ADDRESS = await deployer.deploy(
+    Erc20AssetHolderArtifact,
+    {},
+    NITRO_ADJUDICATOR_ADDRESS,
+    ERC20_ADDRESS
+  );
+  const ETH_ASSET_HOLDER_ADDRESS = await deployer.deploy(
+    EthAssetHolderArtifact,
+    {},
+    NITRO_ADJUDICATOR_ADDRESS
+  );
+
+  return {
+    NITRO_ADJUDICATOR_ADDRESS,
+    ERC20_ADDRESS,
+    ERC20_ASSET_HOLDER_ADDRESS,
+    ETH_ASSET_HOLDER_ADDRESS,
+  };
+}

--- a/packages/chain-service/jest/chain-setup.ts
+++ b/packages/chain-service/jest/chain-setup.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-process-env */
+import {ETHERLIME_ACCOUNTS, GanacheServer} from '@statechannels/devtools';
+import {utils} from 'ethers';
+
+import {deploy} from '../deployment/deploy';
+
+export default async function setup(): Promise<void> {
+  process.env['CHAIN_NETWORK_ID'] = '0x01';
+  process.env['GANACHE_HOST'] = '0.0.0.0';
+  process.env['GANACHE_PORT'] = '8545';
+  process.env[
+    'RPC_ENDPOINT'
+  ] = `http://${process.env['GANACHE_HOST']}:${process.env['GANACHE_PORT']}`;
+
+  const accounts = ETHERLIME_ACCOUNTS.map(account => ({
+    ...account,
+    amount: utils.parseEther('100').toString(),
+  }));
+
+  if (!process.env.GANACHE_PORT) {
+    throw new Error('process.env.GANACHE_PORT must be defined');
+  }
+  const ganacheServer = new GanacheServer(parseInt(process.env.GANACHE_PORT), 1337, accounts);
+  await ganacheServer.ready();
+
+  const deployedArtifacts = await deploy();
+
+  process.env = {...process.env, ...deployedArtifacts};
+
+  (global as any).__ARTIFACTS__ = deployedArtifacts;
+  (global as any).__GANACHE_SERVER__ = ganacheServer;
+}

--- a/packages/chain-service/jest/jest.config.js
+++ b/packages/chain-service/jest/jest.config.js
@@ -1,0 +1,17 @@
+const {resolve} = require('path');
+
+const rootDir = resolve(__dirname, '../');
+
+module.exports = {
+  rootDir,
+  collectCoverageFrom: ['src/**/*.{js,ts}'],
+  globals: {'ts-jest': {tsConfig: './tsconfig.json'}},
+  globalSetup: '<rootDir>/jest/chain-setup.ts',
+  globalTeardown: '<rootDir>/jest/test-teardown.ts',
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/**/__chain-test__/?(*.)test.ts?(x)'],
+  testURL: 'http://localhost',
+  transform: {'^.+\\.ts$': 'ts-jest'},
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|ts)$'],
+};

--- a/packages/chain-service/jest/test-teardown.ts
+++ b/packages/chain-service/jest/test-teardown.ts
@@ -1,0 +1,3 @@
+export default async function teardown(): Promise<void> {
+  await (global as any).__GANACHE_SERVER__.close();
+}

--- a/packages/chain-service/package.json
+++ b/packages/chain-service/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@statechannels/chain-service",
+  "description": "companion package to server-wallet to support chain interactions",
+  "version": "0.0.1",
+  "author": "",
+  "dependencies": {
+    "@ethersproject/experimental": "5.0.5",
+    "@statechannels/client-api-schema": "0.4.5",
+    "@statechannels/nitro-protocol": "0.7.0",
+    "@statechannels/wallet-core": "0.8.0",
+    "ethers": "5.0.12",
+    "p-queue": "6.6.2",
+    "rxjs": "6.6.3"
+  },
+  "devDependencies": {
+    "@statechannels/devtools": "0.4.3",
+    "@types/eslint": "7.2.3",
+    "@types/eslint-plugin-prettier": "2.2.0",
+    "@types/jest": "26.0.14",
+    "@types/lodash": "4.14.161",
+    "@types/prettier": "1.19.0",
+    "@typescript-eslint/eslint-plugin": "4.3.0",
+    "@typescript-eslint/parser": "4.3.0",
+    "eslint": "7.10.0",
+    "eslint-config-prettier": "6.10.0",
+    "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-jest": "23.6.0",
+    "eslint-plugin-prettier": "3.1.2",
+    "eslint-plugin-unicorn": "21.0.0",
+    "jest": "26.4.2",
+    "lint-staged": "10.0.4",
+    "lodash": "4.17.20",
+    "prettier": "1.19.1",
+    "ts-jest": "26.4.1",
+    "ts-node": "8.9.1",
+    "typescript": "4.0.3"
+  },
+  "license": "MIT",
+  "lint-staged": {
+    "src/**/*.ts": "eslint --max-warnings=0"
+  },
+  "main": "lib/src/index.js",
+  "scripts": {
+    "lint:check": "eslint \"*/**/*.{js,ts}\" --cache",
+    "lint:write": "eslint \"*/**/*.{js,ts}\" --fix",
+    "precommit": "lint-staged --quiet",
+    "prepare": "echo 'nothing to prepare; chain-service is TS code only'",
+    "prestart": "yarn prepare",
+    "test": "yarn jest -c ./jest/jest.config.js --runInBand",
+    "test:ci": "yarn test --ci --bail"
+  },
+  "types": "lib/src/index.d.ts"
+}

--- a/packages/chain-service/src/__chain-test__/chain-service.test.ts
+++ b/packages/chain-service/src/__chain-test__/chain-service.test.ts
@@ -12,13 +12,12 @@ import {
 import {BigNumber, constants, Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig} from '../../config';
-import {
-  alice as aliceParticipant,
-  bob as bobParticipant,
-} from '../../wallet/__test__/fixtures/participants';
-import {alice as aWallet, bob as bWallet} from '../../wallet/__test__/fixtures/signing-wallets';
-import {AssetTransferredArg, ChainService, HoldingUpdatedArg} from '../chain-service';
+import {ChainService} from '../chain-service';
+import {AssetTransferredArg, HoldingUpdatedArg} from '../types';
+import config from '../config';
+
+import {alice as aliceParticipant, bob as bobParticipant} from './fixtures/participants';
+import {alice as aWallet, bob as bWallet} from './fixtures/signing-wallets';
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
@@ -26,8 +25,8 @@ const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRE
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 
-if (!defaultTestConfig.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const rpcEndpoint = defaultTestConfig.rpcEndpoint;
+if (!config.rpcEndpoint) throw new Error('rpc endpoint must be defined');
+const rpcEndpoint = config.rpcEndpoint;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 
 let chainService: ChainService;

--- a/packages/chain-service/src/__chain-test__/fixtures/participants.ts
+++ b/packages/chain-service/src/__chain-test__/fixtures/participants.ts
@@ -1,0 +1,31 @@
+import {Participant, makeDestination} from '@statechannels/wallet-core';
+
+import * as wallets from './signing-wallets';
+import {fixture} from './utils';
+
+const _alice: Participant = {
+  signingAddress: wallets.alice().address,
+  destination: makeDestination(
+    '0xaaaa000000000000000000000000000000000000000000000000000000000001'
+  ),
+  participantId: 'alice',
+};
+const _bob: Participant = {
+  signingAddress: wallets.bob().address,
+  destination: makeDestination(
+    '0xbbbb000000000000000000000000000000000000000000000000000000000002'
+  ),
+  participantId: 'bob',
+};
+const _charlie: Participant = {
+  signingAddress: wallets.charlie().address,
+  destination: makeDestination(
+    '0xcccc000000000000000000000000000000000000000000000000000000000003'
+  ),
+  participantId: 'charlie',
+};
+
+export const participant = fixture(_alice);
+export const alice = fixture(_alice);
+export const bob = fixture(_bob);
+export const charlie = fixture(_charlie);

--- a/packages/chain-service/src/__chain-test__/fixtures/signing-wallets.ts
+++ b/packages/chain-service/src/__chain-test__/fixtures/signing-wallets.ts
@@ -1,0 +1,50 @@
+import {
+  Address,
+  makeAddress,
+  makePrivateKey,
+  PrivateKey,
+  signState,
+  State,
+} from '@statechannels/wallet-core';
+
+type LiteSigningWallet = {
+  privateKey: PrivateKey;
+  address: Address;
+  signState: (state: State) => {signer: Address; signature: string};
+};
+
+export const alice = (): LiteSigningWallet => {
+  const address = makeAddress('0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf');
+  const privateKey = makePrivateKey(
+    '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
+  );
+  return {
+    privateKey,
+    address,
+    signState: (state: State) => ({signer: address, signature: signState(state, privateKey)}),
+  };
+};
+
+export const bob = (): LiteSigningWallet => {
+  const address = makeAddress('0x2222E21c8019b14dA16235319D34b5Dd83E644A9');
+  const privateKey = makePrivateKey(
+    '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
+  );
+  return {
+    privateKey,
+    address,
+    signState: (state: State) => ({signer: address, signature: signState(state, privateKey)}),
+  };
+};
+
+export const charlie = (): LiteSigningWallet => {
+  const address = makeAddress('0x33335846dd121B14B4C313Cb6b766F09e75890dF');
+  const privateKey = makePrivateKey(
+    '0xc9a5f30ceaf2a0ccbb30d50aa9de3f273aa6e76f89e26090c42775e9647f5b6a'
+  );
+  return {
+    privateKey,
+    address,
+    signState: (state: State) => ({signer: address, signature: signState(state, privateKey)}),
+  };
+};

--- a/packages/chain-service/src/__chain-test__/fixtures/utils.ts
+++ b/packages/chain-service/src/__chain-test__/fixtures/utils.ts
@@ -1,0 +1,44 @@
+import _ from 'lodash';
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+type Modifier<T, S extends T = T> = (result: T, props?: any) => S;
+
+/**
+ * A fixture accepts two optional, positional arguments
+ * - the first, mergeProps, will merge properties into the defaults
+ * - the second, extendProps, will overwrite properties of the defaults
+ *
+ * An example of a property that you wouldn't want to merge is if you want to set a property
+ * to `undefined`. In this case, merging the defaults {foo: {bar: 'baz'}} into {foo: undefined}
+ * will result in {foo: {bar: 'baz'}}, but extending {foo: undefined} by the defaults
+ * {foo: {bar: 'baz'}} will yield {foo: undefined}
+ */
+export type Fixture<T> = (mergeProps?: DeepPartial<T>, extendProps?: DeepPartial<T>) => T;
+
+/**
+ * a fixture factory that produces a fixture, given a set of default values
+ * @param defaults default values provided by the fixture
+ * @param modifier a generic function that can modify the resulting value returned by the fixture
+ *
+ * Example
+ * ```
+ * const defaultState: StateWithHash = {...}
+ * const stateWithHashFixture = fixture(defaultState, flow(overwriteOutcome, addHash))
+ * ```
+ * - If the consumer wishes to specify `outcome`, which is an array, they probably do not
+ *   want to merge the provided outcome with the default outcome.
+ *   Thus, we probably want to overwrite with the providedoutcome after constructing the object.
+ * - If the consumer provided a state hash, it is probably incorrect, since the properties
+ *   provided will be mixed with the default properties, which changes the state, yielding
+ *   a different state hash
+ *
+ * Note that the consumer could specify `outcome` as an extend prop, but overwriting the outcome
+ * is probably what the consumer expects, and doing it in the modifier serves as a convenience for
+ * developers who wish to pass a single `mergeProps` object.
+ */
+export const fixture = function<T>(defaults: T, modifier: Modifier<T> = _.identity): Fixture<T> {
+  return (mergeProps?: DeepPartial<T>, extendProps?: DeepPartial<T>): T =>
+    modifier(_.extend(_.merge(_.cloneDeep(defaults), mergeProps), extendProps), mergeProps) as T;
+};

--- a/packages/chain-service/src/__chain-test__/stress.test.ts
+++ b/packages/chain-service/src/__chain-test__/stress.test.ts
@@ -4,8 +4,8 @@ import {BN, makeAddress} from '@statechannels/wallet-core';
 import {Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig} from '../../config';
 import {ChainService} from '../chain-service';
+import defaultTestConfig from '../config';
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);

--- a/packages/chain-service/src/chain-service.ts
+++ b/packages/chain-service/src/chain-service.ts
@@ -7,20 +7,24 @@ import {
 import {
   Address,
   BN,
-  Destination,
   makeAddress,
   makeDestination,
   SignedState,
   toNitroSignedState,
-  Uint256,
 } from '@statechannels/wallet-core';
 import {Contract, ethers, providers, utils, Wallet} from 'ethers';
+import {Bytes32} from '@statechannels/client-api-schema';
 import {concat, from, Observable, Subscription} from 'rxjs';
 import {filter, share} from 'rxjs/operators';
 import {NonceManager} from '@ethersproject/experimental';
 import PQueue from 'p-queue';
 
-import {Bytes32} from '../type-aliases';
+import {
+  ChainEventSubscriberInterface,
+  ChainServiceInterface,
+  FundChannelArg,
+  ContractEvent,
+} from './types';
 
 // todo: is it reasonable to assume that the ethAssetHolder address is defined as runtime configuration?
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
@@ -32,58 +36,8 @@ const nitroAdjudicatorAddress = makeAddress(
 );
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 
-export type HoldingUpdatedArg = {
-  channelId: Bytes32;
-  assetHolderAddress: Address;
-  amount: Uint256;
-};
-
-export type AssetTransferredArg = {
-  channelId: Bytes32;
-  assetHolderAddress: Address;
-  to: Destination;
-  amount: Uint256;
-};
-
-export type FundChannelArg = {
-  channelId: Bytes32;
-  assetHolderAddress: Address;
-  expectedHeld: Uint256;
-  amount: Uint256;
-  allowanceAlreadyIncreased?: boolean;
-};
-
-export interface ChainEventSubscriberInterface {
-  holdingUpdated(arg: HoldingUpdatedArg): void;
-  assetTransferred(arg: AssetTransferredArg): void;
-}
-
-interface ChainEventEmitterInterface {
-  registerChannel(
-    channelId: Bytes32,
-    assetHolders: Address[],
-    listener: ChainEventSubscriberInterface
-  ): void;
-  unregisterChannel(channelId: Bytes32): void;
-  destructor(): void;
-}
-
-interface ChainModifierInterface {
-  // todo: should these APIs return ethers TransactionResponses? Or is that too detailed for API consumers
-  fundChannel(arg: FundChannelArg): Promise<providers.TransactionResponse>;
-  concludeAndWithdraw(
-    finalizationProof: SignedState[]
-  ): Promise<providers.TransactionResponse | void>;
-  fetchBytecode(address: string): Promise<string>;
-}
-
-export type ChainServiceInterface = ChainModifierInterface & ChainEventEmitterInterface;
-
 const Deposited = 'Deposited' as const;
 const AssetTransferred = 'AssetTransferred' as const;
-type DepositedEvent = {type: 'Deposited'} & HoldingUpdatedArg;
-type AssetTransferredEvent = {type: 'AssetTransferred'} & AssetTransferredArg;
-type ContractEvent = DepositedEvent | AssetTransferredEvent;
 
 function isEthAssetHolder(address: Address): boolean {
   return address === ethAssetHolderAddress;

--- a/packages/chain-service/src/config.ts
+++ b/packages/chain-service/src/config.ts
@@ -1,0 +1,8 @@
+const config = {
+  rpcEndpoint: process.env.RPC_ENDPOINT,
+  serverPrivateKey:
+    process.env.SERVER_PRIVATE_KEY ||
+    '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
+};
+
+export default config;

--- a/packages/chain-service/src/index.ts
+++ b/packages/chain-service/src/index.ts
@@ -1,0 +1,2 @@
+export * from './chain-service';
+export * from './types';

--- a/packages/chain-service/src/types.ts
+++ b/packages/chain-service/src/types.ts
@@ -1,0 +1,54 @@
+import {Bytes32} from '@statechannels/client-api-schema';
+import {Address, Uint256, SignedState, Destination} from '@statechannels/wallet-core';
+import {providers} from 'ethers';
+
+export type HoldingUpdatedArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  amount: Uint256;
+};
+
+export type AssetTransferredArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  to: Destination;
+  amount: Uint256;
+};
+
+export type FundChannelArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  expectedHeld: Uint256;
+  amount: Uint256;
+  allowanceAlreadyIncreased?: boolean;
+};
+
+export interface ChainEventSubscriberInterface {
+  holdingUpdated(arg: HoldingUpdatedArg): void;
+  assetTransferred(arg: AssetTransferredArg): void;
+}
+
+interface ChainEventEmitterInterface {
+  registerChannel(
+    channelId: Bytes32,
+    assetHolders: Address[],
+    listener: ChainEventSubscriberInterface
+  ): void;
+  unregisterChannel(channelId: Bytes32): void;
+  destructor(): void;
+}
+
+interface ChainModifierInterface {
+  // todo: should these APIs return ethers TransactionResponses? Or is that too detailed for API consumers
+  fundChannel(arg: FundChannelArg): Promise<providers.TransactionResponse>;
+  concludeAndWithdraw(
+    finalizationProof: SignedState[]
+  ): Promise<providers.TransactionResponse | void>;
+  fetchBytecode(address: string): Promise<string>;
+}
+
+export type ChainServiceInterface = ChainModifierInterface & ChainEventEmitterInterface;
+
+export type DepositedEvent = {type: 'Deposited'} & HoldingUpdatedArg;
+export type AssetTransferredEvent = {type: 'AssetTransferred'} & AssetTransferredArg;
+export type ContractEvent = DepositedEvent | AssetTransferredEvent;

--- a/packages/chain-service/tsconfig.json
+++ b/packages/chain-service/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true, // import _ from 'lodash' uses this
+    "outDir": "lib",
+    "target": "es2019",      // same as @statechannels/server-wallet
+    "module": "commonjs",    // same as @statechannels/server-wallet
+    "esModuleInterop": true, // same as @statechannels/server-wallet
+    "lib": [
+      "ES2019", // We use .flatMap in this package
+      "dom" // Monorepo related errors (webgl) if this is omitted :/
+    ],
+    "noImplicitAny": true
+  },
+  "references": [
+    {
+      "path": "../devtools"
+    },
+    {
+      "path": "../client-api-schema"
+    },
+    {
+      "path": "../nitro-protocol"
+    },
+    {
+      "path": "../wallet-core"
+    },
+  ],
+  "include": ["src"]
+}

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -5,12 +5,12 @@
   "author": "",
   "dependencies": {
     "@connext/pure-evm-wasm": "0.1.4",
-    "@ethersproject/experimental": "5.0.5",
     "@statechannels/client-api-schema": "0.4.5",
     "@statechannels/nitro-protocol": "0.7.0",
     "@statechannels/wallet-core": "0.8.0",
     "@statechannels/wasm-utils": "0.1.5",
     "@statechannels/wire-format": "0.8.0",
+    "@statechannels/chain-service": "0.0.1",
     "ethers": "5.0.12",
     "eventemitter3": "4.0.7",
     "fp-ts": "2.7.0",
@@ -20,7 +20,6 @@
     "p-queue": "^6.6.2",
     "pg": "7.17.1",
     "pino": "6.2.0",
-    "rxjs": "6.6.3",
     "tarn": "3.0.0"
   },
   "devDependencies": {
@@ -61,6 +60,7 @@
     "npm-run-all": "4.1.5",
     "pino-pretty": "4.0.0",
     "prettier": "1.19.1",
+    "rxjs": "6.6.3",
     "tree-kill": "1.2.2",
     "ts-jest": "26.4.1",
     "ts-node": "8.9.1",

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -6,6 +6,9 @@
 
 import { Address } from '@statechannels/client-api-schema';
 import { Address as Address_2 } from '@statechannels/wallet-core';
+import { AssetTransferredArg } from '@statechannels/chain-service';
+import { ChainEventSubscriberInterface } from '@statechannels/chain-service';
+import { ChainServiceInterface } from '@statechannels/chain-service';
 import { ChannelConstants } from '@statechannels/wallet-core';
 import { ChannelId } from '@statechannels/client-api-schema';
 import { ChannelResult } from '@statechannels/client-api-schema';
@@ -16,6 +19,7 @@ import { Destination } from '@statechannels/wallet-core';
 import EventEmitter from 'eventemitter3';
 import { FundingStrategy } from '@statechannels/client-api-schema';
 import { GetStateParams } from '@statechannels/client-api-schema';
+import { HoldingUpdatedArg } from '@statechannels/chain-service';
 import { JoinChannelParams } from '@statechannels/client-api-schema';
 import { JSONSchema } from 'objection';
 import Knex from 'knex';
@@ -32,7 +36,6 @@ import { Participant as Participant_2 } from '@statechannels/client-api-schema';
 import { Payload } from '@statechannels/wire-format';
 import * as pino from 'pino';
 import { Pojo } from 'objection';
-import { providers } from 'ethers';
 import { QueryContext } from 'objection';
 import { SignatureEntry } from '@statechannels/wallet-core';
 import { SignedState } from '@statechannels/wallet-core';
@@ -45,7 +48,6 @@ import { StateWithHash } from '@statechannels/wallet-core';
 import { SyncChannelParams } from '@statechannels/client-api-schema';
 import { Transaction } from 'objection';
 import { TransactionOrKnex } from 'objection';
-import { Uint256 as Uint256_2 } from '@statechannels/wallet-core';
 import { UpdateChannelParams } from '@statechannels/client-api-schema';
 
 export { Message }

--- a/packages/server-wallet/src/chain-service/index.ts
+++ b/packages/server-wallet/src/chain-service/index.ts
@@ -1,2 +1,0 @@
-export * from './chain-service';
-export * from './mock-chain-service';

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -1,6 +1,7 @@
 import {Logger} from 'pino';
 import {serializeMessage, Participant, BN, Payload} from '@statechannels/wallet-core';
 import {ChannelResult} from '@statechannels/client-api-schema';
+import {ChainServiceInterface} from '@statechannels/chain-service';
 
 import {Bytes32} from '../type-aliases';
 import * as OpenChannelProtocol from '../protocols/open-channel';
@@ -8,7 +9,6 @@ import * as CloseChannelProtocol from '../protocols/close-channel';
 import * as ChannelState from '../protocols/state';
 import {Store} from '../wallet/store';
 import {LedgerRequest} from '../models/ledger-request';
-import {ChainServiceInterface} from '../chain-service';
 import {Outgoing, ProtocolAction} from '../protocols/actions';
 import {recordFunctionMetrics} from '../metrics';
 import {WALLET_VERSION} from '../version';

--- a/packages/server-wallet/src/objectives/types.ts
+++ b/packages/server-wallet/src/objectives/types.ts
@@ -1,8 +1,8 @@
 import {Logger} from 'pino';
 import {ChannelResult} from '@statechannels/client-api-schema';
+import {ChainServiceInterface} from '@statechannels/chain-service';
 
 import {Store} from '../wallet/store';
-import {ChainServiceInterface} from '../chain-service';
 import {Outgoing} from '../protocols/actions';
 import {WalletEvent} from '../wallet';
 

--- a/packages/server-wallet/src/wallet/mock-chain-service.ts
+++ b/packages/server-wallet/src/wallet/mock-chain-service.ts
@@ -1,11 +1,12 @@
 import {providers, constants} from 'ethers';
 import {Address, SignedState} from '@statechannels/wallet-core';
+import {
+  ChainServiceInterface,
+  ChainEventSubscriberInterface,
+  FundChannelArg,
+} from '@statechannels/chain-service';
 
 import {Bytes32} from '../type-aliases';
-
-import {ChainServiceInterface} from './chain-service';
-
-import {ChainEventSubscriberInterface, FundChannelArg} from './';
 
 const mockTransactionReceipt: providers.TransactionReceipt = {
   to: '',

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -26,6 +26,13 @@ import {
   makeAddress,
   Address as CoreAddress,
 } from '@statechannels/wallet-core';
+import {
+  ChainServiceInterface,
+  ChainEventSubscriberInterface,
+  HoldingUpdatedArg,
+  AssetTransferredArg,
+  ChainService,
+} from '@statechannels/chain-service';
 import * as Either from 'fp-ts/lib/Either';
 import Knex from 'knex';
 import _ from 'lodash';
@@ -46,20 +53,13 @@ import {isWalletError, PushMessageError} from '../errors/wallet-error';
 import {timerFactory, recordFunctionMetrics, setupMetrics} from '../metrics';
 import {mergeChannelResults, mergeOutgoing} from '../utilities/messaging';
 import {ServerWalletConfig, extractDBConfigFromServerWalletConfig, defaultConfig} from '../config';
-import {
-  ChainServiceInterface,
-  ChainEventSubscriberInterface,
-  HoldingUpdatedArg,
-  AssetTransferredArg,
-  ChainService,
-  MockChainService,
-} from '../chain-service';
 import {DBAdmin} from '../db-admin/db-admin';
 import {LedgerRequest} from '../models/ledger-request';
 import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
 import {hasSupportedState, isMyTurn} from '../handlers/helpers';
 
+import {MockChainService} from './mock-chain-service';
 import {Store, AppHandler, MissingAppHandler} from './store';
 import {WalletInterface} from './types';
 

--- a/packages/server-wallet/tsconfig.json
+++ b/packages/server-wallet/tsconfig.json
@@ -22,6 +22,9 @@
     },
     {
       "path": "../wallet-core"
+    },
+    {
+      "path": "../chain-service"
     }
   ],
   "include": ["src", "e2e-test", "deployment", "jest"]

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ This repository is a monorepo, and contains the following packages maintained wi
 
 - [benchmarking](./packages/benchmarking) : Small application that generates time-taken data for our libraries and applications
 - [channel-client](./packages/channel-client) : A JavaScript object interface for the state channels client API
+- [chain-service](./packages/chain-service) : A service for state channels wallets to connect to blockchain data
 - [docs-websitel](./packages/docs-website/website) : Documentation website
 - [iframe-channel-provider](./packages/iframe-channel-provider) : Thin wrapper around PostMessage communication between an App and a Wallet
 - [client-api-schema](./packages/client-api-schema) : JSON-RPC based schema definitions for the Client API with TypeScript typings

--- a/yarn.lock
+++ b/yarn.lock
@@ -18543,20 +18543,20 @@ p-pipe@^1.2.0:
   resolved "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz#4b1a11399a11520a67790ee5a0c1d5881d6befe9"
   integrity sha1-SxoROZoRUgpneQ7loMHViB1r7+k=
 
-p-queue@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/p-queue/-/p-queue-4.0.0.tgz#ed0eee8798927ed6f2c2f5f5b77fdb2061a5d346"
-  integrity sha512-3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==
-  dependencies:
-    eventemitter3 "^3.1.0"
-
-p-queue@^6.6.2:
+p-queue@6.6.2, p-queue@^6.6.2:
   version "6.6.2"
   resolved "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
   integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
   dependencies:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
+
+p-queue@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/p-queue/-/p-queue-4.0.0.tgz#ed0eee8798927ed6f2c2f5f5b77fdb2061a5d346"
+  integrity sha512-3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==
+  dependencies:
+    eventemitter3 "^3.1.0"
 
 p-reduce@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This was initially the intention, but we placed it inside `server-wallet` for short-term convenience.

```
.
├── deployment
│   └── deploy.ts
├── jest
│   ├── chain-setup.ts
│   ├── jest.config.js
│   └── test-teardown.ts
├── src
│   ├── __chain-test__
│   │   ├── fixtures
│   │   │   ├── participants.ts
│   │   │   ├── signing-wallets.ts
│   │   │   └── utils.ts
│   │   ├── chain-service.test.ts
│   │   └── stress.test.ts
│   ├── chain-service.ts
│   ├── config.ts
│   ├── index.ts
│   └── types.ts
├── README.md
├── package.json
└── tsconfig.json

5 directories, 16 files
```

See [README.md](https://github.com/statechannels/statechannels/blob/liam/chain-service/packages/chain-service/README.md)