### PR TITLE
pushUpdate 

### DIFF
--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -121,7 +121,7 @@ export default class PayerClient {
     const payload = await this.createPayment(channelId);
 
     const reply = await this.time(`send message ${channelId}`, async () =>
-      this.messageReceiverAndExpectReply(payload)
+      this.messageReceiverAndExpectReply(payload, '/payment')
     );
 
     await this.time(`push message ${channelId}`, async () => this.wallet.pushMessage(reply));
@@ -143,8 +143,11 @@ export default class PayerClient {
     });
   }
 
-  public async messageReceiverAndExpectReply(message: unknown): Promise<unknown> {
-    const {data: reply} = await axios.post(this.receiverHttpServerURL + '/inbox', {message});
+  public async messageReceiverAndExpectReply(
+    message: unknown,
+    endpoint: '/payment' | '/inbox' = '/inbox'
+  ): Promise<unknown> {
+    const {data: reply} = await axios.post(this.receiverHttpServerURL + endpoint, {message});
     return reply;
   }
 }

--- a/packages/server-wallet/e2e-test/receiver/app.ts
+++ b/packages/server-wallet/e2e-test/receiver/app.ts
@@ -22,11 +22,20 @@ export async function startApp(): Promise<express.Application> {
       .send(controller.participantInfo)
   );
 
