### PR TITLE
replace n * AssetTransferred events with a single AllocationUpdated event

### DIFF
--- a/packages/docs-website/docs/docs/app-devs/make-api-calls.md
+++ b/packages/docs-website/docs/docs/app-devs/make-api-calls.md
@@ -100,7 +100,7 @@ WalletA-->>ClientA: ChannelUpdated('closed')
 WalletA->>Chain: concludePushOutcomeAndTransferAll()
 deactivate WalletA
 deactivate WalletB
-Chain-->>WalletA: AssetTransferred x2
-Chain-->>WalletB: AssetTransferred x2
+Chain-->>WalletA: AllocationUpdated
+Chain-->>WalletB: AllocationUpdated
 end
 " />

--- a/packages/docs-website/docs/docs/protocol-tutorial/release-assets.md
+++ b/packages/docs-website/docs/docs/protocol-tutorial/release-assets.md
@@ -88,18 +88,13 @@ const assetOutcome: AllocationAssetOutcome = {
 const tx3 = ETHAssetHolder.transferAll(channelId, encodeAllocation(assetOutcome.allocationItems));
 
 /* 
-  Check that an AssetTransferred event was emitted.
+  Check that an AllocationUpdated event was emitted. 
 */
 const {events} = await(await tx3).wait();
-expect(events).toMatchObject([
+expect(events).toMatchObject(
   {
-    event: 'AssetTransferred',
-    args: {
-      channelId,
-      destination: destination.toLowerCase(),
-      amount: {_hex: amount}
-    }
-  }
+    event: 'AllocationUpdated',
+  },
 ]);
 
 expect(BigNumber.from(await provider.getBalance(EOA)).eq(BigNumber.from(amount)));
@@ -111,6 +106,10 @@ If the destination specified in the outcome is external, the asset holder pays o
 
 :::tip
 This method executes payouts that might benefit multiple participants. If multiple actors try and call this method, after the first transaction is confirmed the remaining ones may fail.
+:::
+
+:::tip
+It may be desirable to payout to a subset of destinations (or even a single one). The `transfer` method can be used to do this, and accepts a list of `indices` to transfer from. See the contract API for more information. More information coming soon, including how to track the updated allocation after a `transfer` is mined.
 :::
 
 ## Using `claimAll`

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -246,7 +246,7 @@ contract AssetHolder is IAssetHolder {
                 }
             }
         }
-        emit AssetsTransferred(fromChannelId, payouts);
+        emit AllocationUpdated(fromChannelId, initialHoldings);
     }
 
     /**
@@ -374,7 +374,7 @@ contract AssetHolder is IAssetHolder {
         uint256[] memory payouts = new uint256[](1);
         payouts[0] = affordsForDestination;
         // Event emitted
-        emit AssetsTransferred(guarantorChannelId, payouts);
+        emit AllocationUpdated(guarantorChannelId, 0); // TODO emit initial holdings
     }
 
     /**
@@ -499,7 +499,7 @@ contract AssetHolder is IAssetHolder {
                 }
             }
         }
-        emit AssetsTransferred(guarantorChannelId, payouts);
+        emit AllocationUpdated(guarantorChannelId, 0); // TODO emit initial holdings
     }
 
     /**

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -375,7 +375,7 @@ contract AssetHolder is IAssetHolder {
         uint256[] memory payouts = new uint256[](1);
         payouts[0] = affordsForDestination;
         // Event emitted
-        emit AllocationUpdated(guarantorChannelId, initialHoldings); 
+        emit AllocationUpdated(guarantorChannelId, initialHoldings);
     }
 
     /**
@@ -501,7 +501,7 @@ contract AssetHolder is IAssetHolder {
                 }
             }
         }
-        emit AllocationUpdated(guarantorChannelId, initialHoldings); 
+        emit AllocationUpdated(guarantorChannelId, initialHoldings);
     }
 
     /**

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -145,7 +145,7 @@ contract AssetHolder is IAssetHolder {
         Outcome.AllocationItem[] memory allocation,
         uint256[] memory indices
     )
-        internal
+        public
         pure
         returns (
             Outcome.AllocationItem[] memory newAllocation,

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -267,7 +267,8 @@ contract AssetHolder is IAssetHolder {
             allocationBytes,
             (Outcome.AllocationItem[])
         );
-        uint256 balance = holdings[guarantorChannelId];
+        uint256 initialHoldings = holdings[guarantorChannelId];
+        uint256 balance = initialHoldings;
         uint256 affordsForDestination;
         uint256 residualAllocationAmount;
         uint256 i; // indexes target allocations
@@ -374,7 +375,7 @@ contract AssetHolder is IAssetHolder {
         uint256[] memory payouts = new uint256[](1);
         payouts[0] = affordsForDestination;
         // Event emitted
-        emit AllocationUpdated(guarantorChannelId, 0); // TODO emit initial holdings
+        emit AllocationUpdated(guarantorChannelId, initialHoldings); 
     }
 
     /**
@@ -389,7 +390,8 @@ contract AssetHolder is IAssetHolder {
         Outcome.Guarantee memory guarantee,
         bytes memory allocationBytes
     ) internal {
-        uint256 balance = holdings[guarantorChannelId];
+        uint256 initialHoldings = holdings[guarantorChannelId];
+        uint256 balance = initialHoldings;
 
         Outcome.AllocationItem[] memory allocation = abi.decode(
             allocationBytes,
@@ -499,7 +501,7 @@ contract AssetHolder is IAssetHolder {
                 }
             }
         }
-        emit AllocationUpdated(guarantorChannelId, 0); // TODO emit initial holdings
+        emit AllocationUpdated(guarantorChannelId, initialHoldings); 
     }
 
     /**

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -244,10 +244,9 @@ contract AssetHolder is IAssetHolder {
                 } else {
                     holdings[destination] += payouts[j];
                 }
-                // Event emitted
-                emit AssetTransferred(fromChannelId, destination, payouts[j]);
             }
         }
+        emit AssetsTransferred(fromChannelId, payouts);
     }
 
     /**
@@ -371,8 +370,11 @@ contract AssetHolder is IAssetHolder {
         } else {
             holdings[destination] += affordsForDestination;
         }
+
+        uint256[] memory payouts = new uint256[](1);
+        payouts[0] = affordsForDestination;
         // Event emitted
-        emit AssetTransferred(guarantorChannelId, destination, affordsForDestination);
+        emit AssetsTransferred(guarantorChannelId, payouts);
     }
 
     /**
@@ -495,9 +497,9 @@ contract AssetHolder is IAssetHolder {
                 } else {
                     holdings[allocation[j].destination] += payouts[j];
                 }
-                emit AssetTransferred(guarantorChannelId, allocation[j].destination, payouts[j]);
             }
         }
+        emit AssetsTransferred(guarantorChannelId, payouts);
     }
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -45,10 +45,9 @@ interface IAssetHolder {
     );
 
     /**
-     * @dev Indicates that `amount` assets have been transferred (internally or externally) to the destination denoted by `destination`.
+     * @dev Indicates that `amounts` assets have been transferred (internally or externally) to the destinationss pecified the CALLDATA. allocation[indices[k]] was transferred amounts[k]
      * @param channelId The channelId of the funds being withdrawn.
-     * @param destination An internal destination (channelId) of external destination (padded ethereum address)
-     * @param amount Number of assets transferred (wei or tokens).
+     * @param amounts Number of assets transferred (e.g. wei or tokens) to the destinations specified in the calldata
      */
