### PR TITLE
Await registerChannelWithChainService

### DIFF
--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -365,7 +365,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
     await this.takeActions(channelIds, response);
 
-    channelIds.map(id => this.registerChannelWithChainService(id));
+    await Promise.all(channelIds.map(id => this.registerChannelWithChainService(id)));
 
     return response.multipleChannelOutput();
   }


### PR DESCRIPTION
Await `registerChannelWithChainService` so we don't have a bunch of queries attempting to execute after the method has finished executing.

This is an immediate fix for https://github.com/statechannels/the-graph/pull/337

We should probably create a separate issue to discuss longer term implications of this.