### PR TITLE
chore: mark some wallet methods as private

### DIFF
--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -520,7 +520,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
     }
   }
 
-  async _pushMessage(wirePayload: WirePayload, response: WalletResponse): Promise<void> {
+  private async _pushMessage(wirePayload: WirePayload, response: WalletResponse): Promise<void> {
     const store = this.store;
 
     const {channelIds, channelResults: fromStoring} = await this.store.pushMessage(wirePayload);
@@ -540,13 +540,13 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
     }
   }
 
-  takeActions = async (channels: Bytes32[], response: WalletResponse): Promise<void> => {
+  private async takeActions(channels: Bytes32[], response: WalletResponse): Promise<void> {
     let needToCrank = true;
     while (needToCrank) {
       await this.crankUntilIdle(channels, response);
       needToCrank = await this.processLedgerQueue(channels, response);
     }
-  };
+  }
 
   private async processLedgerQueue(
     channels: Bytes32[],


### PR DESCRIPTION
Should avoid potential scenarios where some code unknowingly uses these meant-to-be-private methods
