### PR TITLE
feat: accept a list of indices in transfer method (rebased version of #3011)

### DIFF
--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -7,12 +7,17 @@ pragma experimental ABIEncoderV2;
  */
 interface IAssetHolder {
     /**
-     * @notice Transfers the funds escrowed against `channelId` to the beneficiaries of that channel.
-     * @dev Transfers the funds escrowed against `channelId` and transfers them to the beneficiaries of that channel.
-     * @param channelId Unique identifier for a state channel.
+     * @notice Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries.
+     * @dev Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries.
+     * @param fromChannelId Unique identifier for state channel to transfer funds *from*.
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
+     * @param indices Array with each entry denoting the index of a destination to transfer funds to.
      */
-    function transferAll(bytes32 channelId, bytes calldata allocationBytes) external;
+    function transfer(
+        bytes32 fromChannelId,
+        bytes calldata allocationBytes,
+        uint256[] memory indices
+    ) external;
 
     /**
      * @notice Transfers the funds escrowed against `guarantorChannelId` to the beneficiaries of the __target__ of that channel.

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
@@ -50,7 +50,7 @@ contract TESTAssetHolder is AssetHolder {
         external
         override
     {
-        _transferAll(channelId, allocationBytes);
+        _transfer(channelId, allocationBytes, new uint256[](0));
     }
 
     /**

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -38,32 +38,35 @@ beforeAll(async () => {
 
 const reason0 =
   'AssetHolder | submitted allocationBytes data does not match stored assetOutcomeHash';
-const reason1 = 'affords 0 for destination';
+const reason1 = 'Indices must be sorted';
 
 // c is the channel we are transferring from.
-describe('transferAll', () => {
+describe('transfer', () => {
   it.each`
-    name                              | heldBefore | setOutcome      | destination | newOutcome      | heldAfter       | payouts   | events    | reason
-    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${'A'}      | ${{}}           | ${{}}           | ${{A: 1}} | ${{A: 1}} | ${reason0}
-    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${'A'}      | ${{}}           | ${{}}           | ${{A: 1}} | ${{A: 1}} | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${'A'}      | ${{}}           | ${{c: 1}}       | ${{A: 1}} | ${{A: 1}} | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${'A'}      | ${{A: 1}}       | ${{}}           | ${{A: 1}} | ${{A: 1}} | ${undefined}
-    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${'C'}      | ${{}}           | ${{c: 0, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
-    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${'C'}      | ${{}}           | ${{c: 1, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
-    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${'C'}      | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
-    ${' 7. -> 2 EOA            full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${'A'}      | ${{B: 1}}       | ${{c: 1}}       | ${{A: 1}} | ${{A: 1}} | ${undefined}
-    ${' 8. -> 2 EOA            full'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${'A'}      | ${{B: 1}}       | ${{c: 0}}       | ${{A: 1}} | ${{A: 1}} | ${undefined}
-    ${' 9. -> 2 EOA         partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${'B'}      | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}} | ${{B: 1}} | ${undefined}
-    ${'10. -> 2 chan             no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${'X'}      | ${{C: 1, X: 1}} | ${{c: 0}}       | ${{}}     | ${{}}     | ${reason1}
-    ${'11. -> 2 chan           full'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${'C'}      | ${{X: 1}}       | ${{c: 0, C: 1}} | ${{}}     | ${{C: 1}} | ${undefined}
-    ${'12. -> 2 chan        partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${'X'}      | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}     | ${{X: 1}} | ${undefined}
+    name                               | heldBefore | setOutcome            | indices      | newOutcome      | heldAfter       | payouts         | events                | reason
+    ${' 0. outcome not set         '}  | ${{c: 1}}  | ${{}}                 | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${reason0}
+    ${' 1. funded          -> 1 EOA'}  | ${{c: 1}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'}  | ${{c: 2}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{c: 1}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'}  | ${{c: 1}}  | ${{A: 2}}             | ${[0]}       | ${{A: 1}}       | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
+    ${' 4. funded      -> 1 channel'}  | ${{c: 1}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
+    ${' 5. overfunded  -> 1 channel'}  | ${{c: 2}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 1, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
+    ${' 6. underfunded -> 1 channel'}  | ${{c: 1}}  | ${{C: 2}}             | ${[0]}       | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
+    ${' 7. -> 2 EOA         1 index'}  | ${{c: 2}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 1}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
+    ${' 8. -> 2 EOA         1 index'}  | ${{c: 1}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 0}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
+    ${' 9. -> 2 EOA         partial'}  | ${{c: 3}}  | ${{A: 2, B: 2}}       | ${[1]}       | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}}       | ${{B: 1}}             | ${undefined}
+    ${'10. -> 2 chan             no'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[1]}       | ${{C: 1, X: 1}} | ${{c: 1}}       | ${{}}           | ${{}}                 | ${undefined}
+    ${'11. -> 2 chan           full'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[0]}       | ${{C: 0, X: 1}} | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
+    ${'12. -> 2 chan        partial'}  | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1]}       | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${{X: 1}}             | ${undefined}
+    ${'13. -> 2 indices'}              | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[0, 1]}    | ${{C: 0, X: 1}} | ${{c: 0, X: 1}} | ${{C: 2}}       | ${{C: 2, X: 1}}       | ${undefined}
+    ${'14. -> 3 indices'}              | ${{c: 5}}  | ${{A: 1, C: 2, X: 2}} | ${[0, 1, 2]} | ${{}}           | ${{c: 0, X: 2}} | ${{A: 1, C: 2}} | ${{A: 1, C: 2, X: 2}} | ${undefined}
+    ${'15. -> reverse order (see 13)'} | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1, 0]}    | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${{X: 1}}             | ${reason1}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
     async ({
       name,
       heldBefore,
       setOutcome,
-      destination,
+      indices,
       newOutcome,
       heldAfter,
       payouts,
@@ -82,7 +85,6 @@ describe('transferAll', () => {
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
       payouts = replaceAddressesAndBigNumberify(payouts, addresses);
       events = replaceAddressesAndBigNumberify(events, addresses);
-      destination = addresses[destination];
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
@@ -105,7 +107,7 @@ describe('transferAll', () => {
       ).wait();
       expect(await AssetHolder.assetOutcomeHashes(channelId)).toBe(assetOutcomeHash);
 
-      const tx = AssetHolder.transfer(channelId, encodeAllocation(allocation), destination);
+      const tx = AssetHolder.transfer(channelId, encodeAllocation(allocation), indices);
 
       // Call method in a slightly different way if expecting a revert
       if (reason) {
@@ -121,6 +123,7 @@ describe('transferAll', () => {
           }
         });
         const {events: eventsFromTx, gasUsed} = await (await tx).wait();
+        // NOTE: _transferAsset is a NOOP in TESTAssetHolder, so gas costs will be much lower than for a real Asset Holder
         await writeGasConsumption('transfer.gas.md', name, gasUsed);
         expect(eventsFromTx).toMatchObject(expectedEvents);
         // Check new holdings

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -42,20 +42,20 @@ const reason0 =
 // c is the channel we are transferring from.
 describe('transferAll', () => {
   it.each`
-    name                              | heldBefore | setOutcome      | newOutcome | heldAfter             | payouts         | events          | reason
-    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}      | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${reason0}
-    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}      | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}      | ${{c: 1}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}  | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}      | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}      | ${{c: 1, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}  | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}      | ${{c: 0}}             | ${{A: 1, B: 1}} | ${{A: 1, B: 1}} | ${undefined}
-    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{B: 1}}  | ${{c: 0}}             | ${{A: 2, B: 1}} | ${{A: 2, B: 1}} | ${undefined}
-    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}      | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${{C: 1, X: 1}} | ${undefined}
-    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{X: 1}}  | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{X: 1}}  | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${{C: 2, X: 1}} | ${undefined}
+    name                              | heldBefore | setOutcome      | newOutcome      | heldAfter             | payouts         | events          | reason
+    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}           | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${reason0}
+    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}           | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}           | ${{c: 1}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}       | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}           | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}           | ${{c: 1, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}       | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}           | ${{c: 0}}             | ${{A: 1, B: 1}} | ${{A: 1, B: 1}} | ${undefined}
+    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 2, B: 1}} | ${{A: 2, B: 1}} | ${undefined}
+    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}           | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${{C: 1, X: 1}} | ${undefined}
+    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{C: 0, X: 1}} | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${{C: 1}}       | ${undefined}
+    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{C: 0, X: 1}} | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${{C: 2, X: 1}} | ${undefined}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts, events: $events`,
     async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, events, reason}) => {


### PR DESCRIPTION
- zero amount allocations are not cleaned up
- pure functions used to compute new allocation on chain
(to ease emulation in client code)
- indices = [] implies we pay out to all