### PR TITLE
perf: enable solidity compiler optimization

### DIFF
--- a/packages/nitro-protocol/hardhat.config.ts
+++ b/packages/nitro-protocol/hardhat.config.ts
@@ -2,6 +2,10 @@ export default {
   solidity: {
     version: '0.7.4',
     settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
       outputSelection: {
         '*': {
           '*': [


### PR DESCRIPTION
e.g. for `concludePushOutcomeAndTransferAll` (other stats available as circle artifacts)

master: 
```js
{ETH: {A: 1}}:
88690 gas

{ETH: {A: 1}, ETH2: {A: 2}}:
94890 gas

{ETH2: {A: 1, B: 1}}:
93628 gas

{ERC20: {A: 1, B: 1}}:
155899 gas

{ERC20: {At: 1, Bt: 1}} (At and Bt already have some TOK):
125875 gas

10 TOK payouts:
424057 gas

50 TOK payouts:
1615475 gas

100 TOK payouts:
2694032 gas
```

here:

```js
{ETH: {A: 1}}:
79484 gas

{ETH: {A: 1}, ETH2: {A: 2}}:
83771 gas

{ETH2: {A: 1, B: 1}}:
83692 gas

{ERC20: {A: 1, B: 1}}:
144696 gas

{ERC20: {At: 1, Bt: 1}} (At and Bt already have some TOK):
114708 gas

10 TOK payouts:
402234 gas

50 TOK payouts:
1540636 gas

100 TOK payouts:
2552929 gas
```