### PR TITLE
fix: log failed signState attempt

### DIFF
--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -426,7 +426,10 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
         )
       );
       const signedState = await timer('signing state', () =>
-        this.store.signState(channelId, nextState, tx)
+        this.store.signState(channelId, nextState, tx).catch(err => {
+          this.logger.error({err, nextState}, 'Unable to update channel');
+          throw err;
+        })
       );
       response.queueState(signedState, myIndex, channelId);
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -425,12 +425,14 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
           this.walletConfig.timingMetrics
         )
       );
-      const signedState = await timer('signing state', () =>
-        this.store.signState(channelId, nextState, tx).catch(err => {
+      const signedState = await timer('signing state', async () => {
+        try {
+          return this.store.signState(channelId, nextState, tx);
+        } catch (err) {
           this.logger.error({err, nextState}, 'Unable to update channel');
           throw err;
-        })
-      );
+        }
+      });
       response.queueState(signedState, myIndex, channelId);
 
       const channelState = await this.store.getChannel(channelId, tx);


### PR DESCRIPTION
fixes #2876

signState fails for some indexers when adding a hash.
See issue for context.