+  // endpoint for general state channel messages
   app.post('/inbox', bodyParser.json(), async (req, res) =>
     res
       .status(200)
       .contentType('application/json')
       .send(await controller.acceptMessageAndReturnReplies(req.body.message as Payload))
+  );
+
+  // endpoint for accepting single payment
+  app.post('/payment', bodyParser.json(), async (req, res) =>
+    res
+      .status(200)
+      .contentType('application/json')
+      .send(await controller.acceptPaymentAndReturnReplies(req.body.message as Payload))
   );
   return app;
 }

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -76,7 +76,7 @@ export default class ReceiverController {
     const {
       channelResult,
       outbox: [maybeSyncStateResponse],
-    } = await this.time('push message', async () => this.wallet.pushUpdate(message));
+    } = await this.time('push update', async () => this.wallet.pushUpdate(message));
 
     if (maybeSyncStateResponse) {
       const syncResponse = maybeSyncStateResponse.params.data as Payload;

--- a/packages/server-wallet/src/errors.ts
+++ b/packages/server-wallet/src/errors.ts
@@ -4,7 +4,7 @@ const CHANNEL_EXISTS = new Error(
 const CHANNEL_MISSING = new Error('Channel does not exist');
 const STATE_NOT_SIGNED = new Error('State not signed by mover');
 const INVALID_TRANSITION = new Error('Invalid transition');
-const INVALID_STATE_UNKNOWN_REASON = new Error('State is not valid, but th reason is not known');
+const INVALID_STATE_UNKNOWN_REASON = new Error('State is not valid, but the reason is not known');
 const NOT_OUR_TURN = new Error('Not our turn to create a state');
 const VALUE_LOST = new Error('Value not preserved');
 

--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -1,0 +1,118 @@
+import {BN} from '@statechannels/wallet-core';
+
+import {testKnex as knex} from '../../../jest/knex-setup-teardown';
+import {defaultTestConfig} from '../../config';
+import {Store} from '../../wallet/store';
+import {WalletResponse} from '../../wallet/wallet-response';
+import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
+import {TestLedgerChannel} from '../../wallet/__test__/fixtures/test-ledger-channel';
+import {SingleAppUpdater} from '../single-app-updater';
+
+const testChan = TestChannel.create({channelNonce: 1});
+const testChan2 = TestChannel.create({channelNonce: 2});
+
+let store: Store;
+let singleAppUpdater: SingleAppUpdater;
+let response: WalletResponse;
+
+beforeEach(async () => {
+  store = new Store(
+    knex,
+    defaultTestConfig.metricsConfiguration.timingMetrics,
+    defaultTestConfig.skipEvmValidation,
+    '0'
+  );
+  await store.dbAdmin().truncateDB();
+  singleAppUpdater = SingleAppUpdater.create(store);
+  response = WalletResponse.initialize();
+});
+
+afterEach(async () => await store.dbAdmin().truncateDB());
+
+describe('when given an update for a single, running app channel', () => {
+  it(`updates the channel`, async () => {
+    // put state5 and state6 in the store
+    await setup({states: [testChan.wirePayload(5), testChan.wirePayload(6)]});
+
+    // send state7
+    await singleAppUpdater.update(testChan.wirePayload(7), response);
+
+    // expect to find state7 in the output
+    expect(response.singleChannelOutput().channelResult.turnNum).toEqual(7);
+  });
+});
+
+describe('bad payload', () => {
+  const state0WithObj = testChan.openChannelPayload;
+  const getRequest = TestChannel.mergePayloads(testChan.wirePayload(7), testChan.getChannelRequest);
+  const twoStates = TestChannel.mergePayloads(testChan.wirePayload(7), testChan2.wirePayload(7));
+  const emptyPayload = TestChannel.emptyPayload;
+
+  it.each`
+    case                 | payload          | error
+    ${'multiple states'} | ${twoStates}     | ${`The payload sent to pushUpdate must contain exactly 1 signedState.`}
+    ${'no states'}       | ${emptyPayload}  | ${`The payload sent to pushUpdate must contain exactly 1 signedState.`}
+    ${'an objective'}    | ${state0WithObj} | ${`The payload sent to pushUpdate must not contain objectives.`}
+    ${'a request'}       | ${getRequest}    | ${`The payload sent to pushUpdate must not contain requests.`}
+  `('errors when given $case', async ({payload, error}) => {
+    await expect(singleAppUpdater.update(payload, response)).rejects.toThrow(error);
+  });
+});
+
+describe('app channel not running', () => {
+  it(`errors if the channel is still opening`, async () => {
+    // put state0 and state1 in the store
+    await setup({states: [testChan.wirePayload(0), testChan.wirePayload(1)]});
+
+    // send state2
+    await expect(singleAppUpdater.update(testChan.wirePayload(2), response)).rejects.toThrow(
+      'The update sent to pushUpdate must be for a running channel'
+    );
+  });
+  it(`errors if the channel has a final state`, async () => {
+    // put state5 and state6final in the store
+    await setup({states: [testChan.wirePayload(5), testChan.wirePayload(6, [5, 5], 'final')]});
+
+    // send state7final
+    await expect(
+      singleAppUpdater.update(testChan.wirePayload(7, [5, 5], 'final'), response)
+    ).rejects.toThrow('The update sent to pushUpdate must be for a running channel');
+  });
+  it(`errors if given a final state`, async () => {
+    // put state5 and state6final in the store
+    await setup({states: [testChan.wirePayload(5), testChan.wirePayload(6, [5, 5], 'final')]});
+
+    // send state7final
+    await expect(
+      singleAppUpdater.update(testChan.wirePayload(7, [5, 5], 'final'), response)
+    ).rejects.toThrow('The update sent to pushUpdate must be for a running channel');
+  });
+});
+
+describe('not an app channel', () => {
+  it(`errors if the channel is a ledger channel`, async () => {
+    // want a running ledger channel
+    const testLedger = TestLedgerChannel.create({aBal: 5, bBal: 5, channelNonce: 3});
+    await testLedger.insertIntoStore(store);
+
+    await store.pushMessage(testLedger.wirePayload(5));
+    await store.pushMessage(testLedger.wirePayload(6));
+    await store.updateFunding(testLedger.channelId, BN.from(10), testLedger.assetHolderAddress);
+
+    await expect(singleAppUpdater.update(testLedger.wirePayload(7), response)).rejects.toThrow(
+      'The update sent to pushUpdate must be for an application channel'
+    );
+  });
+});
+
+interface SetupParams {
+  states: any[];
+}
+
+const setup = async ({states}: SetupParams): Promise<void> => {
+  await store.addSigningKey(testChan.signingKeyA);
+  for (const state of states) {
+    await store.pushMessage(state);
+  }
+  await store.updateFunding(testChan.channelId, BN.from(10), testChan.assetHolderAddress);
+};

--- a/packages/server-wallet/src/handlers/single-app-updater.ts
+++ b/packages/server-wallet/src/handlers/single-app-updater.ts
@@ -1,0 +1,51 @@
+import {WirePayload} from '../type-aliases';
+import {WalletResponse} from '../wallet/wallet-response';
+import {Store} from '../wallet/store';
+
+/**
+ * For making a single update to a running application channel
+ * */
+export class SingleAppUpdater {
+  private store: Store;
+
+  public static create(store: Store): SingleAppUpdater {
+    return new SingleAppUpdater(store);
+  }
+
+  private constructor(store: Store) {
+    this.store = store;
+  }
+
+  /**
+   * For pushing a message containing a single update to a running application channel
+   */
+  async update(wirePayload: WirePayload, response: WalletResponse): Promise<void> {
+    // check that we have exactly one signedState and nothing else
+    if (wirePayload.signedStates?.length !== 1)
+      throw new Error(`The payload sent to pushUpdate must contain exactly 1 signedState.`);
+    if (wirePayload.objectives)
+      throw new Error(`The payload sent to pushUpdate must not contain objectives.`);
+    if (wirePayload.requests)
+      throw new Error(`The payload sent to pushUpdate must not contain requests.`);
+
+    const wireState = wirePayload.signedStates[0];
+    const channelId = wireState.channelId;
+
+    await this.store.transaction(async tx => {
+      const channel = await this.store.addSignedState(channelId, wireState, tx);
+
+      // check channel is an application channel. If not, transaction will rollback when promise rejects.
+      if (!channel.isAppChannel)
+        throw new Error(`The update sent to pushUpdate must be for an application channel`);
+
+      // check that the channel is running. If not, transaction will rollback when promise rejects
+      // note that this actually checks that the channel is still running _after_ the update has
+      // been applied, as this is the case where no cranking is required
+      if (!channel.isRunning)
+        throw new Error(`The update sent to pushUpdate must be for a running channel`);
+
+      // and add to response
+      response.queueChannel(channel);
+    });
+  }
+}

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -343,6 +343,21 @@ export class Channel extends Model implements RequiredColumns {
     return !!this.assetHolderAddress;
   }
 
+  public get isAppChannel(): boolean {
+    return !this.isLedger;
+  }
+
+  public get isRunning(): boolean {
+    // running if:
+    //  1. the supported state implies a post-fund-setup
+    //  2. no isFinal states exist
+
+    const havePostFund = !!this.supported && this.supported.turnNum >= 2 * this.nParticipants() - 1;
+    const noFinalStates = _.every(this.sortedStates, s => !s.isFinal);
+
+    return havePostFund && noFinalStates;
+  }
+
   private mySignature(signatures: SignatureEntry[]): boolean {
     return signatures.some(sig => sig.signer === this.myAddress);
   }

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -12,7 +12,7 @@ import {DBOpenChannelObjective} from '../../models/objective';
 
 const logger = createLogger(defaultTestConfig);
 const timingMetrics = false;
-const testChan = TestChannel.create(5, 5);
+const testChan = TestChannel.create({aBal: 5, bBal: 5});
 
 let store: Store;
 

--- a/packages/server-wallet/src/type-aliases.ts
+++ b/packages/server-wallet/src/type-aliases.ts
@@ -1,5 +1,10 @@
+import {Message as _WireMessage} from '@statechannels/wire-format';
+
 export declare type ParticipantId = string;
 export declare type Uint256 = string;
 export declare type Uint48 = number;
 export declare type Bytes32 = string;
 export declare type Bytes = string;
+
+export type WireMessage = _WireMessage;
+export type WirePayload = WireMessage['data'];

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -24,6 +24,12 @@ import {alice, bob} from './participants';
 import {alice as aliceWallet, bob as bobWallet} from './signing-wallets';
 import {stateWithHashSignedBy} from './states';
 
+interface TestChannelArgs {
+  aBal?: number;
+  bBal?: number;
+  channelNonce?: number;
+}
+
 /** A two-party channel between Alice and Bob, with state history. For testing purposes. */
 export class TestChannel {
   public participantA: Participant = alice();
@@ -32,7 +38,7 @@ export class TestChannel {
   public signingWalletA: SigningWallet = aliceWallet();
   public signingWalletB: SigningWallet = bobWallet();
   public startBals: [number, number];
-  public channelNonce = 5;
+  public channelNonce: number;
 
   public get participants(): Participant[] {
     return [this.participantA, this.participantB];
@@ -41,12 +47,14 @@ export class TestChannel {
     return [this.signingWalletA, this.signingWalletB];
   }
 
-  public static create(aBal: number, bBal: number): TestChannel {
-    return new TestChannel(aBal, bBal);
+  public static create(args: TestChannelArgs): TestChannel {
+    return new TestChannel(args);
   }
 
-  private constructor(aBal: number, bBal: number) {
+  protected constructor(args: TestChannelArgs) {
+    const {aBal, bBal, channelNonce} = {aBal: 5, bBal: 5, channelNonce: 5, ...args};
     this.startBals = [aBal, bBal];
+    this.channelNonce = channelNonce;
   }
 
   /**
@@ -57,38 +65,42 @@ export class TestChannel {
    * Note - in cases where participants double-sign the same states, n might _not_
    * be the turnNum
    */
-  public state(n: number): State {
+  public state(n: number, bals?: [number, number], final = ''): State {
     return {
       ...this.channelConstants,
       appData: '0x',
-      isFinal: false,
+      isFinal: final === 'final',
       turnNum: n,
-      outcome: this.startOutcome,
+      outcome: bals ? this.toOutcome(bals) : this.startOutcome,
     };
   }
 
-  public signedStateWithHash(n: number): SignedStateWithHash {
-    return stateWithHashSignedBy([this.signingWallets[n % 2]])(this.state(n));
+  public signedStateWithHash(n: number, bals?: [number, number], final = ''): SignedStateWithHash {
+    return stateWithHashSignedBy([this.signingWallets[n % 2]])(this.state(n, bals, final));
   }
 
   /**
    * Gives the nth state in the history, signed by the correct participant
    */
-  public wireState(n: number): WireState {
-    return serializeState(this.signedStateWithHash(n));
+  public wireState(n: number, bals?: [number, number], final = ''): WireState {
+    return serializeState(this.signedStateWithHash(n, bals, final));
   }
 
-  public wirePayload(n: number): Payload {
+  public wirePayload(n: number, bals?: [number, number], final = ''): Payload {
     return {
       walletVersion: WALLET_VERSION,
-      signedStates: [this.wireState(n)],
+      signedStates: [this.wireState(n, bals, final)],
     };
   }
 
   public get startOutcome(): Outcome {
+    return this.toOutcome(this.startBals);
+  }
+
+  public toOutcome([aBal, bBal]: [number, number]): Outcome {
     return simpleEthAllocation([
-      {destination: this.participantA.destination, amount: BN.from(this.startBals[0])},
-      {destination: this.participantB.destination, amount: BN.from(this.startBals[1])},
+      {destination: this.participantA.destination, amount: BN.from(aBal)},
+      {destination: this.participantB.destination, amount: BN.from(bBal)},
     ]);
   }
 
@@ -129,7 +141,44 @@ export class TestChannel {
     };
   }
 
+  public get openChannelPayload(): Payload {
+    return {
+      walletVersion: WALLET_VERSION,
+      signedStates: [this.wireState(0)],
+      objectives: [this.openChannelObjective],
+    };
+  }
+
   public get assetHolderAddress(): Address {
     return ETH_ASSET_HOLDER_ADDRESS;
+  }
+
+  public get getChannelRequest(): Payload {
+    return {
+      walletVersion: WALLET_VERSION,
+      requests: [{channelId: this.channelId, type: 'GetChannel'}],
+    };
+  }
+
+  static mergePayloads(payload1: Payload, payload2: Payload): Payload {
+    return {
+      walletVersion: payload1.walletVersion,
+      signedStates: combineArrays(payload1.signedStates, payload2.signedStates),
+      requests: combineArrays(payload1.requests, payload2.requests),
+      objectives: combineArrays(payload1.objectives, payload2.objectives),
+    };
+  }
+
+  static get emptyPayload(): Payload {
+    return {walletVersion: WALLET_VERSION};
+  }
+}
+
+function combineArrays<T>(a1: T[] | undefined, a2: T[] | undefined): T[] | undefined {
+  const result = [...(a1 || []), ...(a2 || [])];
+  if (result.length > 0) {
+    return result;
+  } else {
+    return undefined;
   }
 }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
@@ -1,0 +1,51 @@
+import {Objective} from '@statechannels/wallet-core';
+
+import {Store} from '../../store';
+
+import {TestChannel} from './test-channel';
+
+interface TestChannelArgs {
+  aBal?: number;
+  bBal?: number;
+  channelNonce?: number;
+}
+
+/**
+ * A two-party ledger channel between Alice and Bob, with state history.
+ *
+ * For testing purposes.
+ * */
+export class TestLedgerChannel extends TestChannel {
+  public static create(args: TestChannelArgs): TestLedgerChannel {
+    return new TestLedgerChannel(args);
+  }
+
+  private constructor(args: TestChannelArgs) {
+    super(args);
+  }
+
+  public get openChannelObjective(): Objective {
+    return {
+      participants: this.participants,
+      type: 'OpenChannel',
+      data: {
+        role: 'ledger',
+        targetChannelId: this.channelId,
+        fundingStrategy: 'Direct',
+      },
+    };
+  }
+
+  public async insertIntoStore(store: Store): Promise<void> {
+    await store.addSigningKey(this.signingKeyA);
+    // The only way the store currently knows the channel is a ledger is by the role
+    // passed in on the OpenChannel objective. So we need to push in that objective,
+    // and then approve it.
+    await store.pushMessage(this.openChannelPayload);
+    const objectives = await store.getObjectives([this.channelId]);
+    if (objectives.length !== 1) {
+      throw Error(`TestLedgerChannel expected 1 objective. Found ${objectives.length}`);
+    }
+    await store.approveObjective(objectives[0].objectiveId);
+  }
+}

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
@@ -25,6 +25,10 @@ export class MultiThreadedWallet extends SingleThreadedWallet {
     return this.workerManager.pushMessage(rawPayload);
   }
 
+  async pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput> {
+    return this.workerManager.pushUpdate(rawPayload);
+  }
+
   public async destroy(): Promise<void> {
     await this.workerManager.destroy();
     await super.destroy();

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/worker-data.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/worker-data.ts
@@ -9,8 +9,12 @@ type PushMessageRequest = {
   operation: 'PushMessage';
   args: unknown;
 };
+type PushUpdateRequest = {
+  operation: 'PushUpdate';
+  args: unknown;
+};
 
-export type StateChannelWorkerData = UpdateChannelRequest | PushMessageRequest;
+export type StateChannelWorkerData = UpdateChannelRequest | PushMessageRequest | PushUpdateRequest;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function isStateChannelWorkerData(data: any): data is StateChannelWorkerData {

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
@@ -50,6 +50,11 @@ parentPort?.on('message', async (message: any) => {
         return parentPort?.postMessage(
           right(await timer('PushMessage', () => wallet.pushMessage(message.args)))
         );
+      case 'PushUpdate':
+        logger.debug(`Worker-%o handling PushUpdate`, threadId);
+        return parentPort?.postMessage(
+          right(await timer('PushUpdate', () => wallet.pushUpdate(message.args)))
+        );
       default:
         return parentPort?.postMessage(left(new Error('Unknown message type')));
     }

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -40,6 +40,7 @@ export type WalletInterface = {
   updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
   // Wallet <-> Wallet communication
   pushMessage(m: unknown): Promise<MultipleChannelOutput>;
+  pushUpdate(m: unknown): Promise<SingleChannelOutput>;
 
   mergeMessages(messages: Message[]): MultipleChannelOutput;
 };

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -56,6 +56,7 @@ import {DBAdmin} from '../db-admin/db-admin';
 import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
 import {Channel} from '../models/channel';
+import {SingleAppUpdater} from '../handlers/single-app-updater';
 
 import {Store, AppHandler, MissingAppHandler} from './store';
 import {WalletInterface} from './types';
@@ -521,6 +522,20 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
         cause: err,
       });
     }
+  }
+
+  /**
+   * For pushing a message containing a single update to a running application channel
+   */
+  async pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput> {
+    const wirePayload = validatePayload(rawPayload);
+
+    const response = WalletResponse.initialize();
+
+    const singleAppUpdater = SingleAppUpdater.create(this.store);
+    await singleAppUpdater.update(wirePayload, response);
+
+    return response.singleChannelOutput();
   }
 
   private async _pushMessage(wirePayload: WirePayload, response: WalletResponse): Promise<void> {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -532,8 +532,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
     const response = WalletResponse.initialize();
 
-    const singleAppUpdater = SingleAppUpdater.create(this.store);
-    await singleAppUpdater.update(wirePayload, response);
+    await SingleAppUpdater.create(this.store).update(wirePayload, response);
 
     return response.singleChannelOutput();
   }


### PR DESCRIPTION
Adds a `pushUpdate` method to the wallet api, for pushing a message containing a single state that updates a running app channel. Should address some of the performance issues seen in https://github.com/statechannels/project-management/issues/4, by allowing objective cranking to be skipped in this case.

Still todo:
- [x] Write tests for the handler to test success and the various error conditions
- [x] Update the e2e/stress tests to use the new method where appropriate 