### PR TITLE
Add bytecode checking to ChainService constructor

### DIFF
--- a/packages/server-wallet/benchmarks/get-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/get-channel.benchmark.ts
@@ -10,6 +10,7 @@ import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
 import {Channel} from '../src/models/channel';
 import {Wallet} from '../src/wallet';
 import {extractDBConfigFromServerWalletConfig, defaultConfig} from '../src/config';
+import {MockChainService} from '../src/chain-service/mock-chain-service';
 
 const knex: Knex = Knex(extractDBConfigFromServerWalletConfig(defaultConfig));
 
@@ -29,7 +30,7 @@ async function benchmark(): Promise<void> {
   const c = withSupportedState()({vars: [stateVars()]});
   await Channel.query(knex).insert(c);
 
-  const wallet = Wallet.create(defaultConfig);
+  const wallet = Wallet.create(new MockChainService(), defaultConfig);
 
   const iter = _.range(NUM_CALLS);
   const key = `getChannel x ${NUM_CALLS}`;

--- a/packages/server-wallet/benchmarks/update-channel.benchmark.ts
+++ b/packages/server-wallet/benchmarks/update-channel.benchmark.ts
@@ -11,6 +11,7 @@ import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
 import {Channel} from '../src/models/channel';
 import {Wallet} from '../src/wallet';
 import {defaultConfig, extractDBConfigFromServerWalletConfig} from '../src/config';
+import {MockChainService} from '../src/chain-service';
 
 const knex = Knex(extractDBConfigFromServerWalletConfig(defaultConfig));
 
@@ -34,7 +35,7 @@ async function setup(n = NUM_UPDATES): Promise<Channel[]> {
 async function benchmark(): Promise<void> {
   await knex.migrate.rollback();
   await knex.migrate.latest();
-  const wallet = Wallet.create(defaultConfig);
+  const wallet = Wallet.create(new MockChainService(), defaultConfig);
 
   // Warm up each worker thread.
   // eslint-disable-next-line no-process-env

--- a/packages/server-wallet/deployment/deploy.ts
+++ b/packages/server-wallet/deployment/deploy.ts
@@ -1,9 +1,7 @@
 import {Address} from '@statechannels/client-api-schema';
 import {ContractArtifacts} from '@statechannels/nitro-protocol';
-import {GanacheDeployer} from '@statechannels/devtools';
+import {ETHERLIME_ACCOUNTS, GanacheDeployer} from '@statechannels/devtools';
 import {Wallet} from 'ethers';
-
-import {defaultTestConfig} from '../src/config';
 
 // NOTE: deploying contracts like this allows the onchain service package to
 // be easily extracted
@@ -15,8 +13,10 @@ export type TestNetworkContext = {
   NITRO_ADJUDICATOR_ADDRESS: Address;
 };
 
+
 export async function deploy(): Promise<TestNetworkContext> {
-  const {ethereumPrivateKey} = defaultTestConfig();
+  const ethereumPrivateKey = ETHERLIME_ACCOUNTS[0].privateKey;
+
   // TODO: best way to configure this?
   const deployer = new GanacheDeployer(8545, ethereumPrivateKey);
   const {

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -9,6 +9,7 @@ import {Bytes32} from '../../src/type-aliases';
 import {recordFunctionMetrics, timerFactory} from '../../src/metrics';
 import {payerConfig} from '../e2e-utils';
 import {defaultConfig, ServerWalletConfig} from '../../src/config';
+import {MockChainService} from '../../src/chain-service';
 
 export default class PayerClient {
   private readonly wallet: ServerWallet;
@@ -18,7 +19,7 @@ export default class PayerClient {
     readonly config?: ServerWalletConfig
   ) {
     this.wallet = recordFunctionMetrics(
-      ServerWallet.create(this.config || payerConfig),
+      ServerWallet.create(new MockChainService(), this.config || payerConfig),
       payerConfig.metricsConfiguration.timingMetrics
     );
   }

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -7,10 +7,11 @@ import {timerFactory, recordFunctionMetrics} from '../../src/metrics';
 import {receiverConfig} from '../e2e-utils';
 import {defaultConfig} from '../../src/config';
 import {WALLET_VERSION} from '../../src/version';
+import {createWalletForTests} from '../../src/wallet/__test__/fixtures/wallet';
 
 export default class ReceiverController {
   private readonly wallet: Wallet = recordFunctionMetrics(
-    Wallet.create(receiverConfig),
+    createWalletForTests(receiverConfig),
     defaultConfig.metricsConfiguration.timingMetrics
   );
 

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -138,7 +138,6 @@ export type MultipleChannelOutput = {
 
 // @public (undocumented)
 export type NetworkConfiguration = {
-    rpcEndpoint?: string;
     chainNetworkID: number;
 };
 
@@ -195,7 +194,6 @@ export type RequiredDatabaseConfiguration = {
 export type RequiredServerWalletConfig = {
     databaseConfiguration: RequiredDatabaseConfiguration;
     networkConfiguration: NetworkConfiguration;
-    ethereumPrivateKey: string;
 };
 
 // @public (undocumented)
@@ -215,7 +213,7 @@ export type Wallet = SingleThreadedWallet | MultiThreadedWallet;
 
 // @public (undocumented)
 export const Wallet: {
-    create(walletConfig: IncomingServerWalletConfig): Wallet;
+    create(chainService: ChainServiceInterface, walletConfig: IncomingServerWalletConfig): Wallet;
 };
 
 // Warning: (ae-forgotten-export) The symbol "ChannelUpdatedEvent" needs to be exported by the entry point index.d.ts
@@ -223,6 +221,10 @@ export const Wallet: {
 // @public (undocumented)
 export type WalletEvent = ChannelUpdatedEvent;
 
+
+// Warnings were encountered during analysis:
+//
+// src/wallet/index.ts:11:20 - (ae-forgotten-export) The symbol "ChainServiceInterface" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -139,6 +139,8 @@ export type MultipleChannelOutput = {
 // @public (undocumented)
 export type NetworkConfiguration = {
     chainNetworkID: number;
+    nitroAdjudicatorAddress?: Address;
+    ethAssetHolderAddress?: Address;
 };
 
 // @public (undocumented)

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -8,34 +8,45 @@ import {fromEvent} from 'rxjs';
 import {take} from 'rxjs/operators';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../config';
+import {ChainService} from '../chain-service';
 import {Wallet, SingleChannelOutput} from '../wallet';
 import {getChannelResultFor, getPayloadFor} from '../__test__/test-helpers';
 
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
+// eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
+if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
+// eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
+const rpcEndpoint = process.env.RPC_ENDPOINT;
+
 const config = {
   ...defaultTestConfig(),
   networkConfiguration: {
     ...defaultTestConfig().networkConfiguration,
     // eslint-disable-next-line no-process-env
-    rpcEndpoint: process.env.RPC_ENDPOINT,
-    // eslint-disable-next-line no-process-env
     chainNetworkID: parseInt(process.env.CHAIN_NETWORK_ID || '0'),
   },
 };
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
+
 let provider: providers.JsonRpcProvider;
-const b = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_B'}),
-  /* eslint-disable-next-line no-process-env */
-  ethereumPrivateKey: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
-});
-const a = Wallet.create({
-  ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_A'}),
-  /* eslint-disable-next-line no-process-env */
-  ethereumPrivateKey: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
-});
+const b = Wallet.create(
+  new ChainService({
+    provider: rpcEndpoint,
+    /* eslint-disable-next-line no-process-env */
+    pk: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
+    allowanceMode: 'MaxUint',
+  }),
+  overwriteConfigWithDatabaseConnection(config, {database: 'TEST_B'})
+);
+const a = Wallet.create(
+  new ChainService({
+    provider: rpcEndpoint,
+    /* eslint-disable-next-line no-process-env */
+    pk: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
+    allowanceMode: 'MaxUint',
+  }),
+  overwriteConfigWithDatabaseConnection(config, {database: 'TEST_A'})
+);
 
 const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';
 const bAddress = '0x632d0b05c78A83cEd439D3bd6C710c4814D3a6db';

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -8,13 +8,13 @@ import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
-import {Wallet} from '../../wallet';
+import {createWalletForTests} from '../../wallet/__test__/fixtures/wallet';
 import {getChannelResultFor, getPayloadFor, crashAndRestart} from '../test-helpers';
 
-const a = Wallet.create(
+const a = createWalletForTests(
   overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
 );
-let b = Wallet.create(
+let b = createWalletForTests(
   overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
 ); // Wallet that will "crash"
 

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -8,15 +8,15 @@ import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers} from 'ethers';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
-import {Wallet} from '../../wallet';
+import {createWalletForTests} from '../../wallet/__test__/fixtures/wallet';
 import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 
 const {AddressZero} = ethers.constants;
 
-const a = Wallet.create(
+const a = createWalletForTests(
   overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
 );
-const b = Wallet.create(
+const b = createWalletForTests(
   overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
 );
 

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -8,13 +8,13 @@ import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
-import {Wallet} from '../../wallet';
+import {createWalletForTests} from '../../wallet/__test__/fixtures/wallet';
 import {getChannelResultFor, getPayloadFor} from '../test-helpers';
 
-const a = Wallet.create(
+const a = createWalletForTests(
   overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
 );
-const b = Wallet.create(
+const b = createWalletForTests(
   overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
 );
 

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -3,23 +3,27 @@ import {BN, makeAddress, makeDestination, Participant} from '@statechannels/wall
 import {ethers} from 'ethers';
 
 import {Outgoing} from '../..';
-import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
 import {Bytes32} from '../../type-aliases';
-import {Wallet} from '../../wallet';
 import {
   crashAndRestart,
   getChannelResultFor,
   getPayloadFor,
   interParticipantChannelResultsAreEqual,
 } from '../test-helpers';
+import {createWalletForTests} from '../../wallet/__test__/fixtures/wallet';
+import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
 
 const ETH_ASSET_HOLDER_ADDRESS = makeAddress(ethers.constants.AddressZero);
 
-let a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
+let a = createWalletForTests(
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+    database: 'TEST_A',
+  })
 );
-let b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
+let b = createWalletForTests(
+  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+    database: 'TEST_B',
+  })
 );
 
 let participantA: Participant;

--- a/packages/server-wallet/src/__test__/test-helpers.ts
+++ b/packages/server-wallet/src/__test__/test-helpers.ts
@@ -4,6 +4,7 @@ import {AllocationItem, areAllocationItemsEqual} from '@statechannels/wallet-cor
 
 import {Wallet} from '../wallet';
 import {Outgoing} from '..';
+import {createWalletForTests} from '../wallet/__test__/fixtures/wallet';
 
 export function getPayloadFor(participantId: string, outbox: Outgoing[]): unknown {
   const filteredOutbox = outbox.filter(outboxItem => outboxItem.params.recipient === participantId);
@@ -37,7 +38,7 @@ export function getSignedStateFor(channelId: string, outbox: Outgoing[]): Signed
 export async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
   const config = wallet.walletConfig;
   await wallet.destroy();
-  return Wallet.create(config); // Wallet that will "restart"
+  return createWalletForTests(config); // Wallet that will "restart"
 }
 
 export async function interParticipantChannelResultsAreEqual(a: Wallet, b: Wallet): Promise<void> {

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -12,7 +12,6 @@ import {
 import {BigNumber, constants, Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig} from '../../config';
 import {
   alice as aliceParticipant,
   bob as bobParticipant,
@@ -25,16 +24,9 @@ import {AssetTransferredArg, HoldingUpdatedArg} from '../types';
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
-
-const config = {
-  ...defaultTestConfig(),
-  networkConfiguration: {
-    ...defaultTestConfig().networkConfiguration,
-    rpcEndpoint: process.env.RPC_ENDPOINT,
-  },
-};
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
+if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
+const rpcEndpoint = process.env.RPC_ENDPOINT;
+/* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 
 let chainService: ChainService;

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -21,6 +21,7 @@ import {ChainService} from '../chain-service';
 import {AssetTransferredArg, HoldingUpdatedArg} from '../types';
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
+const nitroAdjudicatorAddress = makeAddress(process.env.NITRO_ADJUDICATOR_ADDRESS!);
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
@@ -45,16 +46,18 @@ function mineOnEvent(contract: Contract) {
 
 jest.setTimeout(20_000);
 
-beforeAll(() => {
+beforeAll(async () => {
   // Try to use a different private key for every chain service instantiation to avoid nonce errors
   // Using the first account here as that is the one that:
   // - Deploys the token contract.
   // - And therefore has tokens allocated to it.
   /* eslint-disable no-process-env */
-  chainService = new ChainService({
+  chainService = await ChainService.create({
     provider: rpcEndpoint,
     pk: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[0].privateKey,
     allowanceMode: 'MaxUint',
+    nitroAdjudicatorAddress,
+    ethAssetHolderAddress,
   });
   /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -9,6 +9,8 @@ import {ChainService} from '../chain-service';
 const pk = ETHERLIME_ACCOUNTS[0].privateKey;
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
+const nitroAdjudicatorAddress = makeAddress(process.env.NITRO_ADJUDICATOR_ADDRESS!);
+const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
@@ -24,12 +26,14 @@ const ethWallet = new Wallet(privateKey, provider);
 
 let chainService: ChainService;
 
-beforeEach(() => {
+beforeEach(async () => {
   // Try to use a different private key for every chain service instantiation to avoid nonce errors
-  chainService = new ChainService({
+  chainService = await ChainService.create({
     provider: rpcEndpoint,
     pk: privateKey,
     allowanceMode: 'MaxUint',
+    nitroAdjudicatorAddress,
+    ethAssetHolderAddress,
   });
 });
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -4,26 +4,19 @@ import {BN, makeAddress} from '@statechannels/wallet-core';
 import {Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig} from '../../config';
 import {ChainService} from '../chain-service';
+
+const pk = ETHERLIME_ACCOUNTS[0].privateKey;
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
+if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
+const rpcEndpoint = process.env.RPC_ENDPOINT;
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
-const config = {
-  ...defaultTestConfig(),
-  networkConfiguration: {
-    ...defaultTestConfig().networkConfiguration,
-    // eslint-disable-next-line no-process-env
-    rpcEndpoint: process.env.RPC_ENDPOINT,
-  },
-};
-if (!config.networkConfiguration.rpcEndpoint) throw new Error('rpc endpoint must be defined');
-const {rpcEndpoint} = config.networkConfiguration;
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 // This is the private key for which ERC20 tokens are allocated on contract creation
-const ethWalletWithTokens = new Wallet(config.ethereumPrivateKey, provider);
+const ethWalletWithTokens = new Wallet(pk, provider);
 
 // Try to use a different private key for every chain service instantiation to avoid nonce errors
 const privateKey = ETHERLIME_ACCOUNTS[3].privateKey;

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -55,4 +55,6 @@ export type ChainServiceArgs = {
   pk: string;
   allowanceMode: AllowanceMode;
   pollingInterval?: number;
+  nitroAdjudicatorAddress: Address;
+  ethAssetHolderAddress: Address;
 };

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -64,8 +64,6 @@ export const defaultTestConfig = (
     networkConfiguration: defaultTestNetworkConfiguration,
     skipEvmValidation: true,
     workerThreadAmount: 0, // Disable threading for tests
-    // 0xD9995BAE12FEe327256FFec1e3184d492bD94C31
-    ethereumPrivateKey: '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8',
     databaseConfiguration: {
       connection: {
         host: defaultDatabaseConfiguration.connection.host,

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -54,7 +54,6 @@ export type MetricsConfiguration = {timingMetrics: boolean; metricsOutputFile?: 
 export type RequiredServerWalletConfig = {
   databaseConfiguration: RequiredDatabaseConfiguration;
   networkConfiguration: NetworkConfiguration;
-  ethereumPrivateKey: string;
 };
 
 /**
@@ -84,7 +83,6 @@ export type IncomingServerWalletConfig = RequiredServerWalletConfig &
  * Various network configuration options
  */
 export type NetworkConfiguration = {
-  rpcEndpoint?: string;
   chainNetworkID: number;
 };
 

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -1,3 +1,4 @@
+import {Address} from '@statechannels/wallet-core';
 import {Level} from 'pino';
 
 /**
@@ -84,6 +85,8 @@ export type IncomingServerWalletConfig = RequiredServerWalletConfig &
  */
 export type NetworkConfiguration = {
   chainNetworkID: number;
+  nitroAdjudicatorAddress?: Address;
+  ethAssetHolderAddress?: Address;
 };
 
 export type DeepPartial<T> = {

--- a/packages/server-wallet/src/db-admin/knexfile.ts
+++ b/packages/server-wallet/src/db-admin/knexfile.ts
@@ -63,7 +63,6 @@ const dbDebug = process.env.DEBUG_KNEX?.toLowerCase() === 'true' || false;
 export const {client, connection, debug, migrations, seeds, pool} = createKnexConfig({
   ...defaultConfig,
   databaseConfiguration: {debug: dbDebug, connection: dbConnectionConfig},
-  ethereumPrivateKey: '0x0',
   networkConfiguration: {
     chainNetworkID: 0,
   },

--- a/packages/server-wallet/src/wallet/__test__/fixtures/wallet.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/wallet.ts
@@ -1,0 +1,7 @@
+import {Wallet} from '../..';
+import {MockChainService} from '../../../chain-service';
+import {ServerWalletConfig} from '../../../config';
+
+export function createWalletForTests(config: ServerWalletConfig): Wallet {
+  return Wallet.create(new MockChainService(), config);
+}

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -6,10 +6,11 @@ import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {defaultTestConfig} from '../../../config';
 import {Bytes32} from '../../../type-aliases';
+import {createWalletForTests} from '../fixtures/wallet';
 
 let w: Wallet;
 beforeAll(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = createWalletForTests(defaultTestConfig());
   await seedAlicesSigningWallet(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -4,10 +4,11 @@ import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
+import {createWalletForTests} from '../fixtures/wallet';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = createWalletForTests(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
@@ -6,10 +6,11 @@ import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
+import {createWalletForTests} from '../fixtures/wallet';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = createWalletForTests(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -22,10 +22,11 @@ import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';
+import {createWalletForTests} from '../fixtures/wallet';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = createWalletForTests(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
   await seedBobsSigningWallet(w.knex);
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -14,7 +14,6 @@ import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/confi
 import {PartialModelObject} from 'objection';
 
 import {Channel} from '../../../models/channel';
-import {Wallet} from '../..';
 import {addHash} from '../../../state-utils';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import {alice as aliceP, bob as bobP, charlie as charlieP} from '../fixtures/participants';
@@ -29,10 +28,11 @@ import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-hel
 import {LedgerRequest} from '../../../models/ledger-request';
 import {WALLET_VERSION} from '../../../version';
 import {PushMessageError} from '../../../errors/wallet-error';
+import {createWalletForTests} from '../fixtures/wallet';
 
 jest.setTimeout(20_000);
 
-const wallet = Wallet.create(defaultTestConfig());
+const wallet = createWalletForTests(defaultTestConfig());
 
 beforeAll(async () => {
   await wallet.dbAdmin().migrateDB();

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -10,12 +10,13 @@ import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {channel} from '../../../models/__test__/fixtures/channel';
+import {createWalletForTests} from '../fixtures/wallet';
 
 let w: Wallet;
 beforeEach(async () => {
   await new DBAdmin(knex).truncateDB();
 
-  w = Wallet.create(defaultTestConfig());
+  w = createWalletForTests(defaultTestConfig());
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -12,6 +12,7 @@ import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {AppBytecode} from '../../../models/app-bytecode';
 import {appBytecode, COUNTING_APP_DEFINITION} from '../../../models/__test__/fixtures/app-bytecode';
 import {DBAdmin} from '../../../db-admin/db-admin';
+import {createWalletForTests} from '../fixtures/wallet';
 
 let w: Wallet;
 
@@ -22,7 +23,7 @@ afterEach(async () => {
 const appData1 = utils.defaultAbiCoder.encode(['uint256'], [1]);
 const appData2 = utils.defaultAbiCoder.encode(['uint256'], [2]);
 beforeEach(async () => {
-  w = Wallet.create({...defaultTestConfig(), skipEvmValidation: false});
+  w = createWalletForTests({...defaultTestConfig(), skipEvmValidation: false});
 
   await new DBAdmin(knex).truncateDB();
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -9,15 +9,16 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {ObjectiveModel} from '../../../models/objective';
-import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
+import {createWalletForTests} from '../fixtures/wallet';
+import {defaultTestConfig} from '../../../config';
 
 const AddressZero = makeAddress(ethers.constants.AddressZero);
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = createWalletForTests(defaultTestConfig());
   await new DBAdmin(w.knex).truncateDB();
 });
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -1,6 +1,7 @@
 export {WalletEvent, SingleChannelOutput, MultipleChannelOutput} from './wallet';
 
 import {IncomingServerWalletConfig} from '../config';
+import {ChainServiceInterface} from '../chain-service';
 
 import {MultiThreadedWallet} from './multi-threaded-wallet';
 import {SingleThreadedWallet} from './wallet';
@@ -8,11 +9,11 @@ import {SingleThreadedWallet} from './wallet';
 export type Wallet = SingleThreadedWallet | MultiThreadedWallet;
 
 export const Wallet = {
-  create(walletConfig: IncomingServerWalletConfig): Wallet {
+  create(chainService: ChainServiceInterface, walletConfig: IncomingServerWalletConfig): Wallet {
     if (walletConfig?.workerThreadAmount && walletConfig.workerThreadAmount > 0) {
-      return MultiThreadedWallet.create(walletConfig);
+      return MultiThreadedWallet.create(chainService, walletConfig);
     } else {
-      return SingleThreadedWallet.create(walletConfig);
+      return SingleThreadedWallet.create(chainService, walletConfig);
     }
   },
 };

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
@@ -1,5 +1,6 @@
 import {UpdateChannelParams} from '@statechannels/client-api-schema';
 
+import {ChainServiceInterface} from '../../chain-service';
 import {IncomingServerWalletConfig} from '../../config';
 import {MultipleChannelOutput, SingleChannelOutput, SingleThreadedWallet} from '../wallet';
 
@@ -8,12 +9,18 @@ import {WorkerManager} from './manager';
 export class MultiThreadedWallet extends SingleThreadedWallet {
   private workerManager: WorkerManager;
 
-  public static create(walletConfig: IncomingServerWalletConfig): MultiThreadedWallet {
-    return new this(walletConfig);
+  public static create(
+    chainService: ChainServiceInterface,
+    walletConfig: IncomingServerWalletConfig
+  ): MultiThreadedWallet {
+    return new this(chainService, walletConfig);
   }
 
-  protected constructor(walletConfig: IncomingServerWalletConfig) {
-    super(walletConfig);
+  protected constructor(
+    chainService: ChainServiceInterface,
+    walletConfig: IncomingServerWalletConfig
+  ) {
+    super(chainService, walletConfig);
     this.workerManager = new WorkerManager(this.walletConfig);
   }
 

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
@@ -6,6 +6,7 @@ import {createLogger} from '../../logger';
 import {Wallet} from '../..';
 import {timerFactory} from '../../metrics';
 import {ServerWalletConfig} from '../../config';
+import {MockChainService} from '../../chain-service';
 
 import {isStateChannelWorkerData} from './worker-data';
 
@@ -22,7 +23,7 @@ const walletConfig: ServerWalletConfig = {
 const logger = createLogger(walletConfig);
 
 logger.debug(`Worker %o starting`, threadId);
-const wallet = Wallet.create(walletConfig);
+const wallet = Wallet.create(new MockChainService(), walletConfig);
 parentPort?.on('message', async (message: any) => {
   if (isMainThread) {
     parentPort?.postMessage(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -96,7 +96,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
   implements WalletInterface, ChainEventSubscriberInterface {
   knex: Knex;
   store: Store;
-  chainService: ChainServiceInterface;
   objectiveManager: ObjectiveManager;
   logger: Logger;
 
@@ -111,7 +110,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
   // protected constructor to force consumers to initialize wallet via Wallet.create(..)
   protected constructor(
-    chainService: ChainServiceInterface,
+    private readonly chainService: ChainServiceInterface,
     walletConfig: IncomingServerWalletConfig
   ) {
     super();
@@ -134,8 +133,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       }
       setupMetrics(this.walletConfig.metricsConfiguration.metricsOutputFile);
     }
-
-    this.chainService = chainService;
 
     this.objectiveManager = ObjectiveManager.create({
       store: this.store,


### PR DESCRIPTION
Note this is a stacked PR.

This checks the on-chain code before instantiating a `ChainService`; helpful when building an application which requires the `ChainService` to function in avoiding finding out about a misconfigured `ChainService` until mid-way through operation
