### PR TITLE
Validate Incoming configuration files

### DIFF
--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -14,6 +14,7 @@
     "ethers": "5.0.12",
     "eventemitter3": "4.0.7",
     "fp-ts": "2.7.0",
+    "joi": "^17.3.0",
     "knex": "0.21.12",
     "lodash": "4.17.20",
     "objection": "2.2.3",

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -18,7 +18,6 @@ import EventEmitter from 'eventemitter3';
 import { FundingStatus } from '@statechannels/client-api-schema';
 import { FundingStrategy } from '@statechannels/client-api-schema';
 import { GetStateParams } from '@statechannels/client-api-schema';
-import joi from 'joi';
 import { JoinChannelParams } from '@statechannels/client-api-schema';
 import { JSONSchema } from 'objection';
 import Knex from 'knex';
@@ -64,25 +63,13 @@ export type ChainServiceConfiguration = {
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
 
 // @public (undocumented)
-export const databaseConfigurationSchema: joi.ObjectSchema<any>;
-
-// @public (undocumented)
 export type DatabaseConnectionConfiguration = RequiredConnectionConfiguration & Partial<OptionalConnectionConfiguration>;
-
-// @public (undocumented)
-export const databaseConnectionConfigurationSchema: joi.AlternativesSchema;
-
-// @public (undocumented)
-export const databaseObjectConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type DatabasePoolConfiguration = {
     max?: number;
     min?: number;
 };
-
-// @public (undocumented)
-export const databasePoolConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type DeepPartial<T> = {
@@ -148,9 +135,6 @@ export type LoggingConfiguration = {
     logDestination: string;
 };
 
-// @public (undocumented)
-export const loggingConfigurationSchema: joi.ObjectSchema<any>;
-
 export { Message }
 
 // @public (undocumented)
@@ -158,9 +142,6 @@ export type MetricsConfiguration = {
     timingMetrics: boolean;
     metricsOutputFile?: string;
 };
-
-// @public (undocumented)
-export const metricsConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type MultipleChannelOutput = {
@@ -172,9 +153,6 @@ export type MultipleChannelOutput = {
 export type NetworkConfiguration = {
     chainNetworkID: number;
 };
-
-// @public (undocumented)
-export const networkConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type OptionalConnectionConfiguration = {
@@ -235,9 +213,6 @@ export type RequiredServerWalletConfig = {
 
 // @public (undocumented)
 export type ServerWalletConfig = RequiredServerWalletConfig & OptionalServerWalletConfig;
-
-// @public (undocumented)
-export const serverWalletConfigSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type SingleChannelOutput = {

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -18,6 +18,7 @@ import EventEmitter from 'eventemitter3';
 import { FundingStatus } from '@statechannels/client-api-schema';
 import { FundingStrategy } from '@statechannels/client-api-schema';
 import { GetStateParams } from '@statechannels/client-api-schema';
+import joi from 'joi';
 import { JoinChannelParams } from '@statechannels/client-api-schema';
 import { JSONSchema } from 'objection';
 import Knex from 'knex';
@@ -50,6 +51,7 @@ import { Transaction } from 'objection';
 import { TransactionOrKnex } from 'objection';
 import { Uint256 as Uint256_2 } from '@statechannels/wallet-core';
 import { UpdateChannelParams } from '@statechannels/client-api-schema';
+import { ValidationErrorItem } from 'joi';
 
 // Warning: (ae-forgotten-export) The symbol "ChainServiceArgs" needs to be exported by the entry point index.d.ts
 //
@@ -62,13 +64,25 @@ export type ChainServiceConfiguration = {
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
 
 // @public (undocumented)
+export const databaseConfigurationSchema: joi.ObjectSchema<any>;
+
+// @public (undocumented)
 export type DatabaseConnectionConfiguration = RequiredConnectionConfiguration & Partial<OptionalConnectionConfiguration>;
+
+// @public (undocumented)
+export const databaseConnectionConfigurationSchema: joi.AlternativesSchema;
+
+// @public (undocumented)
+export const databaseObjectConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type DatabasePoolConfiguration = {
     max?: number;
     min?: number;
 };
+
+// @public (undocumented)
+export const databasePoolConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type DeepPartial<T> = {
@@ -134,6 +148,9 @@ export type LoggingConfiguration = {
     logDestination: string;
 };
 
+// @public (undocumented)
+export const loggingConfigurationSchema: joi.ObjectSchema<any>;
+
 export { Message }
 
 // @public (undocumented)
@@ -141,6 +158,9 @@ export type MetricsConfiguration = {
     timingMetrics: boolean;
     metricsOutputFile?: string;
 };
+
+// @public (undocumented)
+export const metricsConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type MultipleChannelOutput = {
@@ -152,6 +172,9 @@ export type MultipleChannelOutput = {
 export type NetworkConfiguration = {
     chainNetworkID: number;
 };
+
+// @public (undocumented)
+export const networkConfigurationSchema: joi.ObjectSchema<any>;
 
 // @public (undocumented)
 export type OptionalConnectionConfiguration = {
@@ -214,9 +237,19 @@ export type RequiredServerWalletConfig = {
 export type ServerWalletConfig = RequiredServerWalletConfig & OptionalServerWalletConfig;
 
 // @public (undocumented)
+export const serverWalletConfigSchema: joi.ObjectSchema<any>;
+
+// @public (undocumented)
 export type SingleChannelOutput = {
     outbox: Outgoing[];
     channelResult: ChannelResult;
+};
+
+// @public (undocumented)
+export function validateServerWalletConfig(config: Record<string, any>): {
+    valid: boolean;
+    value: ServerWalletConfig | undefined;
+    errors: ValidationErrorItem[];
 };
 
 // Warning: (ae-forgotten-export) The symbol "SingleThreadedWallet" needs to be exported by the entry point index.d.ts

--- a/packages/server-wallet/src/config/__test__/validation.test.ts
+++ b/packages/server-wallet/src/config/__test__/validation.test.ts
@@ -7,28 +7,54 @@ describe('config validation', () => {
     it('validates the default test config', () => {
       expect(validateServerWalletConfig(defaultTestConfig()).valid).toBe(true);
     });
+  });
 
+  describe('chain service config', () => {
     it('rejects an invalid private key', () => {
       const {valid, errors} = validateServerWalletConfig(
-        defaultTestConfig({ethereumPrivateKey: 'bla'})
+        defaultTestConfig({
+          chainServiceConfiguration: {
+            pk: 'bla',
+          },
+        })
       );
 
       expect(valid).toBe(false);
       expect(errors[0].message).toMatch(
-        `"ethereumPrivateKey" with value "bla" fails to match the Hex value validator pattern`
+        `"chainServiceConfiguration.pk" with value "bla" fails to match the Hex value validator pattern`
       );
+    });
+    it('rejects an invalid rpc endpoint', () => {
+      const chainServiceConfiguration = {provider: 'badurl'};
+      const result = validateServerWalletConfig(defaultTestConfig({chainServiceConfiguration}));
+      expect(result.errors[0].message).toMatch(
+        '"chainServiceConfiguration.provider" must be a valid uri'
+      );
+      expect(result.valid).toBe(false);
+    });
+    it('rejects an invalid allowance mode', () => {
+      const chainServiceConfiguration = {allowanceMode: 'bad'};
+      const result = validateServerWalletConfig(
+        // eslint-disable-next-line
+        // @ts-ignore
+        defaultTestConfig({chainServiceConfiguration})
+      );
+      expect(result.errors[0].message).toMatch(
+        '"chainServiceConfiguration.allowanceMode" must be one of [MaxUint, PerDeposit]'
+      );
+      expect(result.valid).toBe(false);
+    });
+    it('rejects an invalid polling interval', () => {
+      const chainServiceConfiguration = {pollingInterval: 0};
+      const result = validateServerWalletConfig(defaultTestConfig({chainServiceConfiguration}));
+      expect(result.errors[0].message).toMatch(
+        '"chainServiceConfiguration.pollingInterval" must be a positive number'
+      );
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('network config', () => {
-    it('rejects an invalid rpc endpoint', () => {
-      const networkConfiguration = {rpcEndpoint: 'badurl'};
-      const result = validateServerWalletConfig(defaultTestConfig({networkConfiguration}));
-      expect(result.errors[0].message).toMatch(
-        '"networkConfiguration.rpcEndpoint" must be a valid uri'
-      );
-      expect(result.valid).toBe(false);
-    });
     it('rejects an invalid chain id', () => {
       const networkConfiguration = {chainNetworkID: 0.5};
       const result = validateServerWalletConfig(defaultTestConfig({networkConfiguration}));

--- a/packages/server-wallet/src/config/__test__/validation.test.ts
+++ b/packages/server-wallet/src/config/__test__/validation.test.ts
@@ -38,6 +38,18 @@ describe('config validation', () => {
       expect(result.valid).toBe(false);
     });
   });
+  describe('metrics config', () => {
+    it('requires a metrics file when timingMetrics is enabled', () => {
+      const metricsConfiguration = {
+        timingMetrics: true,
+      };
+      const result = validateServerWalletConfig(defaultTestConfig({metricsConfiguration}));
+      expect(result.errors[0].message).toMatch(
+        '"metricsConfiguration.metricsOutputFile" is required'
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
 
   describe('database config', () => {
     it('accepts a valid config', () => {

--- a/packages/server-wallet/src/config/__test__/validation.test.ts
+++ b/packages/server-wallet/src/config/__test__/validation.test.ts
@@ -1,0 +1,87 @@
+import {defaultTestConfig} from '../defaults';
+import {DatabaseConfiguration} from '../types';
+import {validateServerWalletConfig} from '../validation';
+
+describe('config validation', () => {
+  describe('server wallet config', () => {
+    it('validates the default test config', () => {
+      expect(validateServerWalletConfig(defaultTestConfig()).valid).toBe(true);
+    });
+
+    it('rejects an invalid private key', () => {
+      const {valid, errors} = validateServerWalletConfig(
+        defaultTestConfig({ethereumPrivateKey: 'bla'})
+      );
+
+      expect(valid).toBe(false);
+      expect(errors[0].message).toMatch(
+        `"ethereumPrivateKey" with value "bla" fails to match the Hex value validator pattern`
+      );
+    });
+  });
+
+  describe('network config', () => {
+    it('rejects an invalid rpc endpoint', () => {
+      const networkConfiguration = {rpcEndpoint: 'badurl'};
+      const result = validateServerWalletConfig(defaultTestConfig({networkConfiguration}));
+      expect(result.errors[0].message).toMatch(
+        '"networkConfiguration.rpcEndpoint" must be a valid uri'
+      );
+      expect(result.valid).toBe(false);
+    });
+    it('rejects an invalid chain id', () => {
+      const networkConfiguration = {chainNetworkID: 0.5};
+      const result = validateServerWalletConfig(defaultTestConfig({networkConfiguration}));
+      expect(result.errors[0].message).toMatch(
+        '"networkConfiguration.chainNetworkID" must be an integer'
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('database config', () => {
+    it('accepts a valid config', () => {
+      const databaseConfiguration: DatabaseConfiguration = {
+        connection: 'postgresql://user:pass@localhost:5432/dbname',
+        pool: {max: 5},
+        debug: false,
+      };
+      const result = validateServerWalletConfig(defaultTestConfig({databaseConfiguration}));
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts a valid config with a connection object', () => {
+      const databaseConfiguration: DatabaseConfiguration = {
+        connection: {database: 'abc', host: 'abc', user: 'abc', port: 1234},
+        pool: {max: 5},
+        debug: false,
+      };
+      const result = validateServerWalletConfig(defaultTestConfig({databaseConfiguration}));
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects an invalid connection string', () => {
+      const databaseConfiguration: DatabaseConfiguration = {
+        connection: 'INVALID',
+        pool: {max: 5},
+        debug: false,
+      };
+      const result = validateServerWalletConfig(defaultTestConfig({databaseConfiguration}));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toMatch('Invalid connection string');
+    });
+
+    it('rejects a invalid connection object', () => {
+      const databaseConfiguration: DatabaseConfiguration = {
+        connection: {dbName: 'abc', host: 'abc', user: 'abc', port: 1234} as any,
+        pool: {max: 5},
+        debug: false,
+      };
+      const result = validateServerWalletConfig(defaultTestConfig({databaseConfiguration}));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toMatch(
+        '"databaseConfiguration.connection.dbName" is not allowed'
+      );
+    });
+  });
+});

--- a/packages/server-wallet/src/config/index.ts
+++ b/packages/server-wallet/src/config/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './utils';
 export * from './defaults';
+export * from './validation';

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -48,7 +48,7 @@ export const databaseConfigurationSchema = joi.object({
 
 export const metricsConfigurationSchema = joi.object({
   timingMetrics: joi.boolean().required(),
-  metricsOutputFile: joi.string().optional(),
+  metricsOutputFile: joi.string().when('timingMetrics', {is: true, then: joi.string().required()}),
 });
 
 export const loggingConfigurationSchema = joi.object({

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -11,7 +11,7 @@ const validateConnectionString = (connection: string) => {
   }
   return parsed;
 };
-export const databaseObjectConfigurationSchema = joi.object({
+const databaseObjectConfigurationSchema = joi.object({
   database: joi.string().required(),
   host: joi.string().required(),
   user: joi.string().required(),
@@ -24,13 +24,13 @@ export const databaseObjectConfigurationSchema = joi.object({
     .integer()
     .optional(),
 });
-export const databaseConnectionConfigurationSchema = joi.alternatives().conditional('.', {
+const databaseConnectionConfigurationSchema = joi.alternatives().conditional('.', {
   is: joi.string(),
   then: joi.string().custom(validateConnectionString, 'The connection string is valid'),
   otherwise: databaseObjectConfigurationSchema,
 });
 
-export const databasePoolConfigurationSchema = joi.object({
+const databasePoolConfigurationSchema = joi.object({
   max: joi
     .number()
     .integer()
@@ -43,23 +43,23 @@ export const databasePoolConfigurationSchema = joi.object({
     .optional(),
 });
 
-export const databaseConfigurationSchema = joi.object({
+const databaseConfigurationSchema = joi.object({
   connection: databaseConnectionConfigurationSchema.required(),
   debug: joi.boolean().optional(),
   pool: databasePoolConfigurationSchema.optional(),
 });
 
-export const metricsConfigurationSchema = joi.object({
+const metricsConfigurationSchema = joi.object({
   timingMetrics: joi.boolean().required(),
   metricsOutputFile: joi.string().when('timingMetrics', {is: true, then: joi.string().required()}),
 });
 
-export const loggingConfigurationSchema = joi.object({
+const loggingConfigurationSchema = joi.object({
   logLevel: joi.string().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
   logDestination: joi.string().required(),
 });
 
-export const networkConfigurationSchema = joi.object({
+const networkConfigurationSchema = joi.object({
   rpcEndpoint: joi
     .string()
     .uri()
@@ -72,7 +72,7 @@ export const networkConfigurationSchema = joi.object({
     .required(),
 });
 
-export const serverWalletConfigSchema = joi.object({
+const serverWalletConfigSchema = joi.object({
   databaseConfiguration: databaseConfigurationSchema,
   networkConfiguration: networkConfigurationSchema,
   ethereumPrivateKey: joi

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -1,0 +1,98 @@
+import joi, {ValidationErrorItem} from 'joi';
+import {parse} from 'pg-connection-string';
+
+import {ServerWalletConfig} from './types';
+
+const validateConnectionString = (connection: string) => {
+  const parsed = parse(connection);
+  const result = databaseObjectConfigurationSchema.validate(parsed);
+  if (result.error) {
+    throw new Error('Invalid connection string');
+  }
+  return parsed;
+};
+export const databaseObjectConfigurationSchema = joi.object({
+  database: joi.string().required(),
+  host: joi.string().required(),
+  user: joi.string().required(),
+  password: joi.string().optional(),
+  port: joi
+    .number()
+    .integer()
+    .optional(),
+});
+export const databaseConnectionConfigurationSchema = joi.alternatives().conditional('.', {
+  is: joi.string(),
+  then: joi.string().custom(validateConnectionString, 'The connection string is valid'),
+  otherwise: databaseObjectConfigurationSchema,
+});
+
+export const databasePoolConfigurationSchema = joi.object({
+  max: joi
+    .number()
+    .integer()
+    .min(0)
+    .optional(),
+  min: joi
+    .number()
+    .integer()
+    .min(0)
+    .optional(),
+});
+
+export const databaseConfigurationSchema = joi.object({
+  connection: databaseConnectionConfigurationSchema.required(),
+  debug: joi.boolean().optional(),
+  pool: databasePoolConfigurationSchema.optional(),
+});
+
+export const metricsConfigurationSchema = joi.object({
+  timingMetrics: joi.boolean().required(),
+  metricsOutputFile: joi.string().optional(),
+});
+
+export const loggingConfigurationSchema = joi.object({
+  logLevel: joi.string().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
+  logDestination: joi.string().required(),
+});
+
+export const networkConfigurationSchema = joi.object({
+  rpcEndpoint: joi
+    .string()
+    .uri()
+    .optional(),
+  chainNetworkID: joi
+    .number()
+    .integer()
+    .min(0)
+
+    .required(),
+});
+
+export const serverWalletConfigSchema = joi.object({
+  databaseConfiguration: databaseConfigurationSchema,
+  networkConfiguration: networkConfigurationSchema,
+  ethereumPrivateKey: joi
+    .string()
+    .pattern(/0[xX][0-9a-fA-F]{40}/, {name: 'Hex value validator'})
+    .required(),
+
+  workerThreadAmount: joi
+    .number()
+    .min(0)
+    .optional(),
+  skipEvmValidation: joi.boolean().optional(),
+  loggingConfiguration: loggingConfigurationSchema.optional(),
+  metricsConfiguration: metricsConfigurationSchema.optional(),
+});
+
+export function validateServerWalletConfig(
+  config: Record<string, any>
+): {valid: boolean; value: ServerWalletConfig | undefined; errors: ValidationErrorItem[]} {
+  const results = serverWalletConfigSchema.validate(config);
+  return {
+    valid: !results.error,
+    value: results.value ? (results.value as ServerWalletConfig) : undefined,
+    errors: results.error?.details || [],
+  };
+}

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -15,7 +15,10 @@ export const databaseObjectConfigurationSchema = joi.object({
   database: joi.string().required(),
   host: joi.string().required(),
   user: joi.string().required(),
-  password: joi.string().optional(),
+  password: joi
+    .string()
+    .allow('')
+    .optional(),
   port: joi
     .number()
     .integer()

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -60,10 +60,6 @@ const loggingConfigurationSchema = joi.object({
 });
 
 const networkConfigurationSchema = joi.object({
-  rpcEndpoint: joi
-    .string()
-    .uri()
-    .optional(),
   chainNetworkID: joi
     .number()
     .integer()
@@ -72,13 +68,35 @@ const networkConfigurationSchema = joi.object({
     .required(),
 });
 
+const chainServiceConfigurationSchema = joi.object({
+  attachChainService: joi.boolean().required(),
+  pk: joi
+    .string()
+    .pattern(/0[xX][0-9a-fA-F]{40}/, {name: 'Hex value validator'})
+    .optional(),
+  provider: joi
+    .string()
+    .uri()
+    .optional(),
+  pollingInterval: joi
+    .number()
+    .positive()
+    .optional(),
+  blockConfirmations: joi
+    .number()
+    .not()
+    .negative()
+    .optional(),
+  allowanceMode: joi
+    .string()
+    .valid('MaxUint', 'PerDeposit')
+    .optional(),
+});
+
 const serverWalletConfigSchema = joi.object({
   databaseConfiguration: databaseConfigurationSchema,
   networkConfiguration: networkConfigurationSchema,
-  ethereumPrivateKey: joi
-    .string()
-    .pattern(/0[xX][0-9a-fA-F]{40}/, {name: 'Hex value validator'})
-    .required(),
+  chainServiceConfiguration: chainServiceConfigurationSchema,
 
   workerThreadAmount: joi
     .number()

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -27,6 +27,7 @@ import EventEmitter from 'eventemitter3';
 import {ethers, constants, BigNumber, utils} from 'ethers';
 import {Logger} from 'pino';
 import {Payload as WirePayload} from '@statechannels/wire-format';
+import {ValidationErrorItem} from 'joi';
 
 import {Bytes32, Uint256} from '../type-aliases';
 import {Outgoing} from '../protocols/actions';
@@ -96,6 +97,12 @@ export interface UpdateChannelFundingParams {
   amount: Uint256;
 }
 
+export class ConfigValidationError extends Error {
+  constructor(public errors: ValidationErrorItem[]) {
+    super('Server wallet configuration validation failed');
+  }
+}
+
 export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
   implements WalletInterface, ChainEventSubscriberInterface {
   knex: Knex;
@@ -125,7 +132,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       errors.forEach(error =>
         this.logger.error({error}, `Validation error occured ${error.message}`)
       );
-      throw new Error('Invalid configuration');
+      throw new ConfigValidationError(errors);
     }
     this.walletConfig = populatedConfig;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3866,6 +3866,23 @@
     "@sentry/types" "5.27.4"
     tslib "^1.9.3"
 
+"@sideway/address@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz#0b301ada10ac4e0e3fa525c90615e0b61a72b78d"
+  integrity sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -14253,6 +14270,17 @@ jmespath@^0.15.0:
   version "0.15.0"
   resolved "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
+joi@^17.3.0:
+  version "17.3.0"
+  resolved "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
+  integrity sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 joycon@^2.2.5:
   version "2.2.5"


### PR DESCRIPTION
Uses `joi` to validate incoming config files into the wallet.

Fixes https://github.com/statechannels/the-graph/issues/283

The logged errors are pretty readable out of the box: 
```
[1607031065478] ERROR (37103 on Alexs-MacBook-Pro.local): Validation error occured "databaseConfiguration.connection.password" is not allowed to be empty
    dbName: "TEST_A"
    walletVersion: ""
    error: {
      "message": "\"databaseConfiguration.connection.password\" is not allowed to be empty",
      "path": [
        "databaseConfiguration",
        "connection",
        "password"
      ],
      "type": "string.empty",
      "context": {
        "label": "databaseConfiguration.connection.password",
        "value": "",
        "key": "password"
      }
    }

```

# How did I come to choose Joi?

I chose `joi` because I didn't want to implement validation checks myself. It seemed like I would be rewriting a lot of very basic checks. 

 Based on our past use of `Ajv` and json schema it seemed pretty cumbersome. I think the `joi` notation is a lot more straightforward and a lot less effort to maintain. Also the errors we get back from `joi` seem a lot saner than `ajv`.

It is also trivial to add custom validation to `joi` that does pretty much anything. This allows us the flexibility to do things like validate a db connection by testing the connection to the database.

I also wanted to limit myself to a somewhat popular solution so it would be easy to find info about it and we wouldn't worry about getting bug fixes.