### PR TITLE
Rename private keys

### DIFF
--- a/packages/server-wallet/deployment/deploy.ts
+++ b/packages/server-wallet/deployment/deploy.ts
@@ -15,7 +15,7 @@ export type TestNetworkContext = {
 
 export async function deploy(): Promise<TestNetworkContext> {
   // TODO: best way to configure this?
-  const deployer = new GanacheDeployer(8545, defaultConfig.serverPrivateKey);
+  const deployer = new GanacheDeployer(8545, defaultConfig.ethereumPrivateKey);
   const {
     EthAssetHolderArtifact,
     TokenArtifact,

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -68,6 +68,8 @@ export interface ServerWalletConfig {
     // (undocumented)
     ethAssetHolderAddress?: string;
     // (undocumented)
+    ethereumPrivateKey: string;
+    // (undocumented)
     logDestination?: string;
     // (undocumented)
     logLevel: pino.Level;
@@ -95,11 +97,9 @@ export interface ServerWalletConfig {
     // (undocumented)
     rpcEndpoint?: string;
     // (undocumented)
-    serverPrivateKey: string;
-    // (undocumented)
-    serverSignerPrivateKey: string;
-    // (undocumented)
     skipEvmValidation: boolean;
+    // (undocumented)
+    stateChannelPrivateKey: string;
     // (undocumented)
     timingMetrics: boolean;
     // (undocumented)

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -15,12 +15,12 @@ let provider: providers.JsonRpcProvider;
 const b = Wallet.create({
   ...defaultTestConfig,
   postgresDBName: 'TEST_B',
-  serverPrivateKey: ETHERLIME_ACCOUNTS[1].privateKey,
+  ethereumPrivateKey: ETHERLIME_ACCOUNTS[1].privateKey,
 });
 const a = Wallet.create({
   ...defaultTestConfig,
   postgresDBName: 'TEST_A',
-  serverPrivateKey: ETHERLIME_ACCOUNTS[2].privateKey,
+  ethereumPrivateKey: ETHERLIME_ACCOUNTS[2].privateKey,
 });
 
 const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -16,7 +16,7 @@ if (!defaultTestConfig.rpcEndpoint) throw new Error('rpc endpoint must be define
 const rpcEndpoint = defaultTestConfig.rpcEndpoint;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 // This is the private key for which ERC20 tokens are allocated on contract creation
-const ethWalletWithTokens = new Wallet(defaultTestConfig.serverPrivateKey, provider);
+const ethWalletWithTokens = new Wallet(defaultTestConfig.ethereumPrivateKey, provider);
 
 // Try to use a different private key for every chain service instantiation to avoid nonce errors
 const privateKey = ETHERLIME_ACCOUNTS[3].privateKey;

--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -15,7 +15,7 @@ export interface ServerWalletConfig {
   postgresDBUser?: string;
   postgresDBPassword?: string;
   serverSignerPrivateKey: string;
-  serverPrivateKey: string;
+  ethereumPrivateKey: string;
   rpcEndpoint?: string;
   chainNetworkID: string;
   erc20Address?: string;
@@ -43,7 +43,7 @@ export const defaultConfig: ServerWalletConfig = {
   serverSignerPrivateKey:
     process.env.SERVER_SIGNER_PRIVATE_KEY ||
     '0x1b427b7ab88e2e10674b5aa92bb63c0ca26aa0b5a858e1d17295db6ad91c049b',
-  serverPrivateKey:
+  ethereumPrivateKey:
     process.env.SERVER_PRIVATE_KEY ||
     '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
   rpcEndpoint: process.env.RPC_ENDPOINT,

--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -14,7 +14,7 @@ export interface ServerWalletConfig {
   postgresDBName?: string;
   postgresDBUser?: string;
   postgresDBPassword?: string;
-  serverSignerPrivateKey: string;
+  stateChannelPrivateKey: string;
   ethereumPrivateKey: string;
   rpcEndpoint?: string;
   chainNetworkID: string;
@@ -40,7 +40,7 @@ export const defaultConfig: ServerWalletConfig = {
   postgresDBName: process.env.SERVER_DB_NAME,
   postgresDBUser: process.env.SERVER_DB_USER,
   postgresDBPassword: process.env.SERVER_DB_PASSWORD,
-  serverSignerPrivateKey:
+  stateChannelPrivateKey:
     process.env.SERVER_SIGNER_PRIVATE_KEY ||
     '0x1b427b7ab88e2e10674b5aa92bb63c0ca26aa0b5a858e1d17295db6ad91c049b',
   ethereumPrivateKey:

--- a/packages/server-wallet/src/config.ts
+++ b/packages/server-wallet/src/config.ts
@@ -41,10 +41,10 @@ export const defaultConfig: ServerWalletConfig = {
   postgresDBUser: process.env.SERVER_DB_USER,
   postgresDBPassword: process.env.SERVER_DB_PASSWORD,
   stateChannelPrivateKey:
-    process.env.SERVER_SIGNER_PRIVATE_KEY ||
+    process.env.STATE_CHANNEL_PRIVATE_KEY ||
     '0x1b427b7ab88e2e10674b5aa92bb63c0ca26aa0b5a858e1d17295db6ad91c049b',
   ethereumPrivateKey:
-    process.env.SERVER_PRIVATE_KEY ||
+    process.env.ETHEREUM_PRIVATE_KEY ||
     '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
   rpcEndpoint: process.env.RPC_ENDPOINT,
   chainNetworkID: process.env.CHAIN_NETWORK_ID || '0x00',

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -144,11 +144,14 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       setupMetrics(this.walletConfig.metricsOutputFile);
     }
 
-    if (walletConfig?.rpcEndpoint && walletConfig.serverPrivateKey) {
-      this.chainService = new ChainService(walletConfig.rpcEndpoint, walletConfig.serverPrivateKey);
+    if (walletConfig?.rpcEndpoint && walletConfig.ethereumPrivateKey) {
+      this.chainService = new ChainService(
+        walletConfig.rpcEndpoint,
+        walletConfig.ethereumPrivateKey
+      );
     } else {
       this.logger.debug(
-        'rpcEndpoint and serverPrivateKey must be defined for the wallet to use chain service'
+        'rpcEndpoint and ethereumPrivateKey must be defined for the wallet to use chain service'
       );
       this.chainService = new MockChainService();
     }


### PR DESCRIPTION
The wallet configuration contains 2 private keys. One signs states. The other signs ethereum transaction. Currently, the names are:
- `serverSignerPrivateKey` for state signing. This name is verbose yet communicates little. 
  - server: we are looking at the server code, is that not obvious?
  - signer: private keys are typically used for signing.
  - privateKey: this part is important.
- `serverPrivateKey` for ethereum transaction signing. Same criticism.

