### PR TITLE
docs: clarify role of functions

### DIFF
--- a/packages/server-wallet/src/state-utils.ts
+++ b/packages/server-wallet/src/state-utils.ts
@@ -106,6 +106,7 @@ export function clearOldStates(
 /**
  * Deserializes a state but uses the wasm utility method local to the server-wallet
  * package. This, as opposed to the JS implementation inside wallet-core.
+ * Throws if the recovered signer is not a participant.
  */
 export function fastDeserializeState(channelId: Bytes32, state: WireSignedState): SignedState {
   const {outcome, participants, signatures} = state;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -544,7 +544,7 @@ export class Store {
     const syncTimer = timerFactorySync(this.timingMetrics, `add signed state ${channelId}`);
     const asyncTimer = timerFactory(this.timingMetrics, `add signed state ${channelId}`);
 
-    // Deserialize (and validate signatures in the process)
+    // Deserialize (and throw if signer not a participant)
     const deserializedState = syncTimer('validating signatures', () =>
       fastDeserializeState(channelId, wireState)
     );


### PR DESCRIPTION
"validate signatures" is too broad and can give the false impression
of the more rigorous checks we need
to do in order to infer a support proof
(e.g. was the state signed by its mover)

work towards #3035; increase clarity about where and why we perform checks on state channel state. 