### PR TITLE
ChainService: Add allowanceMode option

### DIFF
--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -171,18 +171,18 @@ describe('fundChannel', () => {
       'cannot estimate gas; transaction may fail or may require manual gas limit'
     );
   });
-});
 
-it('Fund erc20', async () => {
-  const channelId = randomChannelId();
+  it('Fund erc20', async () => {
+    const channelId = randomChannelId();
 
-  await waitForChannelFunding(0, 5, channelId, erc20AssetHolderAddress);
-  const contract: Contract = new Contract(
-    erc20AssetHolderAddress,
-    ContractArtifacts.Erc20AssetHolderArtifact.abi,
-    provider
-  );
-  expect(await contract.holdings(channelId)).toEqual(BigNumber.from(5));
+    await waitForChannelFunding(0, 5, channelId, erc20AssetHolderAddress);
+    const contract: Contract = new Contract(
+      erc20AssetHolderAddress,
+      ContractArtifacts.Erc20AssetHolderArtifact.abi,
+      provider
+    );
+    expect(await contract.holdings(channelId)).toEqual(BigNumber.from(5));
+  });
 });
 
 describe('registerChannel', () => {

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -18,7 +18,8 @@ import {
   bob as bobParticipant,
 } from '../../wallet/__test__/fixtures/participants';
 import {alice as aWallet, bob as bWallet} from '../../wallet/__test__/fixtures/signing-wallets';
-import {AssetTransferredArg, ChainService, HoldingUpdatedArg} from '../chain-service';
+import {ChainService} from '../chain-service';
+import {AssetTransferredArg, HoldingUpdatedArg} from '../types';
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
@@ -52,10 +53,11 @@ beforeAll(() => {
   // - Deploys the token contract.
   // - And therefore has tokens allocated to it.
   /* eslint-disable no-process-env */
-  chainService = new ChainService(
-    rpcEndpoint,
-    process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[0].privateKey
-  );
+  chainService = new ChainService({
+    provider: rpcEndpoint,
+    pk: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[0].privateKey,
+    allowanceMode: 'MaxUint',
+  });
   /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 
   const ethHolder = new Contract(

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -26,7 +26,11 @@ let chainService: ChainService;
 
 beforeEach(() => {
   // Try to use a different private key for every chain service instantiation to avoid nonce errors
-  chainService = new ChainService(rpcEndpoint, privateKey);
+  chainService = new ChainService({
+    provider: rpcEndpoint,
+    pk: privateKey,
+    allowanceMode: 'MaxUint',
+  });
 });
 
 afterEach(() => chainService.destructor());

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -60,7 +60,6 @@ describe('fundChannel', () => {
           assetHolderAddress: erc20AssetHolderAddress,
           expectedHeld: BN.from(0),
           amount: BN.from(depositAmount),
-          allowanceAlreadyIncreased: true,
         })
         .then(response => response.wait())
     );

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -24,6 +24,7 @@ import {Bytes32} from '../type-aliases';
 import {
   AssetTransferredArg,
   ChainEventSubscriberInterface,
+  ChainServiceArgs,
   ChainServiceInterface,
   FundChannelArg,
   HoldingUpdatedArg,
@@ -61,7 +62,7 @@ export class ChainService implements ChainServiceInterface {
 
   private transactionQueue = new PQueue({concurrency: 1});
 
-  constructor(provider: string, pk: string, pollingInterval?: number) {
+  constructor({provider, pk, pollingInterval}: ChainServiceArgs) {
     this.provider = new providers.JsonRpcProvider(provider);
     if (provider.includes('0.0.0.0') || provider.includes('localhost')) {
       pollingInterval = pollingInterval ?? 50;

--- a/packages/server-wallet/src/chain-service/index.ts
+++ b/packages/server-wallet/src/chain-service/index.ts
@@ -1,2 +1,3 @@
 export * from './chain-service';
 export * from './mock-chain-service';
+export * from './types';

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -3,9 +3,7 @@ import {Address, SignedState} from '@statechannels/wallet-core';
 
 import {Bytes32} from '../type-aliases';
 
-import {ChainServiceInterface} from './chain-service';
-
-import {ChainEventSubscriberInterface, FundChannelArg} from './';
+import {ChainEventSubscriberInterface, ChainServiceInterface, FundChannelArg} from './';
 
 const mockTransactionReceipt: providers.TransactionReceipt = {
   to: '',

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -21,7 +21,6 @@ export type FundChannelArg = {
   assetHolderAddress: Address;
   expectedHeld: Uint256;
   amount: Uint256;
-  allowanceAlreadyIncreased?: boolean;
 };
 
 export interface ChainEventSubscriberInterface {

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -49,3 +49,11 @@ interface ChainModifierInterface {
 }
 
 export type ChainServiceInterface = ChainModifierInterface & ChainEventEmitterInterface;
+
+export type AllowanceMode = 'PerDeposit' | 'MaxUint';
+export type ChainServiceArgs = {
+  provider: string;
+  pk: string;
+  allowanceMode: AllowanceMode;
+  pollingInterval?: number;
+};

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -1,0 +1,51 @@
+import {Address, Destination, SignedState, Uint256} from '@statechannels/wallet-core';
+import {providers} from 'ethers';
+
+import {Bytes32} from '../type-aliases';
+
+export type HoldingUpdatedArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  amount: Uint256;
+};
+
+export type AssetTransferredArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  to: Destination;
+  amount: Uint256;
+};
+
+export type FundChannelArg = {
+  channelId: Bytes32;
+  assetHolderAddress: Address;
+  expectedHeld: Uint256;
+  amount: Uint256;
+  allowanceAlreadyIncreased?: boolean;
+};
+
+export interface ChainEventSubscriberInterface {
+  holdingUpdated(arg: HoldingUpdatedArg): void;
+  assetTransferred(arg: AssetTransferredArg): void;
+}
+
+interface ChainEventEmitterInterface {
+  registerChannel(
+    channelId: Bytes32,
+    assetHolders: Address[],
+    listener: ChainEventSubscriberInterface
+  ): void;
+  unregisterChannel(channelId: Bytes32): void;
+  destructor(): void;
+}
+
+interface ChainModifierInterface {
+  // TODO: should these APIs return ethers TransactionResponses? Or is that too detailed for API consumers
+  fundChannel(arg: FundChannelArg): Promise<providers.TransactionResponse>;
+  concludeAndWithdraw(
+    finalizationProof: SignedState[]
+  ): Promise<providers.TransactionResponse | void>;
+  fetchBytecode(address: string): Promise<string>;
+}
+
+export type ChainServiceInterface = ChainModifierInterface & ChainEventEmitterInterface;

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -132,10 +132,11 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
     }
 
     if (this.walletConfig.networkConfiguration.rpcEndpoint) {
-      this.chainService = new ChainService(
-        this.walletConfig.networkConfiguration.rpcEndpoint,
-        this.walletConfig.ethereumPrivateKey
-      );
+      this.chainService = new ChainService({
+        provider: this.walletConfig.networkConfiguration.rpcEndpoint,
+        pk: this.walletConfig.ethereumPrivateKey,
+        allowanceMode: 'MaxUint',
+      });
     } else {
       this.logger.debug(
         'rpcEndpoint and ethereumPrivateKey must be defined for the wallet to use chain service'


### PR DESCRIPTION
The chain service can be run in two modes:
- PerDeposit allowance mode: if the chain service is requested to fund a channel with N tokens, the chain service increases asset holder allowance by N tokens.
- MaxUint mode: if the chain service is asked to fund a channel with N tokens, the chain service increases the allowance for the asset holder to `MaxUint256` if the allowance is less than half of `MaxUint256`.

This also removes the `allowanceAlreadyIncreased` fundChannel function option to simplify chain service behavior.

Fixes https://github.com/statechannels/statechannels/issues/2988, https://github.com/statechannels/statechannels/issues/2987