### PR TITLE
Replace AssetTransferred with AllocationUpdated event

### DIFF
--- a/packages/docs-website/docs/docs/app-devs/make-api-calls.md
+++ b/packages/docs-website/docs/docs/app-devs/make-api-calls.md
@@ -100,7 +100,7 @@ WalletA-->>ClientA: ChannelUpdated('closed')
 WalletA->>Chain: concludePushOutcomeAndTransferAll()
 deactivate WalletA
 deactivate WalletB
-Chain-->>WalletA: AssetTransferred x2
-Chain-->>WalletB: AssetTransferred x2
+Chain-->>WalletA: AllocationUpdated
+Chain-->>WalletB: AllocationUpdated
 end
 " />

--- a/packages/docs-website/docs/docs/protocol-tutorial/release-assets.md
+++ b/packages/docs-website/docs/docs/protocol-tutorial/release-assets.md
@@ -88,18 +88,13 @@ const assetOutcome: AllocationAssetOutcome = {
 const tx3 = ETHAssetHolder.transferAll(channelId, encodeAllocation(assetOutcome.allocationItems));
 
 /* 
-  Check that an AssetTransferred event was emitted.
+  Check that an AllocationUpdated event was emitted. 
 */
 const {events} = await(await tx3).wait();
-expect(events).toMatchObject([
+expect(events).toMatchObject(
   {
-    event: 'AssetTransferred',
-    args: {
-      channelId,
-      destination: destination.toLowerCase(),
-      amount: {_hex: amount}
-    }
-  }
+    event: 'AllocationUpdated',
+  },
 ]);
 
 expect(BigNumber.from(await provider.getBalance(EOA)).eq(BigNumber.from(amount)));
@@ -111,6 +106,10 @@ If the destination specified in the outcome is external, the asset holder pays o
 
 :::tip
 This method executes payouts that might benefit multiple participants. If multiple actors try and call this method, after the first transaction is confirmed the remaining ones may fail.
+:::
+
+:::tip
+It may be desirable to payout to a subset of destinations (or even a single one). The `transfer` method can be used to do this, and accepts a list of `indices` to transfer from. See the contract API for more information. More information coming soon, including how to track the updated allocation after a `transfer` is mined.
 :::
 
 ## Using `claimAll`

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -143,7 +143,7 @@ contract AssetHolder is IAssetHolder {
         Outcome.AllocationItem[] memory allocation,
         uint256[] memory indices
     )
-        internal
+        public
         pure
         returns (
             Outcome.AllocationItem[] memory newAllocation,
@@ -242,10 +242,9 @@ contract AssetHolder is IAssetHolder {
                 } else {
                     holdings[destination] += payouts[j];
                 }
-                // Event emitted
-                emit AssetTransferred(fromChannelId, destination, payouts[j]);
             }
         }
+        emit AllocationUpdated(fromChannelId, initialHoldings);
     }
 
     /**
@@ -266,7 +265,8 @@ contract AssetHolder is IAssetHolder {
             allocationBytes,
             (Outcome.AllocationItem[])
         );
-        uint256 balance = holdings[guarantorChannelId];
+        uint256 initialHoldings = holdings[guarantorChannelId];
+        uint256 balance = initialHoldings;
         uint256 affordsForDestination;
         uint256 residualAllocationAmount;
         uint256 i; // indexes target allocations
@@ -369,8 +369,11 @@ contract AssetHolder is IAssetHolder {
         } else {
             holdings[destination] += affordsForDestination;
         }
+
+        uint256[] memory payouts = new uint256[](1);
+        payouts[0] = affordsForDestination;
         // Event emitted
-        emit AssetTransferred(guarantorChannelId, destination, affordsForDestination);
+        emit AllocationUpdated(guarantorChannelId, initialHoldings);
     }
 
     /**
@@ -385,7 +388,8 @@ contract AssetHolder is IAssetHolder {
         Outcome.Guarantee memory guarantee,
         bytes memory allocationBytes
     ) internal {
-        uint256 balance = holdings[guarantorChannelId];
+        uint256 initialHoldings = holdings[guarantorChannelId];
+        uint256 balance = initialHoldings;
 
         Outcome.AllocationItem[] memory allocation = abi.decode(
             allocationBytes,
@@ -493,9 +497,9 @@ contract AssetHolder is IAssetHolder {
                 } else {
                     holdings[allocation[j].destination] += payouts[j];
                 }
-                emit AssetTransferred(guarantorChannelId, allocation[j].destination, payouts[j]);
             }
         }
+        emit AllocationUpdated(guarantorChannelId, initialHoldings);
     }
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -45,10 +45,12 @@ interface IAssetHolder {
     );
 
     /**
-     * @dev Indicates that `amount` assets have been transferred (internally or externally) to the destination denoted by `destination`.
+     * @dev Indicates the assetOutcomeHash for this channelId has changed due to a transfer or claim. Includes sufficient data to compute:
+     * + the preimage of this hash as well as
+     * - the new holdings for this channelId and any others that were transferred to
+     * - the payouts to external destinations
      * @param channelId The channelId of the funds being withdrawn.
-     * @param destination An internal destination (channelId) of external destination (padded ethereum address)
-     * @param amount Number of assets transferred (wei or tokens).
+     * @param initialHoldings holdings[channelId] **before** the allocations were updated
      */
