### PR TITLE
test: add off-chain tests against max outcome size, and on-chain test for challenging with max outcome size

### DIFF
--- a/packages/nitro-protocol/src/contract/outcome.ts
+++ b/packages/nitro-protocol/src/contract/outcome.ts
@@ -3,7 +3,7 @@ import {utils} from 'ethers';
 import {Address, Bytes, Bytes32, Uint256} from './types';
 
 // CONSTANTS
-export const MAX_OUTCOME_ITEMS = 2025;
+export const MAX_OUTCOME_ITEMS = 2000;
 
 export enum AssetOutcomeType {
   AllocationOutcomeType = 0,

--- a/packages/nitro-protocol/src/contract/outcome.ts
+++ b/packages/nitro-protocol/src/contract/outcome.ts
@@ -2,6 +2,9 @@ import {utils} from 'ethers';
 
 import {Address, Bytes, Bytes32, Uint256} from './types';
 
+// CONSTANTS
+export const MAX_OUTCOME_ITEMS = 2025;
+
 export enum AssetOutcomeType {
   AllocationOutcomeType = 0,
   GuaranteeOutcomeType = 1,

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -6,6 +6,9 @@ import * as forceMoveTrans from './contract/transaction-creators/force-move';
 import * as nitroAdjudicatorTrans from './contract/transaction-creators/nitro-adjudicator';
 import {getStateSignerAddress, SignedState} from './signatures';
 
+// CONSTANTS
+export const MAX_TX_DATA_SIZE = 128 * 1024; // (bytes) https://github.com/ethereum/go-ethereum/blob/f59ed3565d18c1fa676fd34f4fd41ecccad707e8/core/tx_pool.go#L51
+
 export async function getChannelStorage(
   provider: providers.Provider,
   contractAddress: string,

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -8,6 +8,12 @@ import {getStateSignerAddress, SignedState} from './signatures';
 
 // CONSTANTS
 export const MAX_TX_DATA_SIZE = 128 * 1024; // (bytes) https://github.com/ethereum/go-ethereum/blob/f59ed3565d18c1fa676fd34f4fd41ecccad707e8/core/tx_pool.go#L51
+export const NITRO_MAX_GAS = 6_000_000; // should be below the block gas limit, which can change over time and is generally different on mainnet, testnet and ganache.
+// sampling some recent blocks on 26/11/2020:
+// mainnet  12505858
+// ropsten:  8000029
+// rinkeby: 10000000
+// ganache:  6721975 (hardcoded but can be overriden via config)
 
 export async function getChannelStorage(
   provider: providers.Provider,

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
@@ -56,7 +56,12 @@ beforeAll(async () => {
   );
 });
 
-// Scenarios are synonymous with channelNonce:
+// NOTE ABOUT PUSHING A LARGE OUTCOME
+// We run our tests against ganache, which cannot seem to handle a pushOutcome transaction with 2000
+// allocation items (it consumes excessive memory). This is despite the tx being less than 128KB
+// However, such an outcome was pushed successfully on rinkeby https://rinkeby.etherscan.io/tx/0xcc892796857ea8d52d88ed747dd587a91cfd172d384b79f42cfc583f047f6f55
+// It consumed 2,054,158 gas
+// This test falls back to 100 allocation items.
 const description0 =
   'TestNitroAdjudicator accepts a pushOutcome tx for a finalized channel, and 1x AssetHolder storage updated correctly with 100 allocationItems';
 

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
@@ -57,6 +57,8 @@ beforeAll(async () => {
 });
 
 // Scenarios are synonymous with channelNonce:
+const description0 =
+  'TestNitroAdjudicator accepts a pushOutcome tx for a finalized channel, and 1x AssetHolder storage updated correctly with MAX_OUTCOME_ITEMS';
 
 const description1 =
   'TestNitroAdjudicator accepts a pushOutcome tx for a finalized channel, and 2x AssetHolder storage updated correctly';
@@ -72,7 +74,8 @@ describe('pushOutcome', () => {
   });
   it.each`
     description     | storedTurnNumRecord | declaredTurnNumRecord | finalized | outcomeHashExits | numAllocations | reasonString
-    ${description1} | ${5}                | ${5}                  | ${true}   | ${false}         | ${[2, 2]}      | ${undefined}
+    ${description0} | ${5}                | ${5}                  | ${true}   | ${false}         | ${[2, 2]}      | ${undefined}
+    ${description1} | ${5}                | ${5}                  | ${true}   | ${false}         | ${[100, 0]}    | ${undefined}
     ${description2} | ${5}                | ${5}                  | ${false}  | ${false}         | ${[2, 2]}      | ${CHANNEL_NOT_FINALIZED}
     ${description3} | ${4}                | ${5}                  | ${true}   | ${false}         | ${[2, 2]}      | ${WRONG_CHANNEL_STORAGE}
     ${description4} | ${5}                | ${5}                  | ${true}   | ${true}          | ${[2, 2]}      | ${'Outcome hash already exists'}
@@ -116,8 +119,15 @@ describe('pushOutcome', () => {
         challengerAddress
       );
 
-      // Call public wrapper to set state (only works on test contract)
-      // This may cause memory issues when using a large outcome
+      // Use public wrapper to set state (only works on test contract)
+      const txRequest = {
+        data: TestNitroAdjudicator.interface.encodeFunctionData('setChannelStorageHash', [
+          channelId,
+          initialChannelStorageHash,
+        ]),
+      };
+      await sendTransaction(provider, TestNitroAdjudicator.address, txRequest);
+
       const tx = await TestNitroAdjudicator.setChannelStorageHash(
         channelId,
         initialChannelStorageHash

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
@@ -58,7 +58,7 @@ beforeAll(async () => {
 
 // Scenarios are synonymous with channelNonce:
 const description0 =
-  'TestNitroAdjudicator accepts a pushOutcome tx for a finalized channel, and 1x AssetHolder storage updated correctly with MAX_OUTCOME_ITEMS';
+  'TestNitroAdjudicator accepts a pushOutcome tx for a finalized channel, and 1x AssetHolder storage updated correctly with 100 allocationItems';
 
 const description1 =
   'TestNitroAdjudicator accepts a pushOutcome tx for a finalized channel, and 2x AssetHolder storage updated correctly';
@@ -165,12 +165,12 @@ describe('pushOutcome', () => {
         // Ensure we aren't using too much gas
         expect(BigNumber.from(receipt.gasUsed).lt(BigNumber.from(NITRO_MAX_GAS))).toBe(true);
         // Check 2x AssetHolder storage against the expected value
-        if (outcome[0].allocationItems.length > 0) {
+        if (outcome[0]) {
           expect(await ETHAssetHolder.assetOutcomeHashes(channelId)).toEqual(
             hashAssetOutcome(outcome[0].allocationItems)
           );
         }
-        if (outcome[1].allocationItems.length > 0) {
+        if (outcome[1]) {
           expect(await ERC20AssetHolder.assetOutcomeHashes(channelId)).toEqual(
             hashAssetOutcome(outcome[1].allocationItems)
           );

--- a/packages/nitro-protocol/test/src/transactions.test.ts
+++ b/packages/nitro-protocol/test/src/transactions.test.ts
@@ -13,7 +13,7 @@ import {
   createSignatureArguments,
   MAX_TX_DATA_SIZE,
 } from '../../src/transactions';
-import {largeOutcome} from '../test-helpers';
+import {getRandomNonce, largeOutcome} from '../test-helpers';
 
 const walletA = Wallet.createRandom();
 const walletB = Wallet.createRandom();
@@ -22,7 +22,7 @@ const walletB = Wallet.createRandom();
 
 const channel: Channel = {
   chainId: '0x1',
-  channelNonce: 0x1,
+  channelNonce: getRandomNonce('transactions'),
   participants: [walletA.address, walletB.address], // 2 participants is the most common usecase
 };
 
@@ -43,7 +43,7 @@ const state: State = {
   appData: '0x00',
   outcome: [],
   channel,
-  challengeDuration: 0x0,
+  challengeDuration: 0x1,
 };
 let signedStateA: SignedState;
 let signedStateB: SignedState;

--- a/packages/nitro-protocol/test/src/transactions.test.ts
+++ b/packages/nitro-protocol/test/src/transactions.test.ts
@@ -30,13 +30,6 @@ const challengeState = {
   outcome: [],
   challengeDuration: 0x0,
 };
-// Const challengeChannelStorage: ChannelData = {
-//   TurnNumRecord: 0,
-//   FinalizesAt: 1e12,
-//   StateHash: HashZero,
-//   ChallengerAddress: ethers.constants.AddressZero,
-//   OutcomeHash: HashZero,
-// };
 
 let signedState: SignedState;
 

--- a/packages/nitro-protocol/test/src/transactions.test.ts
+++ b/packages/nitro-protocol/test/src/transactions.test.ts
@@ -1,8 +1,9 @@
 import {ethers, Wallet} from 'ethers';
 
-import {Outcome, randomExternalDestination, SignedState} from '../../src';
+import {SignedState} from '../../src';
 import {Channel} from '../../src/contract/channel';
 import {MAX_OUTCOME_ITEMS} from '../../src/contract/outcome';
+import {createPushOutcomeTransaction} from '../../src/contract/transaction-creators/nitro-adjudicator';
 import {signState} from '../../src/signatures';
 import {
   createCheckpointTransaction,
@@ -68,7 +69,6 @@ describe('transaction-generators', () => {
       ],
       wallet.privateKey
     );
-
     expect(transactionRequest.data.toString().slice(2).length / 2).toBeLessThan(MAX_TX_DATA_SIZE); // it's a hex string, so divide by 2 for bytes
   });
 
@@ -95,6 +95,25 @@ describe('transaction-generators', () => {
     ]);
 
     expect(transactionRequest.data).toBeDefined();
+  });
+
+  it('creates a pushOutcome transaction with MAX_OUTCOME_ITEMS outcome items that is smaller than MAX_TX_DATA_SIZE', async () => {
+    const outcome = largeOutcome(MAX_OUTCOME_ITEMS);
+    const transactionRequest: ethers.providers.TransactionRequest = createPushOutcomeTransaction(
+      1,
+      1606389728,
+      {
+        turnNum: 0,
+        isFinal: false,
+        appDefinition: ethers.constants.AddressZero,
+        appData: '0x00',
+        outcome,
+        channel,
+        challengeDuration: 0x0,
+      },
+      outcome
+    );
+    expect(transactionRequest.data.toString().slice(2).length / 2).toBeLessThan(MAX_TX_DATA_SIZE); // it's a hex string, so divide by 2 for bytes
   });
 
   it.each`
@@ -167,7 +186,7 @@ describe('transaction-generators', () => {
       expect(transactionRequest.data).toBeDefined();
     });
 
-    it('creates a transaction when the chabbnel is open', async () => {
+    it('creates a transaction when the channel is open', async () => {
       const transactionRequest: ethers.providers.TransactionRequest = createCheckpointTransaction([
         signedState,
       ]);

--- a/packages/nitro-protocol/test/src/transactions.test.ts
+++ b/packages/nitro-protocol/test/src/transactions.test.ts
@@ -50,7 +50,7 @@ beforeAll(async () => {
 });
 
 describe('transaction-generators', () => {
-  it('creates a challenge transaction with MAX_OUTCOME_ITEMS outcome items that is less than MAX_TX_DATA_SIZE', async () => {
+  it('creates a challenge transaction with MAX_OUTCOME_ITEMS outcome items that is smaller than MAX_TX_DATA_SIZE', async () => {
     const transactionRequest: ethers.providers.TransactionRequest = createChallengeTransaction(
       [
         await signState(

--- a/packages/nitro-protocol/test/src/transactions.test.ts
+++ b/packages/nitro-protocol/test/src/transactions.test.ts
@@ -12,6 +12,7 @@ import {
   createSignatureArguments,
   MAX_TX_DATA_SIZE,
 } from '../../src/transactions';
+import {largeOutcome} from '../test-helpers';
 
 const wallet = Wallet.createRandom();
 
@@ -47,14 +48,6 @@ beforeAll(async () => {
     wallet.privateKey
   );
 });
-
-const randomDestination = randomExternalDestination();
-const largeOutcome = (number: number): Outcome => [
-  {
-    allocationItems: Array(number).fill({destination: randomDestination, amount: '0x01'}),
-    assetHolderAddress: Wallet.createRandom().address,
-  },
-];
 
 describe('transaction-generators', () => {
   it('creates a challenge transaction with MAX_OUTCOME_ITEMS outcome items that is less than MAX_TX_DATA_SIZE', async () => {

--- a/packages/nitro-protocol/test/src/transactions.test.ts
+++ b/packages/nitro-protocol/test/src/transactions.test.ts
@@ -2,6 +2,7 @@ import {ethers, Wallet} from 'ethers';
 
 import {Outcome, randomExternalDestination, SignedState} from '../../src';
 import {Channel} from '../../src/contract/channel';
+import {MAX_OUTCOME_ITEMS} from '../../src/contract/outcome';
 import {signState} from '../../src/signatures';
 import {
   createCheckpointTransaction,
@@ -9,6 +10,7 @@ import {
   createChallengeTransaction,
   createRespondTransaction,
   createSignatureArguments,
+  MAX_TX_DATA_SIZE,
 } from '../../src/transactions';
 
 const wallet = Wallet.createRandom();
@@ -52,9 +54,6 @@ beforeAll(async () => {
     wallet.privateKey
   );
 });
-
-const MAX_OUTCOME_ITEMS = 2025;
-const MAX_TX_DATA_SIZE = 128 * 1024; // (bytes) https://github.com/ethereum/go-ethereum/blob/f59ed3565d18c1fa676fd34f4fd41ecccad707e8/core/tx_pool.go#L51
 
 const randomDestination = randomExternalDestination();
 const largeOutcome = (number: number): Outcome => [

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -396,3 +396,13 @@ export async function writeGasConsumption(
 export function getRandomNonce(seed: string): number {
   return Number.parseInt(ethers.utils.id(seed).slice(2, 11), 16);
 }
+
+export const largeOutcome = (number: number): Outcome => {
+  const randomDestination = randomExternalDestination();
+  return [
+    {
+      allocationItems: Array(number).fill({destination: randomDestination, amount: '0x01'}),
+      assetHolderAddress: ethers.Wallet.createRandom().address,
+    },
+  ];
+};

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -399,7 +399,7 @@ export function getRandomNonce(seed: string): number {
 
 export const largeOutcome = (
   numAllocationItems: number,
-  assetHolderAddress: string = randomExternalDestination()
+  assetHolderAddress: string = ethers.Wallet.createRandom().address
 ): AllocationAssetOutcome[] => {
   const randomDestination = randomExternalDestination();
 

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -402,14 +402,15 @@ export const largeOutcome = (
   assetHolderAddress: string = ethers.Wallet.createRandom().address
 ): AllocationAssetOutcome[] => {
   const randomDestination = randomExternalDestination();
-
-  return [
-    {
-      allocationItems: Array(numAllocationItems).fill({
-        destination: randomDestination,
-        amount: '0x01',
-      }),
-      assetHolderAddress,
-    },
-  ];
+  return numAllocationItems > 0
+    ? [
+        {
+          allocationItems: Array(numAllocationItems).fill({
+            destination: randomDestination,
+            amount: '0x01',
+          }),
+          assetHolderAddress,
+        },
+      ]
+    : [];
 };

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -397,12 +397,19 @@ export function getRandomNonce(seed: string): number {
   return Number.parseInt(ethers.utils.id(seed).slice(2, 11), 16);
 }
 
-export const largeOutcome = (number: number): Outcome => {
+export const largeOutcome = (
+  numAllocationItems: number,
+  assetHolderAddress: string = randomExternalDestination()
+): AllocationAssetOutcome[] => {
   const randomDestination = randomExternalDestination();
+
   return [
     {
-      allocationItems: Array(number).fill({destination: randomDestination, amount: '0x01'}),
-      assetHolderAddress: ethers.Wallet.createRandom().address,
+      allocationItems: Array(numAllocationItems).fill({
+        destination: randomDestination,
+        amount: '0x01',
+      }),
+      assetHolderAddress,
     },
   ];
 };


### PR DESCRIPTION
Happy: by checking the tx size off chain, ganache was happy to accept a `challenge` transaction under 128KB without gorging on memory. 

Sad: tried rolling out the same thing for `pushOutcome`. Can get the same number of allocationItems in under 128KB but still seeing an out-of-memory error. 

- exports new constants
- tidies up test helpers
- adds comments around block gas limits