### PR TITLE
Chain service on-block-mined race condition

### DIFF
--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -108,7 +108,7 @@ export class ChainService implements ChainServiceInterface {
     });
 
     this.provider.on('block', async (blockTag: providers.BlockTag) =>
-      this.onBlockMined(await this.provider.getBlock(blockTag))
+      this.checkFinalizingChannels(await this.provider.getBlock(blockTag))
     );
   }
 
@@ -325,7 +325,7 @@ export class ChainService implements ChainServiceInterface {
     this.channelToSubscribers.set(channelId, []);
   }
 
-  private async onBlockMined(block: providers.Block): Promise<void> {
+  private async checkFinalizingChannels(block: providers.Block): Promise<void> {
     const finalizingChannel = this.finalizingChannels.shift();
     if (!finalizingChannel) return;
 
@@ -346,7 +346,7 @@ export class ChainService implements ChainServiceInterface {
       } else if (finalizesAt) {
         this.addFinalizingChannel({channelId, finalizesAtS: finalizesAt});
       }
-      this.onBlockMined(block);
+      this.checkFinalizingChannels(block);
     }
     this.addFinalizingChannel(finalizingChannel);
   }

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -226,7 +226,7 @@ export class ChainService implements ChainServiceInterface {
       const [, finalizesAt] = await this.nitroAdjudicator.getChannelStorage(channelId);
 
       const {timestamp: latestBlockTimestamp} = await this.provider.getBlock(
-        await this.provider.getBlockNumber()
+        this.provider.getBlockNumber()
       );
 
       // Check if the channel has been finalized in the past

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -325,15 +325,6 @@ export class ChainService implements ChainServiceInterface {
     this.channelToSubscribers.set(channelId, []);
   }
 
-  /**
-   * WARNING: potential for a race condition due to:
-   * 1. Read class state (this.finalizingChannels)
-   * 2. Await a promise (getChannelStorage)
-   * 3. Assume that the state in step 1 has not changed.
-   *
-   * If many onBlockMined are executed in parallel, step 3 assumption does not hold
-   * PQueue is used to avoid these race conditions.
-   */
   private async onBlockMined(block: providers.Block): Promise<void> {
     const finalizingChannel = this.finalizingChannels.shift();
     if (!finalizingChannel) return;

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -142,7 +142,6 @@ export function directFundingStatus(
     .reduce(BN.add, BN.from(0));
 
   const funding = fundingFn(assetHolderAddress);
-  console.log('funding: ', funding);
 
   const amountTransferredToMe = funding.transferredOut
     .filter(tf => tf.toAddress === myDestination)


### PR DESCRIPTION
This PR adds a test for a previously untested codepath: multiple ongoing challenges. This test uncovered [a race condition with the on-block-mined callback](https://github.com/statechannels/statechannels/compare/cs-challenges-test?expand=1#diff-e0f323c73f419174cc1c56b6ea286508cbff6917c2c117382ff61ea7085bc136R332)

While there are a few ways to fix the race condition, it seems that using a [pqueue](https://www.npmjs.com/package/p-queue) has the lowest developer cognitive overhead. With a pqueue, the developer can assume a synchronous on-block-mined callback execution. 