### PR TITLE
Remove configuration by env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,10 +170,10 @@ jobs:
           name: server-wallet setup (postgresql migrations)
           working_directory: packages/server-wallet
           command: |
-            createdb payer $PSQL_ARGS
-            SERVER_DB_NAME=payer yarn db:migrate
-            createdb receiver $PSQL_ARGS
-            SERVER_DB_NAME=receiver yarn db:migrate
+            createdb server_wallet_payer $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_payer yarn db:migrate
+            createdb server_wallet_receiver $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_receiver yarn db:migrate
       - run:
           name: server-wallet-e2e-test
           working_directory: packages/server-wallet
@@ -200,10 +200,10 @@ jobs:
           name: server-wallet setup (postgresql migrations)
           working_directory: packages/server-wallet
           command: |
-            createdb payer $PSQL_ARGS
-            SERVER_DB_NAME=payer yarn db:migrate
-            createdb receiver $PSQL_ARGS
-            SERVER_DB_NAME=receiver yarn db:migrate
+            createdb server_wallet_payer $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_payer yarn db:migrate
+            createdb server_wallet_receiver $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_receiver yarn db:migrate
       - run:
           name: server-wallet-stress-test
           working_directory: packages/server-wallet
@@ -223,10 +223,10 @@ jobs:
           name: server-wallet setup (postgresql migrations)
           working_directory: packages/server-wallet
           command: |
-            createdb payer $PSQL_ARGS
-            SERVER_DB_NAME=payer yarn db:migrate
-            createdb receiver $PSQL_ARGS
-            SERVER_DB_NAME=receiver yarn db:migrate
+            createdb server_wallet_payer $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_payer yarn db:migrate
+            createdb server_wallet_receiver $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_receiver yarn db:migrate
       - run:
           name: server-wallet-stress-test
           working_directory: packages/server-wallet
@@ -245,10 +245,10 @@ jobs:
           name: server-wallet setup (postgresql migrations)
           working_directory: packages/server-wallet
           command: |
-            createdb payer $PSQL_ARGS
-            SERVER_DB_NAME=payer yarn db:migrate
-            createdb receiver $PSQL_ARGS
-            SERVER_DB_NAME=receiver yarn db:migrate
+            createdb server_wallet_payer $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_payer yarn db:migrate
+            createdb server_wallet_receiver $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_receiver yarn db:migrate
       - run:
           name: profile
           working_directory: packages/server-wallet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
   environment:
     NODE_ENV: test
 
-postgres: &postgres  
+postgres: &postgres
   <<: *defaults
   docker:
     - image: cimg/node:12.18.0
@@ -20,9 +20,7 @@ postgres: &postgres
   environment:
     NODE_ENV: test
     PSQL_ARGS: -p 5432 -h localhost -U postgres
-    SERVER_DB_USER: postgres
-    POSTGRES_USER: postgres     
-    AMOUNT_OF_WORKER_THREADS: 0
+    POSTGRES_USER: postgres
 
 # MACROS
 
@@ -143,8 +141,8 @@ jobs:
           name: wallet setup
           working_directory: packages/server-wallet
           command: |
-            yarn db:create $PSQL_ARGS
-            yarn db:migrate
+            SERVER_DB_NAME=server_wallet_test yarn db:create $PSQL_ARGS
+            SERVER_DB_NAME=server_wallet_test yarn db:migrate
       - run:
           name: test
           command: |
@@ -190,7 +188,7 @@ jobs:
       NODE_ENV: test
       PSQL_ARGS: -p 5432 -h localhost -U postgres
       SERVER_DB_USER: postgres
-      POSTGRES_USER: postgres     
+      POSTGRES_USER: postgres
       AMOUNT_OF_WORKER_THREADS: 6
       LOG_DESTINATION: /home/circleci/project/artifacts/wallet.log
     steps:

--- a/packages/server-wallet/.env
+++ b/packages/server-wallet/.env
@@ -1,3 +1,0 @@
-SERVER_DB_HOST=RequiredInLocalDotenv
-SERVER_DB_PORT=RequiredInLocalDotenv
-SERVER_DB_NAME=server_wallet_${NODE_ENV}

--- a/packages/server-wallet/.env.development
+++ b/packages/server-wallet/.env.development
@@ -1,7 +1,3 @@
-SERVER_DB_HOST=localhost
-SERVER_DB_PORT=5432
-SERVER_DB_NAME=server_wallet_development
-SERVER_DB_USER=postgres
 
 HUB_DESTINATION='hub' # wallet-core throws an exception if not in env FIXME:
 

--- a/packages/server-wallet/.env.test
+++ b/packages/server-wallet/.env.test
@@ -1,6 +1,1 @@
-SERVER_DB_HOST=localhost
-SERVER_DB_PORT=5432
-SERVER_DB_NAME=server_wallet_test
-SERVER_DB_USER=postgres
-
 HUB_DESTINATION='hub'

--- a/packages/server-wallet/.eslintrc.js
+++ b/packages/server-wallet/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
   overrides: [
     {
       // process.env allowed in some files
-      files: ['src/config.ts', 'scripts/*', 'e2e-test/jest/*'],
+      files: ['scripts/*', 'e2e-test/jest/*'],
       rules: {'no-process-env': 'off'},
     },
     {

--- a/packages/server-wallet/.vscode/launch.json
+++ b/packages/server-wallet/.vscode/launch.json
@@ -57,7 +57,7 @@
       "internalConsoleOptions": "neverOpen",
       "env": {
         "NODE_ENV": "test",
-        "SERVER_DB_NAME": "payer"
+        "SERVER_DB_NAME": "server_wallet_payer"
       }
     }
   ]

