### PR TITLE
[server-wallet] Prevent closed ledger channels from being able to fund channels

### DIFF
--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -361,8 +361,8 @@ describe('Closing a ledger channel and preventing it from being used again', () 
       status: 'closed',
     });
     const params = testCreateChannelParams(10, 10, ledgerChannelId);
-    await expect(a.createChannel(params)).rejects.toThrow(/already been closed/);
-    await expect(a.createChannels(params, 1)).rejects.toThrow(/already been closed/);
+    await expect(a.createChannel(params)).rejects.toThrow(/closed/);
+    await expect(a.createChannels(params, 1)).rejects.toThrow(/closed/);
   });
 });
 

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -343,15 +343,13 @@ describe('Funding a single channel with 50% of ledger funds', () => {
 });
 
 describe('Closing a ledger channel and preventing it from being used again', () => {
-  let ledgerChannelId: Bytes32;
-
   afterAll(async () => {
     await a.dbAdmin().truncateDB(['channels', 'ledger_requests']);
     await b.dbAdmin().truncateDB(['channels', 'ledger_requests']);
   });
 
-  it('can close the ledger channel', async () => {
-    ledgerChannelId = await createLedgerChannel(10, 10);
+  it('can close a ledger channel and fail to fund a new channel ', async () => {
+    const ledgerChannelId = await createLedgerChannel(10, 10);
     const {outbox} = await a.closeChannel({channelId: ledgerChannelId});
     const {outbox: close} = await b.pushMessage(getPayloadFor(participantB.participantId, outbox));
     await exchangeMessagesBetweenAandB([close], []);
@@ -362,9 +360,6 @@ describe('Closing a ledger channel and preventing it from being used again', () 
       turnNum: 4,
       status: 'closed',
     });
-  });
-
-  it('fails to fund a new channel with this ledger', async () => {
     const params = testCreateChannelParams(10, 10, ledgerChannelId);
     await expect(a.createChannel(params)).rejects.toThrow(/already been closed/);
     await expect(a.createChannels(params, 1)).rejects.toThrow(/already been closed/);

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -207,6 +207,7 @@ function isFunded(ps: ProtocolState): boolean {
     case 'Ledger': {
       if (ps.type !== 'LedgerFundingProtocolState') return false;
       if (!ps.ledger) return false;
+      if (!isRunning(ps.ledger.latest)) return false;
       // TODO: in the future check "funding table"
       if (!isFunded({type: 'DirectFundingProtocolState', app: ps.ledger})) return false;
       return ledgerFundedThisChannel(ps.ledger, ps.app);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -682,7 +682,7 @@ class StoreError extends WalletError {
     unimplementedObjective: 'Unimplemented objective',
     unimplementedFundingStrategy: 'Unimplemented funding strategy',
     invalidFundingLedgerChannelId: 'Ledger channel intended to fund channel does not exist',
-    closedFundingLedgerChannelId: 'Ledger channel intended to fund channel has already been closed',
+    expiredFundingLedgerChannelId: 'Ledger channel intended to fund channel is closed or closing',
   } as const;
   constructor(reason: Values<typeof StoreError.reasons>, public readonly data: any = undefined) {
     super(reason);
@@ -702,8 +702,8 @@ async function createChannel(
   if (fundingLedgerChannelId) {
     const ledger = await Channel.forId(fundingLedgerChannelId, txOrKnex);
     if (!ledger) throw new StoreError(StoreError.reasons.invalidFundingLedgerChannelId);
-    if (ledger.supported && ledger.supported.isFinal)
-      throw new StoreError(StoreError.reasons.closedFundingLedgerChannelId);
+    if (ledger.supported && _.some(ledger.support, 'isFinal'))
+      throw new StoreError(StoreError.reasons.expiredFundingLedgerChannelId);
   }
 
   const addresses = constants.participants.map(p => p.signingAddress);


### PR DESCRIPTION
Presently a ledger channel can be used to fund a channel after the ledger channel has already been closed. This adds a check to prevent `createChannel` from allowing it to be specified and a check in the protocol to ensure the ledger being used to fund a channel is actually running before proceeding with ledger funding.
