### PR TITLE
Add response builder

### DIFF
--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -81,6 +81,8 @@
     "db:rollback": "npx knex migrate:rollback --cwd src/db-admin",
     "db:seed": "npx knex seed:run --cwd src/db-admin",
     "db:setup:dev": "yarn db:drop && yarn db:create && yarn db:migrate",
+    "db:reset": "yarn db:drop; yarn db:create && yarn db:migrate",
+    "db:reset:test": "(NODE_ENV=test yarn db:reset)",
     "generate-api": "yarn api-extractor run --local",
     "lint:check": "eslint \"*/**/*.{js,ts}\" --cache",
     "lint:write": "eslint \"*/**/*.{js,ts}\" --fix",

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -1,4 +1,9 @@
-export {WalletEvent, SingleChannelOutput, ObjectiveSucceededValue} from './wallet';
+export {
+  WalletEvent,
+  SingleChannelOutput,
+  MultipleChannelOutput,
+  ObjectiveSucceededValue,
+} from './wallet';
 
 import {ServerWalletConfig} from '../config';
 

--- a/packages/server-wallet/src/wallet/response-builder.ts
+++ b/packages/server-wallet/src/wallet/response-builder.ts
@@ -1,0 +1,160 @@
+import {ChannelResult} from '@statechannels/client-api-schema';
+import {Participant, serializeMessage, SignedState} from '@statechannels/wallet-core';
+
+import {Channel} from '../models/channel';
+import {DBObjective} from '../models/objective';
+import {Outgoing} from '../protocols/actions';
+import {mergeChannelResults, mergeOutgoing} from '../utilities/messaging';
+import {WALLET_VERSION} from '../version';
+
+import {MultipleChannelOutput, SingleChannelOutput, WalletEvent} from '.';
+
+export interface ResponseBuilder {
+  /**
+   * Queues channel for notification to user
+   */
+  channelUpdated: (channel: Channel) => void;
+
+  /**
+   * Same as channelUpdated but accepts a channelResult instead of a Channel
+   *
+   * Plan to deprecate.
+   */
+  channelUpdatedResult: (channelResult: ChannelResult) => void;
+
+  /**
+   * Queues state for sending to opponent
+   */
+  stateSigned: (state: SignedState, myIndex: number, channelId?: string) => void;
+
+  /**
+   * Queues objectives for sending to opponent
+   */
+  objectiveCreated: (objective: DBObjective) => void;
+
+  /**
+   * Queues objectives for approval by the user
+   */
+  objectiveReceived: (objective: DBObjective) => void;
+
+  /**
+   * Queue succeeded objectives, so we can emit events
+   */
+  objectiveSucceeded: (objective: DBObjective) => void;
+
+  /**
+   * Add a GetChannelRequest to outbox for given channelId
+   */
+  requestGetChannel: (channelId: string, myIndex: number, participants: Participant[]) => void;
+}
+
+export class WalletResponse implements ResponseBuilder {
+  channelResults: ChannelResult[] = [];
+  outbox: Outgoing[] = [];
+  objectivesToSend: DBObjective[] = [];
+  objectivesToApprove: DBObjective[] = [];
+  succeededObjectives: DBObjective[] = [];
+  requests: string[] = [];
+
+  static initialize(): WalletResponse {
+    return new this();
+  }
+
+  channelUpdated(channel: Channel): void {
+    this.channelResults.push(channel.channelResult);
+  }
+
+  channelUpdatedResult(channelResult: ChannelResult): void {
+    this.channelResults.push(channelResult);
+  }
+
+  stateSigned(state: SignedState, myIndex: number, channelId?: string): void {
+    const myParticipantId = state.participants[myIndex].participantId;
+    state.participants.forEach((p, i) => {
+      if (i !== myIndex) {
+        this.outbox.push({
+          method: 'MessageQueued' as const,
+          params: serializeMessage(
+            WALLET_VERSION,
+            {
+              walletVersion: WALLET_VERSION,
+              signedStates: [state],
+            },
+            p.participantId,
+            myParticipantId,
+            channelId
+          ),
+        });
+      }
+    });
+  }
+
+  objectiveCreated(objective: DBObjective): void {
+    this.objectivesToSend.push(objective);
+  }
+
+  objectiveReceived(objective: DBObjective): void {
+    this.objectivesToApprove.push(objective);
+  }
+
+  objectiveSucceeded(objective: DBObjective): void {
+    this.succeededObjectives.push(objective);
+  }
+
+  requestGetChannel(channelId: string, myIndex: number, participants: Participant[]): void {
+    const myParticipantId = participants[myIndex].participantId;
+
+    participants.forEach((p, i) => {
+      if (i !== myIndex) {
+        this.outbox.push({
+          method: 'MessageQueued' as const,
+          params: serializeMessage(
+            WALLET_VERSION,
+            {
+              walletVersion: WALLET_VERSION,
+              requests: [{type: 'GetChannel', channelId}],
+            },
+            p.participantId,
+            myParticipantId,
+            channelId
+          ),
+        });
+      }
+    });
+  }
+
+  multipleChannelOutput(): MultipleChannelOutput {
+    return {
+      outbox: mergeOutgoing(this.outbox),
+      channelResults: mergeChannelResults(this.channelResults),
+      objectivesToApprove: this.objectivesToApprove,
+    };
+  }
+  singleChannelOutput(): SingleChannelOutput {
+    if (this.channelResults.length !== 1) {
+      throw Error(
+        `Response: expected exactly one channelResult. Found ${this.channelResults.length}.`
+      );
+    }
+
+    return {
+      outbox: mergeOutgoing(this.outbox),
+      channelResult: this.channelResults[0],
+      objectivesToApprove: this.objectivesToApprove,
+    };
+  }
+
+  updatedChannels(): ChannelResult[] {
+    return this.channelResults;
+  }
+
+  objectiveSucceededEvents(): WalletEvent[] {
+    return this.succeededObjectives.map(objective => ({
+      type: 'objectiveSucceeded' as const,
+      value: {
+        channelId: objective.data.targetChannelId,
+        objectiveType: objective.type,
+      },
+    }));
+  }
+}