--- a/packages/server-wallet/deployment/deploy.ts
+++ b/packages/server-wallet/deployment/deploy.ts
@@ -16,8 +16,9 @@ export type TestNetworkContext = {
 };
 
 export async function deploy(): Promise<TestNetworkContext> {
+  const {ethereumPrivateKey} = defaultTestConfig();
   // TODO: best way to configure this?
-  const deployer = new GanacheDeployer(8545, defaultTestConfig.ethereumPrivateKey);
+  const deployer = new GanacheDeployer(8545, ethereumPrivateKey);
   const {
     EthAssetHolderArtifact,
     TokenArtifact,
@@ -29,7 +30,7 @@ export async function deploy(): Promise<TestNetworkContext> {
   const ERC20_ADDRESS = await deployer.deploy(
     TokenArtifact as any,
     {},
-    new Wallet(defaultTestConfig.ethereumPrivateKey).address
+    new Wallet(ethereumPrivateKey).address
   );
   const ERC20_ASSET_HOLDER_ADDRESS = await deployer.deploy(
     Erc20AssetHolderArtifact as any,

--- a/packages/server-wallet/e2e-test/e2e-utils.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils.ts
@@ -18,11 +18,11 @@ import {
 } from '../src/config';
 
 export const payerConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
-  defaultTestConfig,
+  defaultTestConfig(),
   {database: 'server_wallet_payer'}
 );
 export const receiverConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
-  defaultTestConfig,
+  defaultTestConfig(),
   {database: 'server_wallet_receiver'}
 );
 

--- a/packages/server-wallet/e2e-test/e2e-utils.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils.ts
@@ -19,11 +19,11 @@ import {
 
 export const payerConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
   defaultTestConfig,
-  {dbName: 'server_wallet_payer'}
+  {database: 'server_wallet_payer'}
 );
 export const receiverConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
   defaultTestConfig,
-  {dbName: 'server_wallet_receiver'}
+  {database: 'server_wallet_receiver'}
 );
 
 import {PerformanceTimer} from './payer/timers';

--- a/packages/server-wallet/e2e-test/e2e-utils.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils.ts
@@ -19,11 +19,11 @@ import {
 
 export const payerConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
   defaultTestConfig,
-  {dbName: 'payer'}
+  {dbName: 'server_wallet_payer'}
 );
 export const receiverConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
   defaultTestConfig,
-  {dbName: 'receiver'}
+  {dbName: 'server_wallet_receiver'}
 );
 
 import {PerformanceTimer} from './payer/timers';
@@ -37,7 +37,7 @@ export const triggerPayments = async (
   channelIds: string[],
   numPayments?: number
 ): Promise<void> => {
-  let args = ['start', '--database', 'payer', '--channels', ...channelIds];
+  let args = ['start', '--database', 'server_wallet_payer', '--channels', ...channelIds];
 
   if (numPayments) args = args.concat(['--numPayments', numPayments.toString()]);
 

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -44,7 +44,7 @@ export default {
       new PayerClient(
         alice().privateKey,
         `http://127.0.0.1:65535`,
-        overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: database})
+        overwriteConfigWithDatabaseConnection(defaultTestConfig, {database})
       )
     );
 

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -44,7 +44,7 @@ export default {
       new PayerClient(
         alice().privateKey,
         `http://127.0.0.1:65535`,
-        overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: database})
+        overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: database})
       )
     );
 

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -44,7 +44,7 @@ export default {
       new PayerClient(
         alice().privateKey,
         `http://127.0.0.1:65535`,
-        overwriteConfigWithDatabaseConnection(defaultTestConfig, {database})
+        overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database})
       )
     );
 

--- a/packages/server-wallet/e2e-test/scripts/profile.sh
+++ b/packages/server-wallet/e2e-test/scripts/profile.sh
@@ -10,13 +10,13 @@ if [ -d ./.clinic ]; then
 fi
 
 echo "Generating flamegraph"
-SERVER_DB_NAME=payer NODE_ENV=test npx ts-node ./e2e-test/scripts/generate-profile-data.ts flamegraph
+ NODE_ENV=test npx ts-node ./e2e-test/scripts/generate-profile-data.ts flamegraph
 npx clinic flame --visualize-only .clinic/*.clinic-flame
 
 echo "Generating bubbleprof"
-SERVER_DB_NAME=payer NODE_ENV=test npx ts-node ./e2e-test/scripts/generate-profile-data.ts bubbleprof
+NODE_ENV=test npx ts-node ./e2e-test/scripts/generate-profile-data.ts bubbleprof
 npx clinic bubbleprof --visualize-only .clinic/*.clinic-bubbleprof
 
 echo "Generating doctor"
-SERVER_DB_NAME=payer NODE_ENV=test npx ts-node ./e2e-test/scripts/generate-profile-data.ts doctor
+NODE_ENV=test npx ts-node ./e2e-test/scripts/generate-profile-data.ts doctor
 npx clinic doctor --visualize-only .clinic/*.clinic-doctor

--- a/packages/server-wallet/jest/jest.e2e.config.js
+++ b/packages/server-wallet/jest/jest.e2e.config.js
@@ -1,3 +1,5 @@
 const config = require('./jest.config');
 config.testMatch = ['<rootDir>/e2e-test/e2e.test.ts?(x)'];
+// We don't want to use the default knex setup as we're using two DBs for the e2e test
+config.setupFilesAfterEnv =[];
 module.exports = config;

--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -10,7 +10,7 @@ import {DBAdmin} from '../src/db-admin/db-admin';
 export let testKnex: Knex;
 
 beforeAll(async () => {
-  testKnex = Knex(extractDBConfigFromServerWalletConfig(defaultTestConfig));
+  testKnex = Knex(extractDBConfigFromServerWalletConfig(defaultTestConfig()));
   await new DBAdmin(testKnex).truncateDB();
 });
 

--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -4,19 +4,13 @@ import _ from 'lodash';
 
 configureEnvVariables();
 
-import {
-  extractDBConfigFromServerWalletConfig,
-  defaultTestConfig,
-  overwriteConfigWithEnvVars,
-} from '../src/config';
+import {extractDBConfigFromServerWalletConfig, defaultTestConfig} from '../src/config';
 import {DBAdmin} from '../src/db-admin/db-admin';
 
 export let testKnex: Knex;
 
 beforeAll(async () => {
-  testKnex = Knex(
-    extractDBConfigFromServerWalletConfig(overwriteConfigWithEnvVars(defaultTestConfig))
-  );
+  testKnex = Knex(extractDBConfigFromServerWalletConfig(defaultTestConfig));
   await new DBAdmin(testKnex).truncateDB();
 });
 

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -77,8 +77,8 @@
   },
   "main": "lib/src/index.js",
   "scripts": {
-    "db:create": "createdb server_wallet_${NODE_ENV}",
-    "db:drop": "dropdb server_wallet_${NODE_ENV}",
+    "db:create": "createdb $SERVER_DB_NAME",
+    "db:drop": "dropdb $SERVER_DB_NAME",
     "db:migrate": "npx knex migrate:latest --cwd src/db-admin",
     "db:rollback": "npx knex migrate:rollback --cwd src/db-admin",
     "db:seed": "npx knex seed:run --cwd src/db-admin",
@@ -93,12 +93,12 @@
     "prestart": "yarn prepare && npm run db:rollback && npm run db:migrate && npm run db:seed",
     "prettier:check": "npx prettier --check 'src/**/*.{ts,tsx}'",
     "prettier:write": "npx prettier --write 'src/**/*.{ts,tsx}'",
