### PR TITLE
[nitro-protocol, docs-website] Resurrect docs#Contract API via patching hardhat

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "git diff --quiet HEAD^ HEAD packages/docs-website/"
+  ignore = "git diff --quiet HEAD^ HEAD packages/docs-website/ packages/nitro-protocol"

--- a/packages/docs-website/docs/contract-api/contract-inheritance.mdx
+++ b/packages/docs-website/docs/contract-api/contract-inheritance.mdx
@@ -77,7 +77,7 @@ classDef Interface fill:#ffffff,stroke:#de1065,stroke-dasharray: 5 5
 classDef TestContract fill:#fafe4f,stroke-width:0px;
 classDef Library fill:#ffffff,stroke:#656664,stroke-dasharray: 5 5
 class Outcome,SafeMath Library;
-class IAdjudicator,IForceMoveApp, IForceMove Interface;
+class IAdjudicator,IForceMoveApp,IForceMove Interface;
 class ForceMove Contract;
 class TESTForceMove,TESTNitroAdjudicator TestContract;
 class NitroAdjudicator DeployedContract;

--- a/packages/docs-website/package.json
+++ b/packages/docs-website/package.json
@@ -34,7 +34,7 @@
   "private": true,
   "scripts": {
     "api-documenter": "node scripts/api-documenter.js",
-    "build:netlify:disabled-for-now": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus build",
+    "build": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus build",
     "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus",
     "examples": "docusaurus-examples",

--- a/packages/docs-website/package.json
+++ b/packages/docs-website/package.json
@@ -9,8 +9,6 @@
     "@docusaurus/preset-classic": "2.0.0-alpha.64",
     "@mdx-js/react": "1.6.18",
     "@microsoft/api-documenter": "7.8.21",
-    "@statechannels/channel-client": "0.4.6",
-    "@statechannels/iframe-channel-provider": "0.3.17",
     "@statechannels/nitro-protocol": "0.11.2",
     "@statechannels/server-wallet": "1.16.0",
     "clsx": "1.1.1",

--- a/packages/docs-website/sidebars.json
+++ b/packages/docs-website/sidebars.json
@@ -40,8 +40,8 @@
     "Base Contracts": [
       "contract-api/natspec/IForceMove",
       "contract-api/natspec/ForceMove",
-      "contract-api/natspec/Adjudicator",
-      "contract-api/natspec/ForceMoveApp",
+      "contract-api/natspec/IAdjudicator",
+      "contract-api/natspec/IForceMoveApp",
       "contract-api/natspec/IAssetHolder",
       "contract-api/natspec/AssetHolder",
       "contract-api/natspec/IERC20",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -67,7 +67,6 @@
   "repository": "statechannels/monorepo.git",
   "scripts": {
     "build:typescript": "rm -rf lib; yarn tsc -b .",
-    "build:webpack": "webpack",
     "contract:compile": "yarn hardhat compile",
     "contract:compile:watch": "yarn hardhat watch compilation",
     "contract:deploy-rinkeby": "yarn hardhat deploy --network rinkeby --config ./hardhat.config-rinkeby.ts",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -34,7 +34,7 @@
     "lint-staged": "10.0.4",
     "prettier": "1.19.1",
     "prettier-plugin-solidity": "1.0.0-alpha.58",
-    "solidoc": "https://github.com/statechannels/solidoc.git#839076945d906dcee02aa1c27460c670b7d373fd",
+    "solidoc": "https://github.com/statechannels/solidoc.git#3235c4f8be624a36710502c9021cfbd47a9a0f49",
     "ts-jest": "26.4.4",
     "typescript": "4.1.2",
     "webpack": "4.44.2"

--- a/packages/nitro-protocol/readme.md
+++ b/packages/nitro-protocol/readme.md
@@ -108,4 +108,4 @@ INFURA_TOKEN=[your token here] RINKEBY_DEPLOYER_PK=[private key used for rinkeby
 
 The config extends from a minimal base config (`hardhat.config.ts`) that is used for other tasks such as compilation.
 
-After succesfully deploying, please  a) update the addresses in `.env.testnet` (at the root of the monorepo) if they exists, and raise a pull request with this file and the updated contract artifacts.
+After succesfully deploying, please  a) update the addresses in `.env.testnet` (at the root of the monorepo) if they exists, and raise a pull request with this file and the updated deployment artifacts.

--- a/patches/hardhat+2.0.3.patch
+++ b/patches/hardhat+2.0.3.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/hardhat/builtin-tasks/compile.js b/node_modules/hardhat/builtin-tasks/compile.js
+index ab562c3..bdf669f 100644
+--- a/node_modules/hardhat/builtin-tasks/compile.js
++++ b/node_modules/hardhat/builtin-tasks/compile.js
+@@ -448,12 +448,14 @@ config_env_1.subtask(task_names_1.TASK_COMPILE_SOLIDITY_EMIT_ARTIFACTS)
+             continue;
+         }
+         const artifactsEmitted = [];
++
+         for (const [contractName, contractOutput] of Object.entries((_b = (_a = output.contracts) === null || _a === void 0 ? void 0 : _a[file.sourceName]) !== null && _b !== void 0 ? _b : {})) {
+             log(`Emitting artifact for contract '${contractName}'`);
++            const richerOutput = {...contractOutput,ast: output.sources[file.sourceName].ast, sourcePath: file.absolutePath}
+             const artifact = await run(task_names_1.TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT, {
+                 sourceName: file.sourceName,
+                 contractName,
+-                contractOutput,
++                contractOutput: richerOutput,
+             });
+             await artifacts.saveArtifactAndDebugFile(artifact, pathToBuildInfo);
+             artifactsEmitted.push(artifact.contractName);
+diff --git a/node_modules/hardhat/internal/artifacts.js b/node_modules/hardhat/internal/artifacts.js
+index 7ea612a..8d8e0d8 100644
+--- a/node_modules/hardhat/internal/artifacts.js
++++ b/node_modules/hardhat/internal/artifacts.js
+@@ -334,6 +334,8 @@ function getArtifactFromContractOutput(sourceName, contractName, contractOutput)
+         contractName,
+         sourceName,
+         abi: contractOutput.abi,
++        ast: contractOutput.ast,
++        sourcePath: contractOutput.sourcePath,
+         bytecode,
+         deployedBytecode,
+         linkReferences,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20891,9 +20891,9 @@ solc@0.7.3:
     semver "^5.5.0"
     tmp "0.0.33"
 
-"solidoc@https://github.com/statechannels/solidoc.git#839076945d906dcee02aa1c27460c670b7d373fd":
+"solidoc@https://github.com/statechannels/solidoc.git#3235c4f8be624a36710502c9021cfbd47a9a0f49":
   version "1.0.4"
-  resolved "https://github.com/statechannels/solidoc.git#839076945d906dcee02aa1c27460c670b7d373fd"
+  resolved "https://github.com/statechannels/solidoc.git#3235c4f8be624a36710502c9021cfbd47a9a0f49"
   dependencies:
     fs-extra "^7.0.0"
     glob "^7.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,36 +3912,6 @@
   resolved "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.1.tgz#1b606578af86b9ad10755409804a6ba83f9ce8a4"
   integrity sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw==
 
-"@statechannels/channel-client@0.4.6":
-  version "0.4.6"
-  resolved "https://registry.npmjs.org/@statechannels/channel-client/-/channel-client-0.4.6.tgz#5f61c73da0457a6ce46b46a0a5f4bb1728591be1"
-  integrity sha512-jlw5R7yeZN8KJvQ6hcDzp9NkVFSYZCWUFaQyu59A03yNxRIRyEO2U5741d/+2R43L0xU3Fak/EkFDdGz69iY7w==
-  dependencies:
-    "@statechannels/client-api-schema" "0.4.5"
-    "@statechannels/iframe-channel-provider" "0.3.17"
-    ethers "5.0.12"
-    eventemitter3 "4.0.7"
-    loglevel "1.6.8"
-
-"@statechannels/client-api-schema@0.4.5":
-  version "0.4.5"
-  resolved "https://registry.npmjs.org/@statechannels/client-api-schema/-/client-api-schema-0.4.5.tgz#bf293179008d136c833c6a1a8e06e4a814a9d656"
-  integrity sha512-gclJYSMF6OazrGM+Q/NbQqGR1qlQb2QrufHN43Dz8TR8McZdJOqg98J8b86oOasJ/T9ZfypP9uLapp4jQDyhLw==
-  dependencies:
-    ajv "6.11.0"
-
-"@statechannels/iframe-channel-provider@0.3.17":
-  version "0.3.17"
-  resolved "https://registry.npmjs.org/@statechannels/iframe-channel-provider/-/iframe-channel-provider-0.3.17.tgz#e0b335ce4db170aef2a9a0765903376155accc9a"
-  integrity sha512-xKDjPdRpdwqvykv/PYpNxT6wHo+lQ+SJNxqVhCKFMVPTlxZ5QR8+nhX9FLwqPCvG7G6XXM9/EbBKsc9ZbGtJjQ==
-  dependencies:
-    "@statechannels/client-api-schema" "0.4.5"
-    eventemitter3 "4.0.7"
-    guid-typescript "1.0.9"
-    lodash "4.17.20"
-    normalize-url "4.5.0"
-    pino "6.2.0"
-
 "@statechannels/wasm-utils@0.1.6":
   version "0.1.6"
   resolved "https://registry.npmjs.org/@statechannels/wasm-utils/-/wasm-utils-0.1.6.tgz#2b0b7de5a63f158d4202718ebb5bdd3a910b0c6c"
@@ -11997,11 +11967,6 @@ growly@^1.3.0:
   resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-guid-typescript@1.0.9:
-  version "1.0.9"
-  resolved "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz#e35f77003535b0297ea08548f5ace6adb1480ddc"
-  integrity sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==
-
 gzip-size@5.1.1, gzip-size@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
@@ -15356,11 +15321,6 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loglevel@1.6.8:
-  version "1.6.8"
-  resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
-  integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
-
 loglevel@^1.6.8:
   version "1.7.0"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz#728166855a740d59d38db01cf46f042caa041bb0"
@@ -16791,15 +16751,15 @@ normalize-url@1.9.1:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-normalize-url@4.5.0, normalize-url@^4.1.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
-  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
-
 normalize-url@^3.0.0, normalize-url@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+
+normalize-url@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
+  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
 npm-bundled@^1.0.1:
   version "1.1.1"


### PR DESCRIPTION
- patches hardhat to incluce `ast` field in contract artifacts
- updates our [solidoc fork](https://github.com/statechannels/solidoc) to ignore some of the `.json` files that hardhat outputs
- configures netlfiy gui to deploy from master and generate deploy previews for PRs (may turn the previews off, but for now they are on to check this works)
