### PR TITLE
[breaking change (new config option)] consolidate chain service configuration options 

### DIFF
--- a/packages/server-wallet/deployment/deploy.ts
+++ b/packages/server-wallet/deployment/deploy.ts
@@ -1,9 +1,7 @@
 import {Address} from '@statechannels/client-api-schema';
 import {ContractArtifacts} from '@statechannels/nitro-protocol';
-import {GanacheDeployer} from '@statechannels/devtools';
+import {ETHERLIME_ACCOUNTS, GanacheDeployer} from '@statechannels/devtools';
 import {Wallet} from 'ethers';
-
-import {defaultTestConfig} from '../src/config';
 
 // NOTE: deploying contracts like this allows the onchain service package to
 // be easily extracted
@@ -15,8 +13,10 @@ export type TestNetworkContext = {
   NITRO_ADJUDICATOR_ADDRESS: Address;
 };
 
+
 export async function deploy(): Promise<TestNetworkContext> {
-  const {ethereumPrivateKey} = defaultTestConfig();
+  const ethereumPrivateKey = ETHERLIME_ACCOUNTS[0].privateKey;
+
   // TODO: best way to configure this?
   const deployer = new GanacheDeployer(8545, ethereumPrivateKey);
   const {

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -51,6 +51,13 @@ import { TransactionOrKnex } from 'objection';
 import { Uint256 as Uint256_2 } from '@statechannels/wallet-core';
 import { UpdateChannelParams } from '@statechannels/client-api-schema';
 
+// Warning: (ae-forgotten-export) The symbol "ChainServiceArgs" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type ChainServiceConfiguration = {
+    attachChainService: boolean;
+} & Partial<ChainServiceArgs>;
+
 // @public (undocumented)
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
 
@@ -73,6 +80,11 @@ export const DEFAULT_DB_NAME = "server_wallet_test";
 
 // @public (undocumented)
 export const DEFAULT_DB_USER = "postgres";
+
+// @public (undocumented)
+export const defaultChainServiceConfiguration: {
+    attachChainService: boolean;
+};
 
 // @public (undocumented)
 export const defaultConfig: OptionalServerWalletConfig;
@@ -138,7 +150,6 @@ export type MultipleChannelOutput = {
 
 // @public (undocumented)
 export type NetworkConfiguration = {
-    rpcEndpoint?: string;
     chainNetworkID: number;
 };
 
@@ -156,6 +167,8 @@ export type OptionalDatabaseConfiguration = {
 
 // @public (undocumented)
 export interface OptionalServerWalletConfig {
+    // (undocumented)
+    chainServiceConfiguration: ChainServiceConfiguration;
     // (undocumented)
     databaseConfiguration: OptionalDatabaseConfiguration;
     // (undocumented)
@@ -195,7 +208,6 @@ export type RequiredDatabaseConfiguration = {
 export type RequiredServerWalletConfig = {
     databaseConfiguration: RequiredDatabaseConfiguration;
     networkConfiguration: NetworkConfiguration;
-    ethereumPrivateKey: string;
 };
 
 // @public (undocumented)

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -13,28 +13,40 @@ import {getChannelResultFor, getPayloadFor} from '../__test__/test-helpers';
 
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
+// eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
+if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
+// eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
+const rpcEndpoint = process.env.RPC_ENDPOINT;
+
 const config = {
   ...defaultTestConfig(),
   networkConfiguration: {
     ...defaultTestConfig().networkConfiguration,
     // eslint-disable-next-line no-process-env
-    rpcEndpoint: process.env.RPC_ENDPOINT,
-    // eslint-disable-next-line no-process-env
     chainNetworkID: parseInt(process.env.CHAIN_NETWORK_ID || '0'),
   },
 };
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
+
 let provider: providers.JsonRpcProvider;
 const b = Wallet.create({
   ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_B'}),
-  /* eslint-disable-next-line no-process-env */
-  ethereumPrivateKey: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
+  chainServiceConfiguration: {
+    attachChainService: true,
+    provider: rpcEndpoint,
+    /* eslint-disable-next-line no-process-env */
+    pk: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
+    allowanceMode: 'MaxUint',
+  },
 });
 const a = Wallet.create({
   ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_A'}),
-  /* eslint-disable-next-line no-process-env */
-  ethereumPrivateKey: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
+  chainServiceConfiguration: {
+    attachChainService: true,
+    provider: rpcEndpoint,
+    /* eslint-disable-next-line no-process-env */
+    pk: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
+    allowanceMode: 'MaxUint',
+  },
 });
 
 const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -3,23 +3,27 @@ import {BN, makeAddress, makeDestination, Participant} from '@statechannels/wall
 import {ethers} from 'ethers';
 
 import {Outgoing} from '../..';
-import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
 import {Bytes32} from '../../type-aliases';
-import {Wallet} from '../../wallet';
 import {
   crashAndRestart,
   getChannelResultFor,
   getPayloadFor,
   interParticipantChannelResultsAreEqual,
 } from '../test-helpers';
+import {Wallet} from '../../wallet';
+import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
 
 const ETH_ASSET_HOLDER_ADDRESS = makeAddress(ethers.constants.AddressZero);
 
 let a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+    database: 'TEST_A',
+  })
 );
 let b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+    database: 'TEST_B',
+  })
 );
 
 let participantA: Participant;

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -12,7 +12,6 @@ import {
 import {BigNumber, constants, Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig} from '../../config';
 import {
   alice as aliceParticipant,
   bob as bobParticipant,
@@ -25,16 +24,9 @@ import {AssetTransferredArg, HoldingUpdatedArg} from '../types';
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
-
-const config = {
-  ...defaultTestConfig(),
-  networkConfiguration: {
-    ...defaultTestConfig().networkConfiguration,
-    rpcEndpoint: process.env.RPC_ENDPOINT,
-  },
-};
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
+if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
+const rpcEndpoint = process.env.RPC_ENDPOINT;
+/* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 
 let chainService: ChainService;

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -4,26 +4,19 @@ import {BN, makeAddress} from '@statechannels/wallet-core';
 import {Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig} from '../../config';
 import {ChainService} from '../chain-service';
+
+const pk = ETHERLIME_ACCOUNTS[0].privateKey;
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
+if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
+const rpcEndpoint = process.env.RPC_ENDPOINT;
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
-const config = {
-  ...defaultTestConfig(),
-  networkConfiguration: {
-    ...defaultTestConfig().networkConfiguration,
-    // eslint-disable-next-line no-process-env
-    rpcEndpoint: process.env.RPC_ENDPOINT,
-  },
-};
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 // This is the private key for which ERC20 tokens are allocated on contract creation
-const ethWalletWithTokens = new Wallet(config.ethereumPrivateKey, provider);
+const ethWalletWithTokens = new Wallet(pk, provider);
 
 // Try to use a different private key for every chain service instantiation to avoid nonce errors
 const privateKey = ETHERLIME_ACCOUNTS[3].privateKey;

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -74,18 +74,19 @@ export class ChainService implements ChainServiceInterface {
     logger,
     blockConfirmations,
     allowanceMode,
-  }: ChainServiceArgs) {
+  }: Partial<ChainServiceArgs>) {
+    if (!pk) throw new Error('ChainService: Private key not provided');
+    this.ethWallet = new NonceManager(new Wallet(pk, new providers.JsonRpcProvider(provider)));
     this.blockConfirmations = blockConfirmations ?? 5;
     this.logger = logger
       ? logger.child({module: 'ChainService'})
       : createLogger(defaultTestConfig());
     this.provider = new providers.JsonRpcProvider(provider);
-    this.allowanceMode = allowanceMode;
-    if (provider.includes('0.0.0.0') || provider.includes('localhost')) {
+    this.allowanceMode = allowanceMode || 'MaxUint';
+    if (provider && (provider.includes('0.0.0.0') || provider.includes('localhost'))) {
       pollingInterval = pollingInterval ?? 50;
     }
     if (pollingInterval) this.provider.pollingInterval = pollingInterval;
-    this.ethWallet = new NonceManager(new Wallet(pk, new providers.JsonRpcProvider(provider)));
     this.nitroAdjudicator = new Contract(
       nitroAdjudicatorAddress,
       ContractArtifacts.NitroAdjudicatorArtifact.abi,

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -31,6 +31,10 @@ export const defaultLoggingConfiguration: LoggingConfiguration = {
 
 export const defaultMetricsConfiguration = {timingMetrics: false};
 
+export const defaultChainServiceConfiguration = {
+  attachChainService: false,
+};
+
 /**
  * Server Wallet config
  */
@@ -43,6 +47,7 @@ export const defaultConfig: OptionalServerWalletConfig = {
   databaseConfiguration: defaultDatabaseConfiguration,
   loggingConfiguration: defaultLoggingConfiguration,
   metricsConfiguration: defaultMetricsConfiguration,
+  chainServiceConfiguration: defaultChainServiceConfiguration,
   skipEvmValidation: false,
   workerThreadAmount: 0,
 };
@@ -64,8 +69,6 @@ export const defaultTestConfig = (
     networkConfiguration: defaultTestNetworkConfiguration,
     skipEvmValidation: true,
     workerThreadAmount: 0, // Disable threading for tests
-    // 0xD9995BAE12FEe327256FFec1e3184d492bD94C31
-    ethereumPrivateKey: '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
     databaseConfiguration: {
       connection: {
         host: defaultDatabaseConfiguration.connection.host,

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -1,5 +1,7 @@
 import {Level} from 'pino';
 
+import {ChainServiceArgs} from '../chain-service';
+
 /**
  * Either a connection string or a config object with the dbName specified
  */
@@ -49,12 +51,16 @@ export type LoggingConfiguration = {logLevel: Level; logDestination: string};
 export type MetricsConfiguration = {timingMetrics: boolean; metricsOutputFile?: string};
 
 /**
+ * Chain service configuration options
+ */
+export type ChainServiceConfiguration = {attachChainService: boolean} & Partial<ChainServiceArgs>;
+
+/**
  * The minimum required configuration to use the server wallet.
  */
 export type RequiredServerWalletConfig = {
   databaseConfiguration: RequiredDatabaseConfiguration;
   networkConfiguration: NetworkConfiguration;
-  ethereumPrivateKey: string;
 };
 
 /**
@@ -64,6 +70,7 @@ export interface OptionalServerWalletConfig {
   databaseConfiguration: OptionalDatabaseConfiguration;
   workerThreadAmount: number;
   skipEvmValidation: boolean;
+  chainServiceConfiguration: ChainServiceConfiguration;
   loggingConfiguration: LoggingConfiguration;
   metricsConfiguration: MetricsConfiguration;
 }
@@ -84,7 +91,6 @@ export type IncomingServerWalletConfig = RequiredServerWalletConfig &
  * Various network configuration options
  */
 export type NetworkConfiguration = {
-  rpcEndpoint?: string;
   chainNetworkID: number;
 };
 

--- a/packages/server-wallet/src/db-admin/knexfile.ts
+++ b/packages/server-wallet/src/db-admin/knexfile.ts
@@ -63,7 +63,6 @@ const dbDebug = process.env.DEBUG_KNEX?.toLowerCase() === 'true' || false;
 export const {client, connection, debug, migrations, seeds, pool} = createKnexConfig({
   ...defaultConfig,
   databaseConfiguration: {debug: dbDebug, connection: dbConnectionConfig},
-  ethereumPrivateKey: '0x0',
   networkConfiguration: {
     chainNetworkID: 0,
   },

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -14,7 +14,6 @@ import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/confi
 import {PartialModelObject} from 'objection';
 
 import {Channel} from '../../../models/channel';
-import {Wallet} from '../..';
 import {addHash} from '../../../state-utils';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import {alice as aliceP, bob as bobP, charlie as charlieP} from '../fixtures/participants';
@@ -29,6 +28,7 @@ import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-hel
 import {LedgerRequest} from '../../../models/ledger-request';
 import {WALLET_VERSION} from '../../../version';
 import {PushMessageError} from '../../../errors/wallet-error';
+import {Wallet} from '../..';
 
 jest.setTimeout(20_000);
 

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -9,9 +9,9 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {ObjectiveModel} from '../../../models/objective';
-import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
+import {defaultTestConfig} from '../../../config';
 
 const AddressZero = makeAddress(ethers.constants.AddressZero);
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -132,16 +132,9 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       setupMetrics(this.walletConfig.metricsConfiguration.metricsOutputFile);
     }
 
-    if (this.walletConfig.networkConfiguration.rpcEndpoint) {
-      this.chainService = new ChainService({
-        provider: this.walletConfig.networkConfiguration.rpcEndpoint,
-        pk: this.walletConfig.ethereumPrivateKey,
-        allowanceMode: 'MaxUint',
-      });
+    if (this.walletConfig.chainServiceConfiguration.attachChainService) {
+      this.chainService = new ChainService(this.walletConfig.chainServiceConfiguration);
     } else {
-      this.logger.debug(
-        'rpcEndpoint and ethereumPrivateKey must be defined for the wallet to use chain service'
-      );
       this.chainService = new MockChainService();
     }
 


### PR DESCRIPTION
~The `ChainService` should not be instantiated inside the `server-wallet` as it is fundamentally an external component that is designed to be provided _to_ the `server-wallet`. Similarly, the implementation details of the wallet should not need to know about mocks or test fixtures, that should be left to the tests. So, this PR moves the instantiation of a `ChainService` into the constructor of a `server-wallet`. Applications are expected to provide it in the constructor.~

~It seems reasonable to force the `ChainService` to be in the constructor as without it the `server-wallet` is not able to do things like make deposits, withdrawals, or monitor the chain. These are fundamental requirements of a state channels wallet.~

Simplified this PR to simply consolidate wallet config options into one place as they relate to the chain service after some discussions