### PR TITLE
perf: use shorter reason strings

### DIFF
--- a/packages/nitro-protocol/.solhint.json
+++ b/packages/nitro-protocol/.solhint.json
@@ -19,6 +19,6 @@
     "prettier/prettier": "error",
     "compiler-version": ["error","0.7.4"],
     "func-visibility": ["warn",{"ignoreConstructors":true}],
-    "reason-string": ["warn",{"maxLength": 96}]
+    "reason-string": ["warn",{"maxLength": 32}]
   }
 }

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -569,7 +569,7 @@ contract AssetHolder is IAssetHolder {
                         )
                     )
                 ),
-            'h(allocation) ≠ assetOutcomeHash'
+            'h(allocation)!=assetOutcomeHash'
         );
     }
 
@@ -587,7 +587,7 @@ contract AssetHolder is IAssetHolder {
                         )
                     )
                 ),
-            'h(guarantee) ≠ assetOutcomeHash'
+            'h(guarantee)!=assetOutcomeHash'
         );
     }
 

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -273,7 +273,7 @@ contract AssetHolder is IAssetHolder {
 
         for (uint256 j = 0; j < guarantee.destinations.length; j++) {
             if (balance == 0) {
-                revert('guarantor affords 0 for dest');
+                revert('guarantor affords zero for dest');
             }
             // for each destination in the guarantee,
             // find the first corresponding allocationItem in the target allocation

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -273,7 +273,7 @@ contract AssetHolder is IAssetHolder {
 
         for (uint256 j = 0; j < guarantee.destinations.length; j++) {
             if (balance == 0) {
-                revert('_claim : guarantorChannel affords 0 for destination');
+                revert('guarantor affords 0 for dest');
             }
             // for each destination in the guarantee,
             // find the first corresponding allocationItem in the target allocation
@@ -308,7 +308,7 @@ contract AssetHolder is IAssetHolder {
             }
         }
 
-        require(affordsForDestination > 0, '_claim | guarantor affords 0 for destination');
+        require(affordsForDestination > 0, 'guarantor affords 0 for dest');
 
         // effects
         holdings[guarantorChannelId] -= affordsForDestination;
@@ -569,7 +569,7 @@ contract AssetHolder is IAssetHolder {
                         )
                     )
                 ),
-            'AssetHolder | submitted allocationBytes data does not match stored assetOutcomeHash'
+            'h(allocation) ≠ assetOutcomeHash'
         );
     }
 
@@ -587,7 +587,7 @@ contract AssetHolder is IAssetHolder {
                         )
                     )
                 ),
-            'AssetHolder | submitted guaranteeBytes data does not match stored assetOutcomeHash'
+            'h(guarantee) ≠ assetOutcomeHash'
         );
     }
 