-    "profile": "TIMING_METRICS=ON METRICS_OUTPUT_FILE=metrics.log ./e2e-test/scripts/profile.sh",
+    "profile": "./e2e-test/scripts/profile.sh",
     "start:shared-ganache": "NODE_ENV=development npx start-shared-ganache",
     "test": "yarn jest -c ./jest/jest.config.js --runInBand",
     "test:chain": "jest -c ./jest/jest.chain.config.js --runInBand",
     "test:ci": "yarn test --bail && yarn test:chain --bail",
-    "test:e2e": "yarn tsc; SERVER_DB_NAME=payer yarn jest -c ./jest/jest.e2e.config.js",
+    "test:e2e": "yarn tsc;  yarn jest -c ./jest/jest.e2e.config.js",
     "test:stress": "yarn tsc;NODE_ENV=test npx ts-node ./e2e-test/scripts/stress-test.ts"
   },
   "types": "lib/src/index.d.ts"

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -10,6 +10,7 @@ import { ChannelId } from '@statechannels/client-api-schema';
 import { ChannelResult } from '@statechannels/client-api-schema';
 import { CloseChannel } from '@statechannels/wallet-core';
 import { CloseChannelParams } from '@statechannels/client-api-schema';
+import { Config } from 'knex';
 import { CreateChannelParams } from '@statechannels/client-api-schema';
 import { Destination } from '@statechannels/wallet-core';
 import { ethers } from 'ethers';
@@ -50,16 +51,153 @@ import { TransactionOrKnex } from 'objection';
 import { Uint256 as Uint256_2 } from '@statechannels/wallet-core';
 import { UpdateChannelParams } from '@statechannels/client-api-schema';
 
+// @public (undocumented)
+export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
+
+// @public (undocumented)
+export type DatabaseConnectionConfiguration = RequiredConnectionConfiguration & Partial<OptionalConnectionConfiguration>;
+
+// @public (undocumented)
+export type DatabasePoolConfiguration = {
+    max?: number;
+    min?: number;
+};
+
+// @public (undocumented)
+export type DeepPartial<T> = {
+    [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+// @public (undocumented)
+export const DEFAULT_DB_NAME = "server_wallet_test";
+
+// @public (undocumented)
+export const DEFAULT_DB_USER = "postgres";
+
+// @public (undocumented)
+export const defaultConfig: OptionalServerWalletConfig;
+
+// @public (undocumented)
+export const defaultDatabaseConfiguration: OptionalDatabaseConfiguration & {
+    connection: {
+        host: string;
+        port: number;
+        user: string;
+    };
+};
+
+// @public (undocumented)
+export const defaultLoggingConfiguration: LoggingConfiguration;
+
+// @public (undocumented)
+export const defaultMetricsConfiguration: {
+    timingMetrics: boolean;
+};
+
+// Warning: (ae-forgotten-export) The symbol "HasDatabaseConnectionConfigObject" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const defaultTestConfig: (partialConfig?: DeepPartial<ServerWalletConfig & HasDatabaseConnectionConfigObject>) => ServerWalletConfig & HasDatabaseConnectionConfigObject;
+
+// @public (undocumented)
+export const defaultTestNetworkConfiguration: NetworkConfiguration;
+
+// @public (undocumented)
+export function extractDBConfigFromServerWalletConfig(serverWalletConfig: ServerWalletConfig): Config;
+
+// Warning: (ae-forgotten-export) The symbol "DatabaseConnectionConfigObject" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export function getDatabaseConnectionConfig(config: ServerWalletConfig): DatabaseConnectionConfigObject & {
+    host: string;
+    port: number;
+};
+
+// @public (undocumented)
+export type IncomingServerWalletConfig = RequiredServerWalletConfig & Partial<OptionalServerWalletConfig>;
+
+// @public (undocumented)
+export type LoggingConfiguration = {
+    logLevel: Level;
+    logDestination: string;
+};
+
 export { Message }
+
+// @public (undocumented)
+export type MetricsConfiguration = {
+    timingMetrics: boolean;
+    metricsOutputFile?: string;
+};
+
+// @public (undocumented)
+export type MultipleChannelOutput = {
+    outbox: Outgoing[];
+    channelResults: ChannelResult[];
+};
+
+// @public (undocumented)
+export type NetworkConfiguration = {
+    rpcEndpoint?: string;
+    chainNetworkID: number;
+};
+
+// @public (undocumented)
+export type OptionalConnectionConfiguration = {
+    port: number;
+} | string;
+
+// @public (undocumented)
+export type OptionalDatabaseConfiguration = {
+    pool?: DatabasePoolConfiguration;
+    debug?: boolean;
+    connection: OptionalConnectionConfiguration;
+};
+
+// @public (undocumented)
+export interface OptionalServerWalletConfig {
+    // (undocumented)
+    databaseConfiguration: OptionalDatabaseConfiguration;
+    // (undocumented)
+    loggingConfiguration: LoggingConfiguration;
+    // (undocumented)
+    metricsConfiguration: MetricsConfiguration;
+    // (undocumented)
+    skipEvmValidation: boolean;
+    // (undocumented)
+    workerThreadAmount: number;
+}
 
 // Warning: (ae-forgotten-export) The symbol "Notice" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type Outgoing = Notice;
 
-// Warning: (ae-forgotten-export) The symbol "RequiredServerWalletConfig" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "OptionalServerWalletConfig" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "PartialConfigObject" needs to be exported by the entry point index.d.ts
 //
+// @public (undocumented)
+export function overwriteConfigWithDatabaseConnection(config: ServerWalletConfig, databaseConnectionConfig: PartialConfigObject | string): ServerWalletConfig;
+
+// @public (undocumented)
+export type RequiredConnectionConfiguration = {
+    database: string;
+    host: string;
+    user: string;
+    password?: string;
+} | string;
+
+// @public (undocumented)
+export type RequiredDatabaseConfiguration = {
+    connection: RequiredConnectionConfiguration;
+};
+
+// @public (undocumented)
+export type RequiredServerWalletConfig = {
+    databaseConfiguration: RequiredDatabaseConfiguration;
+    networkConfiguration: NetworkConfiguration;
+    ethereumPrivateKey: string;
+};
+
 // @public (undocumented)
 export type ServerWalletConfig = RequiredServerWalletConfig & OptionalServerWalletConfig;
 
@@ -80,10 +218,11 @@ export const Wallet: {
     create(walletConfig: IncomingServerWalletConfig): Wallet;
 };
 
-
-// Warnings were encountered during analysis:
+// Warning: (ae-forgotten-export) The symbol "ChannelUpdatedEvent" needs to be exported by the entry point index.d.ts
 //
-// src/wallet/index.ts:10:20 - (ae-forgotten-export) The symbol "IncomingServerWalletConfig" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export type WalletEvent = ChannelUpdatedEvent;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -19,6 +19,8 @@ const config = {
     ...defaultTestConfig.networkConfiguration,
     // eslint-disable-next-line no-process-env
     rpcEndpoint: process.env.RPC_ENDPOINT,
+    // eslint-disable-next-line no-process-env
+    chainNetworkID: parseInt(process.env.CHAIN_NETWORK_ID || '0'),
   },
 };
 if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -14,9 +14,9 @@ import {getChannelResultFor, getPayloadFor} from '../__test__/test-helpers';
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
 const config = {
-  ...defaultTestConfig,
+  ...defaultTestConfig(),
   networkConfiguration: {
-    ...defaultTestConfig.networkConfiguration,
+    ...defaultTestConfig().networkConfiguration,
     // eslint-disable-next-line no-process-env
     rpcEndpoint: process.env.RPC_ENDPOINT,
     // eslint-disable-next-line no-process-env

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -27,12 +27,12 @@ if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must
 const {rpcEndpoint} = config.networkConfiguration;
 let provider: providers.JsonRpcProvider;
 const b = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(config, {dbName: 'TEST_B'}),
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_B'}),
   /* eslint-disable-next-line no-process-env */
   ethereumPrivateKey: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
 });
 const a = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(config, {dbName: 'TEST_A'}),
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_A'}),
   /* eslint-disable-next-line no-process-env */
   ethereumPrivateKey: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
 });

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -7,27 +7,24 @@ import _ from 'lodash';
 import {fromEvent} from 'rxjs';
 import {take} from 'rxjs/operators';
 
