### PR TITLE
perf: remove unecessary abi.encode

### DIFF
--- a/packages/nitro-protocol/contracts/CountingApp.sol
+++ b/packages/nitro-protocol/contracts/CountingApp.sol
@@ -39,6 +39,7 @@ contract CountingApp is IForceMoveApp {
             appData(b.appData).counter == appData(a.appData).counter + 1,
             'CountingApp: Counter must be incremented'
         );
+        // Note this is gas inefficient, and inferior to _bytesEqual in use elsewhere
         require(
             keccak256(b.outcome) == keccak256(a.outcome),
             'CountingApp: Outcome must not change'

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -107,7 +107,7 @@ contract ForceMove is IForceMove {
                 uint48(block.timestamp) + fixedPart.challengeDuration,
                 supportedStateHash,
                 challenger,
-                keccak256(abi.encode(variableParts[variableParts.length - 1].outcome))
+                keccak256(variableParts[variableParts.length - 1].outcome)
             )
         );
     }
@@ -135,8 +135,8 @@ contract ForceMove is IForceMove {
         bytes32 channelId = _getChannelId(fixedPart);
         (uint48 turnNumRecord, uint48 finalizesAt, ) = _getChannelStorage(channelId);
 
-        bytes32 challengeOutcomeHash = _hashOutcome(variablePartAB[0].outcome);
-        bytes32 responseOutcomeHash = _hashOutcome(variablePartAB[1].outcome);
+        bytes32 challengeOutcomeHash = keccak256(variablePartAB[0].outcome);
+        bytes32 responseOutcomeHash = keccak256(variablePartAB[1].outcome);
         bytes32 challengeStateHash = _hashState(
             turnNumRecord,
             isFinalAB[0],
@@ -268,7 +268,7 @@ contract ForceMove is IForceMove {
      * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
      * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
-     * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
+     * @param outcomeHash The keccak256 of the `outcome`. Applies to all stats in the finalization proof.
      * @param numStates The number of states in the finalization proof.
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param sigs An array of signatures that support the state with the `largestTurnNum`.
@@ -533,7 +533,7 @@ contract ForceMove is IForceMove {
                 channelId,
                 fixedPart,
                 variableParts[i].appData,
-                _hashOutcome(variableParts[i].outcome)
+                keccak256(variableParts[i].outcome)
             );
             if (turnNum < largestTurnNum) {
                 _requireValidTransition(
@@ -872,16 +872,6 @@ contract ForceMove is IForceMove {
                     )
                 )
             );
-    }
-
-    /**
-     * @notice Computes the hash of a given outcome.
-     * @dev Computes the hash of a given outcome.
-     * @param outcome An outcome
-     * @return The outcomeHash
-     */
-    function _hashOutcome(bytes memory outcome) internal pure returns (bytes32) {
-        return keccak256(abi.encode(outcome));
     }
 
     function getChainID() public pure returns (uint256) {

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -32,7 +32,7 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
         // requirements
         _requireChannelFinalized(channelId);
 
-        bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
+        bytes32 outcomeHash = keccak256(outcomeBytes);
 
         _requireMatchingStorage(
             ChannelData(turnNumRecord, finalizesAt, stateHash, challengerAddress, outcomeHash),
@@ -72,7 +72,7 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
         // requirements
         _requireChannelFinalized(channelId);
 
-        bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
+        bytes32 outcomeHash = keccak256(outcomeBytes);
 
         _requireMatchingStorage(
             ChannelData(turnNumRecord, finalizesAt, stateHash, challengerAddress, outcomeHash),
@@ -102,7 +102,7 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
     ) public {
-        bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
+        bytes32 outcomeHash = keccak256(outcomeBytes);
         bytes32 channelId = _conclude(
             largestTurnNum,
             fixedPart,

--- a/packages/nitro-protocol/src/contract/outcome.ts
+++ b/packages/nitro-protocol/src/contract/outcome.ts
@@ -143,7 +143,7 @@ export type Outcome = AssetOutcome[];
 
 export function hashOutcome(outcome: Outcome): Bytes32 {
   const encodedOutcome = encodeOutcome(outcome);
-  return utils.keccak256(utils.defaultAbiCoder.encode(['bytes'], [encodedOutcome]));
+  return utils.keccak256(encodedOutcome);
 }
 
 export function decodeOutcome(encodedOutcome: Bytes): Outcome {

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -9,7 +9,7 @@
     "@statechannels/client-api-schema": "0.5.0",
     "@statechannels/nitro-protocol": "0.10.1",
     "@statechannels/wallet-core": "0.9.10",
-    "@statechannels/wasm-utils": "0.1.5",
+    "@statechannels/wasm-utils": "0.1.6",
     "@statechannels/wire-format": "0.8.3",
     "ethers": "5.0.12",
     "eventemitter3": "4.0.7",

--- a/packages/server-wallet/src/models/__test__/signing-wallet.test.ts
+++ b/packages/server-wallet/src/models/__test__/signing-wallet.test.ts
@@ -11,7 +11,7 @@ const stateWithHash = addHash(state);
 
 const expectedResult = {
   signature:
-    '0xc822d44e1452d7d869bbf5ae1d274d01a6f8dee9cd9e7ddb4089882b911ef9bb7c30a36208e9088f9b96748b2aa345e523693cce5fde823c8ebab92db202275c1c',
+    '0x9bc711f3547842642e600120cd369631b5f78ac96bc905ea63503eb6604da7c450fb117ed25110e93a3b4e124baae36f0095224ede7ef225abff93c524399d321c',
   signer: makeAddress('0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'),
 };
 describe('SigningWallet class', () => {

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -48,27 +48,6 @@ export const wireStateFormat: WireState = {
     '0x59069c99dd52a7766e439ef9344e5cee7a51625ec366095cbd7bad66075a54e924ab48b08a683deff7e3642d8017178e55990b2073d169eec64a7fef60648a6a1b'
   ]
 };
-
-console.log(
-  joinSignature(
-    signState(
-      {
-        turnNum: wireStateFormat.turnNum,
-        isFinal: wireStateFormat.isFinal,
-        channel: {
-          chainId: wireStateFormat.chainId,
-          channelNonce: wireStateFormat.channelNonce,
-          participants: wireStateFormat.participants.map(p => p.signingAddress)
-        },
-        challengeDuration: wireStateFormat.challengeDuration,
-        outcome: wireStateFormat.outcome as [SimpleAllocation],
-        appDefinition: wireStateFormat.appDefinition,
-        appData: wireStateFormat.appData
-      },
-      '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
-    ).signature
-  )
-);
 const wireStateFormat2: WireState = {
   ...wireStateFormat,
   channelNonce: 124,

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -45,10 +45,30 @@ export const wireStateFormat: WireState = {
   ],
   turnNum: 1,
   signatures: [
-    '0xef7e226a43c52d4b8f7b14f13acdf9e75d871ea5c51235fbc4d538acf84c61c4727431f0cc83d0f566e222a21d35ae4d8d2a0dd4428cba7bf95bf7b3f11ad0c61c'
+    '0x59069c99dd52a7766e439ef9344e5cee7a51625ec366095cbd7bad66075a54e924ab48b08a683deff7e3642d8017178e55990b2073d169eec64a7fef60648a6a1b'
   ]
 };
 
+console.log(
+  joinSignature(
+    signState(
+      {
+        turnNum: wireStateFormat.turnNum,
+        isFinal: wireStateFormat.isFinal,
+        channel: {
+          chainId: wireStateFormat.chainId,
+          channelNonce: wireStateFormat.channelNonce,
+          participants: wireStateFormat.participants.map(p => p.signingAddress)
+        },
+        challengeDuration: wireStateFormat.challengeDuration,
+        outcome: wireStateFormat.outcome as [SimpleAllocation],
+        appDefinition: wireStateFormat.appDefinition,
+        appData: wireStateFormat.appData
+      },
+      '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
+    ).signature
+  )
+);
 const wireStateFormat2: WireState = {
   ...wireStateFormat,
   channelNonce: 124,
@@ -105,7 +125,7 @@ export const internalStateFormat: SignedState = {
   signatures: [
     {
       signature:
-        '0xef7e226a43c52d4b8f7b14f13acdf9e75d871ea5c51235fbc4d538acf84c61c4727431f0cc83d0f566e222a21d35ae4d8d2a0dd4428cba7bf95bf7b3f11ad0c61c',
+        '0x59069c99dd52a7766e439ef9344e5cee7a51625ec366095cbd7bad66075a54e924ab48b08a683deff7e3642d8017178e55990b2073d169eec64a7fef60648a6a1b',
       signer: makeAddress('0x2222e21c8019b14da16235319d34b5dd83e644a9')
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,10 +3925,10 @@
     normalize-url "4.5.0"
     pino "6.2.0"
 
-"@statechannels/wasm-utils@0.1.5":
-  version "0.1.5"
-  resolved "https://registry.npmjs.org/@statechannels/wasm-utils/-/wasm-utils-0.1.5.tgz#0d4b2def2a910a188ae3bb3f7482268b85c5097d"
-  integrity sha512-lFilI8dOcLDCYOEmIXEK3rZJLY9xwnIezchqP5KbECU8+brHedWRTMQyuAoPH6jV+UWHz1zD73jLMxlyOG7yog==
+"@statechannels/wasm-utils@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@statechannels/wasm-utils/-/wasm-utils-0.1.6.tgz#2b0b7de5a63f158d4202718ebb5bdd3a910b0c6c"
+  integrity sha512-eUBeE/ChxksfhrGHwsdxx5ncvZnY4JkdBta6Y8mcgtJxQxdoxjqrJYiBbyZY5LqgW9mPowAaRQ09gm6Eebf4mQ==
 
 "@svgr/babel-plugin-add-jsx-attribute@^5.4.0":
   version "5.4.0"


### PR DESCRIPTION
 - [x] will require updates to `wasm-utils` to get the tests passing.
