### PR TITLE
ci: upload gas artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,7 @@ commands:
         type: string
     steps:
       - store_artifacts:
-          path: /home/circleci/project/packages/<< parameters.package >>/gas.json
-          destination: << parameters.package >>-gas.json
-      - store_artifacts:
-          path: /home/circleci/project/packages/<< parameters.package >>/gas.md
-          destination: << parameters.package >>-gas.md
+          path: /home/circleci/project/packages/<< parameters.package >>/gas-artifacts
 
   upload_artifacts:
     description: 'Upload generic artifacts'

--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ junit.xml
 **/deployment/network-map.json
 **/.etherlime-store/
 **/.outputParameter
-**/gas.json
-**/gas.md
-**/*.gas.md
 storybook-static
 
 

--- a/packages/nitro-protocol/.gitignore
+++ b/packages/nitro-protocol/.gitignore
@@ -19,9 +19,9 @@ built
 lib
 dist
 .outputParameter
-docs/natspec/*.md
 ganache/*[.js,.json]
 .eslintcache
+gas-artifacts
 
 # hardhat directories
 cache

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -159,7 +159,7 @@ describe('claim', () => {
 
         // Extract logs
         const {logs, gasUsed} = await (await tx).wait();
-        await writeGasConsumption('./claim.gas.md', name, gasUsed);
+        await writeGasConsumption('claim.gas.md', name, gasUsed);
 
         // Compile events from logs
         const eventsFromLogs = compileEventsFromLogs(logs, [AssetHolder]);

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -153,7 +153,7 @@ describe('claimAll', () => {
 
         // Extract logs
         const {logs, gasUsed} = await (await tx).wait();
-        await writeGasConsumption('./claimAll.gas.md', name, gasUsed);
+        await writeGasConsumption('claimAll.gas.md', name, gasUsed);
 
         // Compile events from logs
         const eventsFromLogs = compileEventsFromLogs(logs, [AssetHolder]);

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -100,7 +100,7 @@ describe('transferAll', () => {
         await expectRevert(() => tx, reason);
       } else {
         const {events: eventsFromLogs, gasUsed} = await (await tx).wait();
-        await writeGasConsumption('./transferAll.gas.md', name, gasUsed);
+        await writeGasConsumption('transferAll.gas.md', name, gasUsed);
         const expectedEvents = [];
         Object.keys(events).forEach(destination => {
           if (events[destination] && events[destination].gt(0)) {

--- a/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
@@ -96,7 +96,7 @@ describe('deposit', () => {
       await expectRevert(() => tx, reasonString);
     } else {
       const {gasUsed, events} = await (await tx).wait();
-      await writeGasConsumption('./erc20-deposit.gas.md', description, gasUsed);
+      await writeGasConsumption('erc20-deposit.gas.md', description, gasUsed);
 
       const depositedEvent = getDepositedEvent(events);
       expect(depositedEvent).toMatchObject({

--- a/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
@@ -82,7 +82,7 @@ describe('deposit', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const {gasUsed, events} = await (await tx).wait();
-        await writeGasConsumption('./deposit.gas.md', description, gasUsed);
+        await writeGasConsumption('deposit.gas.md', description, gasUsed);
         const event = getDepositedEvent(events);
         expect(event).toMatchObject({
           destination,

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -209,7 +209,7 @@ describe('challenge', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const receipt = await (await tx).wait();
-        await writeGasConsumption('./challenge.gas.md', description, receipt.gasUsed);
+        await writeGasConsumption('challenge.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
 
         // Catch ChallengeRegistered event

--- a/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
@@ -136,7 +136,7 @@ describe('respond', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const receipt = await (await tx).wait();
-        await writeGasConsumption('./respond.gas.md', description, receipt.gasUsed);
+        await writeGasConsumption('respond.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
 
         expect(event.args).toMatchObject({

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -381,7 +381,14 @@ export async function writeGasConsumption(
   description: string,
   gas: BigNumberish
 ): Promise<void> {
-  await fs.appendFile(filename, description + ':\n' + gas.toString() + ' gas\n\n', err => {
+  const dir = './gas-artifacts';
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+  }
+
+  const path = dir + '/' + filename;
+  await fs.appendFile(path, description + ':\n' + gas.toString() + ' gas\n\n', err => {
     if (err) throw err;
   });
 }


### PR DESCRIPTION
currently we only upload gas information from `jest-gas-reporter`, which actually is not working (empty output). 

This change makes it so we have a record from our test suite. Should make it far easier to track gas savings/regressions in pull requests. 