### PR TITLE
fix: do not do turn number check for funding or closing stage channels

### DIFF
--- a/packages/server-wallet/src/utilities/validate-transition.ts
+++ b/packages/server-wallet/src/utilities/validate-transition.ts
@@ -38,7 +38,9 @@ export function validateTransition(
   const toMoverIndex = toState.turnNum % toState.participants.length;
   const toMover = toState.participants[toMoverIndex].signingAddress;
 
-  if (fromState.appDefinition !== constants.AddressZero) {
+  const isInFundingStage = toState.turnNum < 2 * toState.participants.length;
+
+  if (!isInFundingStage && !toState.isFinal && fromState.appDefinition !== constants.AddressZero) {
     // turn numbers not relevant for the null app
     const turnNumCheck = _.isEqual(toState.turnNum, fromState.turnNum + 1);
     if (!turnNumCheck) {
@@ -84,7 +86,6 @@ export function validateTransition(
   }
 
   // Funding stage specific validation
-  const isInFundingStage = toState.turnNum < 2 * toState.participants.length;
   const fundingStageValidation =
     _.isEqual(fromState.isFinal, false) &&
     _.isEqual(toState.outcome, fromState.outcome) &&


### PR DESCRIPTION
A legit "transition" is from turn 1 to 3 as there are no app rules checked in this phase to warrant enforcing turn taking.
