### PR TITLE
fix: use hexZeroPad to normalize string as bytes32 versus BigNumber.from

### DIFF
--- a/packages/nitro-protocol/src/contract/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/asset-holder.ts
@@ -33,7 +33,7 @@ export function getAssetTransferredEvent(eventResult: any[]): AssetTransferredEv
 }
 
 export function convertBytes32ToAddress(bytes32: string): string {
-  const normalized = BigNumber.from(bytes32).toHexString();
+  const normalized = utils.hexZeroPad(bytes32, 32);
   return utils.getAddress(`0x${normalized.slice(-40)}`);
 }
 

--- a/packages/nitro-protocol/test/src/contract/asset-holder.test.ts
+++ b/packages/nitro-protocol/test/src/contract/asset-holder.test.ts
@@ -1,0 +1,14 @@
+import {convertBytes32ToAddress} from '../../../src/contract/asset-holder';
+
+describe('convertBytes32ToAddress', () => {
+  it.each`
+    bytes32                                                                 | address
+    ${'0x0000000000000000000000000000000000000000000000000000000000000000'} | ${'0x0000000000000000000000000000000000000000'}
+    ${'0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'} | ${'0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'}
+    ${'0x000000000000000000000000aAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'} | ${'0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'}
+    ${'0x000000000000000000000000000000000000000000000000000000000000000a'} | ${'0x000000000000000000000000000000000000000A'}
+    ${'0x000000000000000000000000000000000000000000000000000000000000000A'} | ${'0x000000000000000000000000000000000000000A'}
+  `(`$bytes32 -- $address`, ({bytes32, address}) => {
+    expect(convertBytes32ToAddress(bytes32)).toBe(address);
+  });
+});


### PR DESCRIPTION
The old approach does not work for strings where the first digit is `"0"` e.g., `"0x0..."`.