-    event AssetTransferred(bytes32 indexed channelId, bytes32 indexed destination, uint256 amount);
+    event AssetsTransferred(bytes32 indexed channelId, uint256[] amounts);
 }

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -46,7 +46,7 @@ interface IAssetHolder {
 
     /**
      * @dev Indicates the assetOutcomeHash for this channelId has changed due to a transfer or claim. Includes sufficient data to compute:
-     * + the preimage of this hash as well as 
+     * + the preimage of this hash as well as
      * - the new holdings for this channelId and any others that were transferred to
      * - the payouts to external destinations
      * @param channelId The channelId of the funds being withdrawn.

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -45,9 +45,12 @@ interface IAssetHolder {
     );
 
     /**
-     * @dev Indicates that `amounts` assets have been transferred (internally or externally) to the destinationss pecified the CALLDATA. allocation[indices[k]] was transferred amounts[k]
+     * @dev Indicates the assetOutcomeHash for this channelId has changed due to a transfer or claim. Includes sufficient data to compute:
+     * + the preimage of this hash as well as 
+     * - the new holdings for this channelId and any others that were transferred to
+     * - the payouts to external destinations
      * @param channelId The channelId of the funds being withdrawn.
-     * @param amounts Number of assets transferred (e.g. wei or tokens) to the destinations specified in the calldata
+     * @param initialHoldings holdings[channelId] **before** the allocations were updated
      */
-    event AssetsTransferred(bytes32 indexed channelId, uint256[] amounts);
+    event AllocationUpdated(bytes32 indexed channelId, uint256 initialHoldings);
 }

--- a/packages/nitro-protocol/src/contract/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/asset-holder.ts
@@ -2,6 +2,8 @@ import {utils, BigNumber} from 'ethers';
 
 import {parseEventResult} from '../ethers-utils';
 
