### PR TITLE
emit finalizesAt in Conclude event

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -224,7 +224,7 @@ contract ForceMove is IForceMove {
      * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
      * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
-     * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
+     * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all states in the finalization proof.
      * @param numStates The number of states in the finalization proof.
      * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
      * @param sigs An array of signatures that support the state with the `largestTurnNum`.
@@ -312,7 +312,7 @@ contract ForceMove is IForceMove {
         channelStorageHashes[channelId] = _hashChannelData(
             ChannelData(0, uint48(block.timestamp), bytes32(0), address(0), outcomeHash)
         );
-        emit Concluded(channelId);
+        emit Concluded(channelId, uint48(block.timestamp));
     }
 
     // Internal methods:

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -164,6 +164,7 @@ interface IForceMove {
     /**
      * @dev Indicates that a challenge has been registered against `channelId`.
      * @param channelId Unique identifier for a state channel.
+     * @param finalizesAt The unix timestamp when `channelId` finalized.
      */
-    event Concluded(bytes32 indexed channelId);
+    event Concluded(bytes32 indexed channelId, uint48 finalizesAt);
 }

--- a/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -136,7 +136,8 @@ describe('conclude', () => {
         const receipt = await (await tx).wait();
         await writeGasConsumption('./conclude.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
-        expect(event.args).toMatchObject({channelId});
+        const finalizesAt = (await provider.getBlock(receipt.blockNumber)).timestamp;
+        expect(event.args).toMatchObject({channelId, finalizesAt});
 
         // Compute expected ChannelDataHash
         const blockTimestamp = (await provider.getBlock(receipt.blockNumber)).timestamp;


### PR DESCRIPTION
Closes #2983 

- enhances `createPushOutcomeTransaction` to deal with concluded channels
- adds a test case to cover a concluded channel. 