-import {
-  defaultTestConfig,
-  overwriteConfigWithDatabaseConnection,
-  overwriteConfigWithEnvVars,
-} from '../config';
+import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../config';
 import {Wallet, SingleChannelOutput} from '../wallet';
 import {getChannelResultFor, getPayloadFor} from '../__test__/test-helpers';
 
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
-const config = overwriteConfigWithEnvVars(defaultTestConfig);
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
+
+if (!defaultTestConfig.networkConfiguration.rpcEndpoint)
+  throw new Error('rpc endpoint must be defined');
+const {rpcEndpoint} = defaultTestConfig.networkConfiguration;
 let provider: providers.JsonRpcProvider;
 const b = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(config, {dbName: 'TEST_B'}),
+  ...overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_B'}),
   /* eslint-disable-next-line no-process-env */
   ethereumPrivateKey: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
 });
 const a = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(config, {dbName: 'TEST_A'}),
+  ...overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_A'}),
   /* eslint-disable-next-line no-process-env */
   ethereumPrivateKey: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
 });

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -13,18 +13,24 @@ import {getChannelResultFor, getPayloadFor} from '../__test__/test-helpers';
 
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
-
-if (!defaultTestConfig.networkConfiguration.rpcEndpoint)
-  throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = defaultTestConfig.networkConfiguration;
+const config = {
+  ...defaultTestConfig,
+  networkConfiguration: {
+    ...defaultTestConfig.networkConfiguration,
+    // eslint-disable-next-line no-process-env
+    rpcEndpoint: process.env.RPC_ENDPOINT,
+  },
+};
+if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
+const {rpcEndpoint} = config.networkConfiguration;
 let provider: providers.JsonRpcProvider;
 const b = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_B'}),
+  ...overwriteConfigWithDatabaseConnection(config, {dbName: 'TEST_B'}),
   /* eslint-disable-next-line no-process-env */
   ethereumPrivateKey: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
 });
 const a = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_A'}),
+  ...overwriteConfigWithDatabaseConnection(config, {dbName: 'TEST_A'}),
   /* eslint-disable-next-line no-process-env */
   ethereumPrivateKey: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
 });

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -12,10 +12,10 @@ import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, crashAndRestart} from '../test-helpers';
 
 const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
 );
 let b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
 ); // Wallet that will "crash"
 
 let channelId: string;

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -12,9 +12,11 @@ import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, crashAndRestart} from '../test-helpers';
 
 const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
 );
