### PR TITLE
feat(nitro-protocol): add claim method to AssetHolder

### DIFF
--- a/packages/docs-website/docs/protocol-tutorial/outcomes.md
+++ b/packages/docs-website/docs/protocol-tutorial/outcomes.md
@@ -67,6 +67,10 @@ A channel that has a guarantee outcome is said to be a guarantor channel.
 
 Now while we can _transfer_ assets out of a channel, the terminology is instead to _claim_ on a guarantor channel. Assets will be paid to beneficiaries of the _target_ channel, but in an order of precedence defined by the guarantor. More on this later.
 
+:::warning
+For simplicity, the on-chain code assumes that neither kind of allocation has any repeated entries.
+:::
+
 Constructing the right kind of object in typescript is straightforward:
 
 ```typescript

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -367,7 +367,7 @@ contract AssetHolder is IAssetHolder {
 
         for (j = 0; j < guarantee.destinations.length; j++) {
             // for each _destination in the guarantee
-            bytes32 _destination = guarantee.destinations[i];
+            bytes32 _destination = guarantee.destinations[j];
             // if destination matches the one that is passed in
             // loop over allocations in the target channel and decrease balance until we hit the specified destination
             if (_destination == destination) {

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -411,8 +411,9 @@ contract AssetHolder is IAssetHolder {
             );
             for (uint256 k = 0; k < allocation.length; k++) {
                 newAllocation[k] = allocation[k];
-                if (allocation[k].destination == destination) {
+                if (k == i) {
                     newAllocation[k].amount = residualAllocationAmount;
+                    break;
                 }
             }
             assetOutcomeHashes[guarantee.targetChannelId] = keccak256(

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -426,19 +426,20 @@ contract AssetHolder is IAssetHolder {
         }
 
         if (residualAllocationAmount == 0) {
-            Outcome.AllocationItem[] memory splicedAllocation = new Outcome.AllocationItem[](
-                allocation.length - 1
-            );
-            // full payout so we want to splice a shorter outcome
-            for (uint256 k = 0; k < i; k++) {
-                splicedAllocation[k] = allocation[k];
-            }
-            for (uint256 k = i + 1; k < allocation.length; k++) {
-                splicedAllocation[k - 1] = allocation[k];
-            }
-            if (splicedAllocation.length == 0) {
+            // We want to splice a shorter outcome
+            if (allocation.length == 1) {
+                // special case there are no allocations left in the target's outcome
                 delete assetOutcomeHashes[guarantee.targetChannelId];
             } else {
+                Outcome.AllocationItem[] memory splicedAllocation = new Outcome.AllocationItem[](
+                    allocation.length - 1
+                );
+                for (uint256 k = 0; k < i; k++) {
+                    splicedAllocation[k] = allocation[k];
+                }
+                for (uint256 k = i + 1; k < allocation.length; k++) {
+                    splicedAllocation[k - 1] = allocation[k];
+                }
                 assetOutcomeHashes[guarantee.targetChannelId] = keccak256(
                     abi.encode(
                         Outcome.AssetOutcome(
@@ -448,23 +449,21 @@ contract AssetHolder is IAssetHolder {
                     )
                 );
             }
-        }
 
-        if (residualAllocationAmount == 0) {
-        // we want to splice a shorter guarantee
-            bytes32[] memory newDestinations = new bytes32[](
-                guarantee.destinations.length - 1
-            );
-
-            for (uint256 k = 0; k < j; k++) {
-                newDestinations[k] = guarantee.destinations[k];
-            }
-            for (uint256 k = j + 1; k < allocation.length; k++) {
-                newDestinations[k - 1] = guarantee.destinations[k];
-            }
-            if (newDestinations.length == 0) {
+            if (guarantee.destinations.length == 1) {
+                // special case there are no destinations left in the guarantee
                 delete assetOutcomeHashes[guarantorChannelId];
             } else {
+                // we want to splice a shorter guarantee
+                bytes32[] memory newDestinations = new bytes32[](
+                    guarantee.destinations.length - 1
+                );
+                for (uint256 k = 0; k < j; k++) {
+                    newDestinations[k] = guarantee.destinations[k];
+                }
+                for (uint256 k = j + 1; k < allocation.length; k++) {
+                    newDestinations[k - 1] = guarantee.destinations[k];
+                }
                 assetOutcomeHashes[guarantorChannelId] = keccak256(abi.encode(Outcome.Guarantee(guarantee.targetChannelId, newDestinations)));
             }
         }

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -365,7 +365,7 @@ contract AssetHolder is IAssetHolder {
             if (balance == 0) {
                 revert('_claim | guarantorChannel affords 0 for destination');
             }
-            // for each _destination in the guarantee,
+            // for each destination in the guarantee,
             // find the first corresponding allocationItem in the target allocation
             bytes32 guaranteeDestination = guarantee.destinations[j];
             for (i = 0; i < allocation.length; i++) {
@@ -389,7 +389,7 @@ contract AssetHolder is IAssetHolder {
                             }
                             balance = balance.sub(_amount); // this isn't used after we break
                         }
-                    
+                    break;
                 }
             }
             if (affordsForDestination > 0) {

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -71,7 +71,7 @@ contract AssetHolder is IAssetHolder {
         Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes, (Outcome.Guarantee));
         _requireCorrectAllocationHash(guarantee.targetChannelId, allocationBytes);
         // effects and interactions
-        _claim(guarantorChannelId,guarantee, allocationBytes, destination);
+        _claim(guarantorChannelId, guarantee, allocationBytes, destination);
     }
 
     /**
@@ -238,7 +238,7 @@ contract AssetHolder is IAssetHolder {
                     )
                 )
             );
-        } 
+        }
 
         // storage updated BEFORE external contracts called (prevent reentrancy attacks)
         if (_isExternalDestination(destination)) {
@@ -247,7 +247,7 @@ contract AssetHolder is IAssetHolder {
             holdings[destination] += affordsForDestination;
         }
         // Event emitted
-        emit AssetTransferred(fromChannelId, destination, affordsForDestination);        
+        emit AssetTransferred(fromChannelId, destination, affordsForDestination);
     }
 
     /**
@@ -333,7 +333,7 @@ contract AssetHolder is IAssetHolder {
             } else {
                 holdings[allocation[m].destination] += payoutAmount;
             }
-            // Event emitted 
+            // Event emitted
             emit AssetTransferred(channelId, allocation[m].destination, payoutAmount);
         }
     }
@@ -353,8 +353,8 @@ contract AssetHolder is IAssetHolder {
         bytes32 destination
     ) internal {
         Outcome.AllocationItem[] memory allocation = abi.decode(
-        allocationBytes,
-        (Outcome.AllocationItem[])
+            allocationBytes,
+            (Outcome.AllocationItem[])
         );
         uint256 balance = holdings[guarantorChannelId];
         uint256 affordsForDestination;
@@ -372,23 +372,23 @@ contract AssetHolder is IAssetHolder {
                 if (allocation[i].destination == guaranteeDestination) {
                     // decrease balance
                     uint256 _amount = allocation[i].amount;
-                        if (balance < _amount) {
-                            if (guaranteeDestination == destination) {
-                                affordsForDestination = balance;
-                                residualAllocationAmount = _amount - balance;
-                                break;
-                                // i will point to index that should be modified or removed in the target outcome
-                            }
-                            balance = 0; // this isn't used after we break
-                        } else {
-                            if (guaranteeDestination == destination) {
-                                affordsForDestination = _amount;
-                                residualAllocationAmount = 0;
-                                break;
-                                // i will point to index that should be modified or removed in the target outcome
-                            }
-                            balance = balance.sub(_amount); // this isn't used after we break
+                    if (balance < _amount) {
+                        if (guaranteeDestination == destination) {
+                            affordsForDestination = balance;
+                            residualAllocationAmount = _amount - balance;
+                            break;
+                            // i will point to index that should be modified or removed in the target outcome
                         }
+                        balance = 0; // this isn't used after we break
+                    } else {
+                        if (guaranteeDestination == destination) {
+                            affordsForDestination = _amount;
+                            residualAllocationAmount = 0;
+                            break;
+                            // i will point to index that should be modified or removed in the target outcome
+                        }
+                        balance = balance.sub(_amount); // this isn't used after we break
+                    }
                     break;
                 }
             }
@@ -397,15 +397,15 @@ contract AssetHolder is IAssetHolder {
                 break;
             }
         }
-        
+
         require(affordsForDestination > 0, '_claim | guarantor affords 0 for destination');
-        
+
         // effects
         holdings[guarantorChannelId] -= affordsForDestination;
 
         // construct new outcome for target
         if (residualAllocationAmount > 0) {
-            // new allocation identical save for a single entry 
+            // new allocation identical save for a single entry
             Outcome.AllocationItem[] memory newAllocation = new Outcome.AllocationItem[](
                 allocation.length
             );
@@ -454,12 +454,12 @@ contract AssetHolder is IAssetHolder {
 
         // storage updated BEFORE external contracts called (prevent reentrancy attacks)
         if (_isExternalDestination(destination)) {
-            _transferAsset(_bytes32ToAddress(destination), affordsForDestination);    
+            _transferAsset(_bytes32ToAddress(destination), affordsForDestination);
         } else {
             holdings[destination] += affordsForDestination;
         }
         // Event emitted
-        emit AssetTransferred(guarantorChannelId, destination, affordsForDestination);        
+        emit AssetTransferred(guarantorChannelId, destination, affordsForDestination);
     }
 
     /**

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -43,8 +43,6 @@ const reason5 =
 const reason6 =
   'AssetHolder | submitted guaranteeBytes data does not match stored assetOutcomeHash';
 
-const reason7 = '_claim | guarantorChannel affords 0 for destination';
-
 // 1. claim G1 (step 1 of figure 23 of nitro paper)
 // 2. claim G2 (step 2 of figure 23 of nitro paper)
 // 3. claim G1 (step 1 of alternative in figure 23 of nitro paper)
@@ -55,7 +53,7 @@ describe('claim', () => {
   it.each`
     name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | destination | tOutcomeAfter   | heldAfter | payouts   | events    | reason
     ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${{I: 5}} | ${undefined}
