### PR TITLE
More protocol refactors

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -19,20 +19,22 @@ function extractReferencedChannels(objective: Objective): string[] {
 }
 
 type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+
 /**
  * Objectives that are currently supported by the server wallet (wire format)
  */
 export type SupportedWireObjective = OpenChannel | CloseChannel;
+
+export type DBOpenChannelObjective = OpenChannel & {objectiveId: string; status: ObjectiveStatus};
+export type DBCloseChannelObjective = CloseChannel & {objectiveId: string; status: ObjectiveStatus};
+
 /**
  * A DBObjective is a wire objective with a status and an objectiveId
  *
  * Limited to 'OpenChannel' and 'CloseChannel', which are the only objectives
  * that are currently supported by the server wallet
  */
-export type DBObjective = SupportedWireObjective & {
-  objectiveId: string;
-  status: ObjectiveStatus;
-};
+export type DBObjective = DBOpenChannelObjective | DBCloseChannelObjective;
 
 export const toWireObjective = (dbObj: DBObjective): Objective => {
   return _.omit(dbObj, ['objectiveId', 'status']);

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -55,12 +55,7 @@ export class ObjectiveManager {
    */
   async crank(objectiveId: string, response: WalletResponse): Promise<void> {
     const objective = await this.store.getObjective(objectiveId);
-
-    let channelToLock;
-
-    if (objective.type === 'OpenChannel' || objective.type === 'CloseChannel')
-      channelToLock = objective.data.targetChannelId;
-    else throw new Error('ObjectiveManager.crank(): unsupported objective');
+    const channelToLock = objective.data.targetChannelId;
 
     let attemptAnotherProtocolStep = true;
 

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -4,7 +4,7 @@ import {Transaction} from 'knex';
 import {Store} from '../wallet/store';
 import {Bytes32} from '../type-aliases';
 
-import {Protocol, ChannelState, stage, Stage} from './state';
+import {ChannelState, stage, Stage} from './state';
 import {
   completeObjective,
   Withdraw,

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -4,7 +4,7 @@ import {Transaction} from 'knex';
 import {Store} from '../wallet/store';
 import {Bytes32} from '../type-aliases';
 
-import {Protocol, ProtocolResult, ChannelState, stage, Stage} from './state';
+import {Protocol, ChannelState, stage, Stage} from './state';
 import {
   completeObjective,
   Withdraw,
@@ -14,9 +14,17 @@ import {
   CompleteObjective,
   RequestLedgerDefunding,
   requestLedgerDefunding,
+  SignState,
 } from './actions';
 
-export const protocol: Protocol<ProtocolState> = (ps: ProtocolState): ProtocolResult =>
+type CloseChannelProtocolResult =
+  | Withdraw
+  | SignState
+  | CompleteObjective
+  | RequestLedgerDefunding
+  | undefined;
+
+export const protocol = (ps: ProtocolState): CloseChannelProtocolResult =>
   chainWithdraw(ps) ||
   completeCloseChannel(ps) ||
   defundIntoLedger(ps) ||
@@ -71,7 +79,7 @@ const isMyTurn = (ps: ProtocolState): boolean =>
 //    - there's an existing final state (in which case I double sign)
 //    - or it's my turn (in which case I craft the final state)
 //
-const signFinalState = (ps: ProtocolState): ProtocolResult | false =>
+const signFinalState = (ps: ProtocolState): SignState | false =>
   !!ps.app.supported && // there is a supported state
   !isFinal(ps.app.latestSignedByMe) && // I haven't yet signed a final state
   // if there's an existing final state double-sign it


### PR DESCRIPTION
This PR refactors the `ObjectiveManager.crank` function:

* It now switches on objective type just once, at the beginning
* There are now two similar `crankOpenChannel` and `crankCloseChannel` methods
* And the actions are narrowed to the actual actions that those protocols can return

The PR creates some seemingly unnecessary duplication, but the idea is that these two different behaviours are only accidentally similar, and are heading for different objects. This is part of a move away from a one-size-fits-all, always-lock-exactly-one-channel-per-objective approach.