--- a/packages/server-wallet/src/wallet/response-builder.ts
+++ b/packages/server-wallet/src/wallet/response-builder.ts
@@ -127,7 +127,7 @@ export class WalletResponse implements ResponseBuilder {
     return {
       outbox: mergeOutgoing(this.outbox),
       channelResults: mergeChannelResults(this.channelResults),
-      objectivesToApprove: this.objectivesToApprove,
+      // objectivesToApprove: this.objectivesToApprove, // todo: re-enable
     };
   }
   singleChannelOutput(): SingleChannelOutput {
@@ -140,7 +140,7 @@ export class WalletResponse implements ResponseBuilder {
     return {
       outbox: mergeOutgoing(this.outbox),
       channelResult: this.channelResults[0],
-      objectivesToApprove: this.objectivesToApprove,
+      // objectivesToApprove: this.objectivesToApprove, // todo: re-enable
     };
   }
 


### PR DESCRIPTION
The `ResponseBuilder` is an attempt to clean up the output-generating logic that is currently spread throughout the wallet.

Each call to the wallet's api will start by creating a response object, that is then passed through to the objectives etc. The response object gives a simple interface for adding objectives/states/channelResults etc. to the output, and takes care of any message merging required:
```ts
// initialize a response
const response = WalletResponse.initialize();

// add a signed state to be sent (will be added to outbox.signedStates)
response.stateSigned(state, myIndex, channelId);

// notify user of channel update (will be added to channelResults)
response.channelUpdated(channel)

// queue an objective to be sent to opponent (will be added to outbox.objectives)
response.objectiveCreated(objective)

// queue an objective to be approved by the app (will be added to objectivesToApprove)
response.objectiveReceived(objective)

// at the end you can return a single channel result ..
return response.singleChannelResult() // errors if channelUpdated has been called more than once

// ..or a multiple channel result
return response.multipleChannelResult()
```

This PR introduces the `WalletResponse` and `ResponseBuilder` interfaces. It converts the `syncChannels` api call to use the new interface. Future work will convert other api calls, if we're happy with the approach.