### PR TITLE
refactor: reuse _conclude in concludePush...All

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -218,7 +218,7 @@ contract ForceMove is IForceMove {
         _clearChallenge(channelId, largestTurnNum);
     }
 
-     /**
+    /**
      * @notice Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
      * @dev Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
      * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -237,8 +237,8 @@ contract ForceMove is IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) external override {
-        bytes32 channelId = _getChannelId(fixedPart);
+    ) public override returns (bytes32 channelId) {
+        channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 
         require(

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -218,9 +218,9 @@ contract ForceMove is IForceMove {
         _clearChallenge(channelId, largestTurnNum);
     }
 
-    /**
-     * @notice Finalizes a channel by providing a finalization proof.
-     * @dev Finalizes a channel by providing a finalization proof.
+     /**
+     * @notice Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
+     * @dev Finalizes a channel by providing a finalization proof. External wrapper for _conclude.
      * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
      * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
@@ -237,7 +237,38 @@ contract ForceMove is IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) public override returns (bytes32 channelId) {
+    ) external override {
+        _conclude(
+            largestTurnNum,
+            fixedPart,
+            appPartHash,
+            outcomeHash,
+            numStates,
+            whoSignedWhat,
+            sigs
+        );
+    }
+
+    /**
+     * @notice Finalizes a channel by providing a finalization proof. Internal method.
+     * @dev Finalizes a channel by providing a finalization proof. Internal method.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
+     * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
+     * @param numStates The number of states in the finalization proof.
+     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+     */
+    function _conclude(
+        uint48 largestTurnNum,
+        FixedPart memory fixedPart,
+        bytes32 appPartHash,
+        bytes32 outcomeHash,
+        uint8 numStates,
+        uint8[] memory whoSignedWhat,
+        Signature[] memory sigs
+    ) internal returns (bytes32 channelId) {
         channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -103,7 +103,7 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
         Signature[] memory sigs
     ) public {
         bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
-        bytes32 channelId = conclude(
+        bytes32 channelId = _conclude(
             largestTurnNum,
             fixedPart,
             appPartHash,

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -102,47 +102,16 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
     ) public {
-        // requirements
-        bytes32 channelId = _getChannelId(fixedPart);
-
-        _requireChannelNotFinalized(channelId);
-
-        // By construction, the following states form a valid transition
-        bytes32[] memory stateHashes = new bytes32[](numStates);
-
         bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
-        for (uint48 i = 0; i < numStates; i++) {
-            stateHashes[i] = keccak256(
-                abi.encode(
-                    State(
-                        largestTurnNum + (i + 1) - numStates, // turnNum
-                        true, // isFinal
-                        channelId,
-                        appPartHash,
-                        outcomeHash
-                    )
-                )
-            );
-        }
-
-        require(
-            _validSignatures(
-                largestTurnNum,
-                fixedPart.participants,
-                stateHashes,
-                sigs,
-                whoSignedWhat
-            ),
-            'Invalid signatures'
+        bytes32 channelId = conclude(
+            largestTurnNum,
+            fixedPart,
+            appPartHash,
+            outcomeHash,
+            numStates,
+            whoSignedWhat,
+            sigs
         );
-
-        // effects
-
-        channelStorageHashes[channelId] = _hashChannelData(
-            ChannelData(0, uint48(block.timestamp), bytes32(0), address(0), outcomeHash)
-        );
-        emit Concluded(channelId);
-
         _transferAllFromAllAssetHolders(channelId, outcomeBytes);
     }
 

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -123,9 +123,9 @@ interface IForceMove {
         bytes32 appPartHash,
         bytes32 outcomeHash,
         uint8 numStates,
-        uint8[] calldata whoSignedWhat,
-        Signature[] calldata sigs
-    ) external;
+        uint8[] memory whoSignedWhat,
+        Signature[] memory sigs
+    ) external returns (bytes32);
 
     // events
 

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -123,9 +123,9 @@ interface IForceMove {
         bytes32 appPartHash,
         bytes32 outcomeHash,
         uint8 numStates,
-        uint8[] memory whoSignedWhat,
-        Signature[] memory sigs
-    ) external returns (bytes32);
+        uint8[] calldata whoSignedWhat,
+        Signature[] calldata sigs
+    ) external;
 
     // events
 

--- a/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -20,6 +20,7 @@ import {
   getTestProvider,
   ongoingChallengeHash,
   setupContracts,
+  writeGasConsumption,
 } from '../../test-helpers';
 import {signStates} from '../../../src';
 
@@ -102,7 +103,7 @@ describe('conclude', () => {
     ${reverts3} | ${finalized}              | ${turnNumRecord + 1}             | ${oneState}    | ${CHANNEL_FINALIZED}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
-    async ({initialChannelStorageHash, largestTurnNum, support, reasonString}) => {
+    async ({description, initialChannelStorageHash, largestTurnNum, support, reasonString}) => {
       const channel: Channel = {chainId, participants, channelNonce};
       const channelId = getChannelId(channel);
       const {appData, whoSignedWhat} = support;
@@ -133,6 +134,7 @@ describe('conclude', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const receipt = await (await tx).wait();
+        await writeGasConsumption('./conclude.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
         expect(event.args).toMatchObject({channelId});
 


### PR DESCRIPTION
cherry-picked and refined from #2955 

- also return channelId from conclude, to save some gas.


gas consumption went up a bit overall, however:

master; 
```
{ETH: {A: 1}}:
88585 gas

{ETH: {A: 1}, ETH2: {A: 2}}:
94773 gas

{ETH2: {A: 1, B: 1}}:
93511 gas

{ERC20: {A: 1, B: 1}}:
155782 gas

{ERC20: {At: 1, Bt: 1}} (At and Bt already have some TOK):
125782 gas

10 TOK payouts:
423928 gas

50 TOK payouts:
1615322 gas

100 TOK payouts:
2693927 gas
```

this branch: 
```
{ETH: {A: 1}}:
88714 gas

{ETH: {A: 1}, ETH2: {A: 2}}:
94902 gas

{ETH2: {A: 1, B: 1}}:
93616 gas

{ERC20: {A: 1, B: 1}}:
155887 gas

{ERC20: {At: 1, Bt: 1}} (At and Bt already have some TOK):
125899 gas

10 TOK payouts:
424057 gas

50 TOK payouts:
1615499 gas

100 TOK payouts:
2694080 gas

```