-let b = Wallet.create(overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_B'})); // Wallet that will "crash"
+let b = Wallet.create(
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
+); // Wallet that will "crash"
 
 let channelId: string;
 let participantA: Participant;

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -14,10 +14,10 @@ import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 const {AddressZero} = ethers.constants;
 
 const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
 );
 const b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_B'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
 );
 
 let channelId: string;

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -14,10 +14,10 @@ import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 const {AddressZero} = ethers.constants;
 
 const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
 );
 const b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
 );
 
 let channelId: string;

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -12,10 +12,10 @@ import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 
 const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
 );
 const b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
 );
 
 let channelId: string;

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -12,10 +12,10 @@ import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 
 const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
 );
 const b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_B'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
 );
 
 let channelId: string;

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -15,8 +15,12 @@ import {
 
 const ETH_ASSET_HOLDER_ADDRESS = makeAddress(ethers.constants.AddressZero);
 
-let a = Wallet.create(overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_A'}));
-let b = Wallet.create(overwriteConfigWithDatabaseConnection(defaultTestConfig, {dbName: 'TEST_B'}));
+let a = Wallet.create(
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
+);
+let b = Wallet.create(
+  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
+);
 
 let participantA: Participant;
 let participantB: Participant;

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -16,10 +16,10 @@ import {
 const ETH_ASSET_HOLDER_ADDRESS = makeAddress(ethers.constants.AddressZero);
 
 let a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_A'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
 );
 let b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig, {database: 'TEST_B'})
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
 );
 
 let participantA: Participant;

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -25,11 +25,17 @@ import {AssetTransferredArg, HoldingUpdatedArg} from '../types';
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
-/* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 
-if (!defaultTestConfig.networkConfiguration.rpcEndpoint)
-  throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = defaultTestConfig.networkConfiguration;
+const config = {
+  ...defaultTestConfig,
+  networkConfiguration: {
+    ...defaultTestConfig.networkConfiguration,
+    // eslint-disable-next-line no-process-env
+    rpcEndpoint: process.env.RPC_ENDPOINT,
+  },
+};
+if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
+const {rpcEndpoint} = config.networkConfiguration;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 
 let chainService: ChainService;

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -12,7 +12,7 @@ import {
 import {BigNumber, constants, Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../config';
+import {defaultTestConfig} from '../../config';
 import {
   alice as aliceParticipant,
   bob as bobParticipant,
@@ -26,9 +26,10 @@ const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!)
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
-const config = overwriteConfigWithEnvVars(defaultTestConfig);
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
+
+if (!defaultTestConfig.networkConfiguration.rpcEndpoint)
+  throw new Error('rpc endpoint must be defined');
+const {rpcEndpoint} = defaultTestConfig.networkConfiguration;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 
 let chainService: ChainService;

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -30,7 +30,6 @@ const config = {
   ...defaultTestConfig,
   networkConfiguration: {
     ...defaultTestConfig.networkConfiguration,
-    // eslint-disable-next-line no-process-env
     rpcEndpoint: process.env.RPC_ENDPOINT,
   },
 };

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -27,9 +27,9 @@ const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRE
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 
 const config = {
-  ...defaultTestConfig,
+  ...defaultTestConfig(),
   networkConfiguration: {
-    ...defaultTestConfig.networkConfiguration,
+    ...defaultTestConfig().networkConfiguration,
     rpcEndpoint: process.env.RPC_ENDPOINT,
   },
 };

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -4,16 +4,17 @@ import {BN, makeAddress} from '@statechannels/wallet-core';
 import {Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../config';
+import {defaultTestConfig} from '../../config';
 import {ChainService} from '../chain-service';
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
-const config = overwriteConfigWithEnvVars(defaultTestConfig);
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
+
+if (!defaultTestConfig.networkConfiguration.rpcEndpoint)
+  throw new Error('rpc endpoint must be defined');
+const {rpcEndpoint} = defaultTestConfig.networkConfiguration;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 // This is the private key for which ERC20 tokens are allocated on contract creation
 const ethWalletWithTokens = new Wallet(defaultTestConfig.ethereumPrivateKey, provider);

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -12,9 +12,9 @@ const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRE
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 const config = {
-  ...defaultTestConfig,
+  ...defaultTestConfig(),
   networkConfiguration: {
-    ...defaultTestConfig.networkConfiguration,
+    ...defaultTestConfig().networkConfiguration,
     // eslint-disable-next-line no-process-env
     rpcEndpoint: process.env.RPC_ENDPOINT,
   },

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -11,13 +11,19 @@ import {ChainService} from '../chain-service';
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
-
-if (!defaultTestConfig.networkConfiguration.rpcEndpoint)
-  throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = defaultTestConfig.networkConfiguration;
+const config = {
+  ...defaultTestConfig,
+  networkConfiguration: {
+    ...defaultTestConfig.networkConfiguration,
+    // eslint-disable-next-line no-process-env
+    rpcEndpoint: process.env.RPC_ENDPOINT,
+  },
+};
+if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
+const {rpcEndpoint} = config.networkConfiguration;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 // This is the private key for which ERC20 tokens are allocated on contract creation
-const ethWalletWithTokens = new Wallet(defaultTestConfig.ethereumPrivateKey, provider);
+const ethWalletWithTokens = new Wallet(config.ethereumPrivateKey, provider);
 
 // Try to use a different private key for every chain service instantiation to avoid nonce errors
 const privateKey = ETHERLIME_ACCOUNTS[3].privateKey;

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -47,7 +47,7 @@ export const defaultConfig: OptionalServerWalletConfig = {
 export const DEFAULT_DB_NAME = 'server_wallet_test';
 export const DEFAULT_DB_USER = 'postgres';
 type HasDatabaseConnectionConfigObject = {
-  databaseConfiguration: {connection: {host: string; port: number; dbName: string}};
+  databaseConfiguration: {connection: {host: string; port: number; database: string}};
 };
 export const defaultTestNetworkConfiguration: NetworkConfiguration = {
   chainNetworkID: 0,
@@ -63,7 +63,7 @@ export const defaultTestConfig: ServerWalletConfig & HasDatabaseConnectionConfig
     connection: {
       host: defaultDatabaseConfiguration.connection.host,
       port: defaultDatabaseConfiguration.connection.port,
-      dbName: DEFAULT_DB_NAME,
+      database: DEFAULT_DB_NAME,
       user: DEFAULT_DB_USER,
     },
   },

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -1,4 +1,7 @@
+import _ from 'lodash';
+
 import {
+  DeepPartial,
   LoggingConfiguration,
   NetworkConfiguration,
   OptionalDatabaseConfiguration,
@@ -52,19 +55,25 @@ type HasDatabaseConnectionConfigObject = {
 export const defaultTestNetworkConfiguration: NetworkConfiguration = {
   chainNetworkID: 0,
 };
-export const defaultTestConfig: ServerWalletConfig & HasDatabaseConnectionConfigObject = {
-  ...defaultConfig,
-  networkConfiguration: defaultTestNetworkConfiguration,
-  skipEvmValidation: true,
-  workerThreadAmount: 0, // Disable threading for tests
-  // TODO: List addresses this corresponds to
-  ethereumPrivateKey: '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
-  databaseConfiguration: {
-    connection: {
-      host: defaultDatabaseConfiguration.connection.host,
-      port: defaultDatabaseConfiguration.connection.port,
-      database: DEFAULT_DB_NAME,
-      user: DEFAULT_DB_USER,
+
+export const defaultTestConfig = (
+  partialConfig: DeepPartial<ServerWalletConfig & HasDatabaseConnectionConfigObject> = {}
+): ServerWalletConfig & HasDatabaseConnectionConfigObject => {
+  const fullDefaultConfig = {
+    ...defaultConfig,
+    networkConfiguration: defaultTestNetworkConfiguration,
+    skipEvmValidation: true,
+    workerThreadAmount: 0, // Disable threading for tests
+    // 0xD9995BAE12FEe327256FFec1e3184d492bD94C31
+    ethereumPrivateKey: '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
+    databaseConfiguration: {
+      connection: {
+        host: defaultDatabaseConfiguration.connection.host,
+        port: defaultDatabaseConfiguration.connection.port,
+        database: DEFAULT_DB_NAME,
+        user: DEFAULT_DB_USER,
+      },
     },
-  },
+  };
+  return _.merge({}, fullDefaultConfig, partialConfig);
 };

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -10,7 +10,7 @@ export type DatabaseConnectionConfiguration = RequiredConnectionConfiguration &
  * Either a database connection string or a config object specifying the database name
  */
 export type RequiredConnectionConfiguration =
