### PR TITLE
perf: optimize queries for ledger requests on run loop

### DIFF
--- a/packages/server-wallet/src/db/migrations/20201121100937_ledger_requests_idx.ts
+++ b/packages/server-wallet/src/db/migrations/20201121100937_ledger_requests_idx.ts
@@ -1,0 +1,11 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('ledger_requests', function(table) {
+    table.index('ledger_channel_id');
+  });
+}
+
+export async function down(_knex: Knex): Promise<void> {
+  //
+}

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -469,6 +469,44 @@ export class Store {
     return LedgerRequest.getRequest(channelId, type, tx || this.knex);
   }
 
+  async getChannelIdsPendingLedgerFundingFrom(
+    ledgerChannelIds: Bytes32[],
+    tx?: Transaction
+  ): Promise<Bytes32[]> {
+    const query = await LedgerRequest.query(tx || this.knex)
+      .whereIn('ledgerChannelId', ledgerChannelIds)
+      .where({status: 'pending'})
+      .distinct('channelToBeFunded')
+      .select('channelToBeFunded');
+
+    return _.map(query, 'channelToBeFunded');
+  }
+
+  async getLedgerChannelIdsFundingChannels(
+    channelToBeFunded: Bytes32[],
+    tx?: Transaction
+  ): Promise<Bytes32[]> {
+    const query = await LedgerRequest.query(tx || this.knex)
+      .whereIn('channelToBeFunded', channelToBeFunded)
+      .where({status: 'pending'})
+      .distinct('ledgerChannelId')
+      .select('ledgerChannelId');
+
+    return _.map(query, 'ledgerChannelId');
+  }
+
+  async filterChannelIdsByIsLedger(
+    maybeLedgerChannelIds: Bytes32[],
+    tx?: Transaction
+  ): Promise<Bytes32[]> {
+    const query = await Channel.query(tx || this.knex)
+      .whereIn('channelId', maybeLedgerChannelIds)
+      .whereNotNull('assetHolderAddress')
+      .select('channelId');
+
+    return _.map(query, 'channelId');
+  }
+
   async getAllPendingLedgerRequests(tx?: Transaction): Promise<LedgerRequestType[]> {
     return LedgerRequest.getAllPendingRequests(tx || this.knex);
   }


### PR DESCRIPTION
When thinking about performance a bit I looked at this code and thought I could optimize the query made to the DB a bit instead of doing filtering in JS.
