### PR TITLE
fix: improve semantic meaning of input parameters via runtime validation

### DIFF
--- a/packages/docs-website/docs/protocol-tutorial/execute-state-transitions.md
+++ b/packages/docs-website/docs/protocol-tutorial/execute-state-transitions.md
@@ -106,7 +106,7 @@ const getVariablePart = getVariablePart(state);
 As a state channel participant, it is advised to check the `FixedPart` of any channel before participating in it. A good state channels wallet will perform these checks for you:
 
 - `chainId` -- This needs to match the id of the chain where assets are to be locked. The root of the funding tree for this channel.
-- `participants` -- This should have length at least 2, and include a public key (account) that you control. Each entry should be a nonzero ethereum address.
+- `participants` -- This should have length at least 2, but no more than 255, and include a public key (account) that you control. Each entry should be a nonzero ethereum address.
 - `channelNonce` -- This should be different to any previous channelNonce used by the same `participants` and `chainId`. This is to prevent states from previous channels being "replayed" to conclude subsequent channels with unintended outcomes.
 - `appDefinition` -- There should be a [`ForceMoveApp`]('contract-api/natspec/ForceMove') compliant contract deployed at this address, and you should have confidence that it is not malicious or suffering from security flaws. You should inspect the source code (which should be publically available and verifiable) or appeal to a trusted authority to do this.
 - `challengeDuration` -- In the extreme, this should be at least 1 block time (15 seconds on mainnet) and less than `2**48-1` seconds. In practice we recommend somewhere between 5 minutes and 5 months.

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -54,7 +54,7 @@ contract ForceMove is IForceMove {
         Signature memory challengerSig
     ) external override {
         // input type validation
-        _requireValidInput(
+        requireValidInput(
             fixedPart.participants.length,
             variableParts.length,
             sigs.length,
@@ -205,7 +205,7 @@ contract ForceMove is IForceMove {
         uint8[] memory whoSignedWhat
     ) external override {
         // input type validation
-        _requireValidInput(
+        requireValidInput(
             fixedPart.participants.length,
             variableParts.length,
             sigs.length,
@@ -286,7 +286,7 @@ contract ForceMove is IForceMove {
         _requireChannelNotFinalized(channelId);
 
         // input type validation
-        _requireValidInput(
+        requireValidInput(
             fixedPart.participants.length,
             numStates,
             sigs.length,
@@ -913,12 +913,12 @@ contract ForceMove is IForceMove {
      * @param numSigs Number of signatures submitted
      * @param numWhoSignedWhats whoSignedWhat.length
      */
-    function _requireValidInput(
+    function requireValidInput(
         uint256 numParticipants,
         uint256 numStates,
         uint256 numSigs,
         uint256 numWhoSignedWhats
-    ) internal pure {
+    ) public pure returns (bool) {
         require(
             (numParticipants >= numStates) && (numStates > 0),
             'ForceMove | You must submit at least one but no more than numParticipants states'
@@ -928,5 +928,6 @@ contract ForceMove is IForceMove {
             'ForceMove | You must provide exactly one signature per participant, and assert who signed what for all participants'
         );
         require(numParticipants < type(uint8).max, 'ForceMove | Too many participants!');
+        return true;
     }
 }

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -53,14 +53,13 @@ contract ForceMove is IForceMove {
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
     ) external override {
-
         // input type validation
-        require(
-            (fixedPart.participants.length >= variableParts.length) && (variableParts.length > 0),
-            'challenge | You must submit at least one but no more than numParticipants states'
+        _requireValidInput(
+            fixedPart.participants.length,
+            variableParts.length,
+            sigs.length,
+            whoSignedWhat.length
         );
-        require((sigs.length == fixedPart.participants.length) && (whoSignedWhat.length == fixedPart.participants.length), 'challenge | You must provide exactly one signature per participant, and assert who signed what for all participants');
-        require(fixedPart.participants.length < type(uint8).max, 'challenge | Too many participants!');
 
         bytes32 channelId = _getChannelId(fixedPart);
 
@@ -131,7 +130,6 @@ contract ForceMove is IForceMove {
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
     ) external override {
-
         // No need to validate fixedPart.participants.length here, as that validation would have happened during challenge
 
         bytes32 channelId = _getChannelId(fixedPart);
@@ -206,14 +204,13 @@ contract ForceMove is IForceMove {
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
     ) external override {
-
         // input type validation
-        require(
-            (fixedPart.participants.length >= variableParts.length) && (variableParts.length > 0),
-            'checkpoint | You must submit at least one but no more than numParticipants states'
+        _requireValidInput(
+            fixedPart.participants.length,
+            variableParts.length,
+            sigs.length,
+            whoSignedWhat.length
         );
-        require((sigs.length == fixedPart.participants.length) && (whoSignedWhat.length == fixedPart.participants.length), 'checkpoint | You must provide exactly one signature per participant, and assert who signed what for all participants');
-        require(fixedPart.participants.length < type(uint8).max, 'checkpoint | Too many participants!');
 
         bytes32 channelId = _getChannelId(fixedPart);
 
@@ -289,12 +286,12 @@ contract ForceMove is IForceMove {
         _requireChannelNotFinalized(channelId);
 
         // input type validation
-        require(
-            (fixedPart.participants.length >= numStates) && (numStates > 0),
-            'conclude | You must submit at least one but no more than numParticipants states'
+        _requireValidInput(
+            fixedPart.participants.length,
+            numStates,
+            sigs.length,
+            whoSignedWhat.length
         );
-        require((sigs.length == fixedPart.participants.length) && (whoSignedWhat.length == fixedPart.participants.length), 'challenge | You must provide exactly one signature per participant, and assert who signed what for all participants');
-        require(fixedPart.participants.length < type(uint8).max, 'conclude | Too many participants!');
 
         require(
             largestTurnNum + 1 >= numStates,
@@ -302,7 +299,7 @@ contract ForceMove is IForceMove {
         );
         // ^^ SW-C101: prevent underflow
 
-        bytes32 channelId = _getChannelId(fixedPart);
+        channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 
         // By construction, the following states form a valid transition
@@ -906,5 +903,30 @@ contract ForceMove is IForceMove {
         channelId = keccak256(
             abi.encode(getChainID(), fixedPart.participants, fixedPart.channelNonce)
         );
+    }
+
+    /**
+     * @notice Validates input for several external methods.
+     * @dev Validates input for several external methods.
+     * @param numParticipants Length of the participants array
+     * @param numStates Number of states submitted
+     * @param numSigs Number of signatures submitted
+     * @param numWhoSignedWhats whoSignedWhat.length
+     */
+    function _requireValidInput(
+        uint256 numParticipants,
+        uint256 numStates,
+        uint256 numSigs,
+        uint256 numWhoSignedWhats
+    ) internal pure {
+        require(
+            (numParticipants >= numStates) && (numStates > 0),
+            'ForceMove | You must submit at least one but no more than numParticipants states'
+        );
+        require(
+            (numSigs == numParticipants) && (numWhoSignedWhats == numParticipants),
+            'ForceMove | You must provide exactly one signature per participant, and assert who signed what for all participants'
+        );
+        require(numParticipants < type(uint8).max, 'ForceMove | Too many participants!');
     }
 }

--- a/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -22,7 +22,7 @@ import {
   setupContracts,
   writeGasConsumption,
 } from '../../test-helpers';
-import {signStates} from '../../../src';
+import {signState, signStates} from '../../../src';
 
 const provider = getTestProvider();
 let ForceMove: Contract;
@@ -154,23 +154,24 @@ describe('conclude', () => {
 
   it('Reverts to prevent an underflow', async () => {
     const channel: Channel = {chainId, participants, channelNonce};
-
+    const state: State = {
+      isFinal: true,
+      channel,
+      outcome,
+      appDefinition,
+      appData: '0x00',
+      challengeDuration,
+      turnNum: 99,
+    };
+    const signature = signState(state, wallets[0].privateKey).signature;
     const tx = ForceMove.conclude(
+      0,
+      getFixedPart(state),
+      ethers.constants.HashZero,
+      ethers.constants.HashZero,
       2,
-      getFixedPart({
-        isFinal: true,
-        channel,
-        outcome,
-        appDefinition,
-        appData: '0x00',
-        challengeDuration,
-        turnNum: 99,
-      }),
-      ethers.constants.HashZero,
-      ethers.constants.HashZero,
-      4,
-      [],
-      []
+      [0, 0, 0],
+      [signature, signature, signature] // enough to clear the input type validation
     );
     await expect(() => tx).rejects.toThrow(
       'largestTurnNum + 1 must be greater than or equal to numStates'

--- a/packages/nitro-protocol/test/contracts/ForceMove/requireValidInput.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/requireValidInput.test.ts
@@ -1,0 +1,66 @@
+import {Contract, Wallet} from 'ethers';
+
+import ForceMoveArtifact from '../../../artifacts/contracts/test/TESTForceMove.sol/TESTForceMove.json';
+import {getTestProvider, setupContracts} from '../../test-helpers';
+
+const provider = getTestProvider();
+let ForceMove: Contract;
+
+beforeAll(async () => {
+  ForceMove = await setupContracts(
+    provider,
+    ForceMoveArtifact,
+    process.env.TEST_FORCE_MOVE_ADDRESS
+  );
+});
+
+interface TestCase {
+  numParticipants: number;
+  numStates: number;
+  numSigs: number;
+  numWhoSignedWhats: number;
+}
+
+async function checkGoodCaseAgainstContract(testCase: TestCase) {
+  expect(
+    await ForceMove.requireValidInput(
+      testCase.numParticipants,
+      testCase.numStates,
+      testCase.numSigs,
+      testCase.numWhoSignedWhats
+    )
+  ).toBe(true);
+}
+
+async function checkBadCaseAgainstContract(testCase: TestCase) {
+  await expect(async () =>
+    ForceMove.requireValidInput(
+      testCase.numParticipants,
+      testCase.numStates,
+      testCase.numSigs,
+      testCase.numWhoSignedWhats
+    )
+  ).rejects.toThrow(/ForceMove |/);
+}
+
+// prettier-ignore
+const goodTable: TestCase[] = [
+  { numParticipants: 9, numStates: 9, numSigs: 9, numWhoSignedWhats: 9 },
+  { numParticipants: 8, numStates: 8, numSigs: 8, numWhoSignedWhats: 8 },
+  { numParticipants: 7, numStates: 7, numSigs: 7, numWhoSignedWhats: 7 },
+  { numParticipants: 6, numStates: 1, numSigs: 6, numWhoSignedWhats: 6 },
+  { numParticipants: 5, numStates: 1, numSigs: 5, numWhoSignedWhats: 5 },
+];
+
+// prettier-ignore
+const badTable: TestCase[] = [
+  { numParticipants: 256, numStates: 256, numSigs: 256, numWhoSignedWhats: 256 },
+  { numParticipants: 1, numStates: 0, numSigs: 1, numWhoSignedWhats: 1 },
+  { numParticipants: 2, numStates: 3, numSigs: 3, numWhoSignedWhats: 3 },
+  { numParticipants: 2, numStates: 3, numSigs: 2, numWhoSignedWhats: 2 },
+];
+
+describe('requireValidInput', () => {
+  it.each(goodTable)('Valid input: %o', checkGoodCaseAgainstContract);
+  it.each(badTable)('Invalid input: %o', checkBadCaseAgainstContract);
+});


### PR DESCRIPTION
We are not able to use the type system to constrain the length of dynamically sized arrays; yet we _do_ use the type system  to constrain `numStates` and `whoSignedWhat` entries to be `uint8`s. 

Adding a runtime validation check makes it clear that we do not support more than 255 participants in a channel, and also (therefore) that the chain ought never to be supplied with more than 255 states (meaning `variableParts.length` and `whoSignedWhat[i] \forall i` are also always less than or equal to 255). 

