### PR TITLE
style: consistent prefixing of contract interfaces with 'I'

### DIFF
--- a/packages/docs-website/docs/contract-api/contract-inheritance.mdx
+++ b/packages/docs-website/docs/contract-api/contract-inheritance.mdx
@@ -57,16 +57,16 @@ click IERC20 "/contract-api/natspec/IERC20";
 graph TD
 linkStyle default interpolate basis
 Outcome([Outcome])
-Adjudicator
+IAdjudicator
 IForceMove
 ForceMove
 NitroAdjudicator
 TESTForceMove
 TESTNitroAdjudicator
-ForceMoveApp-.-> ForceMove
+IForceMoveApp-.-> ForceMove
 IForceMove--> ForceMove
 Outcome--> NitroAdjudicator
-Adjudicator--> NitroAdjudicator
+IAdjudicator--> NitroAdjudicator
 ForceMove--> NitroAdjudicator
 ForceMove-->TESTForceMove
 NitroAdjudicator--> TESTNitroAdjudicator
@@ -77,15 +77,14 @@ classDef Interface fill:#ffffff,stroke:#de1065,stroke-dasharray: 5 5
 classDef TestContract fill:#fafe4f,stroke-width:0px;
 classDef Library fill:#ffffff,stroke:#656664,stroke-dasharray: 5 5
 class Outcome,SafeMath Library;
-class IForceMove Abstraction;
-class Adjudicator,ForceMoveApp Interface;
+class IAdjudicator,IForceMoveApp, IForceMove Interface;
 class ForceMove Contract;
 class TESTForceMove,TESTNitroAdjudicator TestContract;
 class NitroAdjudicator DeployedContract;
-click ForceMoveApp "/contract-api/natspec/ForceMoveApp";
+click IForceMoveApp "/contract-api/natspec/IForceMoveApp";
 click SafeMath "/contract-api/natspec/SafeMath";
 click Outcome "/contract-api/natspec/Outcome";
-click Adjudicator "/contract-api/natspec/Adjudicator";
+click IAdjudicator "/contract-api/natspec/IAdjudicator";
 click ForceMove "/contract-api/natspec/ForceMove";
 click IForceMove "/contract-api/natspec/IForceMove";
 click NitroAdjudicator "/contract-api/natspec/NitroAdjudicator";
@@ -106,12 +105,12 @@ ERC20
 IERC20
 Token
 CountingApp
-ForceMoveApp
+IForceMoveApp
 SingleAssetPayments
 TrivialApp
-ForceMoveApp-->CountingApp
-ForceMoveApp-->TrivialApp
-ForceMoveApp-->SingleAssetPayments
+IForceMoveApp-->CountingApp
+IForceMoveApp-->TrivialApp
+IForceMoveApp-->SingleAssetPayments
 IERC20-->ERC20
 ERC20-->Token
 classDef Contract fill:#ffffff,stroke:#656664;
@@ -121,12 +120,12 @@ classDef Interface fill:#ffffff,stroke:#de1065,stroke-dasharray: 5 5
 classDef TestContract fill:#fafe4f,stroke-width:0px;
 classDef fill:#ffffff,stroke:#656664,stroke-dasharray: 5 5
 class Outcome,SafeMath Library;
-class ForceMoveApp,IERC20 Interface;
+class IForceMoveApp,IERC20 Interface;
 class SingleAssetPayments,TrivialApp,CountingApp,ERC20 Contract;
 class Token TestContract;
 click CountingApp "/contract-api/natspec/CountingApp";
 click ERC20 "/contract-api/natspec/ERC20";
-click ForceMoveApp "/contract-api/natspec/ForceMoveApp";
+click IForceMoveApp "/contract-api/natspec/IForceMoveApp";
 click IERC20 "/contract-api/natspec/IERC20";
 click Outcome "/contract-api/natspec/Outcome";
 click SafeMath "/contract-api/natspec/SafeMath";
@@ -150,13 +149,11 @@ Interface-->|Inherited by| Contract
 Library([Library])-.->|Imported by| Contract
 DeployedContract
 classDef Contract fill:#ffffff,stroke:#656664;
-classDef Abstraction fill:#ffffff,stroke:#8dc404,stroke-dasharray: 5 5
 classDef TestContract fill:#fafe4f,stroke-width:0px;
 classDef Interface fill:#ffffff,stroke:#de1065,stroke-dasharray: 5 5
 classDef Library fill:#ffffff,stroke:#656664,stroke-dasharray: 5 5
 classDef DeployedContract fill:#ffffff,stroke:#3531ff,stroke-width:3px;
 class Library Library;
-class Abstraction Abstraction;
 class Contract Contract;
 class TESTContract TestContract;
 class Interface Interface;