-  | {dbName: string; host: string; user: string; password?: string}
+  | {database: string; host: string; user: string; password?: string}
   | string;
 
 /**

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -87,3 +87,7 @@ export type NetworkConfiguration = {
   rpcEndpoint?: string;
   chainNetworkID: number;
 };
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};

--- a/packages/server-wallet/src/config/utils.ts
+++ b/packages/server-wallet/src/config/utils.ts
@@ -12,10 +12,9 @@ export function extractDBConfigFromServerWalletConfig(
 
   return {
     client: 'postgres',
-    // TODO: Might make sense to use `database` instead of `dbName` so its consitent with knex
+
     connection: {
       ...connectionConfig,
-      database: connectionConfig.dbName,
       user: connectionConfig.user || '',
     },
     ...knexSnakeCaseMappers(),
@@ -25,7 +24,7 @@ export function extractDBConfigFromServerWalletConfig(
 type DatabaseConnectionConfigObject = Required<Exclude<DatabaseConnectionConfiguration, string>>;
 
 type PartialConfigObject = Partial<DatabaseConnectionConfigObject> &
-  Required<Pick<DatabaseConnectionConfigObject, 'dbName'>>;
+  Required<Pick<DatabaseConnectionConfigObject, 'database'>>;
 export function overwriteConfigWithDatabaseConnection(
   config: ServerWalletConfig,
   databaseConnectionConfig: PartialConfigObject | string
@@ -38,7 +37,7 @@ export function overwriteConfigWithDatabaseConnection(
         ? {
             host: databaseConnectionConfig.host || defaultDatabaseConfiguration.connection.host,
             port: databaseConnectionConfig.port || defaultDatabaseConfiguration.connection.port,
-            dbName: databaseConnectionConfig.dbName,
+            database: databaseConnectionConfig.database,
             user: databaseConnectionConfig.user || defaultDatabaseConfiguration.connection.user,
             password: databaseConnectionConfig.password || '',
           }
@@ -62,7 +61,7 @@ export function getDatabaseConnectionConfig(
     return {
       port: port ? parseInt(port) : defaultConnection.port,
       host: host || defaultConnection.host,
-      dbName: database || '',
+      database: database || '',
       user: user || defaultConnection.user,
       password: password || '',
     };

--- a/packages/server-wallet/src/config/utils.ts
+++ b/packages/server-wallet/src/config/utils.ts
@@ -1,62 +1,9 @@
-/* eslint-disable no-process-env */
-import {BigNumber} from 'ethers';
 import {Config} from 'knex';
 import {knexSnakeCaseMappers} from 'objection';
 import {parse} from 'pg-connection-string';
-import {Level} from 'pino';
 
 import {defaultDatabaseConfiguration} from './defaults';
 import {ServerWalletConfig, DatabaseConnectionConfiguration} from './types';
