### PR TITLE
Close channel protocol tests

### DIFF
--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -9,7 +9,7 @@ import {TestLedgerChannel} from '../../wallet/__test__/fixtures/test-ledger-chan
 import {SingleAppUpdater} from '../single-app-updater';
 
 const FINAL = 8;
-const testChan = TestChannel.create({channelNonce: 1, startClosingAt: FINAL});
+const testChan = TestChannel.create({channelNonce: 1, finalFrom: FINAL});
 const testChan2 = TestChannel.create({channelNonce: 2});
 
 let store: Store;

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -10,7 +10,7 @@ import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
 import {ChannelCloser} from '../close-channel';
 
 const FINAL = 10; // this will be A's state to sign
-const testChan = TestChannel.create({aBal: 5, bBal: 5, startClosingAt: FINAL});
+const testChan = TestChannel.create({aBal: 5, bBal: 5, finalFrom: FINAL});
 
 let store: Store;
 
@@ -71,7 +71,7 @@ describe(`defunding phase (when the channel is closed)`, () => {
   });
   describe(`fake funding`, () => {
     it('marks the objective as complete', async () => {
-      const testChan = TestChannel.create({startClosingAt: FINAL, fundingStrategy: 'Fake'});
+      const testChan = TestChannel.create({finalFrom: FINAL, fundingStrategy: 'Fake'});
       const objective = await setup(testChan, {participant: 0, statesHeld: [FINAL, FINAL + 1]});
 
       await crankAndAssert(objective, {completesObj: true});

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -146,29 +146,12 @@ interface SetupParams {
   statesHeld: number[];
   totalFunds?: number;
 }
+
 const setup = async (args: SetupParams): Promise<DBOpenChannelObjective> => {
   const {participant, statesHeld} = args;
   const totalFunds = args.totalFunds || 0;
 
-  // load the signingKey for the appopriate participant
-  await store.addSigningKey(testChan.signingKeys[participant]);
-  // load in the states
-  for (const stateNum of statesHeld) {
-    await store.pushMessage(testChan.wirePayload(Number(stateNum)));
-  }
-  // set the funds as specified
-  if (totalFunds > 0) {
-    await store.updateFunding(testChan.channelId, BN.from(totalFunds), testChan.assetHolderAddress);
-  }
-
-  // add the openChannel objective and approve
-  const objective = await store.transaction(async tx => {
-    const o = await store.ensureObjective(testChan.openChannelObjective, tx);
-    await store.approveObjective(o.objectiveId, tx);
-    return o as DBOpenChannelObjective;
-  });
-
-  return objective;
+  return testChan.insertInto(store, {participant, states: statesHeld, funds: totalFunds});
 };
 
 interface AssertionParams {

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -142,6 +142,7 @@ export function directFundingStatus(
     .reduce(BN.add, BN.from(0));
 
   const funding = fundingFn(assetHolderAddress);
+  console.log('funding: ', funding);
 
   const amountTransferredToMe = funding.transferredOut
     .filter(tf => tf.toAddress === myDestination)

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -31,7 +31,7 @@ interface TestChannelArgs {
   aBal?: number;
   bBal?: number;
   channelNonce?: number;
-  startClosingAt?: number;
+  finalFrom?: number;
   fundingStrategy?: FundingStrategy;
 }
 
@@ -44,7 +44,7 @@ export class TestChannel {
   public signingWalletB: SigningWallet = bobWallet();
   public startBals: [number, number];
   public channelNonce: number;
-  public startClosingAt?: number;
+  public finalFrom?: number;
   public fundingStrategy: FundingStrategy;
 
   public get participants(): Participant[] {
@@ -62,7 +62,7 @@ export class TestChannel {
     this.fundingStrategy = args.fundingStrategy || 'Direct';
     this.startBals = [args.aBal || 5, args.bBal || 5];
     this.channelNonce = args.channelNonce || 5;
-    this.startClosingAt = args.startClosingAt;
+    this.finalFrom = args.finalFrom;
   }
 
   /**
@@ -77,8 +77,8 @@ export class TestChannel {
     return {
       ...this.channelConstants,
       appData: '0x',
-      isFinal: !!this.startClosingAt && n >= this.startClosingAt,
-      turnNum: Math.min(n, this.startClosingAt || n),
+      isFinal: !!this.finalFrom && n >= this.finalFrom,
+      turnNum: Math.min(n, this.finalFrom || n),
       outcome: bals ? this.toOutcome(bals) : this.startOutcome,
     };
   }


### PR DESCRIPTION
This PR updates the close channel protocol tests, so they use the same approach as the open channel protocol tests (see https://github.com/statechannels/statechannels/pull/2995). Having the tests in this format will allow us to refactor the close channel protocols. 

It also makes a few improvements to the `TestChannel` class:

1. You can now set the `fundingStrategy` on a test channel
2. test channels can now insert themselves into a store
3. when creating a test channel, you can set `finalFrom: 10`, which will e.g. cause `state(11)` to return a double-signed 10