### PR TITLE
feat: catch external destination collisions

### DIFF
--- a/packages/nitro-protocol/src/contract/channel.ts
+++ b/packages/nitro-protocol/src/contract/channel.ts
@@ -8,12 +8,19 @@ export interface Channel {
   chainId: Uint256;
 }
 
+export function isExternalDestination(bytes32: Bytes32): boolean {
+  return /^0x(0{24})([a-fA-F0-9]{40})$/.test(bytes32);
+}
+
 export function getChannelId(channel: Channel): Bytes32 {
   const {chainId, participants, channelNonce} = channel;
-  return utils.keccak256(
+  const channelId = utils.keccak256(
     utils.defaultAbiCoder.encode(
       ['uint256', 'address[]', 'uint256'],
       [chainId, participants, channelNonce]
     )
   );
+  if (isExternalDestination(channelId))
+    throw Error('This channel would have an external destination as an id');
+  return channelId;
 }

--- a/packages/nitro-protocol/test/src/contract/external-destination.test.ts
+++ b/packages/nitro-protocol/test/src/contract/external-destination.test.ts
@@ -1,0 +1,12 @@
+import {isExternalDestination} from '../../../src/contract/channel';
+
+describe('isExternalDestination', () => {
+  it.each`
+    bytes32                                                                 | result
+    ${'0x0'}                                                                | ${false}
+    ${'0x0000000000000000000000002F0E2cB3c2c98E6AfB89A8c50cbEF0cB6B3DC35c'} | ${true}
+    ${'0x0000000040000000000000002F0E2cB3c2c98E6AfB89A8c50cbEF0cB6B3DC35c'} | ${false}
+  `('$bytes32 -- $result', ({bytes32, result}) => {
+    expect(isExternalDestination(bytes32)).toBe(result);
+  });
+});


### PR DESCRIPTION
when computing channelId
add a test for helper isExternalDestination

Note that this is extremely unlikely to happen in the first place.