### PR TITLE
refactor: wire format validators include useful data

### DIFF
--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
@@ -64,6 +64,7 @@ export class WorkerManager {
     const resultPromise = new Promise<MultipleChannelOutput>((resolve, reject) =>
       worker.once('message', (response: Either<Error, MultipleChannelOutput>) => {
         this.pool?.release(worker);
+
         if (isLeft(response)) {
           reject(response.left);
         } else {

--- a/packages/wire-format/package.json
+++ b/packages/wire-format/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-prettier": "3.1.2",
     "jest": "26.4.2",
     "lint-staged": "10.0.4",
+    "lodash": "^4.17.20",
     "ts-jest": "26.4.1",
     "ts-json-schema-generator": "0.74.0",
     "typescript": "4.0.3"

--- a/packages/wire-format/package.json
+++ b/packages/wire-format/package.json
@@ -11,6 +11,7 @@
     "@types/eslint": "7.2.3",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/jest": "26.0.14",
+    "@types/lodash": "^4.14.165",
     "@types/node": "14.11.2",
     "@typescript-eslint/eslint-plugin": "4.3.0",
     "@typescript-eslint/parser": "4.3.0",

--- a/packages/wire-format/src/__tests__/validator.test.ts
+++ b/packages/wire-format/src/__tests__/validator.test.ts
@@ -22,12 +22,15 @@ describe('validate message', () => {
     expect(validateMessage(good.goodMessage)).toEqual(good.goodMessage);
   });
 
-  expect.extend({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const _expect: any = Object.assign(expect);
+  _expect.extend({
     toThrowValidationError(
-      errThrower,
-      message,
-      jsonBlob,
-      validationError
+      errThrower: () => Error,
+      message: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jsonBlob: any,
+      validationError: string
     ): jest.CustomMatcherResult {
       try {
         errThrower();
@@ -69,38 +72,40 @@ describe('validate message', () => {
     }
   });
 
-  it('test custom matcher', () => {
-    // TODO: I don't know how to get rid of this type error
-    expect(() => validateMessage(bad.dataMissing)).toThrowValidationError(
+  it('returns helpful errors', () => {
+    // Otherwise jest complains about zero expectations
+    expect(0).toEqual(0);
+
+    _expect(() => validateMessage(bad.dataMissing)).toThrowValidationError(
       'Invalid message',
       bad.dataMissing,
       "Missing required property 'data' at root"
     );
-    expect(() => validateMessage(bad.extraProperty)).toThrowValidationError(
+    _expect(() => validateMessage(bad.extraProperty)).toThrowValidationError(
       'Invalid message',
       bad.extraProperty,
       "Unexpected property 'iShouldntBeHere' found at root "
     );
 
-    expect(() => validateMessage(bad.emptyState)).toThrowValidationError(
+    _expect(() => validateMessage(bad.emptyState)).toThrowValidationError(
       'Invalid message',
       bad.emptyState,
       "Missing required property 'appData' at root.data.signedStates[0]"
     );
 
-    expect(() => validateMessage(bad.emptyStringObjectives)).toThrowValidationError(
+    _expect(() => validateMessage(bad.emptyStringObjectives)).toThrowValidationError(
       'Invalid message',
       bad.emptyStringObjectives,
       'Property at root.data.objectives should be array'
     );
 
-    expect(() => validateMessage(bad.nullObjectives)).toThrowValidationError(
+    _expect(() => validateMessage(bad.nullObjectives)).toThrowValidationError(
       'Invalid message',
       bad.nullObjectives,
       'Property at root.data.objectives should be array'
     );
 
-    expect(() => validateState({turnNum: 3})).toThrowValidationError(
+    _expect(() => validateState({turnNum: 3})).toThrowValidationError(
       'Invalid state',
       {turnNum: 3},
       "Missing required property 'appData' at root"

--- a/packages/wire-format/src/__tests__/validator.test.ts
+++ b/packages/wire-format/src/__tests__/validator.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-try-expect */
 import {messageIsValid, validateMessage} from '../validator';
 
 import * as good from './good_sample_messages';
@@ -19,21 +20,82 @@ describe('validate message', () => {
     expect(validateMessage(good.goodMessage)).toEqual(good.goodMessage);
   });
 
-  it('returns helpful error messages', () => {
-    expect(() => validateMessage(bad.dataMissing)).toThrow(
-      `Validation Error: Missing required property 'data' at root`
+  expect.extend({
+    toThrowValidationError(
+      errThrower,
+      message,
+      jsonBlob,
+      validationError
+    ): jest.CustomMatcherResult {
+      try {
+        errThrower();
+      } catch (err) {
+        if (err.constructor.name !== 'WireFormatValidationError')
+          return {
+            pass: false,
+            message: () =>
+              `expected function to throw WireFormatValidationError, threw ${err.constructor.name}`
+          };
+
+        if (err.message !== message) {
+          return {
+            pass: false,
+            message: () => `expected message ${message}, received ${err.message}`
+          };
+        }
+        if (err.jsonBlob !== jsonBlob) {
+          return {
+            pass: false,
+            message: () => `incorrect json blob`
+          };
+        }
+
+        if (!err.errorMessages.includes(validationError)) {
+          return {
+            pass: false,
+            message: () =>
+              `expected validation error ${validationError}, received array ${JSON.stringify(
+                err.errorMessages
+              )}`
+          };
+        }
+
+        return {pass: true, message: () => 'passed'};
+      }
+
+      return {pass: false, message: () => 'expected to throw error'};
+    }
+  });
+
+  it('test custom matcher', () => {
+    // TODO: I don't know how to get rid of this type error
+    expect(() => validateMessage(bad.dataMissing)).toThrowValidationError(
+      'Invalid message',
+      bad.dataMissing,
+      "Missing required property 'data' at root"
     );
-    expect(() => validateMessage(bad.extraProperty)).toThrow(
-      `Validation Error: Unexpected property 'iShouldntBeHere' found at root`
+    expect(() => validateMessage(bad.extraProperty)).toThrowValidationError(
+      'Invalid message',
+      bad.extraProperty,
+      "Unexpected property 'iShouldntBeHere' found at root "
     );
-    expect(() => validateMessage(bad.emptyState)).toThrow(
-      `Validation Error: Missing required property 'appData' at root.data.signedStates[0]`
+
+    expect(() => validateMessage(bad.emptyState)).toThrowValidationError(
+      'Invalid message',
+      bad.emptyState,
+      "Missing required property 'appData' at root.data.signedStates[0]"
     );
-    expect(() => validateMessage(bad.emptyStringObjectives)).toThrow(
-      `Validation Error: Property at root.data.objectives should be array`
+
+    expect(() => validateMessage(bad.emptyStringObjectives)).toThrowValidationError(
+      'Invalid message',
+      bad.emptyStringObjectives,
+      'Property at root.data.objectives should be array'
     );
-    expect(() => validateMessage(bad.nullObjectives)).toThrow(
-      `Validation Error: Property at root.data.objectives should be array`
+
+    expect(() => validateMessage(bad.nullObjectives)).toThrowValidationError(
+      'Invalid message',
+      bad.nullObjectives,
+      'Property at root.data.objectives should be array'
     );
   });
 });

--- a/packages/wire-format/src/__tests__/validator.test.ts
+++ b/packages/wire-format/src/__tests__/validator.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable jest/no-try-expect */
-import {messageIsValid, validateMessage} from '../validator';
+import _ from 'lodash';
+
+import {messageIsValid, validateMessage, validateState} from '../validator';
 
 import * as good from './good_sample_messages';
 import * as bad from './bad_sample_messages';
@@ -43,7 +45,7 @@ describe('validate message', () => {
             message: () => `expected message ${message}, received ${err.message}`
           };
         }
-        if (err.jsonBlob !== jsonBlob) {
+        if (!_.isEqual(err.jsonBlob, jsonBlob)) {
           return {
             pass: false,
             message: () => `incorrect json blob`
@@ -96,6 +98,12 @@ describe('validate message', () => {
       'Invalid message',
       bad.nullObjectives,
       'Property at root.data.objectives should be array'
+    );
+
+    expect(() => validateState({turnNum: 3})).toThrowValidationError(
+      'Invalid state',
+      {turnNum: 3},
+      "Missing required property 'appData' at root"
     );
   });
 });

--- a/packages/wire-format/src/__tests__/validator.test.ts
+++ b/packages/wire-format/src/__tests__/validator.test.ts
@@ -22,9 +22,7 @@ describe('validate message', () => {
     expect(validateMessage(good.goodMessage)).toEqual(good.goodMessage);
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const _expect: any = Object.assign(expect);
-  _expect.extend({
+  expect.extend({
     toThrowValidationError(
       errThrower: () => Error,
       message: string,
@@ -76,36 +74,36 @@ describe('validate message', () => {
     // Otherwise jest complains about zero expectations
     expect(0).toEqual(0);
 
-    _expect(() => validateMessage(bad.dataMissing)).toThrowValidationError(
+    expect(() => validateMessage(bad.dataMissing)).toThrowValidationError(
       'Invalid message',
       bad.dataMissing,
       "Missing required property 'data' at root"
     );
-    _expect(() => validateMessage(bad.extraProperty)).toThrowValidationError(
+    expect(() => validateMessage(bad.extraProperty)).toThrowValidationError(
       'Invalid message',
       bad.extraProperty,
       "Unexpected property 'iShouldntBeHere' found at root "
     );
 
-    _expect(() => validateMessage(bad.emptyState)).toThrowValidationError(
+    expect(() => validateMessage(bad.emptyState)).toThrowValidationError(
       'Invalid message',
       bad.emptyState,
       "Missing required property 'appData' at root.data.signedStates[0]"
     );
 
-    _expect(() => validateMessage(bad.emptyStringObjectives)).toThrowValidationError(
+    expect(() => validateMessage(bad.emptyStringObjectives)).toThrowValidationError(
       'Invalid message',
       bad.emptyStringObjectives,
       'Property at root.data.objectives should be array'
     );
 
-    _expect(() => validateMessage(bad.nullObjectives)).toThrowValidationError(
+    expect(() => validateMessage(bad.nullObjectives)).toThrowValidationError(
       'Invalid message',
       bad.nullObjectives,
       'Property at root.data.objectives should be array'
     );
 
-    _expect(() => validateState({turnNum: 3})).toThrowValidationError(
+    expect(() => validateState({turnNum: 3})).toThrowValidationError(
       'Invalid state',
       {turnNum: 3},
       "Missing required property 'appData' at root"

--- a/packages/wire-format/src/globals.d.ts
+++ b/packages/wire-format/src/globals.d.ts
@@ -1,0 +1,8 @@
+export {};
+declare global {
+  namespace jest {
+    interface Matchers</* eslint-disable-line */ R> {
+      toThrowValidationError<R>(message: string, jsonBlob: any, validationError: string): R;
+    }
+  }
+}

--- a/packages/wire-format/src/globals.d.ts
+++ b/packages/wire-format/src/globals.d.ts
@@ -2,6 +2,7 @@ export {};
 declare global {
   namespace jest {
     interface Matchers</* eslint-disable-line */ R> {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       toThrowValidationError<R>(message: string, jsonBlob: any, validationError: string): R;
     }
   }

--- a/packages/wire-format/src/validator.ts
+++ b/packages/wire-format/src/validator.ts
@@ -33,10 +33,12 @@ function prettyPrintError(e: Ajv.ErrorObject): string {
 export const messageIsValid = ajv.compile({$ref: 'api.json#/definitions/Message'});
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function validateMessage(jsonBlob: object): Message {
-  const valid = messageIsValid(jsonBlob);
-  if (!valid) {
-    const errorMessages = messageIsValid.errors?.map(e => prettyPrintError(e)).join('; ');
-    throw new Error(`Validation Error: ${errorMessages}`);
+  if (!messageIsValid(jsonBlob)) {
+    throw new WireFormatValidationError(
+      'Invalid message',
+      jsonBlob,
+      messageIsValid.errors?.map(e => prettyPrintError(e))
+    );
   }
   return jsonBlob as Message;
 }
@@ -46,8 +48,18 @@ export const stateIsValid = ajv.compile({$ref: 'api.json#/definitions/SignedStat
 export function validateState(jsonBlob: object): SignedState {
   const valid = stateIsValid(jsonBlob);
   if (!valid) {
-    const errorMessages = stateIsValid.errors?.map(e => prettyPrintError(e)).join('; ');
-    throw new Error(`Validation Error: ${errorMessages}`);
+    throw new WireFormatValidationError(
+      'Invalid state',
+      jsonBlob,
+      stateIsValid.errors?.map(e => prettyPrintError(e))
+    );
   }
   return jsonBlob as SignedState;
+}
+
+class WireFormatValidationError extends Error {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(reason: string, public jsonBlob: any, public errorMessages?: string[]) {
+    super(reason);
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4732,6 +4732,11 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
   integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
 
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
 "@types/lru-cache@^5.1.0":
   version "5.1.0"
   resolved "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
@@ -4924,21 +4929,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@16.9.19", "@types/react@16.9.48":
   version "16.9.19"
   resolved "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
   integrity sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
-
-"@types/react@16.9.48":
-  version "16.9.48"
-  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.48.tgz#d3387329f070d1b1bc0ff4a54a54ceefd5a8485c"
-  integrity sha512-4ykBVswgYitPGMXFRxJCHkxJDU2rjfU3/zw67f8+dB7sNdVJXsrwqoYxz/stkAucymnEEbRPFmX7Ce5Mc/kJCw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
 
 "@types/secp256k1@^4.0.1":
   version "4.0.1"
@@ -5009,10 +5006,10 @@
   resolved "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
-"@types/webgl2@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz#c3b0f9d6b465c66138e84e64cb3bdf8373c2c279"
-  integrity sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw==
+"@types/webgl2@0.0.4", "@types/webgl2@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
+  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
 
 "@types/webpack-sources@*":
   version "2.0.0"
@@ -9275,11 +9272,6 @@ csstype@^2.2.0:
   version "2.6.13"
   resolved "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
-
-csstype@^3.0.2:
-  version "3.0.5"
-  resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
-  integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4924,13 +4924,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.9.19", "@types/react@16.9.48":
+"@types/react@*":
   version "16.9.19"
   resolved "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
   integrity sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@16.9.48":
+  version "16.9.48"
+  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.48.tgz#d3387329f070d1b1bc0ff4a54a54ceefd5a8485c"
+  integrity sha512-4ykBVswgYitPGMXFRxJCHkxJDU2rjfU3/zw67f8+dB7sNdVJXsrwqoYxz/stkAucymnEEbRPFmX7Ce5Mc/kJCw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/secp256k1@^4.0.1":
   version "4.0.1"
@@ -5001,10 +5009,10 @@
   resolved "https://registry.npmjs.org/@types/webgl-ext/-/webgl-ext-0.0.30.tgz#0ce498c16a41a23d15289e0b844d945b25f0fb9d"
   integrity sha512-LKVgNmBxN0BbljJrVUwkxwRYqzsAEPcZOe6S2T6ZaBDIrFp0qu4FNlpc5sM1tGbXUYFgdVQIoeLk1Y1UoblyEg==
 
-"@types/webgl2@0.0.4", "@types/webgl2@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
-  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
+"@types/webgl2@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.4.tgz#c3b0f9d6b465c66138e84e64cb3bdf8373c2c279"
+  integrity sha512-PACt1xdErJbMUOUweSrbVM7gSIYm1vTncW2hF6Os/EeWi6TXYAYMPp+8v6rzHmypE5gHrxaxZNXgMkJVIdZpHw==
 
 "@types/webpack-sources@*":
   version "2.0.0"
@@ -9267,6 +9275,11 @@ csstype@^2.2.0:
   version "2.6.13"
   resolved "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
+
+csstype@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
+  integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
Currently, we are seeing validation errors in The Graph testnet, and we don't know why: see https://github.com/graphprotocol/indexer/issues/107

```
> validateMessage({data: {foo: 'bar'}})
Uncaught WireFormatValidationError: Invalid message
    at validateMessage (/Users/andrewstewart/Code/magmo/monorepo/packages/wire-format/lib/src/validator.js:29:15) {
  jsonBlob: { data: { foo: 'bar' } },
  errorMessages: [ "Unexpected property 'foo' found at root.data " ]
}
```

This PR adds the jsonBlob so that we can debug this issue in the test network.