### PR TITLE
test: increase number of tokens minted in Token.sol contract

### DIFF
--- a/packages/nitro-protocol/contracts/Token.sol
+++ b/packages/nitro-protocol/contracts/Token.sol
@@ -3,13 +3,13 @@ pragma solidity 0.7.4;
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 /**
- * @dev This contract extends an ERC20 implementation, and mints 10,000 tokens to the deploying account. Used for testing purposes.
+ * @dev This contract extends an ERC20 implementation, and mints 10,000,000,000 tokens to the deploying account. Used for testing purposes.
  */
 contract Token is ERC20 {
     /**
-     * @dev Constructor function minting 10,000 tokens to the msg.sender (deploying account).
+     * @dev Constructor function minting 10,000,000,000 tokens to the msg.sender (deploying account).
      */
     constructor(uint256) ERC20('TestToken', 'TEST') {
-        _mint(msg.sender, 10000);
+        _mint(msg.sender, 10000000000);
     }
 }


### PR DESCRIPTION
In an end to end stress test with The Graph we require several billion tokens and absent the asset holder I'm using this test artifact, but I'm limited to 10,000 tokens.