### PR TITLE
perf: break out of loops a bit earlier

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -250,6 +250,7 @@ contract AssetHolder is IAssetHolder {
         for (uint256 i = 0; i < allocation.length; i++) {
             if (balance == 0) {
                 // if funds are completely depleted, keep the allocationItem and do not pay out
+                break;
             } else {
                 _amount = allocation[i].amount;
                 if (balance < _amount) {

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -343,7 +343,7 @@ contract AssetHolder is IAssetHolder {
         // first increase payouts according to guarantee
         for (uint256 i = 0; i < guarantee.destinations.length; i++) {
             if (balance == 0) {
-                    break;
+                break;
             }
             // for each destination in the guarantee
             bytes32 _destination = guarantee.destinations[i];

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -342,6 +342,9 @@ contract AssetHolder is IAssetHolder {
 
         // first increase payouts according to guarantee
         for (uint256 i = 0; i < guarantee.destinations.length; i++) {
+            if (balance == 0) {
+                    break;
+            }
             // for each destination in the guarantee
             bytes32 _destination = guarantee.destinations[i];
             for (uint256 j = 0; j < allocation.length; j++) {

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -10,6 +10,7 @@ import {
   randomExternalDestination,
   replaceAddressesAndBigNumberify,
   setupContracts,
+  writeGasConsumption,
 } from '../../test-helpers';
 import {encodeAllocation} from '../../../src/contract/outcome';
 
@@ -98,7 +99,8 @@ describe('transferAll', () => {
       if (reason) {
         await expectRevert(() => tx, reason);
       } else {
-        const {events: eventsFromLogs} = await (await tx).wait();
+        const {events: eventsFromLogs, gasUsed} = await (await tx).wait();
+        await writeGasConsumption('./transferAll.gas.md', name, gasUsed);
         const expectedEvents = [];
         Object.keys(events).forEach(destination => {
           if (events[destination] && events[destination].gt(0)) {


### PR DESCRIPTION
gas savings are very small, and can increase / decrease depending on input data (due to increase equality checks.) 

Currently:
```
 1. funded          -> 1 EOA:
20619 gas
 2. overfunded      -> 1 EOA:
26237 gas
 3. underfunded     -> 1 EOA:
29215 gas
 4. funded      -> 1 channel:
30197 gas
 5. overfunded  -> 1 channel:
45197 gas
 6. underfunded -> 1 channel:
48174 gas
 7. -> 2 EOA       full/full:
22828 gas
 8. -> 2 EOA         full/no:
30556 gas
 9. -> 2 EOA    full/partial:
33880 gas
10. -> 2 chan      full/full:
53590 gas
11. -> 2 chan        full/no:
49648 gas
12. -> 2 chan   full/partial:
71802 gas
```

As of e08e159
```
 1. funded          -> 1 EOA:
20618 gas
 2. overfunded      -> 1 EOA:
26236 gas
 3. underfunded     -> 1 EOA:
29214 gas
 4. funded      -> 1 channel:
30196 gas
 5. overfunded  -> 1 channel:
45196 gas
 6. underfunded -> 1 channel:
48173 gas
 7. -> 2 EOA       full/full:
22833 gas
 8. -> 2 EOA         full/no:
30495 gas
 9. -> 2 EOA    full/partial:
33878 gas
10. -> 2 chan      full/full:
53588 gas
11. -> 2 chan        full/no:
49599 gas
12. -> 2 chan   full/partial:
71800 gas
```

