### PR TITLE
ci: invalidate cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ postgres: &postgres
 
 save_dep: &save_dep
   save_cache:
-    key: v10-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v11-dependency-cache-{{ checksum "yarn.lock" }}
     paths:
       - node_modules
       - packages/client-api-schema/node_modules
@@ -42,7 +42,7 @@ save_dep: &save_dep
 
 restore_dep: &restore_dep
   restore_cache:
-    key: v10-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v11-dependency-cache-{{ checksum "yarn.lock" }}
 
 # END MACROS
 


### PR DESCRIPTION
I am yet again seeing cache hits followed by yarn installing stuff. Invalidating periodically seems to help. 