-    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5, B: 5}} | ${{g: 5}} | ${{}}     | ${{}}     | ${reason7}
+    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${{B: 5}} | ${undefined}
     ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${{I: 5}} | ${undefined}
     ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${'A'}      | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}} | ${{A: 5}} | ${undefined}
     ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${{}}     | ${reason5}

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -1,0 +1,187 @@
+import {expectRevert} from '@statechannels/devtools';
+import {Contract, BigNumber, utils} from 'ethers';
+
+import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
+import {claimAllArgs} from '../../../src/contract/transaction-creators/asset-holder';
+import {
+  allocationToParams,
+  AssetOutcomeShortHand,
+  assetTransferredEventsFromPayouts,
+  compileEventsFromLogs,
+  getRandomNonce,
+  getTestProvider,
+  guaranteeToParams,
+  randomChannelId,
+  randomExternalDestination,
+  replaceAddressesAndBigNumberify,
+  setupContracts,
+  writeGasConsumption,
+} from '../../test-helpers';
+
+const provider = getTestProvider();
+const addresses = {
+  // Channels
+  t: undefined, // Target
+  g: undefined, // Guarantor
+  // Externals
+  I: randomExternalDestination(),
+  A: randomExternalDestination(),
+  B: randomExternalDestination(),
+};
+let AssetHolder: Contract;
+
+beforeAll(async () => {
+  AssetHolder = await setupContracts(
+    provider,
+    AssetHolderArtifact,
+    process.env.TEST_ASSET_HOLDER_ADDRESS
+  );
+});
+
+const reason5 =
+  'AssetHolder | submitted allocationBytes data does not match stored assetOutcomeHash';
+const reason6 =
+  'AssetHolder | submitted guaranteeBytes data does not match stored assetOutcomeHash';
+
+const reason7 = '_claim | guarantorChannel affords 0 for destination';
+
+// 1. claim G1 (step 1 of figure 23 of nitro paper)
+// 2. claim G2 (step 2 of figure 23 of nitro paper)
+// 3. claim G1 (step 1 of alternative in figure 23 of nitro paper)
+// 4. claim G2 (step 2 of alternative of figure 23 of nitro paper)
+
+// Amounts are valueString representations of wei
+describe('claim', () => {
+  it.each`
+    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | destination | tOutcomeAfter   | heldAfter | payouts   | events    | reason
+    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${{I: 5}} | ${undefined}
+    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5, B: 5}} | ${{g: 5}} | ${{}}     | ${{}}     | ${reason7}
+    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${{I: 5}} | ${undefined}
+    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${'A'}      | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}} | ${{A: 5}} | ${undefined}
+    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${{}}     | ${reason5}
+    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${{}}     | ${reason6}
+    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 7}} | ${{B: 5}} | ${{B: 5}} | ${undefined}
+    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 7}} | ${{B: 5}} | ${{B: 5}} | ${undefined}
+  `(
+    '$name',
+    async ({
+      name,
+      heldBefore,
+      guaranteeDestinations,
+      tOutcomeBefore,
+      destination,
+      tOutcomeAfter,
+      heldAfter,
+      payouts,
+      events,
+      reason,
+    }: {
+      name;
+      heldBefore: AssetOutcomeShortHand;
+      guaranteeDestinations;
+      tOutcomeBefore: AssetOutcomeShortHand;
+      destination: string;
+      tOutcomeAfter: AssetOutcomeShortHand;
+      heldAfter: AssetOutcomeShortHand;
+      payouts: AssetOutcomeShortHand;
+      events: AssetOutcomeShortHand;
+      reason;
+    }) => {
+      // Compute channelIds
+      const tNonce = getRandomNonce(name);
+      const gNonce = getRandomNonce(name + 'g');
+      const targetId = randomChannelId(tNonce);
+      const guarantorId = randomChannelId(gNonce);
+      addresses.t = targetId;
+      addresses.g = guarantorId;
+
+      // Transform input data (unpack addresses and BigNumber amounts)
+      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts, events] = [
+        heldBefore,
+        tOutcomeBefore,
+        tOutcomeAfter,
+        heldAfter,
+        payouts,
+        events,
+      ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
+      guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
+      destination = addresses[destination];
+
+      // Set holdings (only works on test contract)
+      new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
+        // Key must be either in heldBefore or heldAfter or both
+        const amount = heldBefore[key] ? heldBefore[key] : BigNumber.from(0);
+        await (await AssetHolder.setHoldings(key, amount)).wait();
+        expect((await AssetHolder.holdings(key)).eq(amount)).toBe(true);
+      });
+
+      // Compute an appropriate allocation.
+      const allocation = [];
+      Object.keys(tOutcomeBefore).forEach(key =>
+        allocation.push({destination: key, amount: tOutcomeBefore[key]})
+      );
+      const [, outcomeHash] = allocationToParams(allocation);
+
+      // Set outcomeHash for target
+      await (await AssetHolder.setAssetOutcomeHashPermissionless(targetId, outcomeHash)).wait();
+      expect(await AssetHolder.assetOutcomeHashes(targetId)).toBe(outcomeHash);
+
+      // Compute an appropriate guarantee
+
+      const guarantee = {
+        destinations: guaranteeDestinations,
+        targetChannelId: targetId,
+      };
+
+      if (guaranteeDestinations.length > 0) {
+        const [, gOutcomeContentHash] = guaranteeToParams(guarantee);
+
+        // Set outcomeHash for guarantor
+        await (
+          await AssetHolder.setAssetOutcomeHashPermissionless(guarantorId, gOutcomeContentHash)
+        ).wait();
+        expect(await AssetHolder.assetOutcomeHashes(guarantorId)).toBe(gOutcomeContentHash);
+      }
+
+      const tx = AssetHolder.claim(
+        ...claimAllArgs(guarantorId, guarantee, allocation),
+        destination
+      );
+
+      // Call method in a slightly different way if expecting a revert
+      if (reason) {
+        await expectRevert(() => tx, reason);
+      } else {
+        // Compile event expectations
+        const expectedEvents = assetTransferredEventsFromPayouts(
+          guarantorId,
+          events,
+          AssetHolder.address
+        );
+
+        // Extract logs
+        const {logs, gasUsed} = await (await tx).wait();
+        await writeGasConsumption('./claim.gas.md', name, gasUsed);
+
+        // Compile events from logs
+        const eventsFromLogs = compileEventsFromLogs(logs, [AssetHolder]);
+
+        // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!
+        expect(eventsFromLogs).toMatchObject(expectedEvents);
+
+        // Check new holdings
+        Object.keys(heldAfter).forEach(async key =>
+          expect(await AssetHolder.holdings(key)).toEqual(heldAfter[key])
+        );
+
+        // Check new outcomeHash
+        const allocationAfter = [];
+        Object.keys(tOutcomeAfter).forEach(key => {
+          allocationAfter.push({destination: key, amount: tOutcomeAfter[key]});
+        });
+        const [, expectedNewOutcomeHash] = allocationToParams(allocationAfter);
+        expect(await AssetHolder.assetOutcomeHashes(targetId)).toEqual(expectedNewOutcomeHash);
+      }
+    }
+  );
+});


### PR DESCRIPTION
Includes #2931

See also #2814 .

Gas costs (see accompanying test suite)

```
1. straight-through guarantee, 3 destinations:
40559 gas
3. swap guarantee,             3 destinations:
40547 gas
4. straight-through guarantee, 2 destinations:
37586 gas
7. swap guarantee, overfunded, 2 destinations:
53094 gas
8. underspecified guarantee, overfunded      :
52393 gas
```