### PR TITLE
fix: remove store.destroy method

### DIFF
--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -89,10 +89,6 @@ export class Store {
     }
   }
 
-  async destroy(): Promise<void> {
-    await this.knex.destroy();
-  }
-
   async addSigningKey(privateKey: PrivateKey): Promise<void> {
     await this.getOrCreateSigningAddress(new ethers.Wallet(privateKey));
   }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -193,7 +193,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
   }
 
   public async destroy(): Promise<void> {
-    await this.store.destroy(); // TODO this destroys this.knex(), which seems quite unexpected
+    await this.knex.destroy();
     this.chainService.destructor();
   }
 


### PR DESCRIPTION
Method is only used in one place and that one place is essentially hiding complexity of  modifiying the property of the parent class itself that is using it — no need to overcomplicate things
