### PR TITLE
refactor: store.getChannel -> store.getChannelState

### DIFF
--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -253,7 +253,7 @@ export const getCloseChannelProtocolState = async (
   channelId: Bytes32,
   tx: Transaction
 ): Promise<ProtocolState> => {
-  const app = await store.getChannel(channelId, tx);
+  const app = await store.getChannelState(channelId, tx);
   switch (app.fundingStrategy) {
     case 'Direct':
     case 'Fake':

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -327,7 +327,7 @@ export const getOpenChannelProtocolState = async (
   channelId: Bytes32,
   tx: Transaction
 ): Promise<ProtocolState> => {
-  const app = await store.getChannel(channelId, tx);
+  const app = await store.getChannelState(channelId, tx);
   switch (app.fundingStrategy) {
     case 'Direct':
     case 'Fake':
@@ -338,7 +338,7 @@ export const getOpenChannelProtocolState = async (
         type: 'LedgerFundingProtocolState',
         app,
         ledgerFundingRequested: !!req,
-        ledger: req ? await store.getChannel(req.ledgerChannelId, tx) : undefined,
+        ledger: req ? await store.getChannelState(req.ledgerChannelId, tx) : undefined,
       };
     }
     case 'Unknown':

--- a/packages/server-wallet/src/protocols/process-ledger-queue.ts
+++ b/packages/server-wallet/src/protocols/process-ledger-queue.ts
@@ -330,7 +330,7 @@ export const getProcessLedgerQueueProtocolState = async (
   ledgerChannelId: Bytes32,
   tx: Transaction
 ): Promise<ProtocolState> => {
-  const fundingChannel = await store.getChannel(ledgerChannelId, tx);
+  const fundingChannel = await store.getChannelState(ledgerChannelId, tx);
   const ledgerRequests = await store.getPendingLedgerRequests(ledgerChannelId, tx);
   const proposals = await store.getLedgerProposals(ledgerChannelId, tx);
   const [[mine], [theirs]] = _.partition(proposals, [
@@ -345,7 +345,9 @@ export const getProcessLedgerQueueProtocolState = async (
 
     channelsRequestingFunds: await Promise.all<ChannelState>(
       compose(
-        map(({channelToBeFunded}: LedgerRequestType) => store.getChannel(channelToBeFunded, tx)),
+        map(({channelToBeFunded}: LedgerRequestType) =>
+          store.getChannelState(channelToBeFunded, tx)
+        ),
         filter(['status', 'pending']),
         filter(['type', 'fund'])
       )(ledgerRequests)
@@ -353,7 +355,9 @@ export const getProcessLedgerQueueProtocolState = async (
 
     channelsReturningFunds: await Promise.all<ChannelState>(
       compose(
-        map(({channelToBeFunded}: LedgerRequestType) => store.getChannel(channelToBeFunded, tx)),
+        map(({channelToBeFunded}: LedgerRequestType) =>
+          store.getChannelState(channelToBeFunded, tx)
+        ),
         filter(['status', 'pending']),
         filter(['type', 'defund'])
       )(ledgerRequests)

--- a/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/lock-app.test.ts
@@ -93,7 +93,7 @@ describe('concurrency', () => {
     expect(numRejected).toEqual(numAttempts - 1);
     expect(numSettled).toEqual(numAttempts);
 
-    await expect(store.getChannel(channelId)).resolves.toMatchObject({
+    await expect(store.getChannelState(channelId)).resolves.toMatchObject({
       latest: {turnNum: 6},
     });
   });
@@ -135,7 +135,7 @@ describe('concurrency', () => {
 
       expect([numResolved, numRejected, numSettled]).toMatchObject([NUM_ATTEMPTS, 0, NUM_ATTEMPTS]);
 
-      await expect(store.getChannel(channels[1].channelId)).resolves.toMatchObject({
+      await expect(store.getChannelState(channels[1].channelId)).resolves.toMatchObject({
         latest: {turnNum: 6},
       });
     },
@@ -158,7 +158,7 @@ describe('concurrency', () => {
     expect(numRejected).toEqual(0);
     expect(numSettled).toEqual(NUM_ATTEMPTS);
 
-    await expect(store.getChannel(channelId)).resolves.toMatchObject({
+    await expect(store.getChannelState(channelId)).resolves.toMatchObject({
       latest: next(c.latest),
     });
   });

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -83,7 +83,7 @@ export class Store {
       this.getOrCreateSigningAddress = recordFunctionMetrics(this.getOrCreateSigningAddress);
       this.lockApp = recordFunctionMetrics(this.lockApp);
       this.signState = recordFunctionMetrics(this.signState);
-      this.getChannel = recordFunctionMetrics(this.getChannel);
+      this.getChannelState = recordFunctionMetrics(this.getChannelState);
       this.getStates = recordFunctionMetrics(this.getStates);
       this.getChannels = recordFunctionMetrics(this.getChannels);
       this.ensureObjective = recordFunctionMetrics(this.ensureObjective);
@@ -248,7 +248,7 @@ export class Store {
     return result;
   }
 
-  async getChannel(channelId: Bytes32, tx?: Transaction): Promise<ChannelState> {
+  async getChannelState(channelId: Bytes32, tx?: Transaction): Promise<ChannelState> {
     // This is somewhat faster than Channel.forId for simply fetching a channel:
     // - the signingWallet isn't needed to construct the protocol state
     // - withGraphJoined is slightly faster in this case
@@ -377,7 +377,7 @@ export class Store {
     } = objective;
 
     // fetch the channel to make sure the channel exists
-    const channel = await this.getChannel(channelId, tx);
+    const channel = await this.getChannelState(channelId, tx);
     if (!channel) {
       throw new StoreError(StoreError.reasons.channelMissing, {channelId});
     }
@@ -429,7 +429,7 @@ export class Store {
     } = objective;
 
     // fetch the channel to make sure the channel exists
-    const channel = await this.getChannel(targetChannelId, tx);
+    const channel = await this.getChannelState(targetChannelId, tx);
     if (!channel)
       throw new StoreError(StoreError.reasons.channelMissing, {
         channelId: targetChannelId,
@@ -657,7 +657,7 @@ export class Store {
       const objective = await this.ensureObjective(objectiveParams, tx);
       await this.approveObjective(objective.objectiveId, tx);
 
-      return {channel: await this.getChannel(channelId, tx), firstSignedState, objective};
+      return {channel: await this.getChannelState(channelId, tx), firstSignedState, objective};
     });
   }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -249,9 +249,6 @@ export class Store {
   }
 
   async getChannelState(channelId: Bytes32, tx?: Transaction): Promise<ChannelState> {
-    // This is somewhat faster than Channel.forId for simply fetching a channel:
-    // - the signingWallet isn't needed to construct the protocol state
-    // - withGraphJoined is slightly faster in this case
     const channel = await this.getChannel(channelId, tx);
 
     // TODO: throwing here is a quick fix until we can update all consumers of getChannelState

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -374,7 +374,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
   async joinChannel({channelId}: JoinChannelParams): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
-    const channel = await this.store.getChannel(channelId);
+    const channel = await this.store.getChannelState(channelId);
 
     if (!channel)
       throw new JoinChannel.JoinChannelError(
@@ -439,7 +439,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
       });
       response.queueState(signedState, myIndex, channelId);
 
-      const channelState = await this.store.getChannel(channelId, tx);
+      const channelState = await this.store.getChannelState(channelId, tx);
       response.queueChannelState(channelState);
 
       return response.singleChannelOutput();
@@ -500,7 +500,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
     const response = WalletResponse.initialize();
 
     try {
-      const channel = await this.store.getChannel(channelId);
+      const channel = await this.store.getChannelState(channelId);
 
       response.queueChannelState(channel);
 
@@ -799,7 +799,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
   }
 
   private async registerChannelWithChainService(channelId: string): Promise<void> {
-    const channel = await this.store.getChannel(channelId);
+    const channel = await this.store.getChannelState(channelId);
     const channelResult = ChannelState.toChannelResult(channel);
 
     const assetHolderAddresses = channelResult.allocations.map(a =>


### PR DESCRIPTION
* We have an object called a `Channel` and an object called a `ChannelState`.
* Currently `store.getChannel` returns a `ChannelState`. 
* This PR renames it to `getChannelState`
* In another PR, I'm going to recreate `getChannel` so that it actually returns a `Channel`