--- a/packages/nitro-protocol/contracts/CountingApp.sol
+++ b/packages/nitro-protocol/contracts/CountingApp.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
-import './interfaces/ForceMoveApp.sol';
+import './interfaces/IForceMoveApp.sol';
 
 /**
  * @dev The CountingApp contracts complies with the ForceMoveApp interface and allows only for a simple counter to be incremented. Used for testing purposes.
  */
-contract CountingApp is ForceMoveApp {
+contract CountingApp is IForceMoveApp {
     struct CountingAppData {
         uint256 counter;
     }

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -3,7 +3,7 @@ pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/IForceMove.sol';
-import './interfaces/ForceMoveApp.sol';
+import './interfaces/IForceMoveApp.sol';
 
 /**
  * @dev An implementation of ForceMove protocol, which allows state channels to be adjudicated and finalized.
@@ -47,7 +47,7 @@ contract ForceMove is IForceMove {
     function challenge(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
@@ -117,7 +117,7 @@ contract ForceMove is IForceMove {
         address challenger,
         bool[2] memory isFinalAB,
         FixedPart memory fixedPart,
-        ForceMoveApp.VariablePart[2] memory variablePartAB,
+        IForceMoveApp.VariablePart[2] memory variablePartAB,
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
@@ -189,7 +189,7 @@ contract ForceMove is IForceMove {
     function checkpoint(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
@@ -413,7 +413,7 @@ contract ForceMove is IForceMove {
      */
     function _requireStateSupportedBy(
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount,
         bytes32 channelId,
         FixedPart memory fixedPart,
@@ -456,7 +456,7 @@ contract ForceMove is IForceMove {
         // returns stateHashes array if valid
         // else, reverts
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount,
         bytes32 channelId,
         FixedPart memory fixedPart
@@ -502,7 +502,7 @@ contract ForceMove is IForceMove {
     function _requireValidTransition(
         uint256 nParticipants,
         bool[2] memory isFinalAB, // [a.isFinal, b.isFinal]
-        ForceMoveApp.VariablePart[2] memory ab, // [a,b]
+        IForceMoveApp.VariablePart[2] memory ab, // [a,b]
         uint48 turnNumB,
         address appDefinition
     ) internal pure returns (bool) {
@@ -530,7 +530,7 @@ contract ForceMove is IForceMove {
                 );
             } else {
                 require(
-                    ForceMoveApp(appDefinition).validTransition(
+                    IForceMoveApp(appDefinition).validTransition(
                         ab[0],
                         ab[1],
                         turnNumB,

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
-import './interfaces/Adjudicator.sol';
+import './interfaces/IAdjudicator.sol';
 import './ForceMove.sol';
 import './Outcome.sol';
 import './AssetHolder.sol';
@@ -10,7 +10,7 @@ import './AssetHolder.sol';
 /**
  * @dev The NitroAdjudicator contract extends ForceMove and hence inherits all ForceMove methods, and also extends and implements the Adjudicator interface, allowing for a finalized outcome to be pushed to an asset holder.
  */
-contract NitroAdjudicator is Adjudicator, ForceMove {
+contract NitroAdjudicator is IAdjudicator, ForceMove {
     /**
      * @notice Allows a finalized channel's outcome to be decoded and one or more AssetOutcomes registered in external Asset Holder contracts.
      * @dev Allows a finalized channel's outcome to be decoded and one or more AssetOutcomes registered in external Asset Holder contracts.
@@ -187,7 +187,7 @@ contract NitroAdjudicator is Adjudicator, ForceMove {
     function validTransition(
         uint256 nParticipants,
         bool[2] memory isFinalAB, // [a.isFinal, b.isFinal]
-        ForceMoveApp.VariablePart[2] memory ab, // [a,b]
+        IForceMoveApp.VariablePart[2] memory ab, // [a,b]
         uint48 turnNumB,
         address appDefinition
     ) public pure returns (bool) {

--- a/packages/nitro-protocol/contracts/TrivialApp.sol
+++ b/packages/nitro-protocol/contracts/TrivialApp.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
-import './interfaces/ForceMoveApp.sol';
+import './interfaces/IForceMoveApp.sol';
 
 /**
  * @dev The Trivialp contracts complies with the ForceMoveApp interface and allows all transitions, regardless of the data. Used for testing purposes.
  */
-contract TrivialApp is ForceMoveApp {
+contract TrivialApp is IForceMoveApp {
     /**
      * @notice Encodes trivial rules.
      * @dev Encodes trivial rules.

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
-import '../interfaces/ForceMoveApp.sol';
+import '../interfaces/IForceMoveApp.sol';
 import '../Outcome.sol';
 
 /**
  * @dev The SingleAssetPayments contract complies with the ForceMoveApp interface and implements a simple payment channel with a single asset type only.
  */
-contract SingleAssetPayments is ForceMoveApp {
+contract SingleAssetPayments is IForceMoveApp {
     /**
      * @notice Encodes the payment channel update rules.
      * @dev Encodes the payment channel update rules.

--- a/packages/nitro-protocol/contracts/interfaces/IAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAdjudicator.sol
@@ -3,9 +3,9 @@ pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
 /**
- * @dev An Adjudicator Interface calls for a method that allows a finalized outcome to be pushed to an asset holder.
+ * @dev The IAdjudicator Interface calls for a method that allows a finalized outcome to be pushed to an asset holder.
  */
-interface Adjudicator {
+interface IAdjudicator {
     /**
      * @notice Allows a finalized channel's outcome to be decoded and one or more AssetOutcomes registered in external Asset Holder contracts.
      * @dev Allows a finalized channel's outcome to be decoded and one or more AssetOutcomes registered in external Asset Holder contracts.

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
-import './ForceMoveApp.sol';
+import './IForceMoveApp.sol';
 
 /**
- * @dev The IForceMove contract abstraction defines the interface that an implementation of ForceMove should implement. ForceMove protocol allows state channels to be adjudicated and finalized.
+ * @dev The IForceMove interface defines the interface that an implementation of ForceMove should implement. ForceMove protocol allows state channels to be adjudicated and finalized.
  */
-abstract contract IForceMove {
+interface IForceMove {
     struct Signature {
         uint8 v;
         bytes32 r;
@@ -48,6 +48,7 @@ abstract contract IForceMove {
     enum ChannelMode {Open, Challenge, Finalized}
 
     /**
+    
      * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
@@ -61,12 +62,12 @@ abstract contract IForceMove {
     function challenge(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
-    ) public virtual;
+    ) external ;
 
     /**
      * @notice Repsonds to an ongoing challenge registered against a state channel.
@@ -81,11 +82,11 @@ abstract contract IForceMove {
         address challenger,
         bool[2] memory isFinalAB,
         FixedPart memory fixedPart,
-        ForceMoveApp.VariablePart[2] memory variablePartAB,
+        IForceMoveApp.VariablePart[2] memory variablePartAB,
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
-    ) public virtual;
+    ) external ;
 
     /**
      * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
@@ -100,11 +101,11 @@ abstract contract IForceMove {
     function checkpoint(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        IForceMoveApp.VariablePart[] memory variableParts,
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
-    ) public virtual;
+    ) external ;
 
     /**
      * @notice Finalizes a channel by providing a finalization proof.
@@ -125,7 +126,7 @@ abstract contract IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) public virtual;
+    ) external ;
 
     // events
 
@@ -149,7 +150,7 @@ abstract contract IForceMove {
         address challenger,
         bool isFinal,
         FixedPart fixedPart,
-        ForceMoveApp.VariablePart[] variableParts,
+        IForceMoveApp.VariablePart[] variableParts,
         Signature[] sigs,
         uint8[] whoSignedWhat
     );

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -48,7 +48,6 @@ interface IForceMove {
     enum ChannelMode {Open, Challenge, Finalized}
 
     /**
-    
      * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
@@ -67,7 +66,7 @@ interface IForceMove {
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
-    ) external ;
+    ) external;
 
     /**
      * @notice Repsonds to an ongoing challenge registered against a state channel.
@@ -86,7 +85,7 @@ interface IForceMove {
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
-    ) external ;
+    ) external;
 
     /**
      * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
@@ -105,7 +104,7 @@ interface IForceMove {
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
-    ) external ;
+    ) external;
 
     /**
      * @notice Finalizes a channel by providing a finalization proof.
@@ -126,7 +125,7 @@ interface IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) external ;
+    ) external;
 
     // events
 

--- a/packages/nitro-protocol/contracts/interfaces/IForceMoveApp.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMoveApp.sol
@@ -3,9 +3,9 @@ pragma solidity 0.7.4;
 pragma experimental ABIEncoderV2;
 
 /**
- * @dev The ForceMoveApp interface calls for its children to implement an application-specific validTransition function, defining the state machine of a ForceMove state channel DApp.
+ * @dev The IForceMoveApp interface calls for its children to implement an application-specific validTransition function, defining the state machine of a ForceMove state channel DApp.
  */
-interface ForceMoveApp {
+interface IForceMoveApp {
     struct VariablePart {
         bytes outcome;
         bytes appData;

--- a/packages/nitro-protocol/src/contract/force-move-app.ts
+++ b/packages/nitro-protocol/src/contract/force-move-app.ts
@@ -1,6 +1,6 @@
 import {utils, Contract} from 'ethers';
 
-import ForceMoveAppArtifact from '../../artifacts/contracts/interfaces/ForceMoveApp.sol/ForceMoveApp.json';
+import ForceMoveAppArtifact from '../../artifacts/contracts/interfaces/IForceMoveApp.sol/IForceMoveApp.json';
 import {State, getVariablePart} from '../contract/state';
 
 //  https://github.com/ethers-io/ethers.js/issues/602#issuecomment-574671078


### PR DESCRIPTION
Also, make `IForceMove` an `interface`, not an abstract contract. 