+import {AllocationItem} from './outcome';
+
 export interface DepositedEvent {
   destination: string;
   amountDeposited: BigNumber;
@@ -48,4 +50,55 @@ export function convertAddressToBytes32(address: string): string {
 
   // We pad to 66 = (32*2) + 2('0x')
   return utils.hexZeroPad(normalizedAddress, 32);
+}
+
+/**
+ *
+ * Emulates solidity code. TODO replace with PureEVM implementation?
+ * @param initialHoldings
+ * @param allocation
+ * @param indices
+ */
+export function computeNewAllocation(
+  initialHoldings: string,
+  allocation: AllocationItem[], // we must index this with a JS number that is less than 2**32 - 1
+  indices: number[]
+): {newAllocation: AllocationItem[]; deleted: boolean; payouts: string[]; totalPayouts: string} {
+  const payouts = Array(indices.length).fill(0);
+  let totalPayouts = BigNumber.from(0);
+  const newAllocation: AllocationItem[] = [];
+  let safeToDelete = true;
+  let surplus = BigNumber.from(initialHoldings);
+  let k = 0;
+
+  for (let i = 0; i < allocation.length; i++) {
+    newAllocation.push({
+      destination: allocation[i].destination,
+      amount: BigNumber.from(0).toHexString(),
+    });
+    const affordsForDestination = min(BigNumber.from(allocation[i].amount), surplus);
+    if (indices.length == 0 || (k < indices.length && indices[k] === i)) {
+      newAllocation[i].amount = BigNumber.from(allocation[i].amount)
+        .sub(affordsForDestination)
+        .toHexString();
+      payouts[k] = affordsForDestination.toHexString();
+      totalPayouts = totalPayouts.add(affordsForDestination);
+      ++k;
+    } else {
+      newAllocation[i].amount = allocation[i].amount;
+    }
+    if (!BigNumber.from(newAllocation[i].amount).isZero()) safeToDelete = false;
+    surplus = surplus.sub(affordsForDestination);
+  }
+
+  return {
+    newAllocation,
+    deleted: safeToDelete,
+    payouts,
+    totalPayouts: totalPayouts.toHexString(),
+  };
+}
+
+function min(a: BigNumber, b: BigNumber) {
+  return a.gt(b) ? b : a;
 }

--- a/packages/nitro-protocol/src/contract/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/asset-holder.ts
@@ -10,27 +10,12 @@ export interface DepositedEvent {
   destinationHoldings: BigNumber;
 }
 
-export interface AssetTransferredEvent {
-  channelId: string;
-  destination: string;
-  amount: BigNumber;
-}
-
 export function getDepositedEvent(eventResult: any[]): DepositedEvent {
   const {destination, amountDeposited, destinationHoldings} = parseEventResult(eventResult);
   return {
     destination,
     amountDeposited: BigNumber.from(amountDeposited),
     destinationHoldings: BigNumber.from(destinationHoldings),
-  };
-}
-
-export function getAssetTransferredEvent(eventResult: any[]): AssetTransferredEvent {
-  const {channelId, destination, amount} = parseEventResult(eventResult);
-  return {
-    channelId,
-    destination,
-    amount: BigNumber.from(amount),
   };
 }
 

--- a/packages/nitro-protocol/src/contract/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/asset-holder.ts
@@ -64,7 +64,7 @@ export function computeNewAllocation(
   allocation: AllocationItem[], // we must index this with a JS number that is less than 2**32 - 1
   indices: number[]
 ): {newAllocation: AllocationItem[]; deleted: boolean; payouts: string[]; totalPayouts: string} {
-  const payouts = Array(indices.length).fill(0);
+  const payouts: string[] = Array(indices.length).fill(BigNumber.from(0).toHexString());
   let totalPayouts = BigNumber.from(0);
   const newAllocation: AllocationItem[] = [];
   let safeToDelete = true;

--- a/packages/nitro-protocol/src/contract/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/asset-holder.ts
@@ -1,7 +1,7 @@
 import {utils, BigNumber, ethers} from 'ethers';
 
 import {parseEventResult} from '../ethers-utils';
-import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
+import AssetHolderArtifact from '../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 
 import {AllocationAssetOutcome, AllocationItem, AssetOutcome, decodeAllocation} from './outcome';
 import {Address, Bytes32} from './types';

--- a/packages/nitro-protocol/src/index.ts
+++ b/packages/nitro-protocol/src/index.ts
@@ -25,8 +25,6 @@ export {
 } from '../test/test-helpers';
 export {
   DepositedEvent,
-  AssetTransferredEvent,
-  getAssetTransferredEvent,
   getDepositedEvent,
   convertBytes32ToAddress,
   convertAddressToBytes32,

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -6,7 +6,6 @@ import {claimAllArgs} from '../../../src/contract/transaction-creators/asset-hol
 import {
   allocationToParams,
   AssetOutcomeShortHand,
-  EventsFromPayouts,
   compileEventsFromLogs,
   getRandomNonce,
   getTestProvider,

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -6,7 +6,7 @@ import {claimAllArgs} from '../../../src/contract/transaction-creators/asset-hol
 import {
   allocationToParams,
   AssetOutcomeShortHand,
-  assetTransferredEventsFromPayouts,
+  EventsFromPayouts,
   compileEventsFromLogs,
   getRandomNonce,
   getTestProvider,

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -156,14 +156,11 @@ describe('claim', () => {
         ];
 
         // Extract logs
-        const {logs, gasUsed} = await (await tx).wait();
+        const {events: eventsFromTx, gasUsed} = await (await tx).wait();
         await writeGasConsumption('claim.gas.md', name, gasUsed);
 
-        // Compile events from logs
-        const eventsFromLogs = compileEventsFromLogs(logs, [AssetHolder]);
-
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!
-        expect(eventsFromLogs).toMatchObject(expectedEvents);
+        expect(eventsFromTx).toMatchObject(expectedEvents);
 
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -52,15 +52,15 @@ const reason6 =
 // Amounts are valueString representations of wei
 describe('claimAll', () => {
   it.each`
-    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter   | heldAfter | payouts          reason
-    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}               | ${undefined}
-    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}               | ${undefined}
-    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}               | ${undefined}
-    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}}               | ${undefined}
-    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}               | ${reason5}
-    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}               | ${reason6}
-    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}}         | ${undefined}
-    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}}         | ${undefined}
+    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter   | heldAfter | payouts         | reason
+    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason6}
+    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
   `(
     '$name',
     async ({
@@ -150,14 +150,11 @@ describe('claimAll', () => {
         ];
 
         // Extract logs
-        const {logs, gasUsed} = await (await tx).wait();
+        const {events: eventsFromTx, gasUsed} = await (await tx).wait();
         await writeGasConsumption('claimAll.gas.md', name, gasUsed);
 
-        // Compile events from logs
-        const eventsFromLogs = compileEventsFromLogs(logs, [AssetHolder]);
-
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!
-        expect(eventsFromLogs).toMatchObject(expectedEvents);
+        expect(eventsFromTx).toMatchObject(expectedEvents);
 
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -6,7 +6,6 @@ import {claimAllArgs} from '../../../src/contract/transaction-creators/asset-hol
 import {
   allocationToParams,
   AssetOutcomeShortHand,
-  assetTransferredEventsFromPayouts,
   compileEventsFromLogs,
   getRandomNonce,
   getTestProvider,

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -53,15 +53,15 @@ const reason6 =
 // Amounts are valueString representations of wei
 describe('claimAll', () => {
   it.each`
-    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter   | heldAfter | payouts         | events          | reason
-    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${{I: 5}}       | ${undefined}
-    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${{B: 5}}       | ${undefined}
-    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${{I: 5}}       | ${undefined}
-    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${{A: 5}}       | ${undefined}
-    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${{}}           | ${reason5}
-    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${{}}           | ${reason6}
-    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}} | ${{A: 5, B: 5}} | ${undefined}
+    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter   | heldAfter | payouts          reason
+    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}               | ${undefined}
+    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}               | ${undefined}
+    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}               | ${undefined}
+    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}}               | ${undefined}
+    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}               | ${reason5}
+    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}}               | ${reason6}
+    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}}         | ${undefined}
+    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${{}}           | ${{g: 2}} | ${{A: 5, B: 5}}         | ${undefined}
   `(
     '$name',
     async ({
@@ -72,7 +72,6 @@ describe('claimAll', () => {
       tOutcomeAfter,
       heldAfter,
       payouts,
-      events,
       reason,
     }: {
       name;
@@ -82,7 +81,6 @@ describe('claimAll', () => {
       tOutcomeAfter: AssetOutcomeShortHand;
       heldAfter: AssetOutcomeShortHand;
       payouts: AssetOutcomeShortHand;
-      events: AssetOutcomeShortHand;
       reason;
     }) => {
       // Compute channelIds
@@ -94,13 +92,12 @@ describe('claimAll', () => {
       addresses.g = guarantorId;
 
       // Transform input data (unpack addresses and BigNumber amounts)
-      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts, events] = [
+      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [
         heldBefore,
         tOutcomeBefore,
         tOutcomeAfter,
         heldAfter,
         payouts,
-        events,
       ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
       guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
 
@@ -146,12 +143,12 @@ describe('claimAll', () => {
       if (reason) {
         await expectRevert(() => tx, reason);
       } else {
-        // Compile event expectations
-        const expectedEvents = assetTransferredEventsFromPayouts(
-          guarantorId,
-          events,
-          AssetHolder.address
-        );
+        const expectedEvents = [
+          {
+            event: 'AllocationUpdated',
+            args: {channelId: guarantorId, initialHoldings: heldBefore[guarantorId]},
+          },
+        ];
 
         // Extract logs
         const {logs, gasUsed} = await (await tx).wait();

--- a/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
@@ -1,0 +1,68 @@
+import {Contract, Wallet, BigNumber} from 'ethers';
+
+import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
+import {getTestProvider, setupContracts, randomExternalDestination} from '../../test-helpers';
+
+const provider = getTestProvider();
+
+let AssetHolder: Contract;
+
+const participants = ['', '', ''];
+const wallets = new Array(3);
+
+// Populate wallets and participants array
+for (let i = 0; i < 3; i++) {
+  wallets[i] = Wallet.createRandom();
+  participants[i] = wallets[i].address;
+}
+
+beforeAll(async () => {
+  AssetHolder = await setupContracts(
+    provider,
+    AssetHolderArtifact,
+    process.env.TEST_ASSET_HOLDER_ADDRESS
+  );
+});
+
+import {AllocationItem} from '../../../src';
+import {computeNewAllocation} from '../../../src/contract/asset-holder';
+
+const randomAllocation = (numAllocationItems: number): AllocationItem[] => {
+  return numAllocationItems > 0
+    ? [...Array(numAllocationItems)].map(e => ({
+        destination: randomExternalDestination(),
+        amount: BigNumber.from(Math.ceil(Math.random() * 10)).toHexString(),
+      }))
+    : [];
+};
+
+const heldBefore = BigNumber.from(100).toHexString();
+const allocation = randomAllocation(10);
+const indices = [...Array(3)].map(e => ~~(Math.random() * 10));
+
+describe('AsserHolder._computeNewAllocation', () => {
+  it('matches on chain method', async () => {
+    // check local function works as expected
+    const locallyComputedNewAllocation = computeNewAllocation(heldBefore, allocation, indices);
+
+    const result = await AssetHolder._computeNewAllocation(heldBefore, allocation, indices);
+    expect(result).toBeDefined();
+
+    expect((result as ReturnType<typeof computeNewAllocation>).newAllocation).toMatchObject(
+      locallyComputedNewAllocation.newAllocation.map(a => ({
+        ...a,
+        amount: BigNumber.from(a.amount),
+      }))
+    );
+
+    expect((result as any).safeToDelete).toEqual(locallyComputedNewAllocation.deleted);
+
+    expect((result as ReturnType<typeof computeNewAllocation>).payouts).toMatchObject(
+      locallyComputedNewAllocation.payouts.map(p => BigNumber.from(p))
+    );
+
+    expect((result as ReturnType<typeof computeNewAllocation>).totalPayouts).toEqual(
+      BigNumber.from(locallyComputedNewAllocation.totalPayouts)
+    );
+  });
+});

--- a/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
@@ -1,7 +1,8 @@
 import {Contract, Wallet, BigNumber} from 'ethers';
 
-import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 import {getTestProvider, setupContracts, randomExternalDestination} from '../../test-helpers';
+// eslint-disable-next-line import/order
+import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 
 const provider = getTestProvider();
 

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -43,36 +43,26 @@ const reason1 = 'Indices must be sorted';
 // c is the channel we are transferring from.
 describe('transfer', () => {
   it.each`
-    name                               | heldBefore | setOutcome            | indices      | newOutcome      | heldAfter       | payouts         | events                | reason
-    ${' 0. outcome not set         '}  | ${{c: 1}}  | ${{}}                 | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${reason0}
-    ${' 1. funded          -> 1 EOA'}  | ${{c: 1}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'}  | ${{c: 2}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{c: 1}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'}  | ${{c: 1}}  | ${{A: 2}}             | ${[0]}       | ${{A: 1}}       | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 4. funded      -> 1 channel'}  | ${{c: 1}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${' 5. overfunded  -> 1 channel'}  | ${{c: 2}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 1, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${' 6. underfunded -> 1 channel'}  | ${{c: 1}}  | ${{C: 2}}             | ${[0]}       | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${' 7. -> 2 EOA         1 index'}  | ${{c: 2}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 1}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 8. -> 2 EOA         1 index'}  | ${{c: 1}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 0}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 9. -> 2 EOA         partial'}  | ${{c: 3}}  | ${{A: 2, B: 2}}       | ${[1]}       | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}}       | ${{B: 1}}             | ${undefined}
-    ${'10. -> 2 chan             no'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[1]}       | ${{C: 1, X: 1}} | ${{c: 1}}       | ${{}}           | ${{}}                 | ${undefined}
-    ${'11. -> 2 chan           full'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[0]}       | ${{C: 0, X: 1}} | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${'12. -> 2 chan        partial'}  | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1]}       | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${{X: 1}}             | ${undefined}
-    ${'13. -> 2 indices'}              | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[0, 1]}    | ${{C: 0, X: 1}} | ${{c: 0, X: 1}} | ${{C: 2}}       | ${{C: 2, X: 1}}       | ${undefined}
-    ${'14. -> 3 indices'}              | ${{c: 5}}  | ${{A: 1, C: 2, X: 2}} | ${[0, 1, 2]} | ${{}}           | ${{c: 0, X: 2}} | ${{A: 1, C: 2}} | ${{A: 1, C: 2, X: 2}} | ${undefined}
-    ${'15. -> reverse order (see 13)'} | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1, 0]}    | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${{X: 1}}             | ${reason1}
+    name                               | heldBefore | setOutcome            | indices      | newOutcome      | heldAfter       | payouts         | reason
+    ${' 0. outcome not set         '}  | ${{c: 1}}  | ${{}}                 | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${reason0}
+    ${' 1. funded          -> 1 EOA'}  | ${{c: 1}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'}  | ${{c: 2}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{c: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'}  | ${{c: 1}}  | ${{A: 2}}             | ${[0]}       | ${{A: 1}}       | ${{}}           | ${{A: 1}}       | ${undefined}
+    ${' 4. funded      -> 1 channel'}  | ${{c: 1}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 0, C: 1}} | ${{}}           | ${undefined}
+    ${' 5. overfunded  -> 1 channel'}  | ${{c: 2}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 1, C: 1}} | ${{}}           | ${undefined}
+    ${' 6. underfunded -> 1 channel'}  | ${{c: 1}}  | ${{C: 2}}             | ${[0]}       | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}           | ${undefined}
+    ${' 7. -> 2 EOA         1 index'}  | ${{c: 2}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 8. -> 2 EOA         1 index'}  | ${{c: 1}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 0}}       | ${{A: 1}}       | ${undefined}
+    ${' 9. -> 2 EOA         partial'}  | ${{c: 3}}  | ${{A: 2, B: 2}}       | ${[1]}       | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}}       | ${undefined}
+    ${'10. -> 2 chan             no'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[1]}       | ${{C: 1, X: 1}} | ${{c: 1}}       | ${{}}           | ${undefined}
+    ${'11. -> 2 chan           full'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[0]}       | ${{C: 0, X: 1}} | ${{c: 0, C: 1}} | ${{}}           | ${undefined}
+    ${'12. -> 2 chan        partial'}  | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1]}       | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${undefined}
+    ${'13. -> 2 indices'}              | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[0, 1]}    | ${{C: 0, X: 1}} | ${{c: 0, X: 1}} | ${{C: 2}}       | ${undefined}
+    ${'14. -> 3 indices'}              | ${{c: 5}}  | ${{A: 1, C: 2, X: 2}} | ${[0, 1, 2]} | ${{}}           | ${{c: 0, X: 2}} | ${{A: 1, C: 2}} | ${undefined}
+    ${'15. -> reverse order (see 13)'} | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1, 0]}    | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${reason1}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
-    async ({
-      name,
-      heldBefore,
-      setOutcome,
-      indices,
-      newOutcome,
-      heldAfter,
-      payouts,
-      events,
-      reason,
-    }) => {
+    async ({name, heldBefore, setOutcome, indices, newOutcome, heldAfter, payouts, reason}) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -84,7 +74,6 @@ describe('transfer', () => {
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
       payouts = replaceAddressesAndBigNumberify(payouts, addresses);
-      events = replaceAddressesAndBigNumberify(events, addresses);
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
@@ -113,15 +102,13 @@ describe('transfer', () => {
       if (reason) {
         await expectRevert(() => tx, reason);
       } else {
-        const expectedEvents = [];
-        Object.keys(events).forEach(destination => {
-          if (events[destination] && events[destination].gt(0)) {
-            expectedEvents.push({
-              event: 'AssetTransferred',
-              args: {channelId, destination, amount: events[destination]},
-            });
-          }
-        });
+        const expectedEvents = [
+          {
+            event: 'AllocationUpdated',
+            args: {channelId, initialHoldings: heldBefore[channelId]},
+          },
+        ];
+
         const {events: eventsFromTx, gasUsed} = await (await tx).wait();
         // NOTE: _transferAsset is a NOOP in TESTAssetHolder, so gas costs will be much lower than for a real Asset Holder
         await writeGasConsumption('transfer.gas.md', name, gasUsed);

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -42,23 +42,23 @@ const reason0 =
 // c is the channel we are transferring from.
 describe('transferAll', () => {
   it.each`
-    name                              | heldBefore | setOutcome      | newOutcome      | heldAfter             | payouts         | events          | reason
-    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}           | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${reason0}
-    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}           | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}           | ${{c: 1}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}       | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}           | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}           | ${{c: 1, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}       | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}           | ${{c: 0}}             | ${{A: 1, B: 1}} | ${{A: 1, B: 1}} | ${undefined}
-    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 2, B: 1}} | ${{A: 2, B: 1}} | ${undefined}
-    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}           | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${{C: 1, X: 1}} | ${undefined}
-    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{C: 0, X: 1}} | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{C: 0, X: 1}} | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${{C: 2, X: 1}} | ${undefined}
+    name                              | heldBefore | setOutcome      | newOutcome      | heldAfter             | payouts         | reason
+    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}           | ${{}}                 | ${{A: 1}}       | ${reason0}
+    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}           | ${{}}                 | ${{A: 1}}       | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}           | ${{c: 1}}             | ${{A: 1}}       | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}       | ${{}}                 | ${{A: 1}}       | ${undefined}
+    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}           | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
+    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}           | ${{c: 1, C: 1}}       | ${{}}           | ${undefined}
+    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}       | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
+    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}           | ${{c: 0}}             | ${{A: 1, B: 1}} | ${undefined}
+    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 1}}       | ${undefined}
+    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 2, B: 1}} | ${undefined}
+    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}           | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${undefined}
+    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{C: 0, X: 1}} | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${undefined}
+    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{C: 0, X: 1}} | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${undefined}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts, events: $events`,
-    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, events, reason}) => {
+    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, reason}) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -70,7 +70,6 @@ describe('transferAll', () => {
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
       payouts = replaceAddressesAndBigNumberify(payouts, addresses);
-      events = replaceAddressesAndBigNumberify(events, addresses);
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
@@ -101,15 +100,12 @@ describe('transferAll', () => {
       } else {
         const {events: eventsFromLogs, gasUsed} = await (await tx).wait();
         await writeGasConsumption('transferAll.gas.md', name, gasUsed);
-        const expectedEvents = [];
-        Object.keys(events).forEach(destination => {
-          if (events[destination] && events[destination].gt(0)) {
-            expectedEvents.push({
-              event: 'AssetTransferred',
-              args: {channelId, destination, amount: events[destination]},
-            });
-          }
-        });
+        const expectedEvents = [
+          {
+            event: 'AllocationUpdated',
+            args: {channelId, initialHoldings: heldBefore[channelId]},
+          },
+        ];
         expect(eventsFromLogs).toMatchObject(expectedEvents);
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -12,7 +12,6 @@ import {AllocationAssetOutcome} from '../../../src/contract/outcome';
 import {State} from '../../../src/contract/state';
 import {concludePushOutcomeAndTransferAllArgs} from '../../../src/contract/transaction-creators/nitro-adjudicator';
 import {
-  assetTransferredEventsFromPayouts,
   checkMultipleAssetOutcomeHashes,
   checkMultipleHoldings,
   compileEventsFromLogs,
@@ -268,7 +267,7 @@ describe('concludePushOutcomeAndTransferAll', () => {
           args: {channelId},
         });
 
-        // Add AssetTransferred events to expectations
+        // Add an AllocationUpdated event to expectations
 
         Object.keys(heldBefore).forEach(key => {
           expectedEvents.push({

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -258,7 +258,8 @@ describe('concludePushOutcomeAndTransferAll', () => {
         ]);
 
         // Compile event expectations
-        let expectedEvents = [];
+
+        const expectedEvents = [];
 
         // Add Conclude event to expectations
         expectedEvents.push({
@@ -268,10 +269,16 @@ describe('concludePushOutcomeAndTransferAll', () => {
         });
 
         // Add AssetTransferred events to expectations
-        Object.keys(payouts).forEach(assetHolder => {
-          expectedEvents = expectedEvents.concat(
-            assetTransferredEventsFromPayouts(channelId, payouts[assetHolder], assetHolder)
-          );
+
+        Object.keys(heldBefore).forEach(key => {
+          expectedEvents.push({
+            name: 'AllocationUpdated',
+            contract: key,
+            args: {
+              channelId,
+              initialHoldings: heldBefore[key][channelId], // initialHoldings
+            },
+          });
         });
 
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
@@ -8,7 +8,6 @@ import {Channel, getChannelId} from '../../../src/contract/channel';
 import {AllocationAssetOutcome, encodeOutcome} from '../../../src/contract/outcome';
 import {hashState, State} from '../../../src/contract/state';
 import {
-  assetTransferredEventsFromPayouts,
   checkMultipleAssetOutcomeHashes,
   checkMultipleHoldings,
   compileEventsFromLogs,
@@ -183,7 +182,7 @@ describe('pushOutcomeAndTransferAll', () => {
         // Build up event expectations
         const expectedEvents = [];
 
-        // Add AssetTransferred events to expectations
+        // Add an AllocationUpdated event to expectations
         Object.keys(heldBefore).forEach(key => {
           expectedEvents.push({
             name: 'AllocationUpdated',

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
@@ -181,13 +181,18 @@ describe('pushOutcomeAndTransferAll', () => {
         const events = compileEventsFromLogs(logs, [AssetHolder1, AssetHolder2, NitroAdjudicator]);
 
         // Build up event expectations
-        let expectedEvents = [];
+        const expectedEvents = [];
 
         // Add AssetTransferred events to expectations
-        Object.keys(payouts).forEach(assetHolder => {
-          expectedEvents = expectedEvents.concat(
-            assetTransferredEventsFromPayouts(channelId, payouts[assetHolder], assetHolder)
-          );
+        Object.keys(heldBefore).forEach(key => {
+          expectedEvents.push({
+            name: 'AllocationUpdated',
+            contract: key,
+            args: {
+              channelId,
+              initialHoldings: heldBefore[key][channelId], // initialHoldings
+            },
+          });
         });
 
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -24,7 +24,7 @@ import {
   Allocation,
   AllocationItem,
 } from '../src/contract/outcome';
-import {AssetTransferredEvent, Bytes32, DepositedEvent} from '../src';
+import {Bytes32} from '../src';
 
 // Interfaces
 
@@ -174,29 +174,6 @@ export const newDepositedEvent = (
   });
 };
 
-export const newTransferEvent = (
-  contract: ethers.Contract,
-  to: string
-): Promise<AssetTransferredEvent[keyof AssetTransferredEvent]> => {
-  const filter = contract.filters.Transfer(null, to);
-  return new Promise((resolve, reject) => {
-    contract.on(filter, (eventFrom, eventTo, amountTransferred, event) => {
-      // Match event for this destination only
-      contract.removeAllListeners(filter);
-      resolve(amountTransferred);
-    });
-  });
-};
-
-export const newAssetTransferredEvent = (
-  destination: string,
-  payout: number
-): AssetTransferredEvent => ({
-  channelId: destination,
-  destination: destination.toLowerCase(),
-  amount: BigNumber.from(payout),
-});
-
 export function randomChannelId(channelNonce = 0): Bytes32 {
   // Populate participants array (every test run targets a unique channel)
   const participants = [];
@@ -344,24 +321,6 @@ export function computeOutcome(outcomeShortHand: OutcomeShortHand): AllocationAs
     outcome.push(assetOutcome);
   });
   return outcome;
-}
-
-export function assetTransferredEventsFromPayouts(
-  channelId: string,
-  singleAssetPayouts: AssetOutcomeShortHand,
-  assetHolder: string
-): AssetTransferredEvent[] {
-  const assetTransferredEvents = [];
-  Object.keys(singleAssetPayouts).forEach(destination => {
-    if (singleAssetPayouts[destination] && BigNumber.from(singleAssetPayouts[destination]).gt(0)) {
-      assetTransferredEvents.push({
-        contract: assetHolder,
-        name: 'AssetTransferred',
-        args: {channelId, destination, amount: singleAssetPayouts[destination]},
-      });
-    }
-  });
-  return assetTransferredEvents;
 }
 
 export function compileEventsFromLogs(logs: any[], contractsArray: Contract[]): Event[] {

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -5,6 +5,8 @@
 ```ts
 
 import { Address } from '@statechannels/wallet-core';
+import { AllocationItem } from '@statechannels/nitro-protocol';
+import { AssetOutcome } from '@statechannels/nitro-protocol';
 import { ChannelConstants } from '@statechannels/wallet-core';
 import { ChannelId } from '@statechannels/client-api-schema';
 import { ChannelResult } from '@statechannels/client-api-schema';

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -136,9 +136,10 @@ it('Create a directly funded channel between two wallets ', async () => {
     .pipe(take(2))
     .toPromise();
 
-  const assetTransferredAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
-    .pipe(take(3))
-    .toPromise();
+  // TODO replace with AllocationUpdated
+  // const assetTransferredAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
+  //   .pipe(take(3))
+  //   .toPromise();
 
   //        A <> B
   // PreFund0
@@ -246,13 +247,14 @@ it('Create a directly funded channel between two wallets ', async () => {
   });
 
   await mineBlocks(2);
-  const assetTransferredA = await assetTransferredAPromise;
+  // TODO
+  // const assetTransferredA = await assetTransferredAPromise;
 
-  expect(assetTransferredA.channelResult).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-    fundingStatus: 'Defunded',
-  });
+  // expect(assetTransferredA.channelResult).toMatchObject({
+  //   status: 'closed',
+  //   turnNum: 4,
+  //   fundingStatus: 'Defunded',
+  // });
 
   const aBalanceFinal = await getBalance(aAddress);
   const bBalanceFinal = await getBalance(bAddress);

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -136,10 +136,9 @@ it('Create a directly funded channel between two wallets ', async () => {
     .pipe(take(2))
     .toPromise();
 
-  // TODO replace with AllocationUpdated
-  // const assetTransferredAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
-  //   .pipe(take(3))
-  //   .toPromise();
+  const channelClosedAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
+    .pipe(take(3))
+    .toPromise();
 
   //        A <> B
   // PreFund0
@@ -247,14 +246,14 @@ it('Create a directly funded channel between two wallets ', async () => {
   });
 
   await mineBlocks(2);
-  // TODO
-  // const assetTransferredA = await assetTransferredAPromise;
 
-  // expect(assetTransferredA.channelResult).toMatchObject({
-  //   status: 'closed',
-  //   turnNum: 4,
-  //   fundingStatus: 'Defunded',
-  // });
+  const channelClosedA = await channelClosedAPromise;
+
+  expect(channelClosedA.channelResult).toMatchObject({
+    status: 'closed',
+    turnNum: 4,
+    fundingStatus: 'Defunded',
+  });
 
   const aBalanceFinal = await getBalance(aAddress);
   const bBalanceFinal = await getBalance(bAddress);

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -304,11 +304,11 @@ describe('concludeAndWithdraw', () => {
     const objectsToMatch = [
       {
         amount: BN.from(1),
-        destination: makeDestination(aAddress),
+        destination: makeDestination(aAddress).toLowerCase(),
       },
       {
         amount: BN.from(3),
-        destination: makeDestination(bAddress),
+        destination: makeDestination(bAddress).toLowerCase(),
       },
     ];
 
@@ -340,22 +340,23 @@ describe('concludeAndWithdraw', () => {
     const objectsToMatch = [
       {
         amount: BN.from(1),
-        assetHolderAddress: erc20AssetHolderAddress,
-        to: makeDestination(aAddress),
-        channelId,
+        destination: makeDestination(aAddress).toLowerCase(),
       },
       {
         amount: BN.from(3),
-        assetHolderAddress: erc20AssetHolderAddress,
-        to: makeDestination(bAddress),
-        channelId,
+        destination: makeDestination(bAddress).toLowerCase(),
       },
     ];
 
     const p = new Promise<void>(resolve =>
       chainService.registerChannel(channelId, [erc20AssetHolderAddress], {
         holdingUpdated: _.noop,
-        assetOutcomeUpdated: _.noop,
+        assetOutcomeUpdated: arg => {
+          expect(arg.assetHolderAddress).toEqual(erc20AssetHolderAddress);
+          expect(arg.channelId).toMatch(channelId);
+          expect(arg.externalPayouts).toMatchObject(expect.arrayContaining(objectsToMatch));
+          resolve();
+        },
         channelFinalized: _.noop,
       })
     );

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -19,7 +19,7 @@ import {
 import {alice as aWallet, bob as bWallet} from '../../wallet/__test__/fixtures/signing-wallets';
 import {stateSignedBy} from '../../wallet/__test__/fixtures/states';
 import {ChainService} from '../chain-service';
-import {AssetTransferredArg, HoldingUpdatedArg} from '../types';
+import {HoldingUpdatedArg} from '../types';
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
@@ -43,7 +43,7 @@ async function mineBlocks() {
 
 function mineOnEvent(contract: Contract) {
   contract.on('Deposited', mineBlocks);
-  contract.on('AssetTransferred', mineBlocks);
+  contract.on('AllocationUpdated', mineBlocks);
 }
 
 async function mineBlockPeriodically(blocks: number) {
@@ -234,7 +234,6 @@ describe('registerChannel', () => {
 
     chainService.registerChannel(channelId, [ethAssetHolderAddress], {
       holdingUpdated,
-      assetTransferred: _.noop,
       channelFinalized: _.noop,
     });
     await p;
@@ -254,7 +253,6 @@ describe('registerChannel', () => {
           });
           resolve(true);
         },
-        assetTransferred: _.noop,
         channelFinalized: _.noop,
       })
     );
@@ -288,7 +286,7 @@ describe('registerChannel', () => {
     };
     chainService.registerChannel(channelId, [ethAssetHolderAddress, erc20AssetHolderAddress], {
       holdingUpdated,
-      assetTransferred: _.noop,
+      // assetTransferred: _.noop,
       channelFinalized: _.noop,
     });
     fundChannel(0, 5, channelId, ethAssetHolderAddress);
@@ -320,16 +318,6 @@ describe('concludeAndWithdraw', () => {
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         holdingUpdated: _.noop,
         channelFinalized: _.noop,
-        assetTransferred: (arg: AssetTransferredArg) => {
-          const predicate = (elem: AssetTransferredArg) =>
-            arg.amount === elem.amount &&
-            arg.assetHolderAddress === elem.assetHolderAddress &&
-            arg.to === elem.to &&
-            arg.channelId === elem.channelId;
-          const removed = _.remove(objectsToMatch, predicate);
-          expect(removed).toHaveLength(1);
-          if (!objectsToMatch.length) resolve();
-        },
       })
     );
 
@@ -364,16 +352,6 @@ describe('concludeAndWithdraw', () => {
       chainService.registerChannel(channelId, [erc20AssetHolderAddress], {
         holdingUpdated: _.noop,
         channelFinalized: _.noop,
-        assetTransferred: (arg: AssetTransferredArg) => {
-          const predicate = (elem: AssetTransferredArg) =>
-            arg.amount === elem.amount &&
-            arg.assetHolderAddress === elem.assetHolderAddress &&
-            arg.to === elem.to &&
-            arg.channelId === elem.channelId;
-          const removed = _.remove(objectsToMatch, predicate);
-          expect(removed).toHaveLength(1);
-          if (!objectsToMatch.length) resolve();
-        },
       })
     );
 
@@ -427,7 +405,6 @@ describe('challenge', () => {
     const p = new Promise(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         holdingUpdated: _.noop,
-        assetTransferred: _.noop,
         channelFinalized: resolve,
       })
     );

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -304,22 +304,23 @@ describe('concludeAndWithdraw', () => {
     const objectsToMatch = [
       {
         amount: BN.from(1),
-        assetHolderAddress: ethAssetHolderAddress,
-        to: makeDestination(aAddress),
-        channelId,
+        destination: makeDestination(aAddress),
       },
       {
         amount: BN.from(3),
-        assetHolderAddress: ethAssetHolderAddress,
-        to: makeDestination(bAddress),
-        channelId,
+        destination: makeDestination(bAddress),
       },
     ];
 
     const p = new Promise<void>(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         holdingUpdated: _.noop,
-        assetOutcomeUpdated: _.noop,
+        assetOutcomeUpdated: arg => {
+          expect(arg.assetHolderAddress).toEqual(ethAssetHolderAddress);
+          expect(arg.channelId).toMatch(channelId);
+          expect(arg.externalPayouts).toMatchObject(expect.arrayContaining(objectsToMatch));
+          resolve();
+        },
         channelFinalized: _.noop,
       })
     );

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -234,6 +234,7 @@ describe('registerChannel', () => {
 
     chainService.registerChannel(channelId, [ethAssetHolderAddress], {
       holdingUpdated,
+      assetOutcomeUpdated: _.noop,
       channelFinalized: _.noop,
     });
     await p;
@@ -253,6 +254,7 @@ describe('registerChannel', () => {
           });
           resolve(true);
         },
+        assetOutcomeUpdated: _.noop,
         channelFinalized: _.noop,
       })
     );
@@ -286,7 +288,7 @@ describe('registerChannel', () => {
     };
     chainService.registerChannel(channelId, [ethAssetHolderAddress, erc20AssetHolderAddress], {
       holdingUpdated,
-      // assetTransferred: _.noop,
+      assetOutcomeUpdated: _.noop,
       channelFinalized: _.noop,
     });
     fundChannel(0, 5, channelId, ethAssetHolderAddress);
@@ -317,6 +319,7 @@ describe('concludeAndWithdraw', () => {
     const p = new Promise<void>(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         holdingUpdated: _.noop,
+        assetOutcomeUpdated: _.noop,
         channelFinalized: _.noop,
       })
     );
@@ -351,6 +354,7 @@ describe('concludeAndWithdraw', () => {
     const p = new Promise<void>(resolve =>
       chainService.registerChannel(channelId, [erc20AssetHolderAddress], {
         holdingUpdated: _.noop,
+        assetOutcomeUpdated: _.noop,
         channelFinalized: _.noop,
       })
     );
@@ -405,6 +409,7 @@ describe('challenge', () => {
     const p = new Promise(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         holdingUpdated: _.noop,
+        assetOutcomeUpdated: _.noop,
         channelFinalized: resolve,
       })
     );

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -10,7 +10,7 @@ import {
   Address,
   BN,
   makeAddress,
-  makeDestination,
+  // makeDestination,
   PrivateKey,
   SignedState,
   State,
@@ -30,7 +30,7 @@ import {defaultTestConfig} from '../config';
 
 import {
   AllowanceMode,
-  AssetTransferredArg,
+  // AssetTransferredArg,
   ChainEventSubscriberInterface,
   ChainServiceArgs,
   ChainServiceInterface,
@@ -39,11 +39,11 @@ import {
 } from './types';
 
 const Deposited = 'Deposited' as const;
-const AssetTransferred = 'AssetTransferred' as const;
+// const AssetTransferred = 'AssetTransferred' as const;
 const ChallengeRegistered = 'ChallengeRegistered' as const;
 type DepositedEvent = {type: 'Deposited'; ethersEvent: Event} & HoldingUpdatedArg;
-type AssetTransferredEvent = {type: 'AssetTransferred'; ethersEvent: Event} & AssetTransferredArg;
-type AssetHolderEvent = DepositedEvent | AssetTransferredEvent;
+// type AssetTransferredEvent = {type: 'AssetTransferred'; ethersEvent: Event} & AssetTransferredArg;
+type AssetHolderEvent = DepositedEvent;
 
 // TODO: is it reasonable to assume that the ethAssetHolder address is defined as runtime configuration?
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
@@ -402,16 +402,17 @@ export class ChainService implements ChainServiceInterface {
             ethersEvent: event,
           })
       );
-      assetHolderContract.on(AssetTransferred, (channelId, destination, payoutAmount, event) =>
-        subs.next({
-          type: AssetTransferred,
-          channelId,
-          assetHolderAddress: makeAddress(assetHolderContract.address),
-          to: makeDestination(destination),
-          amount: BN.from(payoutAmount),
-          ethersEvent: event,
-        })
-      );
+      // TODO replace with AllocationUpdated
+      // assetHolderContract.on(AssetTransferred, (channelId, destination, payoutAmount, event) =>
+      //   subs.next({
+      //     type: AssetTransferred,
+      //     channelId,
+      //     assetHolderAddress: makeAddress(assetHolderContract.address),
+      //     to: makeDestination(destination),
+      //     amount: BN.from(payoutAmount),
+      //     ethersEvent: event,
+      //   })
+      // );
     });
     obs.subscribe({
       next: async event => {
@@ -425,8 +426,8 @@ export class ChainService implements ChainServiceInterface {
             case Deposited:
               subscriber.holdingUpdated(event);
               break;
-            case AssetTransferred:
-              subscriber.assetTransferred(event);
+              // case AssetTransferred:
+              //   subscriber.assetTransferred(event);
               break;
             default:
               throw new Error('Unexpected event from contract observable');

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -17,11 +17,9 @@ export type HoldingUpdatedArg = {
   amount: Uint256;
 };
 
-export type AssetTransferredArg = {
+export type AllocationupdatedArg = {
   channelId: Bytes32;
-  assetHolderAddress: Address;
-  to: Destination;
-  amount: Uint256;
+  initialHoldings: Uint256;
 };
 
 export type FundChannelArg = {
@@ -37,7 +35,7 @@ export type ChannelFinalizedArg = {
 
 export interface ChainEventSubscriberInterface {
   holdingUpdated(arg: HoldingUpdatedArg): void;
-  assetTransferred(arg: AssetTransferredArg): void;
+  allocationUpdated(arg: AllocationupdatedArg): void;
   channelFinalized(arg: ChannelFinalizedArg): void;
 }
 

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -1,11 +1,5 @@
-import {
-  Address,
-  Destination,
-  PrivateKey,
-  SignedState,
-  State,
-  Uint256,
-} from '@statechannels/wallet-core';
+import {AllocationItem, AssetOutcome} from '@statechannels/nitro-protocol';
+import {Address, PrivateKey, SignedState, State, Uint256} from '@statechannels/wallet-core';
 import {providers} from 'ethers';
 import {Logger} from 'pino';
 
@@ -17,9 +11,13 @@ export type HoldingUpdatedArg = {
   amount: Uint256;
 };
 
-export type AllocationupdatedArg = {
+export type AssetOutcomeUpdatedArg = {
   channelId: Bytes32;
-  initialHoldings: Uint256;
+  assetHolderAddress: Address;
+  newHoldings: Uint256;
+  externalPayouts: AllocationItem[];
+  internalPayouts: AllocationItem[];
+  newAssetOutcome: AssetOutcome | '0x00'; // '0x00' in case the asset outcome hash was deleted on chain
 };
 
 export type FundChannelArg = {
@@ -35,7 +33,7 @@ export type ChannelFinalizedArg = {
 
 export interface ChainEventSubscriberInterface {
   holdingUpdated(arg: HoldingUpdatedArg): void;
-  allocationUpdated(arg: AllocationupdatedArg): void;
+  assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg): void;
   channelFinalized(arg: ChannelFinalizedArg): void;
 }
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -47,7 +47,7 @@ import {
   ChainServiceInterface,
   ChainEventSubscriberInterface,
   HoldingUpdatedArg,
-  AssetTransferredArg,
+  Arg,
   ChainService,
   MockChainService,
   ChannelFinalizedArg,
@@ -660,19 +660,20 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
     response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));
   }
 
-  async assetTransferred(arg: AssetTransferredArg): Promise<void> {
-    const response = WalletResponse.initialize();
-    // TODO: make sure that arg.to is checksummed
-    await this.store.updateTransferredOut(
-      arg.channelId,
-      arg.assetHolderAddress,
-      arg.to,
-      arg.amount
-    );
-    await this.takeActions([arg.channelId], response);
+  // TODO replace this with an AllocationUpdated solution (needs calldata)
+  // async assetTransferred(arg: AssetTransferredArg): Promise<void> {
+  //   const response = WalletResponse.initialize();
+  //   // TODO: make sure that arg.to is checksummed
+  //   await this.store.updateTransferredOut(
+  //     arg.channelId,
+  //     arg.assetHolderAddress,
+  //     arg.to,
+  //     arg.amount
+  //   );
+  //   await this.takeActions([arg.channelId], response);
 
-    response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));
-  }
+  //   response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));
+  // }
 
   async channelFinalized(_arg: ChannelFinalizedArg): Promise<void> {
     return;


### PR DESCRIPTION
This emits a close-to-minimal amount of information when `transfer` or `claim` is called: the information is sufficient for clients to construct a new `AssetOutcome` for a given channel in a given `AssetHolder`. They need this up-to-date data in order to successfully call `transfer` in future.

Example: my counterparty concluded, pushed, and transferred their own money out of a channel. Now I want to transfer my money out, but my view of the outcome on chain is out of date and my transaction will fail if I don't keep it fresh. 

- [x] contracts updated with new event type
- [x]  off-chain version of `_computeNewAllocation`. We could go down the pureEVM route, but for now I just reimplemented it in typescript and
- [x] wrote a test that uses random data to check against the solidity version. 
- [x] existing tests updated to catch and assert on new event 
- [x] AssetTransferred deprecated in nitro-protocol and the documentation
- [x] Chain Service updated to watch for the new event and call into `computeNewAllocation` to infer the data it wants to understand.