--- a/packages/nitro-protocol/contracts/CountingApp.sol
+++ b/packages/nitro-protocol/contracts/CountingApp.sol
@@ -37,13 +37,10 @@ contract CountingApp is IForceMoveApp {
     ) public override pure returns (bool) {
         require(
             appData(b.appData).counter == appData(a.appData).counter + 1,
-            'CountingApp: Counter must be incremented'
+            'Counter must be incremented'
         );
         // Note this is gas inefficient, and inferior to _bytesEqual in use elsewhere
-        require(
-            keccak256(b.outcome) == keccak256(a.outcome),
-            'CountingApp: Outcome must not change'
-        );
+        require(keccak256(b.outcome) == keccak256(a.outcome), 'Outcome must not change');
         return true;
     }
 }

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -35,21 +35,15 @@ contract ERC20AssetHolder is AssetHolder {
         uint256 expectedHeld,
         uint256 amount
     ) external {
-        require(!_isExternalDestination(destination), 'Cannot deposit to external destination');
+        require(!_isExternalDestination(destination), 'Deposit to external destination');
         uint256 amountDeposited;
         // this allows participants to reduce the wait between deposits, while protecting them from losing funds by depositing too early. Specifically it protects against the scenario:
         // 1. Participant A deposits
         // 2. Participant B sees A's deposit, which means it is now safe for them to deposit
         // 3. Participant B submits their deposit
         // 4. The chain re-orgs, leaving B's deposit in the chain but not A's
-        require(
-            holdings[destination] >= expectedHeld,
-            'Deposit | holdings[destination] is less than expected'
-        );
-        require(
-            holdings[destination] < expectedHeld.add(amount),
-            'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'
-        );
+        require(holdings[destination] >= expectedHeld, 'holdings < expectedHeld');
+        require(holdings[destination] < expectedHeld.add(amount), 'holdings already sufficient');
 
         // The depositor wishes to increase the holdings against channelId to amount + expectedHeld
         // The depositor need only deposit (at most) amount + (expectedHeld - holdings) (the term in parentheses is non-positive)

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -30,7 +30,7 @@ contract ETHAssetHolder is AssetHolder {
         uint256 expectedHeld,
         uint256 amount
     ) external payable {
-        require(!_isExternalDestination(destination), 'Cannot deposit to external destination');
+        require(!_isExternalDestination(destination), 'Deposit to external destination');
         require(msg.value == amount, 'Insufficient ETH for ETH deposit');
         uint256 amountDeposited;
         // this allows participants to reduce the wait between deposits, while protecting them from losing funds by depositing too early. Specifically it protects against the scenario:
@@ -38,14 +38,8 @@ contract ETHAssetHolder is AssetHolder {
         // 2. Participant B sees A's deposit, which means it is now safe for them to deposit
         // 3. Participant B submits their deposit
         // 4. The chain re-orgs, leaving B's deposit in the chain but not A's
-        require(
-            holdings[destination] >= expectedHeld,
-            'Deposit | holdings[destination] is less than expected'
-        );
-        require(
-            holdings[destination] < expectedHeld.add(amount),
-            'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'
-        );
+        require(holdings[destination] >= expectedHeld, 'holdings < expectedHeld');
+        require(holdings[destination] < expectedHeld.add(amount), 'holdings already sufficient');
 
         // The depositor wishes to increase the holdings against channelId to amount + expectedHeld
         // The depositor need only deposit (at most) amount + (expectedHeld - holdings) (the term in parentheses is non-positive)

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -426,7 +426,7 @@ contract ForceMove is IForceMove {
         uint256 nParticipants,
         uint256 nStates
     ) internal pure returns (bool) {
-        require(whoSignedWhat.length == nParticipants, '|whoSignedWhat| ≠ nParticipants');
+        require(whoSignedWhat.length == nParticipants, '|whoSignedWhat|!=nParticipants');
         for (uint256 i = 0; i < nParticipants; i++) {
             uint256 offset = (nParticipants + largestTurnNum - i) % nParticipants;
             // offset is the difference between the index of participant[i] and the index of the participant who owns the largesTurnNum state
@@ -760,7 +760,7 @@ contract ForceMove is IForceMove {
      * @param channelId Unique identifier for a channel.
      */
     function _requireMatchingStorage(ChannelData memory data, bytes32 channelId) internal view {
-        require(_matchesHash(data, channelStorageHashes[channelId]), 'hash(ChannelData) ≠ storage');
+        require(_matchesHash(data, channelStorageHashes[channelId]), 'hash(ChannelData)!=storage');
     }
 
     /**
@@ -922,7 +922,7 @@ contract ForceMove is IForceMove {
         require((numParticipants >= numStates) && (numStates > 0), 'Insufficient or excess states');
         require(
             (numSigs == numParticipants) && (numWhoSignedWhats == numParticipants),
-            'Bad |signatures|∨|whoSignedWhat|'
+            'Bad |signatures|v|whoSignedWhat|'
         );
         require(numParticipants < type(uint8).max, 'Too many participants!');
         return true;

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -563,7 +563,7 @@ contract ForceMove is IForceMove {
         // chainId, participants, channelNonce, appDefinition, challengeDuration
         // and that the b.turnNum = a.turnNum + 1
         if (isFinalAB[1]) {
-            require(_bytesEqual(ab[1].outcome, ab[0].outcome), 'Outcome change forbidden');
+            require(_bytesEqual(ab[1].outcome, ab[0].outcome), 'Outcome change verboten');
         } else {
             require(!isFinalAB[0], 'isFinal retrograde');
             if (turnNumB < 2 * nParticipants) {

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -135,7 +135,7 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
                     assetOutcome.allocationOrGuaranteeBytes
                 );
             } else {
-                revert('_transferAllFromAllAssetHolders: AssetOutcomeType is not an allocation');
+                revert('AssetOutcome not an allocation');
             }
         }
     }

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -42,11 +42,11 @@ contract SingleAssetPayments is IForceMoveApp {
         );
         require(
             assetOutcomeA.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
-            'AssetOutcome must be Allocation'
+            'AssetOutcomeA must be Allocation'
         );
         require(
             assetOutcomeB.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
-            'AssetOutcome must be Allocation'
+            'AssetOutcomeB must be Allocation'
         );
 
         // Throws unless that allocation has exactly n outcomes
@@ -58,8 +58,8 @@ contract SingleAssetPayments is IForceMoveApp {
             assetOutcomeB.allocationOrGuaranteeBytes,
             (Outcome.AllocationItem[])
         );
-        require(allocationA.length == nParticipants, '|Allocation|!=|participants|');
-        require(allocationB.length == nParticipants, '|Allocation|!=|participants|');
+        require(allocationA.length == nParticipants, '|AllocationA|!=|participants|');
+        require(allocationB.length == nParticipants, '|AllocationB|!=|participants|');
 
         // Interprets the nth outcome as benefiting participant n
         // checks the destinations have not changed

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -58,8 +58,8 @@ contract SingleAssetPayments is IForceMoveApp {
             assetOutcomeB.allocationOrGuaranteeBytes,
             (Outcome.AllocationItem[])
         );
-        require(allocationA.length == nParticipants, '|Allocation| ≠ |participants|');
-        require(allocationB.length == nParticipants, '|Allocation| ≠ |participants|');
+        require(allocationA.length == nParticipants, '|Allocation|!=|participants|');
+        require(allocationB.length == nParticipants, '|Allocation|!=|participants|');
 
         // Interprets the nth outcome as benefiting participant n
         // checks the destinations have not changed

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -28,8 +28,8 @@ contract SingleAssetPayments is IForceMoveApp {
         Outcome.OutcomeItem[] memory outcomeB = abi.decode(b.outcome, (Outcome.OutcomeItem[]));
 
         // Throws if more than one asset
-        require(outcomeA.length == 1, 'SingleAssetPayments: outcomeA: Only one asset allowed');
-        require(outcomeB.length == 1, 'SingleAssetPayments: outcomeB: Only one asset allowed');
+        require(outcomeA.length == 1, 'outcomeA: Only one asset allowed');
+        require(outcomeB.length == 1, 'outcomeB: Only one asset allowed');
 
         // Throws unless the assetoutcome is an allocation
         Outcome.AssetOutcome memory assetOutcomeA = abi.decode(
@@ -42,11 +42,11 @@ contract SingleAssetPayments is IForceMoveApp {
         );
         require(
             assetOutcomeA.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
-            'SingleAssetPayments: outcomeA: AssetOutcomeType must be Allocation'
+            'AssetOutcome must be Allocation'
         );
         require(
             assetOutcomeB.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
-            'SingleAssetPayments: outcomeB: AssetOutcomeType must be Allocation'
+            'AssetOutcome must be Allocation'
         );
 
         // Throws unless that allocation has exactly n outcomes
@@ -58,14 +58,8 @@ contract SingleAssetPayments is IForceMoveApp {
             assetOutcomeB.allocationOrGuaranteeBytes,
             (Outcome.AllocationItem[])
         );
-        require(
-            allocationA.length == nParticipants,
-            'SingleAssetPayments: outcomeA: Allocation length must equal number of participants'
-        );
-        require(
-            allocationB.length == nParticipants,
-            'SingleAssetPayments: outcomeB: Allocation length must equal number of participants'
-        );
+        require(allocationA.length == nParticipants, '|Allocation| ≠ |participants|');
+        require(allocationB.length == nParticipants, '|Allocation| ≠ |participants|');
 
         // Interprets the nth outcome as benefiting participant n
         // checks the destinations have not changed
@@ -77,21 +71,18 @@ contract SingleAssetPayments is IForceMoveApp {
         for (uint256 i = 0; i < nParticipants; i++) {
             require(
                 allocationB[i].destination == allocationA[i].destination,
-                'SingleAssetPayments: Destinations may not change'
+                'Destinations may not change'
             );
             allocationSumA += allocationA[i].amount;
             allocationSumB += allocationB[i].amount;
             if (i != turnNumB % nParticipants) {
                 require(
                     allocationB[i].amount >= allocationA[i].amount,
-                    'SingleAssetPayments: Nonmovers cannot have their balance decreased'
+                    'Nonmover balance decreased'
                 );
             }
         }
-        require(
-            allocationSumA == allocationSumB,
-            'SingleAssetPayments: Total amount allocated cannot change'
-        );
+        require(allocationSumA == allocationSumB, 'Total allocated cannot change');
 
         return true;
     }

--- a/packages/nitro-protocol/src/contract/transaction-creators/revert-reasons.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/revert-reasons.ts
@@ -7,14 +7,12 @@ export const NO_ONGOING_CHALLENGE = 'No ongoing challenge.';
 export const TURN_NUM_RECORD_DECREASED = 'turnNumRecord decreased.';
 export const TURN_NUM_RECORD_NOT_INCREASED = 'turnNumRecord not increased.';
 export const UNACCEPTABLE_WHO_SIGNED_WHAT = 'Unacceptable whoSignedWhat array';
-export const WHO_SIGNED_WHAT_WRONG_LENGTH =
-  '_validSignatures: whoSignedWhat must be the same length as participants';
-export const WRONG_CHANNEL_STORAGE = 'Channel storage does not match stored version.';
+export const WHO_SIGNED_WHAT_WRONG_LENGTH = '|whoSignedWhat|!=nParticipants';
+export const WRONG_CHANNEL_STORAGE = 'hash(ChannelData)!=storage';
 export const INVALID_SIGNATURE = 'Invalid signature';
-export const INVALID_NUMBER_OF_STATES =
-  'You must submit at least one but no more than numParticipants states';
+export const INVALID_NUMBER_OF_STATES = 'Insufficient or excess states';
 
 // Function-specific messages
 export const CHALLENGER_NON_PARTICIPANT = 'Challenger is not a participant';
-export const RESPONSE_UNAUTHORIZED = 'Response not signed by authorized mover';
+export const RESPONSE_UNAUTHORIZED = 'Signer not authorized mover';
 export const WRONG_REFUTATION_SIGNATURE = 'Refutation state not signed by challenger';

--- a/packages/nitro-protocol/src/valid-transition.ts
+++ b/packages/nitro-protocol/src/valid-transition.ts
@@ -20,24 +20,12 @@ export function requireValidProtocolTransition(fromState: State, toState: State)
 
   // directly ported checks:
   if (toState.isFinal) {
-    _require(
-      isEqual(toState.outcome, fromState.outcome),
-      'InvalidTransitionError: Cannot move to a final state with a different default outcome'
-    );
+    _require(isEqual(toState.outcome, fromState.outcome), 'Outcome change forbidden');
   } else {
-    _require(
-      !fromState.isFinal,
-      'InvalidTransitionError: Cannot move from a final state to a non final state'
-    );
+    _require(!fromState.isFinal, 'isFinal retrograde');
     if (toState.turnNum < 2 * toState.channel.participants.length) {
-      _require(
-        isEqual(toState.outcome, fromState.outcome),
-        'InvalidTransitionError: Cannot change the default outcome during setup phase'
-      );
-      _require(
-        toState.appData == fromState.appData,
-        'InvalidTransitionError: Cannot change the appData during setup phase'
-      );
+      _require(isEqual(toState.outcome, fromState.outcome), 'Outcome change forbidden');
+      _require(toState.appData == fromState.appData, 'appData change forbidden');
     } else {
       return Status.NeedToCheckApp;
     }

--- a/packages/nitro-protocol/src/valid-transition.ts
+++ b/packages/nitro-protocol/src/valid-transition.ts
@@ -20,7 +20,7 @@ export function requireValidProtocolTransition(fromState: State, toState: State)
 
   // directly ported checks:
   if (toState.isFinal) {
-    _require(isEqual(toState.outcome, fromState.outcome), 'Outcome change forbidden');
+    _require(isEqual(toState.outcome, fromState.outcome), 'Outcome change verboten');
   } else {
     _require(!fromState.isFinal, 'isFinal retrograde');
     if (toState.turnNum < 2 * toState.channel.participants.length) {

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -37,10 +37,8 @@ beforeAll(async () => {
   );
 });
 
-const reason5 =
-  'AssetHolder | submitted allocationBytes data does not match stored assetOutcomeHash';
-const reason6 =
-  'AssetHolder | submitted guaranteeBytes data does not match stored assetOutcomeHash';
+const reason5 = 'h(allocation)!=assetOutcomeHash';
+const reason6 = 'h(guarantee)!=assetOutcomeHash';
 
 // 1. claim G1 (step 1 of figure 23 of nitro paper)
 // 2. claim G2 (step 2 of figure 23 of nitro paper)

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -39,10 +39,8 @@ beforeAll(async () => {
   );
 });
 
-const reason5 =
-  'AssetHolder | submitted allocationBytes data does not match stored assetOutcomeHash';
-const reason6 =
-  'AssetHolder | submitted guaranteeBytes data does not match stored assetOutcomeHash';
+const reason5 = 'h(allocation)!=assetOutcomeHash';
+const reason6 = 'h(guarantee)!=assetOutcomeHash';
 
 // 1. claim G1 (step 1 of figure 23 of nitro paper)
 // 2. claim G2 (step 2 of figure 23 of nitro paper)

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -36,8 +36,7 @@ beforeAll(async () => {
   );
 });
 
-const reason0 =
-  'AssetHolder | submitted allocationBytes data does not match stored assetOutcomeHash';
+const reason0 = 'h(allocation)!=assetOutcomeHash';
 const reason1 = 'Indices must be sorted';
 
 // c is the channel we are transferring from.

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -36,8 +36,7 @@ beforeAll(async () => {
   );
 });
 
-const reason0 =
-  'AssetHolder | submitted allocationBytes data does not match stored assetOutcomeHash';
+const reason0 = 'h(allocation)!=assetOutcomeHash';
 
 // c is the channel we are transferring from.
 describe('transferAll', () => {

--- a/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
@@ -51,8 +51,8 @@ describe('deposit', () => {
     description     | held | expectedHeld | amount | heldAfter | reasonString
     ${description0} | ${0} | ${0}         | ${1}   | ${1}      | ${undefined}
     ${description1} | ${1} | ${1}         | ${1}   | ${2}      | ${undefined}
-    ${description2} | ${0} | ${1}         | ${2}   | ${0}      | ${'Deposit | holdings[destination] is less than expected'}
-    ${description3} | ${3} | ${1}         | ${1}   | ${3}      | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
+    ${description2} | ${0} | ${1}         | ${2}   | ${0}      | ${'holdings < expectedHeld'}
+    ${description3} | ${3} | ${1}         | ${1}   | ${3}      | ${'holdings already sufficient'}
     ${description4} | ${3} | ${2}         | ${2}   | ${4}      | ${undefined}
   `('$description', async ({description, held, expectedHeld, amount, reasonString, heldAfter}) => {
     held = BigNumber.from(held);

--- a/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
@@ -44,8 +44,8 @@ describe('deposit', () => {
   it.each`
     description     | held   | expectedHeld | amount | msgValue | heldAfterString | reasonString
     ${description0} | ${'0'} | ${'0'}       | ${'1'} | ${'1'}   | ${'1'}          | ${undefined}
-    ${description1} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}          | ${'Deposit | holdings[destination] is less than expected'}
-    ${description2} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}          | ${'Deposit | holdings[destination] already meets or exceeds expectedHeld + amount'}
+    ${description1} | ${'0'} | ${'1'}       | ${'2'} | ${'2'}   | ${'0'}          | ${'holdings < expectedHeld'}
+    ${description2} | ${'3'} | ${'1'}       | ${'1'} | ${'1'}   | ${'3'}          | ${'holdings already sufficient'}
     ${description3} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}          | ${undefined}
   `(
     '$description',

--- a/packages/nitro-protocol/test/contracts/ForceMove/_acceptableWhoSignedWhat.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/_acceptableWhoSignedWhat.test.ts
@@ -52,7 +52,7 @@ describe('_acceptableWhoSignedWhat (expect a boolean)', () => {
 describe('_acceptableWhoSignedWhat (expect revert)', () => {
   it.each`
     whoSignedWhat | largestTurnNum | nParticipants | nStates | reasonString
-    ${[0, 0]}     | ${2}           | ${3}          | ${1}    | ${'_validSignatures: whoSignedWhat must be the same length as participants'}
+    ${[0, 0]}     | ${2}           | ${3}          | ${1}    | ${'|whoSignedWhat|!=nParticipants'}
   `(
     'reverts for whoSignedWhat = $whoSignedWhat, largestTurnNum = $largestTurnNum, nParticipants = $nParticipants, nStates = $nStates',
     async ({whoSignedWhat, largestTurnNum, nParticipants, nStates, reasonString}) => {

--- a/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -174,8 +174,6 @@ describe('conclude', () => {
       [0, 0, 0],
       [signature, signature, signature] // enough to clear the input type validation
     );
-    await expect(() => tx).rejects.toThrow(
-      'largestTurnNum + 1 must be greater than or equal to numStates'
-    );
+    await expect(() => tx).rejects.toThrow('largestTurnNum too low');
   });
 });

--- a/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
@@ -73,7 +73,7 @@ describe('respond', () => {
     ${description2} | ${past}     | ${false}  | ${[false, false]} | ${8}          | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${NO_ONGOING_CHALLENGE}
     ${description3} | ${future}   | ${true}   | ${[false, false]} | ${8}          | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${WRONG_CHANNEL_STORAGE}
     ${description4} | ${future}   | ${false}  | ${[false, false]} | ${8}          | ${[0, 1]} | ${wallets[2]} | ${nonParticipant} | ${RESPONSE_UNAUTHORIZED}
-    ${description5} | ${future}   | ${false}  | ${[false, false]} | ${8}          | ${[0, 0]} | ${wallets[2]} | ${wallets[0]}     | ${'CountingApp: Counter must be incremented'}
+    ${description5} | ${future}   | ${false}  | ${[false, false]} | ${8}          | ${[0, 0]} | ${wallets[2]} | ${wallets[0]}     | ${'Counter must be incremented'}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
@@ -164,12 +164,9 @@ describe('pushOutcome', () => {
 
       // Call method in a slightly different way if expecting a revert
       if (reasonString) {
-        const regex = new RegExp(
-          '(' + 'VM Exception while processing transaction: revert ' + reasonString + ')'
-        );
         await expectRevert(
           () => sendTransaction(provider, TestNitroAdjudicator.address, transactionRequest),
-          regex
+          reasonString
         );
       } else {
         const receipt = await sendTransaction(

--- a/packages/nitro-protocol/test/revert-reasons.ts
+++ b/packages/nitro-protocol/test/revert-reasons.ts
@@ -1,1 +1,1 @@
-export const COUNTING_APP_INVALID_TRANSITION = 'CountingApp: Counter must be incremented';
+export const COUNTING_APP_INVALID_TRANSITION = 'Counter must be incremented';

--- a/packages/nitro-protocol/test/src/valid-transition.test.ts
+++ b/packages/nitro-protocol/test/src/valid-transition.test.ts
@@ -46,19 +46,19 @@ const changedAConstantCases: TestCaseWithError[] = [
 ];
 //prettier-ignore
 const changedOutcomeWhenToIsFinal: TestCaseWithError[] = [
-    [/Cannot move to a final state with a different default outcome/, {}, { isFinal:true, outcome: []}],
+    [/Outcome change forbidden/, {}, { isFinal:true, outcome: []}],
 ]
 //prettier-ignore
 const fromFinalToNotFinal: TestCaseWithError[] = [
-    [/Cannot move from a final state to a non final state/, {isFinal:true}, {}],
+    [/isFinal retrograde/, {isFinal:true}, {}],
 ]
 //prettier-ignore
 const changedOutcomeDuringSetup: TestCaseWithError[] = [
-    [/Cannot change the default outcome during setup phase/, {turnNum:1}, { turnNum:2, outcome:[]}, ],
+    [/Outcome change forbidden/, {turnNum:1}, { turnNum:2, outcome:[]}, ],
 ]
 //prettier-ignore
 const changedAppDataDuringSetup: TestCaseWithError[] = [
-    [/Cannot change the appData during setup phase/, {turnNum:1}, { turnNum:2, appData:'0x02'}],
+    [/appData change forbidden/, {turnNum:1}, { turnNum:2, appData:'0x02'}],
 ]
 //prettier-ignore
 const commonCase: TestCase[] = [

--- a/packages/nitro-protocol/test/src/valid-transition.test.ts
+++ b/packages/nitro-protocol/test/src/valid-transition.test.ts
@@ -46,7 +46,7 @@ const changedAConstantCases: TestCaseWithError[] = [
 ];
 //prettier-ignore
 const changedOutcomeWhenToIsFinal: TestCaseWithError[] = [
-    [/Outcome change forbidden/, {}, { isFinal:true, outcome: []}],
+    [/Outcome change verboten/, {}, { isFinal:true, outcome: []}],
 ]
 //prettier-ignore
 const fromFinalToNotFinal: TestCaseWithError[] = [


### PR DESCRIPTION
The test will fail for now but easily fixed.

Reduces estimated gas costs of deploying NitroAdjudicator: `2566237` becomes `2420522` => `145715` drop.

Closes #3081 