-
-function readBoolean(envValue: string | undefined, defaultValue?: boolean): boolean {
-  if (!envValue) return defaultValue || false;
-  return envValue?.toLowerCase() === 'true';
-}
-function readInt(envValue: string | undefined, defaultValue?: number): number {
-  if (!envValue) return defaultValue || 0;
-  return Number.parseInt(envValue);
-}
-
-export function overwriteConfigWithEnvVars(config: ServerWalletConfig): ServerWalletConfig {
-  const connection = process.env.SERVER_URL || {
-    host: process.env.SERVER_HOST || defaultDatabaseConfiguration.connection.host,
-    port: Number(process.env.SERVER_PORT) || defaultDatabaseConfiguration.connection.port,
-    dbName: process.env.SERVER_DB_NAME || '',
-    user: process.env.SERVER_DB_USER || '',
-    password: process.env.SERVER_DB_PASSWORD,
-  };
-  // TODO: This belongs with other validation when we add it
-  if (!connection) {
-    throw new Error('No database configuration provided by env vars');
-  }
-  return {
-    databaseConfiguration: {
-      connection,
-      debug: readBoolean(process.env.DEBUG_KNEX, config.databaseConfiguration.debug),
-    },
-    metricsConfiguration: {
-      timingMetrics: readBoolean(
-        process.env.TIMING_METRICS,
-        config.metricsConfiguration.timingMetrics
-      ),
-      metricsOutputFile: process.env.METRICS_OUTPUT_FILE,
-    },
-
-    ethereumPrivateKey: process.env.ETHEREUM_PRIVATE_KEY || config.ethereumPrivateKey,
-    networkConfiguration: {
-      rpcEndpoint: process.env.RPC_ENDPOINT,
-      chainNetworkID: BigNumber.from(process.env.CHAIN_NETWORK_ID || '0x00').toNumber(),
-    },
-
-    skipEvmValidation: (process.env.SKIP_EVM_VALIDATION || 'true').toLowerCase() === 'true',
-
-    workerThreadAmount: readInt(process.env.AMOUNT_OF_WORKER_THREADS, config.workerThreadAmount),
-    loggingConfiguration: {
-      logLevel: (process.env.LOG_LEVEL as Level) || config.loggingConfiguration.logLevel,
-      logDestination: process.env.LOG_DESTINATION || config.loggingConfiguration.logDestination,
-    },
-  };
-}
 
 export function extractDBConfigFromServerWalletConfig(
   serverWalletConfig: ServerWalletConfig

--- a/packages/server-wallet/src/db-admin/knexfile.ts
+++ b/packages/server-wallet/src/db-admin/knexfile.ts
@@ -53,7 +53,7 @@ export function createKnexConfig(walletConfig: ServerWalletConfig): Config<any> 
 const dbConnectionConfig = process.env.SERVER_URL || {
   host: process.env.SERVER_HOST || defaultDatabaseConfiguration.connection.host,
   port: Number(process.env.SERVER_PORT) || defaultDatabaseConfiguration.connection.port,
-  dbName: process.env.SERVER_DB_NAME || '',
+  database: process.env.SERVER_DB_NAME || '',
   user: process.env.SERVER_DB_USER || 'postgres', // Default to postgres so the command will work in most cases without specifying a user
   password: process.env.SERVER_DB_PASSWORD,
 };

--- a/packages/server-wallet/src/db-admin/knexfile.ts
+++ b/packages/server-wallet/src/db-admin/knexfile.ts
@@ -2,7 +2,6 @@
 import * as path from 'path';
 
 import {Config} from 'knex';
-import {constants} from 'ethers';
 
 import {
   defaultConfig,
@@ -66,9 +65,6 @@ export const {client, connection, debug, migrations, seeds, pool} = createKnexCo
   databaseConfiguration: {debug: dbDebug, connection: dbConnectionConfig},
   ethereumPrivateKey: '0x0',
   networkConfiguration: {
-    chainNetworkID: '0x0',
-    erc20Address: constants.AddressZero,
-    erc20AssetHolderAddress: constants.AddressZero,
-    ethAssetHolderAddress: constants.AddressZero,
+    chainNetworkID: 0,
   },
 });

--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -6,7 +6,7 @@ import {Bytes} from './type-aliases';
 import {createLogger} from './logger';
 import {defaultTestConfig} from './config';
 
