### PR TITLE
perf: make many public methods external

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -18,7 +18,7 @@ contract AssetHolder is IAssetHolder {
     mapping(bytes32 => bytes32) public assetOutcomeHashes;
 
     // **************
-    // Public methods
+    // External methods
     // **************
 
     /**
@@ -28,11 +28,7 @@ contract AssetHolder is IAssetHolder {
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
      * @param destination External destination or channel to transfer funds *to*.
      */
-    function transfer(
-        bytes32 fromChannelId,
-        bytes memory allocationBytes,
-        bytes32 destination
-    ) public {
+    function transfer(bytes32 fromChannelId, bytes calldata allocationBytes, bytes32 destination) external {
         // checks
         _requireCorrectAllocationHash(fromChannelId, allocationBytes);
         // effects and interactions
@@ -45,7 +41,7 @@ contract AssetHolder is IAssetHolder {
      * @param channelId Unique identifier for a state channel.
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
      */
-    function transferAll(bytes32 channelId, bytes memory allocationBytes) public override {
+    function transferAll(bytes32 channelId, bytes calldata allocationBytes) external override {
         // checks
         _requireCorrectAllocationHash(channelId, allocationBytes);
         // effects and interactions
@@ -62,10 +58,10 @@ contract AssetHolder is IAssetHolder {
      */
     function claim(
         bytes32 guarantorChannelId,
-        bytes memory guaranteeBytes,
-        bytes memory allocationBytes,
+        bytes calldata guaranteeBytes,
+        bytes calldata allocationBytes,
         bytes32 destination
-    ) public {
+    ) external {
         // checks
         _requireCorrectGuaranteeHash(guarantorChannelId, guaranteeBytes);
         Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes, (Outcome.Guarantee));
@@ -83,9 +79,9 @@ contract AssetHolder is IAssetHolder {
      */
     function claimAll(
         bytes32 guarantorChannelId,
-        bytes memory guaranteeBytes,
-        bytes memory allocationBytes
-    ) public override {
+        bytes calldata guaranteeBytes,
+        bytes calldata allocationBytes
+    ) external override {
         // checks
         _requireCorrectGuaranteeHash(guarantorChannelId, guaranteeBytes);
         Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes, (Outcome.Guarantee));

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -28,7 +28,11 @@ contract AssetHolder is IAssetHolder {
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
      * @param destination External destination or channel to transfer funds *to*.
      */
-    function transfer(bytes32 fromChannelId, bytes calldata allocationBytes, bytes32 destination) external {
+    function transfer(
+        bytes32 fromChannelId,
+        bytes calldata allocationBytes,
+        bytes32 destination
+    ) external {
         // checks
         _requireCorrectAllocationHash(fromChannelId, allocationBytes);
         // effects and interactions

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -34,7 +34,7 @@ contract ERC20AssetHolder is AssetHolder {
         bytes32 destination,
         uint256 expectedHeld,
         uint256 amount
-    ) public {
+    ) external {
         require(!_isExternalDestination(destination), 'Cannot deposit to external destination');
         uint256 amountDeposited;
         // this allows participants to reduce the wait between deposits, while protecting them from losing funds by depositing too early. Specifically it protects against the scenario:

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -29,7 +29,7 @@ contract ETHAssetHolder is AssetHolder {
         bytes32 destination,
         uint256 expectedHeld,
         uint256 amount
-    ) public payable {
+    ) external payable {
         require(!_isExternalDestination(destination), 'Cannot deposit to external destination');
         require(msg.value == amount, 'Insufficient ETH for ETH deposit');
         uint256 amountDeposited;

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -22,7 +22,7 @@ contract ForceMove is IForceMove {
      * @return fingerprint Unique identifier for the channel's current state, up to hash collisions.
      */
     function getChannelStorage(bytes32 channelId)
-        public
+        external
         view
         returns (
             uint48 turnNumRecord,
@@ -52,7 +52,7 @@ contract ForceMove is IForceMove {
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
-    ) public override {
+    ) external override {
         bytes32 channelId = _getChannelId(fixedPart);
 
         if (_mode(channelId) == ChannelMode.Open) {
@@ -121,7 +121,7 @@ contract ForceMove is IForceMove {
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
-    ) public override {
+    ) external override {
         bytes32 channelId = _getChannelId(fixedPart);
         (uint48 turnNumRecord, uint48 finalizesAt, ) = _getChannelStorage(channelId);
 
@@ -193,7 +193,7 @@ contract ForceMove is IForceMove {
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
-    ) public override {
+    ) external override {
         bytes32 channelId = _getChannelId(fixedPart);
 
         // checks
@@ -232,7 +232,7 @@ contract ForceMove is IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) public override {
+    ) external override {
         bytes32 channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -59,7 +59,7 @@ interface IForceMove {
      * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
      */
     function challenge(
-        FixedPart memory fixedPart,
+        FixedPart calldata fixedPart,
         uint48 largestTurnNum,
         IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount, // how many of the states are final
@@ -98,7 +98,7 @@ interface IForceMove {
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      */
     function checkpoint(
-        FixedPart memory fixedPart,
+        FixedPart calldata fixedPart,
         uint48 largestTurnNum,
         IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount, // how many of the states are final
@@ -119,7 +119,7 @@ interface IForceMove {
      */
     function conclude(
         uint48 largestTurnNum,
-        FixedPart memory fixedPart,
+        FixedPart calldata fixedPart,
         bytes32 appPartHash,
         bytes32 outcomeHash,
         uint8 numStates,

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -61,11 +61,11 @@ interface IForceMove {
     function challenge(
         FixedPart calldata fixedPart,
         uint48 largestTurnNum,
-        IForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] calldata variableParts,
         uint8 isFinalCount, // how many of the states are final
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat,
-        Signature memory challengerSig
+        Signature[] calldata sigs,
+        uint8[] calldata whoSignedWhat,
+        Signature calldata challengerSig
     ) external;
 
     /**
@@ -79,12 +79,12 @@ interface IForceMove {
      */
     function respond(
         address challenger,
-        bool[2] memory isFinalAB,
-        FixedPart memory fixedPart,
-        IForceMoveApp.VariablePart[2] memory variablePartAB,
+        bool[2] calldata isFinalAB,
+        FixedPart calldata fixedPart,
+        IForceMoveApp.VariablePart[2] calldata variablePartAB,
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
-        Signature memory sig
+        Signature calldata sig
     ) external;
 
     /**
@@ -100,10 +100,10 @@ interface IForceMove {
     function checkpoint(
         FixedPart calldata fixedPart,
         uint48 largestTurnNum,
-        IForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] calldata variableParts,
         uint8 isFinalCount, // how many of the states are final
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat
+        Signature[] calldata sigs,
+        uint8[] calldata whoSignedWhat
     ) external;
 
     /**
@@ -123,8 +123,8 @@ interface IForceMove {
         bytes32 appPartHash,
         bytes32 outcomeHash,
         uint8 numStates,
-        uint8[] memory whoSignedWhat,
-        Signature[] memory sigs
+        uint8[] calldata whoSignedWhat,
+        Signature[] calldata sigs
     ) external;
 
     // events


### PR DESCRIPTION
In theory this saves gas, although I am not seeing that in our test suite. 