### PR TITLE
Undisable solhint

### DIFF
--- a/packages/nitro-protocol/.solhint.json
+++ b/packages/nitro-protocol/.solhint.json
@@ -19,6 +19,6 @@
     "prettier/prettier": "error",
     "compiler-version": ["error","0.7.4"],
     "func-visibility": ["warn",{"ignoreConstructors":true}],
-    "reason-string": "off"
+    "reason-string": ["warn",{"maxLength": 96}]
   }
 }

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -130,10 +130,8 @@ contract AssetHolder is IAssetHolder {
     function setAssetOutcomeHash(bytes32 channelId, bytes32 assetOutcomeHash)
         external
         AdjudicatorOnly
-        returns (bool success)
     {
         _setAssetOutcomeHash(channelId, assetOutcomeHash);
-        return true;
     }
 
     // **************
@@ -275,7 +273,7 @@ contract AssetHolder is IAssetHolder {
 
         for (uint256 j = 0; j < guarantee.destinations.length; j++) {
             if (balance == 0) {
-                revert('_claim | guarantorChannel affords 0 for destination');
+                revert('_claim : guarantorChannel affords 0 for destination');
             }
             // for each destination in the guarantee,
             // find the first corresponding allocationItem in the target allocation

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -919,7 +919,7 @@ contract ForceMove is IForceMove {
         );
         require(
             (numSigs == numParticipants) && (numWhoSignedWhats == numParticipants),
-            'ForceMove | You must provide exactly one signature per participant, and assert who signed what for all participants'
+            'ForceMove | Require exactly 1 signature per participant & who signed what for all participants'
         );
         require(numParticipants < type(uint8).max, 'ForceMove | Too many participants!');
         return true;

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -594,9 +594,9 @@ contract ForceMove is IForceMove {
                         ab[1],
                         turnNumB,
                         nParticipants
-                    )
+                    ),
+                    'Invalid ForceMoveApp Transition'
                 );
-                // reason string not necessary (called function will provide reason for reverting)
             }
         }
         return true;

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -42,11 +42,9 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
         Outcome.OutcomeItem[] memory outcome = abi.decode(outcomeBytes, (Outcome.OutcomeItem[]));
 
         for (uint256 i = 0; i < outcome.length; i++) {
-            require(
-                AssetHolder(outcome[i].assetHolderAddress).setAssetOutcomeHash(
-                    channelId,
-                    keccak256(outcome[i].assetOutcomeBytes)
-                )
+            AssetHolder(outcome[i].assetHolderAddress).setAssetOutcomeHash(
+                channelId,
+                keccak256(outcome[i].assetOutcomeBytes)
             );
         }
     }


### PR DESCRIPTION
Closes #3053 

Removes one unecessary `require`. Adds a reason string to an existing require where it is useful. 


I stopped short of imposing a 32 byte limit on reason strings (as is the default lint rule). It doesn't currently seem worth the effort, given that it is not clear the advantages of shorter strings. 

If you hit a revert, [all of your gas is refunded. ](https://docs.soliditylang.org/en/v0.7.5/control-structures.html#error-handling-assert-require-revert-and-exceptions)

The reason strings will influence the deployment cost of the contract, but this is not a top concern of ours right now. 

At some point in the future we may wish to overhaul all of our reason strings, perhaps introducing error codes or otherwise cleaning them up (they are pretty ad hoc currently). 