### PR TITLE
fix: do not rely on revert reason in chain service

### DIFF
--- a/packages/server-wallet/.eslintrc.js
+++ b/packages/server-wallet/.eslintrc.js
@@ -43,7 +43,10 @@ module.exports = {
         '@typescript-eslint/camelcase': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
-        '@typescript-eslint/no-unused-vars': [1, {argsIgnorePattern: '^_'}],
+        '@typescript-eslint/no-unused-vars': [
+          1,
+          {argsIgnorePattern: '^_', varsIgnorePattern: '^_'},
+        ],
       },
     },
   ],

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -213,15 +213,11 @@ export class ChainService implements ChainServiceInterface {
         })
       );
 
-      // Check if the channel has been finalized in the past or will finalize in the next 10 minutes
-      const timeNowSeconds = Date.now() / 1_000;
-      if (
-        finalizesAt &&
-        (timeNowSeconds - Number(finalizesAt) >= 0 ||
-          Number(finalizesAt) - timeNowSeconds <= 60 * 10)
-      ) {
-        return;
-      }
+      const latestBlockTimestamp = (
+        await this.provider.getBlock(await this.provider.getBlockNumber())
+      ).timestamp;
+      // Check if the channel has been finalized in the past
+      if (latestBlockTimestamp >= Number(finalizesAt)) return;
 
       throw reason;
     };


### PR DESCRIPTION
With Ganache, when transaction execution reverts, the revert reason is included in the thrown exeption. This is not the case for testnets like rinkeby (https://github.com/ethers-io/ethers.js/issues/446).

The alternative to querying the nitro adjudicator for its state is to use the [`eth-revert-reason` npm module](https://www.npmjs.com/package/eth-revert-reason). However, that module is not reliable as we see the following error: `You cannot use a blocknumber that has not yet happened.`

`eth-revert-reason` can be used more reliably if a delay is added before `ether-revert-reason` is invoked.

FIxes https://github.com/statechannels/statechannels/issues/2872