-    event AssetTransferred(bytes32 indexed channelId, bytes32 indexed destination, uint256 amount);
+    event AllocationUpdated(bytes32 indexed channelId, uint256 initialHoldings);
 }

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -46,7 +46,7 @@ interface IAssetHolder {
 
     /**
      * @dev Indicates the assetOutcomeHash for this channelId has changed due to a transfer or claim. Includes sufficient data to compute:
-     * + the preimage of this hash as well as
+     * - the preimage of this hash as well as
      * - the new holdings for this channelId and any others that were transferred to
      * - the payouts to external destinations
      * @param channelId The channelId of the funds being withdrawn.

--- a/packages/nitro-protocol/src/contract/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/asset-holder.ts
@@ -1,17 +1,25 @@
-import {utils, BigNumber} from 'ethers';
+import {utils, BigNumber, ethers} from 'ethers';
+import {TransactionDescription} from 'ethers/lib/utils';
 
 import {parseEventResult} from '../ethers-utils';
+import AssetHolderArtifact from '../../artifacts/contracts/AssetHolder.sol/AssetHolder.json';
+import NitroAdjudicatorArtifact from '../../artifacts/contracts/NitroAdjudicator.sol/NitroAdjudicator.json';
+
+import {
+  AllocationAssetOutcome,
+  AllocationItem,
+  AssetOutcome,
+  decodeAllocation,
+  decodeOutcome,
+  isAllocationOutcome,
+} from './outcome';
+import {Address, Bytes32} from './types';
+import {isExternalDestination} from './channel';
 
 export interface DepositedEvent {
   destination: string;
   amountDeposited: BigNumber;
   destinationHoldings: BigNumber;
-}
-
-export interface AssetTransferredEvent {
-  channelId: string;
-  destination: string;
-  amount: BigNumber;
 }
 
 export function getDepositedEvent(eventResult: any[]): DepositedEvent {
@@ -20,15 +28,6 @@ export function getDepositedEvent(eventResult: any[]): DepositedEvent {
     destination,
     amountDeposited: BigNumber.from(amountDeposited),
     destinationHoldings: BigNumber.from(destinationHoldings),
-  };
-}
-
-export function getAssetTransferredEvent(eventResult: any[]): AssetTransferredEvent {
-  const {channelId, destination, amount} = parseEventResult(eventResult);
-  return {
-    channelId,
-    destination,
-    amount: BigNumber.from(amount),
   };
 }
 
@@ -48,4 +47,144 @@ export function convertAddressToBytes32(address: string): string {
 
   // We pad to 66 = (32*2) + 2('0x')
   return utils.hexZeroPad(normalizedAddress, 32);
+}
+
+/**
+ *
+ * Emulates solidity code. TODO replace with PureEVM implementation?
+ * @param initialHoldings
+ * @param allocation
+ * @param indices
+ */
+export function computeNewAllocation(
+  initialHoldings: string,
+  allocation: AllocationItem[], // we must index this with a JS number that is less than 2**32 - 1
+  indices: number[]
+): {newAllocation: AllocationItem[]; deleted: boolean; payouts: string[]; totalPayouts: string} {
+  const payouts: string[] = Array(indices.length).fill(BigNumber.from(0).toHexString());
+  let totalPayouts = BigNumber.from(0);
+  const newAllocation: AllocationItem[] = [];
+  let safeToDelete = true;
+  let surplus = BigNumber.from(initialHoldings);
+  let k = 0;
+
+  for (let i = 0; i < allocation.length; i++) {
+    newAllocation.push({
+      destination: allocation[i].destination,
+      amount: BigNumber.from(0).toHexString(),
+    });
+    const affordsForDestination = min(BigNumber.from(allocation[i].amount), surplus);
+    if (indices.length == 0 || (k < indices.length && indices[k] === i)) {
+      newAllocation[i].amount = BigNumber.from(allocation[i].amount)
+        .sub(affordsForDestination)
+        .toHexString();
+      payouts[k] = affordsForDestination.toHexString();
+      totalPayouts = totalPayouts.add(affordsForDestination);
+      ++k;
+    } else {
+      newAllocation[i].amount = allocation[i].amount;
+    }
+    if (!BigNumber.from(newAllocation[i].amount).isZero()) safeToDelete = false;
+    surplus = surplus.sub(affordsForDestination);
+  }
+
+  return {
+    newAllocation,
+    deleted: safeToDelete,
+    payouts,
+    totalPayouts: totalPayouts.toHexString(),
+  };
+}
+
+/**
+ *
+ * Takes an AllocationUpdatedEvent and the transaction that emittted it, and returns updated information in a convenient format.
+ * Requires both an adjudicator and asset holder address.
+ * @param assetHolderAddress
+ * @param nitroAdjudicatorAddress
+ * @param allocationUpdatedEvent
+ * @param tx Transaction which gave rise to the event
+ */
+export function computeNewAssetOutcome(
+  assetHolderAddress: Address,
+  nitroAdjudicatorAddress: Address,
+  allocationUpdatedEvent: {channelId: Bytes32; initialHoldings: string},
+  tx?: ethers.Transaction
+): {
+  newAssetOutcome: AssetOutcome | '0x00'; // '0x00' if the outcome was deleted on chain
+  newHoldings: BigNumber;
+  externalPayouts: AllocationItem[];
+  internalPayouts: AllocationItem[];
+} {
+  let oldAllocation;
+  let indices = [];
+  let txDescription: TransactionDescription;
+  if (tx.to === assetHolderAddress) {
+    txDescription = new ethers.Contract(
+      assetHolderAddress,
+      AssetHolderArtifact.abi
+    ).interface.parseTransaction(tx);
+    // originating tx may be on the supplied AssetHolder:
+    // all methods have a parameter allocationBytes
+    // transfer, transferAll, claim, claimAll
+    oldAllocation = decodeAllocation(txDescription.args.allocationBytes);
+    indices = txDescription.name == 'transfer' ? txDescription.args.indices : []; // TODO: claim does not use indices!
+  } else if (tx.to === nitroAdjudicatorAddress) {
+    // or it may have been on the NitroAdjudicator
+    indices = []; // all the adjudicator methods use 'all'.
+    // all methods have a parameter outcomeBytes
+    // pushOutcomeAndTransferAll, concludePushOutcomeAndTransferAll
+    txDescription = new ethers.Contract(
+      nitroAdjudicatorAddress,
+      NitroAdjudicatorArtifact.abi
+    ).interface.parseTransaction(tx);
+    const oldOutcome = decodeOutcome(txDescription.args.outcomeBytes); // We have the entire outcome here, extract the relevant AssetOutcome
+    const assetOutcome = oldOutcome.find(
+      outcome => outcome.assetHolderAddress === assetHolderAddress
+    );
+    if (isAllocationOutcome(assetOutcome)) {
+      oldAllocation = assetOutcome.allocationItems;
+    } else throw Error('No allocation for this asset holder');
+  } else
+    throw Error('transaction did not originate from either of the supplied contract addresses');
+
+  const {newAllocation, deleted, payouts, totalPayouts} = computeNewAllocation(
+    allocationUpdatedEvent.initialHoldings,
+    oldAllocation,
+    indices
+  );
+  const newHoldings = BigNumber.from(allocationUpdatedEvent.initialHoldings).sub(totalPayouts);
+  const newAssetOutcome: AllocationAssetOutcome | '0x00' = deleted
+    ? '0x00'
+    : {
+        assetHolderAddress: assetHolderAddress,
+        allocationItems: newAllocation,
+      };
+
+  let hydratedPayouts: AllocationItem[];
+
+  if (indices.length === 0) {
+    hydratedPayouts = payouts.map((v, i) => ({
+      destination: oldAllocation[i].destination,
+      amount: v,
+    }));
+  } else {
+    hydratedPayouts = payouts.map((v, i) => ({
+      destination: oldAllocation[txDescription.args.indices[i]].destination,
+      amount: v,
+    }));
+  }
+
+  const externalPayouts = hydratedPayouts.filter(payout =>
+    isExternalDestination(payout.destination)
+  );
+
+  const internalPayouts = hydratedPayouts.filter(
+    payout => !isExternalDestination(payout.destination)
+  );
+  return {newAssetOutcome, newHoldings, externalPayouts, internalPayouts};
+}
+
+function min(a: BigNumber, b: BigNumber) {
+  return a.gt(b) ? b : a;
 }

--- a/packages/nitro-protocol/src/index.ts
+++ b/packages/nitro-protocol/src/index.ts
@@ -37,8 +37,6 @@ export {
 } from '../test/test-helpers';
 export {
   DepositedEvent,
-  AssetTransferredEvent,
-  getAssetTransferredEvent,
   getDepositedEvent,
   convertBytes32ToAddress,
   convertAddressToBytes32,

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -6,7 +6,6 @@ import {claimAllArgs} from '../../../src/contract/transaction-creators/asset-hol
 import {
   allocationToParams,
   AssetOutcomeShortHand,
-  assetTransferredEventsFromPayouts,
   compileEventsFromLogs,
   getRandomNonce,
   getTestProvider,
@@ -51,15 +50,15 @@ const reason6 =
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | destination | tOutcomeAfter   | heldAfter | payouts   | events    | reason
-    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${{I: 5}} | ${undefined}
-    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${{B: 5}} | ${undefined}
-    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${{I: 5}} | ${undefined}
-    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${'A'}      | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}} | ${{A: 5}} | ${undefined}
-    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${{}}     | ${reason5}
-    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${{}}     | ${reason6}
-    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 7}} | ${{B: 5}} | ${{B: 5}} | ${undefined}
-    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 7}} | ${{B: 5}} | ${{B: 5}} | ${undefined}
+    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | destination | tOutcomeAfter   | heldAfter | payouts   | reason
+    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
+    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${undefined}
+    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${'I'}      | ${{A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
+    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${'A'}      | ${{B: 5}}       | ${{g: 0}} | ${{A: 5}} | ${undefined}
+    ${'5. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${reason5}
+    ${'6. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 0}} | ${{B: 5}} | ${reason6}
+    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 7}} | ${{B: 5}} | ${undefined}
+    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${'B'}      | ${{A: 5}}       | ${{g: 7}} | ${{B: 5}} | ${undefined}
   `(
     '$name',
     async ({
@@ -71,7 +70,6 @@ describe('claim', () => {
       tOutcomeAfter,
       heldAfter,
       payouts,
-      events,
       reason,
     }: {
       name;
@@ -82,7 +80,6 @@ describe('claim', () => {
       tOutcomeAfter: AssetOutcomeShortHand;
       heldAfter: AssetOutcomeShortHand;
       payouts: AssetOutcomeShortHand;
-      events: AssetOutcomeShortHand;
       reason;
     }) => {
       // Compute channelIds
@@ -94,13 +91,12 @@ describe('claim', () => {
       addresses.g = guarantorId;
 
       // Transform input data (unpack addresses and BigNumber amounts)
-      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts, events] = [
+      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [
         heldBefore,
         tOutcomeBefore,
         tOutcomeAfter,
         heldAfter,
         payouts,
-        events,
       ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
       guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
       destination = addresses[destination];
@@ -151,21 +147,20 @@ describe('claim', () => {
         await expectRevert(() => tx, reason);
       } else {
         // Compile event expectations
-        const expectedEvents = assetTransferredEventsFromPayouts(
-          guarantorId,
-          events,
-          AssetHolder.address
-        );
+
+        const expectedEvents = [
+          {
+            event: 'AllocationUpdated',
+            args: {channelId: guarantorId, initialHoldings: heldBefore[guarantorId]},
+          },
+        ];
 
         // Extract logs
-        const {logs, gasUsed} = await (await tx).wait();
+        const {events: eventsFromTx, gasUsed} = await (await tx).wait();
         await writeGasConsumption('claim.gas.md', name, gasUsed);
 
-        // Compile events from logs
-        const eventsFromLogs = compileEventsFromLogs(logs, [AssetHolder]);
-
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!
-        expect(eventsFromLogs).toMatchObject(expectedEvents);
+        expect(eventsFromTx).toMatchObject(expectedEvents);
 
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>

--- a/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
@@ -38,18 +38,26 @@ const randomAllocation = (numAllocationItems: number): AllocationItem[] => {
 };
 
 const heldBefore = BigNumber.from(100).toHexString();
-const allocation = randomAllocation(10);
-const indices = [...Array(3)].map(e => ~~(Math.random() * 10));
+const allocation = randomAllocation(Math.floor(Math.random() * 20));
+const indices = [...Array(3)].map(e => Math.floor(Math.random() * 10));
 
 describe('AsserHolder._computeNewAllocation', () => {
-  it('matches on chain method', async () => {
+  it(`matches on chain method for input \n heldBefore: ${heldBefore}, \n allocation: ${JSON.stringify(
+    allocation,
+    null,
+    2
+  )}, \n indices: ${indices}`, async () => {
     // check local function works as expected
     const locallyComputedNewAllocation = computeNewAllocation(heldBefore, allocation, indices);
 
-    const result = await AssetHolder._computeNewAllocation(heldBefore, allocation, indices);
+    const result = (await AssetHolder._computeNewAllocation(
+      heldBefore,
+      allocation,
+      indices
+    )) as ReturnType<typeof computeNewAllocation>;
     expect(result).toBeDefined();
 
-    expect((result as ReturnType<typeof computeNewAllocation>).newAllocation).toMatchObject(
+    expect(result.newAllocation).toMatchObject(
       locallyComputedNewAllocation.newAllocation.map(a => ({
         ...a,
         amount: BigNumber.from(a.amount),
@@ -58,12 +66,10 @@ describe('AsserHolder._computeNewAllocation', () => {
 
     expect((result as any).safeToDelete).toEqual(locallyComputedNewAllocation.deleted);
 
-    expect((result as ReturnType<typeof computeNewAllocation>).payouts).toMatchObject(
+    expect(result.payouts).toMatchObject(
       locallyComputedNewAllocation.payouts.map(p => BigNumber.from(p))
     );
 
-    expect((result as ReturnType<typeof computeNewAllocation>).totalPayouts).toEqual(
-      BigNumber.from(locallyComputedNewAllocation.totalPayouts)
-    );
+    expect(result.totalPayouts).toEqual(BigNumber.from(locallyComputedNewAllocation.totalPayouts));
   });
 });

--- a/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
@@ -1,0 +1,69 @@
+import {Contract, Wallet, BigNumber} from 'ethers';
+
+import {getTestProvider, setupContracts, randomExternalDestination} from '../../test-helpers';
+// eslint-disable-next-line import/order
+import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
+
+const provider = getTestProvider();
+
+let AssetHolder: Contract;
+
+const participants = ['', '', ''];
+const wallets = new Array(3);
+
+// Populate wallets and participants array
+for (let i = 0; i < 3; i++) {
+  wallets[i] = Wallet.createRandom();
+  participants[i] = wallets[i].address;
+}
+
+beforeAll(async () => {
+  AssetHolder = await setupContracts(
+    provider,
+    AssetHolderArtifact,
+    process.env.TEST_ASSET_HOLDER_ADDRESS
+  );
+});
+
+import {AllocationItem} from '../../../src';
+import {computeNewAllocation} from '../../../src/contract/asset-holder';
+
+const randomAllocation = (numAllocationItems: number): AllocationItem[] => {
+  return numAllocationItems > 0
+    ? [...Array(numAllocationItems)].map(e => ({
+        destination: randomExternalDestination(),
+        amount: BigNumber.from(Math.ceil(Math.random() * 10)).toHexString(),
+      }))
+    : [];
+};
+
+const heldBefore = BigNumber.from(100).toHexString();
+const allocation = randomAllocation(10);
+const indices = [...Array(3)].map(e => ~~(Math.random() * 10));
+
+describe('AsserHolder._computeNewAllocation', () => {
+  it('matches on chain method', async () => {
+    // check local function works as expected
+    const locallyComputedNewAllocation = computeNewAllocation(heldBefore, allocation, indices);
+
+    const result = await AssetHolder._computeNewAllocation(heldBefore, allocation, indices);
+    expect(result).toBeDefined();
+
+    expect((result as ReturnType<typeof computeNewAllocation>).newAllocation).toMatchObject(
+      locallyComputedNewAllocation.newAllocation.map(a => ({
+        ...a,
+        amount: BigNumber.from(a.amount),
+      }))
+    );
+
+    expect((result as any).safeToDelete).toEqual(locallyComputedNewAllocation.deleted);
+
+    expect((result as ReturnType<typeof computeNewAllocation>).payouts).toMatchObject(
+      locallyComputedNewAllocation.payouts.map(p => BigNumber.from(p))
+    );
+
+    expect((result as ReturnType<typeof computeNewAllocation>).totalPayouts).toEqual(
+      BigNumber.from(locallyComputedNewAllocation.totalPayouts)
+    );
+  });
+});

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -43,36 +43,26 @@ const reason1 = 'Indices must be sorted';
 // c is the channel we are transferring from.
 describe('transfer', () => {
   it.each`
-    name                               | heldBefore | setOutcome            | indices      | newOutcome      | heldAfter       | payouts         | events                | reason
-    ${' 0. outcome not set         '}  | ${{c: 1}}  | ${{}}                 | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${reason0}
-    ${' 1. funded          -> 1 EOA'}  | ${{c: 1}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'}  | ${{c: 2}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{c: 1}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'}  | ${{c: 1}}  | ${{A: 2}}             | ${[0]}       | ${{A: 1}}       | ${{}}           | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 4. funded      -> 1 channel'}  | ${{c: 1}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${' 5. overfunded  -> 1 channel'}  | ${{c: 2}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 1, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${' 6. underfunded -> 1 channel'}  | ${{c: 1}}  | ${{C: 2}}             | ${[0]}       | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${' 7. -> 2 EOA         1 index'}  | ${{c: 2}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 1}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 8. -> 2 EOA         1 index'}  | ${{c: 1}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 0}}       | ${{A: 1}}       | ${{A: 1}}             | ${undefined}
-    ${' 9. -> 2 EOA         partial'}  | ${{c: 3}}  | ${{A: 2, B: 2}}       | ${[1]}       | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}}       | ${{B: 1}}             | ${undefined}
-    ${'10. -> 2 chan             no'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[1]}       | ${{C: 1, X: 1}} | ${{c: 1}}       | ${{}}           | ${{}}                 | ${undefined}
-    ${'11. -> 2 chan           full'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[0]}       | ${{C: 0, X: 1}} | ${{c: 0, C: 1}} | ${{}}           | ${{C: 1}}             | ${undefined}
-    ${'12. -> 2 chan        partial'}  | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1]}       | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${{X: 1}}             | ${undefined}
-    ${'13. -> 2 indices'}              | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[0, 1]}    | ${{C: 0, X: 1}} | ${{c: 0, X: 1}} | ${{C: 2}}       | ${{C: 2, X: 1}}       | ${undefined}
-    ${'14. -> 3 indices'}              | ${{c: 5}}  | ${{A: 1, C: 2, X: 2}} | ${[0, 1, 2]} | ${{}}           | ${{c: 0, X: 2}} | ${{A: 1, C: 2}} | ${{A: 1, C: 2, X: 2}} | ${undefined}
-    ${'15. -> reverse order (see 13)'} | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1, 0]}    | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${{X: 1}}             | ${reason1}
+    name                               | heldBefore | setOutcome            | indices      | newOutcome      | heldAfter       | payouts         | reason
+    ${' 0. outcome not set         '}  | ${{c: 1}}  | ${{}}                 | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${reason0}
+    ${' 1. funded          -> 1 EOA'}  | ${{c: 1}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{}}           | ${{A: 1}}       | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'}  | ${{c: 2}}  | ${{A: 1}}             | ${[0]}       | ${{}}           | ${{c: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'}  | ${{c: 1}}  | ${{A: 2}}             | ${[0]}       | ${{A: 1}}       | ${{}}           | ${{A: 1}}       | ${undefined}
+    ${' 4. funded      -> 1 channel'}  | ${{c: 1}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 0, C: 1}} | ${{}}           | ${undefined}
+    ${' 5. overfunded  -> 1 channel'}  | ${{c: 2}}  | ${{C: 1}}             | ${[0]}       | ${{}}           | ${{c: 1, C: 1}} | ${{}}           | ${undefined}
+    ${' 6. underfunded -> 1 channel'}  | ${{c: 1}}  | ${{C: 2}}             | ${[0]}       | ${{C: 1}}       | ${{c: 0, C: 1}} | ${{}}           | ${undefined}
+    ${' 7. -> 2 EOA         1 index'}  | ${{c: 2}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 1}}       | ${{A: 1}}       | ${undefined}
+    ${' 8. -> 2 EOA         1 index'}  | ${{c: 1}}  | ${{A: 1, B: 1}}       | ${[0]}       | ${{A: 0, B: 1}} | ${{c: 0}}       | ${{A: 1}}       | ${undefined}
+    ${' 9. -> 2 EOA         partial'}  | ${{c: 3}}  | ${{A: 2, B: 2}}       | ${[1]}       | ${{A: 2, B: 1}} | ${{c: 2}}       | ${{B: 1}}       | ${undefined}
+    ${'10. -> 2 chan             no'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[1]}       | ${{C: 1, X: 1}} | ${{c: 1}}       | ${{}}           | ${undefined}
+    ${'11. -> 2 chan           full'}  | ${{c: 1}}  | ${{C: 1, X: 1}}       | ${[0]}       | ${{C: 0, X: 1}} | ${{c: 0, C: 1}} | ${{}}           | ${undefined}
+    ${'12. -> 2 chan        partial'}  | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1]}       | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${undefined}
+    ${'13. -> 2 indices'}              | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[0, 1]}    | ${{C: 0, X: 1}} | ${{c: 0, X: 1}} | ${{C: 2}}       | ${undefined}
+    ${'14. -> 3 indices'}              | ${{c: 5}}  | ${{A: 1, C: 2, X: 2}} | ${[0, 1, 2]} | ${{}}           | ${{c: 0, X: 2}} | ${{A: 1, C: 2}} | ${undefined}
+    ${'15. -> reverse order (see 13)'} | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1, 0]}    | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${reason1}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
-    async ({
-      name,
-      heldBefore,
-      setOutcome,
-      indices,
-      newOutcome,
-      heldAfter,
-      payouts,
-      events,
-      reason,
-    }) => {
+    async ({name, heldBefore, setOutcome, indices, newOutcome, heldAfter, payouts, reason}) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -84,7 +74,6 @@ describe('transfer', () => {
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
       payouts = replaceAddressesAndBigNumberify(payouts, addresses);
-      events = replaceAddressesAndBigNumberify(events, addresses);
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
@@ -113,15 +102,13 @@ describe('transfer', () => {
       if (reason) {
         await expectRevert(() => tx, reason);
       } else {
-        const expectedEvents = [];
-        Object.keys(events).forEach(destination => {
-          if (events[destination] && events[destination].gt(0)) {
-            expectedEvents.push({
-              event: 'AssetTransferred',
-              args: {channelId, destination, amount: events[destination]},
-            });
-          }
-        });
+        const expectedEvents = [
+          {
+            event: 'AllocationUpdated',
+            args: {channelId, initialHoldings: heldBefore[channelId]},
+          },
+        ];
+
         const {events: eventsFromTx, gasUsed} = await (await tx).wait();
         // NOTE: _transferAsset is a NOOP in TESTAssetHolder, so gas costs will be much lower than for a real Asset Holder
         await writeGasConsumption('transfer.gas.md', name, gasUsed);

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -42,23 +42,23 @@ const reason0 =
 // c is the channel we are transferring from.
 describe('transferAll', () => {
   it.each`
-    name                              | heldBefore | setOutcome      | newOutcome      | heldAfter             | payouts         | events          | reason
-    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}           | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${reason0}
-    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}           | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}           | ${{c: 1}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}       | ${{}}                 | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}           | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}           | ${{c: 1, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}       | ${{c: 0, C: 1}}       | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}           | ${{c: 0}}             | ${{A: 1, B: 1}} | ${{A: 1, B: 1}} | ${undefined}
-    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 1}}       | ${{A: 1}}       | ${undefined}
-    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 2, B: 1}} | ${{A: 2, B: 1}} | ${undefined}
-    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}           | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${{C: 1, X: 1}} | ${undefined}
-    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{C: 0, X: 1}} | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${{C: 1}}       | ${undefined}
-    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{C: 0, X: 1}} | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${{C: 2, X: 1}} | ${undefined}
+    name                              | heldBefore | setOutcome      | newOutcome      | heldAfter             | payouts         | reason
+    ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}           | ${{}}                 | ${{A: 1}}       | ${reason0}
+    ${' 1. funded          -> 1 EOA'} | ${{c: 1}}  | ${{A: 1}}       | ${{}}           | ${{}}                 | ${{A: 1}}       | ${undefined}
+    ${' 2. overfunded      -> 1 EOA'} | ${{c: 2}}  | ${{A: 1}}       | ${{}}           | ${{c: 1}}             | ${{A: 1}}       | ${undefined}
+    ${' 3. underfunded     -> 1 EOA'} | ${{c: 1}}  | ${{A: 2}}       | ${{A: 1}}       | ${{}}                 | ${{A: 1}}       | ${undefined}
+    ${' 4. funded      -> 1 channel'} | ${{c: 1}}  | ${{C: 1}}       | ${{}}           | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
+    ${' 5. overfunded  -> 1 channel'} | ${{c: 2}}  | ${{C: 1}}       | ${{}}           | ${{c: 1, C: 1}}       | ${{}}           | ${undefined}
+    ${' 6. underfunded -> 1 channel'} | ${{c: 1}}  | ${{C: 2}}       | ${{C: 1}}       | ${{c: 0, C: 1}}       | ${{}}           | ${undefined}
+    ${' 7. -> 2 EOA       full/full'} | ${{c: 2}}  | ${{A: 1, B: 1}} | ${{}}           | ${{c: 0}}             | ${{A: 1, B: 1}} | ${undefined}
+    ${' 8. -> 2 EOA         full/no'} | ${{c: 1}}  | ${{A: 1, B: 1}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 1}}       | ${undefined}
+    ${' 9. -> 2 EOA    full/partial'} | ${{c: 3}}  | ${{A: 2, B: 2}} | ${{A: 0, B: 1}} | ${{c: 0}}             | ${{A: 2, B: 1}} | ${undefined}
+    ${'10. -> 2 chan      full/full'} | ${{c: 2}}  | ${{C: 1, X: 1}} | ${{}}           | ${{c: 0, C: 1, X: 1}} | ${{}}           | ${undefined}
+    ${'11. -> 2 chan        full/no'} | ${{c: 1}}  | ${{C: 1, X: 1}} | ${{C: 0, X: 1}} | ${{c: 0, C: 1, X: 0}} | ${{}}           | ${undefined}
+    ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{C: 0, X: 1}} | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${undefined}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts, events: $events`,
-    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, events, reason}) => {
+    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, reason}) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -70,7 +70,6 @@ describe('transferAll', () => {
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
       payouts = replaceAddressesAndBigNumberify(payouts, addresses);
-      events = replaceAddressesAndBigNumberify(events, addresses);
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {
@@ -101,15 +100,12 @@ describe('transferAll', () => {
       } else {
         const {events: eventsFromLogs, gasUsed} = await (await tx).wait();
         await writeGasConsumption('transferAll.gas.md', name, gasUsed);
-        const expectedEvents = [];
-        Object.keys(events).forEach(destination => {
-          if (events[destination] && events[destination].gt(0)) {
-            expectedEvents.push({
-              event: 'AssetTransferred',
-              args: {channelId, destination, amount: events[destination]},
-            });
-          }
-        });
+        const expectedEvents = [
+          {
+            event: 'AllocationUpdated',
+            args: {channelId, initialHoldings: heldBefore[channelId]},
+          },
+        ];
         expect(eventsFromLogs).toMatchObject(expectedEvents);
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -12,7 +12,6 @@ import {AllocationAssetOutcome} from '../../../src/contract/outcome';
 import {State} from '../../../src/contract/state';
 import {concludePushOutcomeAndTransferAllArgs} from '../../../src/contract/transaction-creators/nitro-adjudicator';
 import {
-  assetTransferredEventsFromPayouts,
   checkMultipleAssetOutcomeHashes,
   checkMultipleHoldings,
   compileEventsFromLogs,
@@ -258,7 +257,8 @@ describe('concludePushOutcomeAndTransferAll', () => {
         ]);
 
         // Compile event expectations
-        let expectedEvents = [];
+
+        const expectedEvents = [];
 
         // Add Conclude event to expectations
         expectedEvents.push({
@@ -267,11 +267,17 @@ describe('concludePushOutcomeAndTransferAll', () => {
           args: {channelId},
         });
 
-        // Add AssetTransferred events to expectations
-        Object.keys(payouts).forEach(assetHolder => {
-          expectedEvents = expectedEvents.concat(
-            assetTransferredEventsFromPayouts(channelId, payouts[assetHolder], assetHolder)
-          );
+        // Add an AllocationUpdated event to expectations
+
+        Object.keys(heldBefore).forEach(key => {
+          expectedEvents.push({
+            name: 'AllocationUpdated',
+            contract: key,
+            args: {
+              channelId,
+              initialHoldings: heldBefore[key][channelId], // initialHoldings
+            },
+          });
         });
 
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcomeAndTransferAll.test.ts
@@ -8,7 +8,6 @@ import {Channel, getChannelId} from '../../../src/contract/channel';
 import {AllocationAssetOutcome, encodeOutcome} from '../../../src/contract/outcome';
 import {hashState, State} from '../../../src/contract/state';
 import {
-  assetTransferredEventsFromPayouts,
   checkMultipleAssetOutcomeHashes,
   checkMultipleHoldings,
   compileEventsFromLogs,
@@ -181,13 +180,18 @@ describe('pushOutcomeAndTransferAll', () => {
         const events = compileEventsFromLogs(logs, [AssetHolder1, AssetHolder2, NitroAdjudicator]);
 
         // Build up event expectations
-        let expectedEvents = [];
+        const expectedEvents = [];
 
-        // Add AssetTransferred events to expectations
-        Object.keys(payouts).forEach(assetHolder => {
-          expectedEvents = expectedEvents.concat(
-            assetTransferredEventsFromPayouts(channelId, payouts[assetHolder], assetHolder)
-          );
+        // Add an AllocationUpdated event to expectations
+        Object.keys(heldBefore).forEach(key => {
+          expectedEvents.push({
+            name: 'AllocationUpdated',
+            contract: key,
+            args: {
+              channelId,
+              initialHoldings: heldBefore[key][channelId], // initialHoldings
+            },
+          });
         });
 
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -24,7 +24,7 @@ import {
   Allocation,
   AllocationItem,
 } from '../src/contract/outcome';
-import {AssetTransferredEvent, Bytes32, DepositedEvent} from '../src';
+import {Bytes32} from '../src';
 
 // Interfaces
 
@@ -174,29 +174,6 @@ export const newDepositedEvent = (
   });
 };
 
-export const newTransferEvent = (
-  contract: ethers.Contract,
-  to: string
-): Promise<AssetTransferredEvent[keyof AssetTransferredEvent]> => {
-  const filter = contract.filters.Transfer(null, to);
-  return new Promise((resolve, reject) => {
-    contract.on(filter, (eventFrom, eventTo, amountTransferred, event) => {
-      // Match event for this destination only
-      contract.removeAllListeners(filter);
-      resolve(amountTransferred);
-    });
-  });
-};
-
-export const newAssetTransferredEvent = (
-  destination: string,
-  payout: number
-): AssetTransferredEvent => ({
-  channelId: destination,
-  destination: destination.toLowerCase(),
-  amount: BigNumber.from(payout),
-});
-
 export function randomChannelId(channelNonce = 0): Bytes32 {
   // Populate participants array (every test run targets a unique channel)
   const participants = [];
@@ -344,24 +321,6 @@ export function computeOutcome(outcomeShortHand: OutcomeShortHand): AllocationAs
     outcome.push(assetOutcome);
   });
   return outcome;
-}
-
-export function assetTransferredEventsFromPayouts(
-  channelId: string,
-  singleAssetPayouts: AssetOutcomeShortHand,
-  assetHolder: string
-): AssetTransferredEvent[] {
-  const assetTransferredEvents = [];
-  Object.keys(singleAssetPayouts).forEach(destination => {
-    if (singleAssetPayouts[destination] && BigNumber.from(singleAssetPayouts[destination]).gt(0)) {
-      assetTransferredEvents.push({
-        contract: assetHolder,
-        name: 'AssetTransferred',
-        args: {channelId, destination, amount: singleAssetPayouts[destination]},
-      });
-    }
-  });
-  return assetTransferredEvents;
 }
 
 export function compileEventsFromLogs(logs: any[], contractsArray: Contract[]): Event[] {

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -5,6 +5,8 @@
 ```ts
 
 import { Address } from '@statechannels/wallet-core';
+import { AllocationItem } from '@statechannels/nitro-protocol';
+import { AssetOutcome } from '@statechannels/nitro-protocol';
 import { ChannelConstants } from '@statechannels/wallet-core';
 import { ChannelId } from '@statechannels/client-api-schema';
 import { ChannelResult } from '@statechannels/client-api-schema';

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -137,7 +137,7 @@ it('Create a directly funded channel between two wallets ', async () => {
     .pipe(take(2))
     .toPromise();
 
-  const assetTransferredAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
+  const channelClosedAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
     .pipe(take(3))
     .toPromise();
 
@@ -247,9 +247,10 @@ it('Create a directly funded channel between two wallets ', async () => {
   });
 
   await mineBlocks(2);
-  const assetTransferredA = await assetTransferredAPromise;
 
-  expect(assetTransferredA.channelResult).toMatchObject({
+  const channelClosedA = await channelClosedAPromise;
+
+  expect(channelClosedA.channelResult).toMatchObject({
     status: 'closed',
     turnNum: 4,
     fundingStatus: 'Defunded',

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -10,7 +10,6 @@ import {
   Address,
   BN,
   makeAddress,
-  // makeDestination,
   PrivateKey,
   SignedState,
   State,

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -10,7 +10,7 @@ import {
   Address,
   BN,
   makeAddress,
-  makeDestination,
+  // makeDestination,
   PrivateKey,
   SignedState,
   State,
@@ -23,6 +23,7 @@ import {NonceManager} from '@ethersproject/experimental';
 import PQueue from 'p-queue';
 import {Logger} from 'pino';
 import _ from 'lodash';
+import {computeNewAssetOutcome} from '@statechannels/nitro-protocol/lib/src/contract/asset-holder';
 
 import {Bytes32} from '../type-aliases';
 import {createLogger} from '../logger';
@@ -30,7 +31,7 @@ import {defaultTestConfig} from '../config';
 
 import {
   AllowanceMode,
-  AssetTransferredArg,
+  AssetOutcomeUpdatedArg,
   ChainEventSubscriberInterface,
   ChainServiceArgs,
   ChainServiceInterface,
@@ -39,11 +40,14 @@ import {
 } from './types';
 
 const Deposited = 'Deposited' as const;
-const AssetTransferred = 'AssetTransferred' as const;
+const AllocationUpdated = 'AllocationUpdated';
 const ChallengeRegistered = 'ChallengeRegistered' as const;
 type DepositedEvent = {type: 'Deposited'; ethersEvent: Event} & HoldingUpdatedArg;
-type AssetTransferredEvent = {type: 'AssetTransferred'; ethersEvent: Event} & AssetTransferredArg;
-type AssetHolderEvent = DepositedEvent | AssetTransferredEvent;
+type AllocationUpdatedEvent = {
+  type: 'AllocationUpdated';
+  ethersEvent: Event;
+} & AssetOutcomeUpdatedArg;
+type AssetHolderEvent = DepositedEvent | AllocationUpdatedEvent;
 
 // TODO: is it reasonable to assume that the ethAssetHolder address is defined as runtime configuration?
 /* eslint-disable no-process-env, */
@@ -297,6 +301,14 @@ export class ChainService implements ChainServiceInterface {
     return this.sendTransaction(pushTransactionRequest);
   }
 
+  // TODO add another public method for transferring from an channel that has already been concluded *and* pushed
+  // i.e. one that calls NitroAdjudicator.transfer. We could call the new method "withdraw" to match the other methods in this class
+  // The new method will uses the latest outcome that we know exists ON CHAIN, which can be "newer" than the latest OFF CHAIN outcome.
+  // Choices:
+  // - the chain service stores the latest outcome in it's own DB table
+  // - the wallet.store stores them
+  // - nothing is stored, and the chain service searches through historic transaction data that it pulls from the provider (seems riskier, but we may need to do this in case we are offline for a time, anyway)
+
   registerChannel(
     channelId: Bytes32,
     assetHolders: Address[],
@@ -425,16 +437,31 @@ export class ChainService implements ChainServiceInterface {
             ethersEvent: event,
           })
       );
-      assetHolderContract.on(AssetTransferred, (channelId, destination, payoutAmount, event) =>
-        subs.next({
-          type: AssetTransferred,
+      assetHolderContract.on(AllocationUpdated, async (channelId, initialHoldings, event) => {
+        const tx = await this.provider.getTransaction(event.transactionHash);
+        const {
+          newAssetOutcome,
+          newHoldings,
+          externalPayouts,
+          internalPayouts,
+        } = computeNewAssetOutcome(
+          assetHolderContract.address,
+          nitroAdjudicatorAddress,
+          {channelId, initialHoldings},
+          tx
+        );
+
+        return subs.next({
+          type: AllocationUpdated,
           channelId,
           assetHolderAddress: makeAddress(assetHolderContract.address),
-          to: makeDestination(destination),
-          amount: BN.from(payoutAmount),
+          newAssetOutcome,
+          externalPayouts,
+          internalPayouts,
+          newHoldings: BN.from(newHoldings),
           ethersEvent: event,
-        })
-      );
+        });
+      });
     });
     obs.subscribe({
       next: async event => {
@@ -448,8 +475,8 @@ export class ChainService implements ChainServiceInterface {
             case Deposited:
               subscriber.holdingUpdated(event);
               break;
-            case AssetTransferred:
-              subscriber.assetTransferred(event);
+            case AllocationUpdated:
+              subscriber.assetOutcomeUpdated(event);
               break;
             default:
               throw new Error('Unexpected event from contract observable');
@@ -522,7 +549,7 @@ export class ChainService implements ChainServiceInterface {
    *
    * @param appDefinition Address of state channels app
    *
-   * Rejects with 'Bytecode missint' if there is no contract deployed at `appDefinition`.
+   * Rejects with 'Bytecode missing' if there is no contract deployed at `appDefinition`.
    */
   public async fetchBytecode(appDefinition: string): Promise<string> {
     const result = await this.provider.getCode(appDefinition);

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -1,11 +1,5 @@
-import {
-  Address,
-  Destination,
-  PrivateKey,
-  SignedState,
-  State,
-  Uint256,
-} from '@statechannels/wallet-core';
+import {AllocationItem, AssetOutcome} from '@statechannels/nitro-protocol';
+import {Address, PrivateKey, SignedState, State, Uint256} from '@statechannels/wallet-core';
 import {providers} from 'ethers';
 import {Logger} from 'pino';
 
@@ -17,11 +11,13 @@ export type HoldingUpdatedArg = {
   amount: Uint256;
 };
 
-export type AssetTransferredArg = {
+export type AssetOutcomeUpdatedArg = {
   channelId: Bytes32;
   assetHolderAddress: Address;
-  to: Destination;
-  amount: Uint256;
+  newHoldings: Uint256;
+  externalPayouts: AllocationItem[];
+  internalPayouts: AllocationItem[];
+  newAssetOutcome: AssetOutcome | '0x00'; // '0x00' in case the asset outcome hash was deleted on chain
 };
 
 export type FundChannelArg = {
@@ -37,7 +33,7 @@ export type ChannelFinalizedArg = {
 
 export interface ChainEventSubscriberInterface {
   holdingUpdated(arg: HoldingUpdatedArg): void;
-  assetTransferred(arg: AssetTransferredArg): void;
+  assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg): void;
   channelFinalized(arg: ChannelFinalizedArg): void;
 }
 


### PR DESCRIPTION
This emits a close-to-minimal amount of information when transfer or claim is called: the information is sufficient for clients to construct a new AssetOutcome for a given channel in a given AssetHolder. They need this up-to-date data in order to successfully call transfer in future.

Example 1: my counterparty concluded, pushed, and transferred their own money out of a channel. Now I want to transfer my money out, but my view of the outcome on chain is out of date and my transaction will fail if I don't keep it fresh.

Example 2: someone called `concludePushOutcomeAndTransferAll`, and I want to be sure all the money got paid out. It's not the only way of doing this, but I can catch the `AllocationUpdated` event, feed it into the new typescript functions this PR introduces, and infer which payouts have been made. 

- [x] contracts updated with new event type
- [x] off-chain version of _computeNewAllocation. We could go down the pureEVM route, but for now I just reimplemented it in typescript and
 wrote a test that uses random data to check against the solidity version.
- [x] existing tests updated to catch and assert on new event
- [x] AssetTransferred deprecated in nitro-protocol and the documentation
- [x] Chain Service updated to watch for the new event and call into computeNewAllocation to infer the data it wants to understand.
Closes #3046 