### PR TITLE
Do not allow non variable data in the db

### DIFF
--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -10,7 +10,7 @@ beforeEach(async () => seedAlicesSigningWallet(knex));
 afterAll(async () => await knex.destroy());
 
 it('can insert Channel instances to, and fetch them from, the database', async () => {
-  const vars = [stateWithHashSignedBy()()];
+  const vars = [stateWithHashSignedBy()({channelNonce: 1234})];
   const c1 = channel({channelNonce: 1234, vars});
 
   await Channel.query(knex)
@@ -39,9 +39,8 @@ it('does not store extraneous fields in the variables property', async () => {
 });
 
 it('can insert multiple channels instances within a transaction', async () => {
-  const vars = [stateWithHashSignedBy()()];
-  const c1 = channel({vars});
-  const c2 = channel({channelNonce: 1234, vars});
+  const c1 = channel({vars: [stateWithHashSignedBy()()]});
+  const c2 = channel({channelNonce: 1234, vars: [stateWithHashSignedBy()({channelNonce: 1234})]});
 
   await Channel.transaction(knex, async tx => {
     await Channel.query(tx).insert(c1);

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -22,6 +22,7 @@ import {
   ChannelStateFunding,
 } from '../protocols/state';
 import {WalletError, Values} from '../errors/wallet-error';
+import {dropNonVariables} from '../state-utils';
 
 import {SigningWallet} from './signing-wallet';
 import {Funding} from './funding';
@@ -190,6 +191,8 @@ export class Channel extends Model implements RequiredColumns {
         correctChannelId,
       });
     }
+    // Prevent extraneous fields from being stored
+    this.vars = this.vars.map(sv => dropNonVariables(sv));
 
     this.vars.map(sv => {
       const correctHash = hashState({...this.channelConstants, ...sv});

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -44,7 +44,7 @@ it("signs a final state when it's my turn", async () => {
 it("accepts and sends an objective when it isn't my turn", async () => {
   const appData = '0x0f00';
   const turnNum = 8;
-  const runningState = {turnNum, appData};
+  const runningState = {turnNum, appData, channelNonce: 2};
   const c = channel({
     channelNonce: 2,
     vars: [stateWithHashSignedBy([alice(), bob()])(runningState)],
@@ -69,7 +69,7 @@ it("signs a final state when it's my turn for many channels at once", async () =
   for (let i = 3; i < 7; i++) {
     const c = channel({
       channelNonce: i,
-      vars: [stateWithHashSignedBy([alice(), bob()])(runningState)],
+      vars: [stateWithHashSignedBy([alice(), bob()])({...runningState, channelNonce: i})],
     });
     await Channel.query(w.knex).insert(c);
     channelIds.push(c.channelId);

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import {Channel} from '../../../models/channel';
 import {Wallet} from '../..';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
@@ -35,7 +37,7 @@ it('returns an outgoing message with the latest state', async () => {
     appData,
     participants,
   };
-  const nextState = {turnNum: turnNum + 1, appData};
+  const nextState = {turnNum: turnNum + 1, appData, participants};
   const c = channel({
     participants,
     vars: [
@@ -45,7 +47,10 @@ it('returns an outgoing message with the latest state', async () => {
   });
 
   const inserted = await Channel.query(w.knex).insert(c);
-  expect(inserted.vars).toMatchObject([runningState, nextState]);
+  expect(inserted.vars).toMatchObject([
+    _.omit(runningState, ['participants']),
+    _.omit(nextState, ['participants']),
+  ]);
 
   const channelId = c.channelId;
 


### PR DESCRIPTION
Use the `dropNonVariables` to prevent additional fields being stored in the database.

Fixes #2780 
