### PR TITLE
ci: swap carrot for memo

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -20,7 +20,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: ':carrot: conventional'
+              name: ':memo: conventional'
             })
       - uses: actions/github-script@v3
         continue-on-error: true
@@ -31,5 +31,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: [':carrot: conventional']
+              labels: [':memo: conventional']
             })


### PR DESCRIPTION
This month, 103 of 131 (79%) merged pull requests got the carrot, meaning all of the commits on those PRs were conventional. I think it has done its job of encouraging conventional commits. 

The time seems right to refine this a little, as our changelogs are full of things like `fix: typo` which don't belong there. The carrot has probably encouraged overuse of `fix:`.

This is definitely not the long term solution but changing the emoji is designed to nudge everyone to remember: "These commits are going to affect the changelog" before clicking "merge". If the merger sees `fix: typo` they can either

1) ask the originator to rewrite the history
2) squash-merge the PR and fixup the commit message themselves. 

(NB: if you are unconventional in a single commit you won't get the badge at all, and this nudge won't work).



