### PR TITLE
Mark _transferAsset as virtual

### DIFF
--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -70,7 +70,7 @@ contract ERC20AssetHolder is AssetHolder {
      * @param destination Ethereum address to be credited.
      * @param amount Quantity of tokens to be transferred.
      */
-    function _transferAsset(address payable destination, uint256 amount) internal override {
+    function _transferAsset(address payable destination, uint256 amount) internal virtual override {
         Token.transfer(destination, amount);
     }
 }


### PR DESCRIPTION
The current implementation of `GRTAssetHolder` expects to override `_transferAsset` so this marks it as `virtual` allowing for the `GRTAssetHolder` .

I don't think there's any security implications here but would be good to get a second opinion on that.