### PR TITLE
fix: fix incorrect ledger funding insufficient funds error string equality check

### DIFF
--- a/packages/server-wallet/src/protocols/process-ledger-queue.ts
+++ b/packages/server-wallet/src/protocols/process-ledger-queue.ts
@@ -10,6 +10,7 @@ import {
   areAllocationItemsEqual,
   BN,
   AllocationItem,
+  Errors,
 } from '@statechannels/wallet-core';
 import {Transaction} from 'knex';
 
@@ -88,9 +89,9 @@ const allocateFundsToChannels = (
     } catch (e) {
       if (
         // A proposed channel wants more funds than are available from a participant
-        e.message.toString() === 'Insufficient funds in fundingChannel channel' ||
+        e.message.toString() === Errors.InsufficientFunds ||
         // There is no participant balance at all (exactly 0 left)
-        e.message.toString() === 'Destination missing from ledger channel'
+        e.message.toString() === Errors.DestinationMissing
       )
         insufficientFunds.push(channelId);
       return outcome;


### PR DESCRIPTION
Accidentally used wrong string equality check here: https://github.com/statechannels/statechannels/commit/aa92714f0070b3136ae8433d711ba278a3177f16#diff-964098fad72916397eba2a9798e08abfcd87f0c109078cb67deb01ed7a916321R55.

TODO:
- [x] Add failing teswt case