-const logger = createLogger(defaultTestConfig);
+const logger = createLogger(defaultTestConfig());
 /**
  * Takes two states and runs the validateTransition in an evm (pureevm).
  * Returns a promise that resolves to true if the validateTransition

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -1,4 +1,4 @@
 export {Payload as Message} from '@statechannels/wallet-core';
 
-export {Wallet, SingleChannelOutput, ServerWalletConfig} from './wallet';
+export * from './wallet';
 export {Outgoing} from './protocols/actions';

--- a/packages/server-wallet/src/logger.ts
+++ b/packages/server-wallet/src/logger.ts
@@ -13,7 +13,7 @@ export function createLogger(config: ServerWalletConfig): pino.Logger {
     ? pino({level: config.loggingConfiguration.logLevel}, destination)
     : pino({level: config.loggingConfiguration.logLevel})
   ).child({
-    dbName: getDatabaseConnectionConfig(config).dbName,
+    dbName: getDatabaseConnectionConfig(config).database,
     walletVersion: WALLET_VERSION,
   });
 }

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -10,7 +10,7 @@ import {MockChainService} from '../../chain-service';
 import {createLogger} from '../../logger';
 import {DBOpenChannelObjective} from '../../models/objective';
 
-const logger = createLogger(defaultTestConfig);
+const logger = createLogger(defaultTestConfig());
 const timingMetrics = false;
 const testChan = TestChannel.create(5, 5);
 
@@ -19,8 +19,8 @@ let store: Store;
 beforeEach(async () => {
   store = new Store(
     knex,
-    defaultTestConfig.metricsConfiguration.timingMetrics,
-    defaultTestConfig.skipEvmValidation,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
     '0'
   );
   await store.dbAdmin().truncateDB();

--- a/packages/server-wallet/src/utilities/__test__/signatures.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/signatures.test.ts
@@ -15,7 +15,7 @@ import {addHash} from '../../state-utils';
 import {createLogger} from '../../logger';
 import {defaultTestConfig} from '../../config';
 
-const logger = createLogger(defaultTestConfig);
+const logger = createLogger(defaultTestConfig());
 it('sign vs wasmSign', async () => {
   const promises = _.range(5).map(async channelNonce => {
     const {address: ethAddress, privateKey} = Wallet.createRandom();

--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -14,8 +14,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig.metricsConfiguration.timingMetrics,
-    defaultTestConfig.skipEvmValidation,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-signed-state.test.ts
@@ -11,8 +11,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig.metricsConfiguration.timingMetrics,
-    defaultTestConfig.skipEvmValidation,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -14,8 +14,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig.metricsConfiguration.timingMetrics,
-    defaultTestConfig.skipEvmValidation,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -4,12 +4,12 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {Bytes32} from '../../../type-aliases';
 
 let w: Wallet;
 beforeAll(async () => {
-  w = Wallet.create(overwriteConfigWithEnvVars(defaultTestConfig));
+  w = Wallet.create(defaultTestConfig);
   await seedAlicesSigningWallet(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -9,7 +9,7 @@ import {Bytes32} from '../../../type-aliases';
 
 let w: Wallet;
 beforeAll(async () => {
-  w = Wallet.create(defaultTestConfig);
+  w = Wallet.create(defaultTestConfig());
   await seedAlicesSigningWallet(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -7,7 +7,7 @@ import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig);
+  w = Wallet.create(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -2,12 +2,12 @@ import {Channel} from '../../../models/channel';
 import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(overwriteConfigWithEnvVars(defaultTestConfig));
+  w = Wallet.create(defaultTestConfig);
   await new DBAdmin(w.knex).truncateDB();
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
@@ -9,7 +9,7 @@ import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig);
+  w = Wallet.create(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
@@ -4,12 +4,12 @@ import {Channel} from '../../../models/channel';
 import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(overwriteConfigWithEnvVars(defaultTestConfig));
+  w = Wallet.create(defaultTestConfig);
   await new DBAdmin(w.knex).truncateDB();
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -25,7 +25,7 @@ import {ObjectiveModel} from '../../../models/objective';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig);
+  w = Wallet.create(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
   await seedBobsSigningWallet(w.knex);
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -18,14 +18,14 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {bob, alice} from '../fixtures/signing-wallets';
 import {bob as bobP} from '../fixtures/participants';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(overwriteConfigWithEnvVars(defaultTestConfig));
+  w = Wallet.create(defaultTestConfig);
   await new DBAdmin(w.knex).truncateDB();
   await seedBobsSigningWallet(w.knex);
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -23,7 +23,7 @@ import {stateSignedBy, stateWithHashSignedBy} from '../fixtures/states';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
 import {ObjectiveModel} from '../../../models/objective';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {LedgerRequest} from '../../../models/ledger-request';
@@ -32,7 +32,7 @@ import {PushMessageError} from '../../../errors/wallet-error';
 
 jest.setTimeout(20_000);
 
-const wallet = Wallet.create(overwriteConfigWithEnvVars(defaultTestConfig));
+const wallet = Wallet.create(defaultTestConfig);
 
 beforeAll(async () => {
   await wallet.dbAdmin().migrateDB();

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -32,7 +32,7 @@ import {PushMessageError} from '../../../errors/wallet-error';
 
 jest.setTimeout(20_000);
 
-const wallet = Wallet.create(defaultTestConfig);
+const wallet = Wallet.create(defaultTestConfig());
 
 beforeAll(async () => {
   await wallet.dbAdmin().migrateDB();

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -15,7 +15,7 @@ let w: Wallet;
 beforeEach(async () => {
   await new DBAdmin(knex).truncateDB();
 
-  w = Wallet.create(defaultTestConfig);
+  w = Wallet.create(defaultTestConfig());
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -7,7 +7,7 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import * as participantFixtures from '../fixtures/participants';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {channel} from '../../../models/__test__/fixtures/channel';
 
@@ -15,7 +15,7 @@ let w: Wallet;
 beforeEach(async () => {
   await new DBAdmin(knex).truncateDB();
 
-  w = Wallet.create(overwriteConfigWithEnvVars(defaultTestConfig));
+  w = Wallet.create(defaultTestConfig);
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -22,7 +22,7 @@ afterEach(async () => {
 const appData1 = utils.defaultAbiCoder.encode(['uint256'], [1]);
 const appData2 = utils.defaultAbiCoder.encode(['uint256'], [2]);
 beforeEach(async () => {
-  w = Wallet.create({...defaultTestConfig, skipEvmValidation: false});
+  w = Wallet.create({...defaultTestConfig(), skipEvmValidation: false});
 
   await new DBAdmin(knex).truncateDB();
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -7,7 +7,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {AppBytecode} from '../../../models/app-bytecode';
 import {appBytecode, COUNTING_APP_DEFINITION} from '../../../models/__test__/fixtures/app-bytecode';
@@ -22,7 +22,7 @@ afterEach(async () => {
 const appData1 = utils.defaultAbiCoder.encode(['uint256'], [1]);
 const appData2 = utils.defaultAbiCoder.encode(['uint256'], [2]);
 beforeEach(async () => {
-  w = Wallet.create({...overwriteConfigWithEnvVars(defaultTestConfig), skipEvmValidation: false});
+  w = Wallet.create({...defaultTestConfig, skipEvmValidation: false});
 
   await new DBAdmin(knex).truncateDB();
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -17,7 +17,7 @@ const AddressZero = makeAddress(ethers.constants.AddressZero);
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig);
+  w = Wallet.create(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
 });
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -9,7 +9,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {ObjectiveModel} from '../../../models/objective';
-import {defaultTestConfig, overwriteConfigWithEnvVars} from '../../../config';
+import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 
@@ -17,7 +17,7 @@ const AddressZero = makeAddress(ethers.constants.AddressZero);
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(overwriteConfigWithEnvVars(defaultTestConfig));
+  w = Wallet.create(defaultTestConfig);
   await new DBAdmin(w.knex).truncateDB();
 });
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -17,8 +17,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig.metricsConfiguration.timingMetrics,
-    defaultTestConfig.skipEvmValidation,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -18,8 +18,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig.metricsConfiguration.timingMetrics,
-    defaultTestConfig.skipEvmValidation,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -13,8 +13,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig.metricsConfiguration.timingMetrics,
-    defaultTestConfig.skipEvmValidation,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/wallet/__test__/validate-transition.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/validate-transition.test.ts
@@ -35,7 +35,7 @@ describe('validate transition', () => {
         stateWithHashSignedBy([fromSigner])(fromState),
         stateWithHashSignedBy([toSigner])(toState),
         undefined,
-        createLogger(defaultTestConfig),
+        createLogger(defaultTestConfig()),
         true
       )
     ).toEqual(expectedResult);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -50,7 +50,7 @@ import {defaultTestConfig} from '../config';
 import {createLogger} from '../logger';
 import {DBAdmin} from '../db-admin/db-admin';
 
-const defaultLogger = createLogger(defaultTestConfig);
+const defaultLogger = createLogger(defaultTestConfig());
 
 export type AppHandler<T> = (tx: Transaction, channelRecord: Channel) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;


### PR DESCRIPTION
Fixes #2960 

This removes the majority environmental variable usage for configuration. The test configuration is now specified by `defaultTestConfig`  

There is still some environment variable usage but it's limited to two cases:
- Configuration for tests (ie: contract artifacts)
- Setting the database to run a yarn command against (ie: `SERVER_DB_NAME='test' yarn db:create`)

This means the only way to configure the `wallet` is now via the config object passed in.

We should wait to merge this until `the-graph` repo is updated to work against this branch.