### PR TITLE
Config clean up

### DIFF
--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -50,7 +50,7 @@ type HasDatabaseConnectionConfigObject = {
   databaseConfiguration: {connection: {host: string; port: number; dbName: string}};
 };
 export const defaultTestNetworkConfiguration: NetworkConfiguration = {
-  chainNetworkID: '0x00',
+  chainNetworkID: 0,
 };
 export const defaultTestConfig: ServerWalletConfig & HasDatabaseConnectionConfigObject = {
   ...defaultConfig,

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-process-env */
-import {constants} from 'ethers';
-
 import {
   LoggingConfiguration,
   NetworkConfiguration,
@@ -54,9 +51,6 @@ type HasDatabaseConnectionConfigObject = {
 };
 export const defaultTestNetworkConfiguration: NetworkConfiguration = {
   chainNetworkID: '0x00',
-  erc20Address: constants.AddressZero,
-  ethAssetHolderAddress: constants.AddressZero,
-  erc20AssetHolderAddress: constants.AddressZero,
 };
 export const defaultTestConfig: ServerWalletConfig & HasDatabaseConnectionConfigObject = {
   ...defaultConfig,

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -84,9 +84,6 @@ export type IncomingServerWalletConfig = RequiredServerWalletConfig &
  * Various network configuration options
  */
 export type NetworkConfiguration = {
-  erc20Address: string;
-  ethAssetHolderAddress: string;
-  erc20AssetHolderAddress: string;
   rpcEndpoint?: string;
   chainNetworkID: string;
 };

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -85,5 +85,5 @@ export type IncomingServerWalletConfig = RequiredServerWalletConfig &
  */
 export type NetworkConfiguration = {
   rpcEndpoint?: string;
-  chainNetworkID: string;
+  chainNetworkID: number;
 };

--- a/packages/server-wallet/src/config/utils.ts
+++ b/packages/server-wallet/src/config/utils.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-process-env */
-import {constants} from 'ethers';
 import {Config} from 'knex';
 import {knexSnakeCaseMappers} from 'objection';
 import {parse} from 'pg-connection-string';
@@ -46,9 +45,6 @@ export function overwriteConfigWithEnvVars(config: ServerWalletConfig): ServerWa
     networkConfiguration: {
       rpcEndpoint: process.env.RPC_ENDPOINT,
       chainNetworkID: process.env.CHAIN_NETWORK_ID || '0x00',
-      ethAssetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS || constants.AddressZero,
-      erc20Address: process.env.ERC20_ADDRESS || constants.AddressZero,
-      erc20AssetHolderAddress: process.env.ERC20_ASSET_HOLDER_ADDRESS || constants.AddressZero,
     },
 
     skipEvmValidation: (process.env.SKIP_EVM_VALIDATION || 'true').toLowerCase() === 'true',

--- a/packages/server-wallet/src/config/utils.ts
+++ b/packages/server-wallet/src/config/utils.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-process-env */
+import {BigNumber} from 'ethers';
 import {Config} from 'knex';
 import {knexSnakeCaseMappers} from 'objection';
 import {parse} from 'pg-connection-string';
@@ -44,7 +45,7 @@ export function overwriteConfigWithEnvVars(config: ServerWalletConfig): ServerWa
     ethereumPrivateKey: process.env.ETHEREUM_PRIVATE_KEY || config.ethereumPrivateKey,
     networkConfiguration: {
       rpcEndpoint: process.env.RPC_ENDPOINT,
-      chainNetworkID: process.env.CHAIN_NETWORK_ID || '0x00',
+      chainNetworkID: BigNumber.from(process.env.CHAIN_NETWORK_ID || '0x00').toNumber(),
     },
 
     skipEvmValidation: (process.env.SKIP_EVM_VALIDATION || 'true').toLowerCase() === 'true',

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -1,6 +1,6 @@
 export {WalletEvent, SingleChannelOutput, MultipleChannelOutput} from './wallet';
 
-import {IncomingServerWalletConfig, ServerWalletConfig} from '../config';
+import {IncomingServerWalletConfig} from '../config';
 
 import {MultiThreadedWallet} from './multi-threaded-wallet';
 import {SingleThreadedWallet} from './wallet';
@@ -17,4 +17,4 @@ export const Wallet = {
   },
 };
 
-export {ServerWalletConfig};
+export * from '../config';

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -24,7 +24,7 @@ import * as Either from 'fp-ts/lib/Either';
 import Knex from 'knex';
 import _ from 'lodash';
 import EventEmitter from 'eventemitter3';
-import {ethers, constants} from 'ethers';
+import {ethers, constants, BigNumber, utils} from 'ethers';
 import {Logger} from 'pino';
 import {Payload as WirePayload} from '@statechannels/wire-format';
 
@@ -118,7 +118,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       this.knex,
       this.walletConfig.metricsConfiguration.timingMetrics,
       this.walletConfig.skipEvmValidation,
-      this.walletConfig.networkConfiguration.chainNetworkID,
+      utils.hexlify(this.walletConfig.networkConfiguration.chainNetworkID),
       this.logger
     );
 
@@ -158,7 +158,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
   public async registerAppDefinition(appDefinition: string): Promise<void> {
     const bytecode = await this.chainService.fetchBytecode(appDefinition);
     await this.store.upsertBytecode(
-      this.walletConfig.networkConfiguration.chainNetworkID,
+      utils.hexlify(this.walletConfig.networkConfiguration.chainNetworkID),
       makeAddress(appDefinition),
       bytecode
     );
@@ -166,7 +166,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
   public async registerAppBytecode(appDefinition: string, bytecode: string): Promise<void> {
     return this.store.upsertBytecode(
-      this.walletConfig.networkConfiguration.chainNetworkID,
+      utils.hexlify(this.walletConfig.networkConfiguration.chainNetworkID),
       makeAddress(appDefinition),
       bytecode
     );
@@ -323,7 +323,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
     const constants = {
       appDefinition: makeAddress(appDefinition),
-      chainId: this.walletConfig.networkConfiguration.chainNetworkID,
+      chainId: BigNumber.from(this.walletConfig.networkConfiguration.chainNetworkID).toHexString(),
       challengeDuration: 9001,
       channelNonce,
       participants,


### PR DESCRIPTION
Some minor changes to clean up the config.

- Removes some unused assetholder address config
- Exported config types from `ServerWallet` package
- Accept `chainId` as a number.