### PR TITLE
Remove one query from the critical path

### DIFF
--- a/packages/server-wallet/src/models/__test__/fixtures/channel.ts
+++ b/packages/server-wallet/src/models/__test__/fixtures/channel.ts
@@ -56,4 +56,7 @@ function overwriteVars(result: Channel, props?: {vars: SignedStateVarsWithHash[]
 export const withSupportedState = (
   signingWallets: SigningWallet[] = [alice(), bob()]
 ): Fixture<Channel> =>
-  fixture(channel(), flow(overwriteVars, addHashes, signVars(signingWallets), addChannelId));
+  fixture(
+    channel({signingWallet: signingWallets.length > 0 ? signingWallets[0] : undefined}),
+    flow(overwriteVars, addHashes, signVars(signingWallets), addChannelId)
+  );

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -11,6 +11,7 @@ import {ChainServiceInterface} from '../chain-service';
 import {ProtocolAction} from '../protocols/actions';
 import {recordFunctionMetrics} from '../metrics';
 import {WalletResponse} from '../wallet/response-builder';
+import {Channel} from '../models/channel';
 
 import {ObjectiveManagerParams} from './types';
 import {CloseChannelObjective} from './close-channel';
@@ -80,7 +81,8 @@ export class ObjectiveManager {
           switch (action.type) {
             case 'SignState': {
               const {myIndex, channelId} = protocolState.app;
-              const signedState = await this.store.signState(action.channelId, action, tx);
+              const channel = await Channel.forId(channelId, tx);
+              const signedState = await this.store.signState(channel, action, tx);
               response.queueState(signedState, myIndex, channelId);
               return;
             }

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -37,7 +37,9 @@ describe('signState', () => {
   let c: Channel;
 
   beforeEach(async () => {
-    c = await Channel.query(knex).insert(channel({vars: [stateWithHashSignedBy([bob()])()]}));
+    c = await Channel.query(knex)
+      .insert(channel({vars: [stateWithHashSignedBy([bob()])()]}))
+      .withGraphFetched('signingWallet');
   });
 
   it('signs the state, returning the signed state', async () => {
@@ -45,12 +47,12 @@ describe('signState', () => {
     expect(c.latestSignedByMe).toBeUndefined();
     const state = {...c.vars[0], ...c.channelConstants};
     const signature = signState(state, alice().privateKey).signature;
-    const result = await store.signState(c.channelId, c.vars[0], tx);
+    const result = await store.signState(c, c.vars[0], tx);
     expect(result).toMatchObject({...state, signatures: [{signature, signer: alice().address}]});
   });
 
   it('uses a transaction', async () => {
-    const updatedC = await store.signState(c.channelId, c.vars[0], tx);
+    const updatedC = await store.signState(c, c.vars[0], tx);
     expect(updatedC).toBeDefined();
 
     // Fetch the current channel outside the transaction context

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -409,7 +409,11 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
         {channelId}
       );
     };
-    const criticalCode: AppHandler<Promise<SingleChannelOutput>> = async (tx, channel) => {
+    const criticalCode: AppHandler<Promise<SingleChannelOutput>> = async (
+      tx,
+      channel,
+      channelRecord
+    ) => {
       const response = WalletResponse.initialize();
       const {myIndex} = channel;
 
@@ -426,7 +430,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       );
       const signedState = await timer('signing state', async () => {
         try {
-          return this.store.signState(channelId, nextState, tx);
+          return this.store.signState(channelRecord, nextState, tx);
         } catch (err) {
           this.logger.error({err, nextState}, 'Unable to update channel');
           throw err;
@@ -440,7 +444,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       return response.singleChannelOutput();
     };
 
-    return this.store.lockApp(channelId, criticalCode, handleMissingChannel);
+    return this.store.lockApp(channelId, criticalCode, handleMissingChannel, true);
   }
 
   async closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput> {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -50,6 +50,7 @@ import {
 import {DBAdmin} from '../db-admin/db-admin';
 import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
+import {Channel} from '../models/channel';
 
 import {Store, AppHandler, MissingAppHandler} from './store';
 import {WalletInterface} from './types';
@@ -602,8 +603,8 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
             switch (action.type) {
               case 'SignLedgerState': {
                 const {myIndex, channelId} = protocolState.fundingChannel;
-
-                const signedState = await this.store.signState(channelId, action.stateToSign, tx);
+                const channel = await Channel.forId(channelId, tx);
+                const signedState = await this.store.signState(channel, action.stateToSign, tx);
 
                 response.queueState(signedState, myIndex, channelId);
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -409,11 +409,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
         {channelId}
       );
     };
-    const criticalCode: AppHandler<Promise<SingleChannelOutput>> = async (
-      tx,
-      channel,
-      channelRecord
-    ) => {
+    const criticalCode: AppHandler<Promise<SingleChannelOutput>> = async (tx, channel) => {
       const response = WalletResponse.initialize();
       const {myIndex} = channel;
 
@@ -424,13 +420,13 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
       const nextState = getOrThrow(
         recordFunctionMetrics(
-          UpdateChannel.updateChannel({channelId, appData, outcome}, channel),
+          UpdateChannel.updateChannel({channelId, appData, outcome}, channel.protocolState),
           this.walletConfig.timingMetrics
         )
       );
       const signedState = await timer('signing state', async () => {
         try {
-          return this.store.signState(channelRecord, nextState, tx);
+          return this.store.signState(channel, nextState, tx);
         } catch (err) {
           this.logger.error({err, nextState}, 'Unable to update channel');
           throw err;


### PR DESCRIPTION
With this change, I see a consistent ~15% increase in throughput on my machine (2018 15" Macbook Pro)

`master`:
```

┌─────────┬────────┬────────┬────────┬────────┬───────────┬──────────┬─────────┐
│ Stat    │ 2.5%   │ 50%    │ 97.5%  │ 99%    │ Avg       │ Stdev    │ Max     │
├─────────┼────────┼────────┼────────┼────────┼───────────┼──────────┼─────────┤
│ Latency │ 429 ms │ 469 ms │ 663 ms │ 965 ms │ 490.36 ms │ 86.47 ms │ 1351 ms │
└─────────┴────────┴────────┴────────┴────────┴───────────┴──────────┴─────────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Req/Sec   │ 13      │ 13      │ 52      │ 57      │ 50.6    │ 8.33    │ 13      │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes/Sec │ 1.59 kB │ 1.59 kB │ 6.35 kB │ 6.96 kB │ 6.17 kB │ 1.02 kB │ 1.59 kB │
└───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
```

This branch:
```

┌─────────┬────────┬────────┬────────┬────────┬───────────┬──────────┬─────────┐
│ Stat    │ 2.5%   │ 50%    │ 97.5%  │ 99%    │ Avg       │ Stdev    │ Max     │
├─────────┼────────┼────────┼────────┼────────┼───────────┼──────────┼─────────┤
│ Latency │ 381 ms │ 411 ms │ 573 ms │ 635 ms │ 426.93 ms │ 70.51 ms │ 1343 ms │
└─────────┴────────┴────────┴────────┴────────┴───────────┴──────────┴─────────┘
┌───────────┬────────┬─────────┬─────────┬─────────┬─────────┬───────┬────────┐
│ Stat      │ 1%     │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev │ Min    │
├───────────┼────────┼─────────┼─────────┼─────────┼─────────┼───────┼────────┤
│ Req/Sec   │ 9      │ 42      │ 61      │ 65      │ 58.35   │ 8.19  │ 9      │
├───────────┼────────┼─────────┼─────────┼─────────┼─────────┼───────┼────────┤
│ Bytes/Sec │ 1.1 kB │ 5.13 kB │ 7.44 kB │ 7.93 kB │ 7.12 kB │ 999 B │ 1.1 kB │
└───────────┴────────┴─────────┴─────────┴─────────┴─────────┴───────┴────────┘
```