### PR TITLE
refactor open channel

### DIFF
--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -165,15 +165,14 @@ it('Create a directly funded channel between two wallets ', async () => {
   const prefundB = await b.joinChannel({channelId});
   expect(getChannelResultFor(channelId, [prefundB.channelResult])).toMatchObject({
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   const resultA0 = await a.pushMessage(getPayloadFor(participantA.participantId, prefundB.outbox));
 
   expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
     status: 'opening',
-    turnNum: 1,
-    fundingStatus: 'ReadyToFund',
+    turnNum: 0,
   });
 
   const postFundA = await postFundAPromise;
@@ -182,15 +181,13 @@ it('Create a directly funded channel between two wallets ', async () => {
   expect(postFundA.channelResult).toMatchObject({
     channelId,
     status: 'opening',
-    turnNum: 2,
-    fundingStatus: 'Funded',
+    turnNum: 0,
   });
 
   expect(postFundB.channelResult).toMatchObject({
     channelId,
     status: 'opening',
-    turnNum: 1,
-    fundingStatus: 'Funded',
+    turnNum: 0,
   });
 
   await b.pushMessage(getPayloadFor(participantB.participantId, postFundA.outbox));
@@ -199,7 +196,6 @@ it('Create a directly funded channel between two wallets ', async () => {
   expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
     status: 'running',
     turnNum: 3,
-    fundingStatus: 'Funded',
   });
 
   const resultB1 = await b.pushMessage(getPayloadFor(participantB.participantId, postFundA.outbox));

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -94,7 +94,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
   const resultB1 = await b.joinChannel({channelId});
   expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   //  PreFund0B <
@@ -109,7 +109,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
 
   expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   const depositByA = {
@@ -134,13 +134,13 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
 
   expect(getChannelResultFor(channelId, resultA2.channelResults)).toMatchObject({
     status: 'opening', // Still opening because turnNum 3 is not supported yet, but is signed by A
-    turnNum: 2,
+    turnNum: 0,
   });
 
   expect(getChannelResultFor(channelId, resultB2.channelResults)).toMatchObject({
     // Still opening because turnNum 3 is not supported yet (2 is not in the wallet)
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   //  > PostFund3A

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -97,7 +97,7 @@ it('Create a directly funded channel between two wallets ', async () => {
   const resultB1 = await b.joinChannel({channelId});
   expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   //  PreFund0B <
@@ -112,7 +112,7 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   const depositByA = {
@@ -138,12 +138,12 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   expect(getChannelResultFor(channelId, resultA2.channelResults)).toMatchObject({
     status: 'opening',
-    turnNum: 2,
+    turnNum: 0,
   });
 
   expect(getChannelResultFor(channelId, resultB2.channelResults)).toMatchObject({
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   //  > PostFund3A

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -92,7 +92,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   expect(getChannelResultFor(channelId, [bJoinChannelOutput.channelResult])).toMatchObject({
     status: 'opening',
-    turnNum: 1,
+    turnNum: 0,
   });
 
   // B sends signed PreFund1 and PostFund3 to A

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -232,21 +232,21 @@ describe('Funding a single channel with 100% of available ledger funds', () => {
     const {outbox: join} = await b.joinChannel({channelId});
 
     await exchangeMessagesBetweenAandB([join], []);
+    // so the problem is that we don't end up ledger funded here
 
     const {channelResults} = await a.getChannels();
 
-    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: []});
-
-    const ledger = getChannelResultFor(ledgerChannelId, channelResults);
-
-    const {
-      allocations: [{allocationItems}],
-    } = ledger;
+    await interParticipantChannelResultsAreEqual(a, b);
 
     expect(getChannelResultFor(channelId, channelResults)).toMatchObject({
       turnNum: 3,
       status: 'running',
     });
+
+    const ledger = getChannelResultFor(ledgerChannelId, channelResults);
+    const {
+      allocations: [{allocationItems}],
+    } = ledger;
 
     expect(allocationItems).toContainAllocationItem({
       destination: channelId,
@@ -608,11 +608,11 @@ describe('Funding multiple channels syncronously without enough funds', () => {
 
     expect(unfundedChannels).toMatchObject([
       {
-        turnNum: 1,
+        turnNum: 0,
         status: 'opening',
       },
       {
-        turnNum: 1,
+        turnNum: 0,
         status: 'opening',
       },
     ]);
@@ -655,7 +655,7 @@ describe('Funding multiple channels syncronously without enough funds', () => {
 
     const unfundedChannels = channelResults.filter(c => c.channelId === channelId);
 
-    expect(unfundedChannels).toMatchObject([{turnNum: 1, status: 'opening'}]);
+    expect(unfundedChannels).toMatchObject([{turnNum: 0, status: 'opening'}]);
     expect(allocationItems).not.toContainAllocationItem({
       destination: makeDestination(channelId),
       amount: BN.from(2),

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -357,10 +357,43 @@ export class Channel extends Model implements RequiredColumns {
     //  1. the supported state implies a post-fund-setup
     //  2. no isFinal states exist
 
-    const havePostFund = !!this.supported && this.supported.turnNum >= 2 * this.nParticipants() - 1;
     const noFinalStates = _.every(this.sortedStates, s => !s.isFinal);
 
-    return havePostFund && noFinalStates;
+    return this.postfundSupported && noFinalStates;
+  }
+
+  /**
+   * Have we signed a prefund state (or later)
+   */
+  public get prefundSigned(): boolean {
+    // all states are later than the prefund, so we just check if we've signed any state
+    return !!this.latestSignedByMe;
+  }
+
+  /**
+   * Have we signed a postfund state (or later)
+   */
+  public get postfundSigned(): boolean {
+    return !!this.latestSignedByMe && this.latestSignedByMe.turnNum >= 2 * this.nParticipants() - 1;
+  }
+
+  /**
+   * Is a prefund state (or later) supported
+   */
+  public get prefundSupported(): boolean {
+    // all states are later than the prefund, so we just check if have any supported state
+    return !!this.supported;
+  }
+
+  /**
+   * Is a postfund state (or later) supported
+   */
+  public get postfundSupported(): boolean {
+    return !!this.supported && this.supported.turnNum >= 2 * this.nParticipants() - 1;
+  }
+
+  public get isDirectFunded(): boolean {
+    return this.protocolState.directFundingStatus === 'Funded';
   }
 
   private mySignature(signatures: SignatureEntry[]): boolean {

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -374,7 +374,7 @@ export class Channel extends Model implements RequiredColumns {
    * Have we signed a postfund state (or later)
    */
   public get postfundSigned(): boolean {
-    return !!this.latestSignedByMe && this.latestSignedByMe.turnNum >= 2 * this.nParticipants() - 1;
+    return !!this.latestSignedByMe && this.latestSignedByMe.turnNum >= 2 * this.nParticipants - 1;
   }
 
   /**
@@ -389,7 +389,7 @@ export class Channel extends Model implements RequiredColumns {
    * Is a postfund state (or later) supported
    */
   public get postfundSupported(): boolean {
-    return !!this.supported && this.supported.turnNum >= 2 * this.nParticipants() - 1;
+    return !!this.supported && this.supported.turnNum >= 2 * this.nParticipants - 1;
   }
 
   public get isDirectFunded(): boolean {
@@ -400,7 +400,7 @@ export class Channel extends Model implements RequiredColumns {
     return signatures.some(sig => sig.signer === this.myAddress);
   }
 
-  private nParticipants(): number {
+  get nParticipants(): number {
     return this.participants.length;
   }
 
@@ -417,7 +417,7 @@ export class Channel extends Model implements RequiredColumns {
         support = [];
         participantsWhoHaveNotSigned = new Set(this.participants.map(p => p.signingAddress));
       }
-      const moverIndex = signedState.turnNum % this.nParticipants();
+      const moverIndex = signedState.turnNum % this.nParticipants;
       const moverForThisTurn = this.participants[moverIndex].signingAddress;
 
       // If the mover hasn't signed the state then we know it cannot be part of the support
@@ -445,7 +445,7 @@ export class Channel extends Model implements RequiredColumns {
     if (secondState.isFinal) {
       return outcomesEqual(firstState.outcome, secondState.outcome);
     }
-    if (secondState.turnNum < 2 * this.nParticipants()) {
+    if (secondState.turnNum < 2 * this.nParticipants) {
       return (
         outcomesEqual(firstState.outcome, secondState.outcome) &&
         firstState.appData === secondState.appData

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -27,7 +27,9 @@ beforeEach(async () => {
   await store.dbAdmin().truncateDB();
 });
 
-afterEach(async () => await store.dbAdmin().truncateDB());
+afterEach(async () => {
+  await store.dbAdmin().truncateDB();
+});
 
 describe(`pre-fund-setup phase`, () => {
   describe(`as participant 0`, () => {

--- a/packages/server-wallet/src/protocols/direct-funder.ts
+++ b/packages/server-wallet/src/protocols/direct-funder.ts
@@ -1,4 +1,4 @@
-import {BN, checkThat, isSimpleAllocation} from '@statechannels/wallet-core';
+import {Address, BN, checkThat, isSimpleAllocation, Uint256} from '@statechannels/wallet-core';
 import _ from 'lodash';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
@@ -38,69 +38,83 @@ export class DirectFunder {
     response: WalletResponse,
     tx: Transaction
   ): Promise<boolean> {
-    // don't check channel state - that should already have happened
-    // check funding state
+    const assetHolderAddress = this.assetHolder(channel);
+    const [targetBefore, targetAfter, targetTotal] = this.fundingMilestones(channel);
 
-    if (channel.protocolState.directFundingStatus === 'Funded') {
-      return true;
-    }
+    const currentFunding = await this.store.getFunding(channel.channelId, assetHolderAddress, tx);
+    const currentAmount = currentFunding?.amount || 0;
 
-    // request fund channel if my turn
-    await this.requestFundChannelIfMyTurn(channel, tx);
+    // if we're fully funded, we're done
+    if (BN.gte(currentAmount, targetTotal)) return true;
+
+    // if it isn't my turn yet, take no action
+    if (BN.lt(currentAmount, targetBefore)) return false;
+
+    // if my deposit is already on chain, take no action
+    if (BN.gte(currentAmount, targetAfter)) return false;
+
+    // if there's an outstanding chain request, take no action
+    if (await this.store.fundingRequestExists(channel.channelId, tx)) return false;
+
+    // otherwise, deposit
+    const amountToDeposit = BN.sub(targetAfter, currentAmount); // previous checks imply this is >0
+    await ChainServiceRequest.insertOrUpdate(channel.channelId, 'fund', tx);
+    await this.chainService.fundChannel({
+      channelId: channel.channelId,
+      assetHolderAddress: assetHolderAddress,
+      expectedHeld: BN.from(currentAmount),
+      amount: BN.from(amountToDeposit),
+    });
 
     return false;
   }
 
-  private async requestFundChannelIfMyTurn(channel: Channel, tx: Transaction): Promise<void> {
-    const app = channel.protocolState;
+  private assetHolder(channel: Channel): Address {
+    const supported = channel.supported;
+    if (!supported) {
+      throw new Error(`Channel passed to DriectFunded has no supported state`);
+    }
+
+    const {assetHolderAddress} = checkThat(supported?.outcome, isSimpleAllocation);
+
+    return assetHolderAddress;
+  }
+
+  /**
+   * Returns a triple of balance [targetBefore, targetAfter, targetTotal], where
+   *  - targetBefore is the balance where I should start depositing
+   *  - targetAfter should be the balance where I stop depositing
+   *  - targetTotal is the total amount that should be in the channel
+   *
+   * @param channel
+   */
+  private fundingMilestones(channel: Channel): [Uint256, Uint256, Uint256] {
     /**
      * The below logic assumes:
      *  1. Each destination occurs at most once.
      *  2. We only care about a single destination.
      * One reason to drop (2), for instance, is to support ledger top-ups with as few state updates as possible.
      */
-
-    if (!app.supported) return;
-
-    const existingRequest = app.chainServiceRequests.find(csr => csr.request === 'fund');
-    if (existingRequest?.isValid()) return;
-
-    if (app.directFundingStatus !== 'ReadyToFund') return;
-
-    const myDestination = app.participants[app.myIndex].destination;
-    const {allocationItems, assetHolderAddress} = checkThat(
-      app.supported?.outcome,
-      isSimpleAllocation
-    );
-
-    const currentFunding = app.funding(assetHolderAddress)?.amount;
-    if (!currentFunding) {
-      // this is a developer error, so throw
-      throw new Error(
-        `Funding not loaded from db. Make sure you use .withGraphJoined('funding') when fetching the channel.`
-      );
+    const supported = channel.supported;
+    if (!supported) {
+      throw new Error(`Channel passed to DriectFunded has no supported state`);
     }
 
-    const allocationsBeforeMe = _.takeWhile(allocationItems, a => a.destination !== myDestination);
-    const targetBeforeMyDeposit = allocationsBeforeMe.map(a => a.amount).reduce(BN.add, BN.from(0));
-    if (BN.lt(currentFunding, targetBeforeMyDeposit)) return;
+    const myDestination = channel.participants[channel.myIndex].destination;
+    const {allocationItems} = checkThat(supported.outcome, isSimpleAllocation);
 
     const myAllocationItem = _.find(allocationItems, ai => ai.destination === myDestination);
     if (!myAllocationItem) {
       throw new Error(`My destination ${myDestination} is not in allocations ${allocationItems}`);
     }
-    if (BN.eq(myAllocationItem.amount, 0)) return;
-    const targetAfterMyDeposit = BN.add(targetBeforeMyDeposit, myAllocationItem.amount);
-    if (BN.gte(currentFunding, targetAfterMyDeposit)) return;
-    const amountToDeposit = BN.sub(targetAfterMyDeposit, currentFunding); // previous line implies this is >0
 
-    // actions
-    await ChainServiceRequest.insertOrUpdate(app.channelId, 'fund', tx);
-    await this.chainService.fundChannel({
-      channelId: app.channelId,
-      assetHolderAddress: assetHolderAddress,
-      expectedHeld: BN.from(currentFunding),
-      amount: BN.from(amountToDeposit),
-    });
+    const allocationsBefore = _.takeWhile(allocationItems, a => a.destination !== myDestination);
+    const targetBefore = allocationsBefore.map(a => a.amount).reduce(BN.add, BN.from(0));
+
+    const targetAfter = BN.add(targetBefore, myAllocationItem.amount);
+
+    const total = allocationItems.map(a => a.amount).reduce(BN.add, BN.from(0));
+
+    return [targetBefore, targetAfter, total];
   }
 }

--- a/packages/server-wallet/src/protocols/direct-funder.ts
+++ b/packages/server-wallet/src/protocols/direct-funder.ts
@@ -72,7 +72,7 @@ export class DirectFunder {
   private assetHolder(channel: Channel): Address {
     const supported = channel.supported;
     if (!supported) {
-      throw new Error(`Channel passed to DriectFunded has no supported state`);
+      throw new Error(`Channel passed to DirectFunded has no supported state`);
     }
 
     const {assetHolderAddress} = checkThat(supported?.outcome, isSimpleAllocation);

--- a/packages/server-wallet/src/protocols/direct-funder.ts
+++ b/packages/server-wallet/src/protocols/direct-funder.ts
@@ -1,0 +1,106 @@
+import {BN, checkThat, isSimpleAllocation} from '@statechannels/wallet-core';
+import _ from 'lodash';
+import {Transaction} from 'objection';
+import {Logger} from 'pino';
+
+import {ChainServiceInterface} from '../chain-service';
+import {ChainServiceRequest} from '../models/chain-service-request';
+import {Channel} from '../models/channel';
+import {DBOpenChannelObjective} from '../models/objective';
+import {Store} from '../wallet/store';
+import {WalletResponse} from '../wallet/wallet-response';
+
+export class DirectFunder {
+  constructor(
+    private store: Store,
+    private chainService: ChainServiceInterface,
+    private logger: Logger,
+    private timingMetrics = false
+  ) {}
+
+  public static create(
+    store: Store,
+    chainService: ChainServiceInterface,
+    logger: Logger,
+    timingMetrics = false
+  ): DirectFunder {
+    return new DirectFunder(store, chainService, logger, timingMetrics);
+  }
+
+  /**
+   * Runs the ledger funding protocol
+   *
+   * Returns true if the channel is funded, false otherwise
+   */
+  public async crank(
+    objective: DBOpenChannelObjective,
+    channel: Channel,
+    response: WalletResponse,
+    tx: Transaction
+  ): Promise<boolean> {
+    // don't check channel state - that should already have happened
+    // check funding state
+
+    if (channel.protocolState.directFundingStatus === 'Funded') {
+      return true;
+    }
+
+    // request fund channel if my turn
+    await this.requestFundChannelIfMyTurn(channel, tx);
+
+    return false;
+  }
+
+  private async requestFundChannelIfMyTurn(channel: Channel, tx: Transaction): Promise<void> {
+    const app = channel.protocolState;
+    /**
+     * The below logic assumes:
+     *  1. Each destination occurs at most once.
+     *  2. We only care about a single destination.
+     * One reason to drop (2), for instance, is to support ledger top-ups with as few state updates as possible.
+     */
+
+    if (!app.supported) return;
+
+    const existingRequest = app.chainServiceRequests.find(csr => csr.request === 'fund');
+    if (existingRequest?.isValid()) return;
+
+    if (app.directFundingStatus !== 'ReadyToFund') return;
+
+    const myDestination = app.participants[app.myIndex].destination;
+    const {allocationItems, assetHolderAddress} = checkThat(
+      app.supported?.outcome,
+      isSimpleAllocation
+    );
+
+    const currentFunding = app.funding(assetHolderAddress)?.amount;
+    if (!currentFunding) {
+      // this is a developer error, so throw
+      throw new Error(
+        `Funding not loaded from db. Make sure you use .withGraphJoined('funding') when fetching the channel.`
+      );
+    }
+
+    const allocationsBeforeMe = _.takeWhile(allocationItems, a => a.destination !== myDestination);
+    const targetBeforeMyDeposit = allocationsBeforeMe.map(a => a.amount).reduce(BN.add, BN.from(0));
+    if (BN.lt(currentFunding, targetBeforeMyDeposit)) return;
+
+    const myAllocationItem = _.find(allocationItems, ai => ai.destination === myDestination);
+    if (!myAllocationItem) {
+      throw new Error(`My destination ${myDestination} is not in allocations ${allocationItems}`);
+    }
+    if (BN.eq(myAllocationItem.amount, 0)) return;
+    const targetAfterMyDeposit = BN.add(targetBeforeMyDeposit, myAllocationItem.amount);
+    if (BN.gte(currentFunding, targetAfterMyDeposit)) return;
+    const amountToDeposit = BN.sub(targetAfterMyDeposit, currentFunding); // previous line implies this is >0
+
+    // actions
+    await ChainServiceRequest.insertOrUpdate(app.channelId, 'fund', tx);
+    await this.chainService.fundChannel({
+      channelId: app.channelId,
+      assetHolderAddress: assetHolderAddress,
+      expectedHeld: BN.from(currentFunding),
+      amount: BN.from(amountToDeposit),
+    });
+  }
+}

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -70,7 +70,7 @@ export class LedgerFunder {
     // ledger is running
     if (!ledger.isRunning) return false;
 
-    return ledgerFundedThisChannel(ledger, channel);
+    return doesLedgerFundApp(ledger, channel);
   }
 
   private async requestLedgerFunding(
@@ -87,7 +87,7 @@ export class LedgerFunder {
   }
 }
 
-function ledgerFundedThisChannel(ledger: Channel, app: Channel): boolean {
+function doesLedgerFundApp(ledger: Channel, app: Channel): boolean {
   if (!ledger.supported) return false;
   if (!app.supported) return false;
 

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -51,7 +51,7 @@ export class LedgerFunder {
     if (await this.alreadyFunded(channel, ledger, tx)) return true;
 
     // if we already requested funding return false
-    if (await this.alreadyRequestedFunding) return false;
+    if (await this.alreadyRequestedFunding(channel.channelId, tx)) return false;
 
     // otherwise request funding
     await this.requestLedgerFunding(channel.channelId, ledgerId, tx);

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -1,0 +1,102 @@
+import {BN, checkThat, isSimpleAllocation} from '@statechannels/wallet-core';
+import _ from 'lodash';
+import {Transaction} from 'objection';
+import {Logger} from 'pino';
+
+import {ChainServiceInterface} from '../chain-service';
+import {Channel} from '../models/channel';
+import {LedgerRequest} from '../models/ledger-request';
+import {DBOpenChannelObjective} from '../models/objective';
+import {Store} from '../wallet/store';
+import {WalletResponse} from '../wallet/wallet-response';
+
+export class LedgerFunder {
+  constructor(
+    private store: Store,
+    private chainService: ChainServiceInterface,
+    private logger: Logger,
+    private timingMetrics = false
+  ) {}
+
+  public static create(
+    store: Store,
+    chainService: ChainServiceInterface,
+    logger: Logger,
+    timingMetrics = false
+  ): LedgerFunder {
+    return new LedgerFunder(store, chainService, logger, timingMetrics);
+  }
+
+  /**
+   * Runs the ledger funding protocol
+   *
+   * Returns true if the channel is funded, false otherwise
+   */
+  public async crank(
+    objective: DBOpenChannelObjective,
+    channel: Channel,
+    response: WalletResponse,
+    tx: Transaction
+  ): Promise<boolean> {
+    const ledgerId = objective.data.fundingLedgerChannelId;
+    // sanity check
+    if (!ledgerId) {
+      throw new Error(`LedgerFunder called with objective without a fundingLedgerChannelId`);
+    }
+
+    const ledger = await this.store.getChannel(ledgerId, tx);
+    if (!ledger) return false;
+
+    // are we already funded? if so, return true
+    if (await this.alreadyFunded(channel, ledger, tx)) return true;
+
+    // if we already requested funding return false
+    if (await this.alreadyRequestedFunding) return false;
+
+    // otherwise request funding
+    await this.requestLedgerFunding(channel.channelId, ledgerId, tx);
+    return false;
+  }
+
+  private async alreadyFunded(
+    channel: Channel,
+    ledger: Channel,
+    _tx: Transaction
+  ): Promise<boolean> {
+    // for time being ledger must be a direct channel
+    // TODO: in the future check "funding table"
+    if (!ledger.isDirectFunded) return false;
+
+    // ledger is running
+    if (!ledger.isRunning) return false;
+
+    return ledgerFundedThisChannel(ledger, channel);
+  }
+
+  private async requestLedgerFunding(
+    channelId: string,
+    ledgerId: string,
+    tx: Transaction
+  ): Promise<void> {
+    await LedgerRequest.requestLedgerFunding(channelId, ledgerId, tx);
+  }
+
+  private async alreadyRequestedFunding(channelId: string, tx: Transaction): Promise<boolean> {
+    const req = await this.store.getLedgerRequest(channelId, 'fund', tx);
+    return !!req;
+  }
+}
+
+function ledgerFundedThisChannel(ledger: Channel, app: Channel): boolean {
+  if (!ledger.supported) return false;
+  if (!app.supported) return false;
+
+  const {allocationItems: ledgerFunding} = checkThat(ledger.supported.outcome, isSimpleAllocation);
+  const {allocationItems: appFunding} = checkThat(app.supported.outcome, isSimpleAllocation);
+  const targetFunding = appFunding.map(a => a.amount).reduce(BN.add, BN.from(0));
+
+  return _.some(
+    ledgerFunding,
+    ({destination, amount}) => destination === app.channelId && amount === targetFunding
+  );
+}

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -107,6 +107,7 @@ export class ChannelOpener {
     const postfund = {...channel.latest, turnNum: 0};
     const signedState = await this.store.signState(channel, postfund, tx);
     response.queueState(signedState, channel.myIndex, channel.channelId);
+    response.queueChannel(channel);
   }
 
   private async signPostfundSetup(
@@ -118,5 +119,6 @@ export class ChannelOpener {
     const postfund = {...channel.latest, turnNum: channel.nParticipants * 2 - 1};
     const signedState = await this.store.signState(channel, postfund, tx);
     response.queueState(signedState, channel.myIndex, channel.channelId);
+    response.queueChannel(channel);
   }
 }

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -104,8 +104,8 @@ export class ChannelOpener {
     tx: Transaction
   ): Promise<void> {
     // TODO: should probably have more checking around the form of channel.latest
-    const postfund = {...channel.latest, turnNum: 0};
-    const signedState = await this.store.signState(channel, postfund, tx);
+    const prefund = {...channel.latest, turnNum: 0};
+    const signedState = await this.store.signState(channel, prefund, tx);
     response.queueState(signedState, channel.myIndex, channel.channelId);
     response.queueChannel(channel);
   }

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -46,6 +46,7 @@ export class ChannelOpener {
 
       // if we don't have a supported preFundSetup, we're done for now
       if (!channel.prefundSupported) {
+        response.queueChannel(channel); // always queue the channel if we've potentially touched it
         return;
       }
 
@@ -61,9 +62,10 @@ export class ChannelOpener {
       if (channel.postfundSupported) {
         await this.store.markObjectiveAsSucceeded(objective, tx);
 
-        response.queueChannel(channel); // why am I doing this?
         response.queueSucceededObjective(objective);
       }
+
+      response.queueChannel(channel); // always queue the channel if we've potentially touched it
     });
   }
 

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -35,6 +35,8 @@ export class ChannelOpener {
     this.store.transaction(async tx => {
       const channel = await this.store.getLockedChannel(channelToLock, tx);
 
+      if (!channel) throw new Error(`ChannelOpener can't find channel with id ${channelToLock}`);
+
       // if we haven't signed the pre-fund, sign it
       if (!channel.prefundSigned) {
         const signedState = await this.store.signState(channel, channel.latest, tx);

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -1,30 +1,16 @@
 import {Logger} from 'pino';
-import {BN, isSimpleAllocation, checkThat, State, unreachable} from '@statechannels/wallet-core';
+import {unreachable} from '@statechannels/wallet-core';
 import _ from 'lodash';
 import {Transaction} from 'knex';
 
 import {Store} from '../wallet/store';
-import {Bytes32} from '../type-aliases';
 import {DBOpenChannelObjective} from '../models/objective';
 import {WalletResponse} from '../wallet/wallet-response';
-import {recordFunctionMetrics} from '../metrics';
-import {Channel} from '../models/channel';
 import {ChainServiceInterface} from '../chain-service';
-import {LedgerRequest} from '../models/ledger-request';
-import {ChainServiceRequest} from '../models/chain-service-request';
+import {Channel} from '../models/channel';
 
-import {ChannelState, stage, Stage} from './state';
-import {
-  signState,
-  noAction,
-  fundChannel as requestFundChannel,
-  FundChannel,
-  requestLedgerFunding as requestLedgerFundingAction,
-  RequestLedgerFunding,
-  completeObjective,
-  CompleteObjective,
-  SignState,
-} from './actions';
+import {DirectFunder} from './direct-funder';
+import {LedgerFunder} from './ledger-funder';
 
 export class ChannelOpener {
   constructor(
@@ -46,311 +32,67 @@ export class ChannelOpener {
   public async crank(objective: DBOpenChannelObjective, response: WalletResponse): Promise<void> {
     const channelToLock = objective.data.targetChannelId;
 
-    let attemptAnotherProtocolStep = true;
+    this.store.transaction(async tx => {
+      const channel = await this.store.getLockedChannel(channelToLock, tx);
 
-    while (attemptAnotherProtocolStep) {
-      await this.store.lockApp(channelToLock, async tx => {
-        const protocolState = await getOpenChannelProtocolState(
-          this.store,
-          objective.data.targetChannelId,
-          tx
-        );
-        const nextAction = recordFunctionMetrics(protocol(protocolState), this.timingMetrics);
+      // if we haven't signed the pre-fund, sign it
+      if (!channel.prefundSigned) {
+        const signedState = await this.store.signState(channel, channel.latest, tx);
+        response.queueState(signedState, channel.myIndex, channel.channelId);
+      }
 
-        if (nextAction) {
-          try {
-            switch (nextAction.type) {
-              case 'SignState':
-                await this.signState(nextAction, protocolState, tx, response);
-                break;
-              case 'FundChannel':
-                await this.fundChannel(nextAction, tx);
-                break;
-              case 'CompleteObjective':
-                attemptAnotherProtocolStep = false;
-                await this.completeObjective(objective, protocolState, tx, response);
-                break;
-              case 'RequestLedgerFunding':
-                await this.requestLedgerFunding(protocolState, tx);
-                break;
-              default:
-                unreachable(nextAction);
-            }
-          } catch (error) {
-            this.logger.error({error}, 'Error handling action');
-            await tx.rollback(error);
-            attemptAnotherProtocolStep = false;
-          }
-        } else {
-          response.queueChannelState(protocolState.app);
-          attemptAnotherProtocolStep = false;
-        }
-      });
-    }
-  }
+      // if we don't have a supported preFundSetup, we're done for now
+      if (!channel.prefundSupported) {
+        return;
+      }
 
-  private async signState(
-    action: SignState,
-    protocolState: ProtocolState,
-    tx: Transaction,
-    response: WalletResponse
-  ): Promise<void> {
-    const {myIndex, channelId} = protocolState.app;
-    const channel = await Channel.forId(channelId, tx);
-    const signedState = await this.store.signState(channel, action, tx);
-    response.queueState(signedState, myIndex, channelId);
-  }
+      // if we have a full pre fund setup, delegate to the funding process to (a) see if
+      // the channel is funded, and (b) take action if not
+      const funded = await this.crankChannelFunder(objective, channel, response, tx);
 
-  private async fundChannel(action: FundChannel, tx: Transaction): Promise<void> {
-    await ChainServiceRequest.insertOrUpdate(action.channelId, 'fund', tx);
-    await this.chainService.fundChannel({
-      ...action,
-      expectedHeld: BN.from(action.expectedHeld),
-      amount: BN.from(action.amount),
+      // if the channel is funded and I haven't signed the post-fund, sign it
+      if (funded && !channel.postfundSigned) {
+        const signedState = await this.store.signState(channel, channel.latest, tx);
+        response.queueState(signedState, channel.myIndex, channel.channelId);
+      }
+
+      if (channel.postfundSupported) {
+        await this.store.markObjectiveAsSucceeded(objective, tx);
+
+        response.queueChannel(channel); // why am I doing this?
+        response.queueSucceededObjective(objective);
+      }
     });
   }
 
-  private async completeObjective(
+  private async crankChannelFunder(
     objective: DBOpenChannelObjective,
-    protocolState: ProtocolState,
-    tx: Transaction,
-    response: WalletResponse
-  ): Promise<void> {
-    await this.store.markObjectiveAsSucceeded(objective, tx);
-
-    response.queueChannelState(protocolState.app);
-    response.queueSucceededObjective(objective);
-  }
-
-  private async requestLedgerFunding(protocolState: ProtocolState, tx: Transaction): Promise<void> {
-    await LedgerRequest.requestLedgerFunding(
-      protocolState.app.channelId,
-      protocolState.app.fundingLedgerChannelId as string,
-      tx
-    );
-  }
-}
-
-type OpenChannelProtocolResult =
-  | FundChannel
-  | SignState
-  | CompleteObjective
-  | RequestLedgerFunding
-  | undefined;
-
-export const protocol = (ps: ProtocolState): OpenChannelProtocolResult =>
-  signPreFundSetup(ps) ||
-  signPostFundSetup(ps) ||
-  fundChannel(ps) ||
-  completeOpenChannel(ps) ||
-  noAction;
-
-export type AppState = {
-  app: ChannelState;
-};
-
-export type DirectlyFundedAppState = AppState & {
-  type: 'DirectFundingProtocolState';
-};
-
-export type LedgerFundedAppState = AppState & {
-  type: 'LedgerFundingProtocolState';
-  ledgerFundingRequested: boolean;
-  ledger: ChannelState | undefined;
-};
-
-export type ProtocolState = DirectlyFundedAppState | LedgerFundedAppState;
-
-const stageGuard = (guardStage: Stage) => (s: State | undefined): s is State =>
-  !!s && stage(s) === guardStage;
-
-const isPrefundSetup = stageGuard('PrefundSetup');
-
-// These are currently unused, but will be used
-// const isRunning = stageGuard('Running');
-// const isPostfundSetup = stageGuard('PostfundSetup');
-const isRunning = stageGuard('Running');
-// const isMissing = (s: State | undefined): s is undefined => stage(s) === 'Missing';
-
-function ledgerFundedThisChannel(ledger: ChannelState, app: ChannelState): boolean {
-  if (!ledger.supported) return false;
-  if (!app.supported) return false;
-
-  const {allocationItems: ledgerFunding} = checkThat(ledger.supported.outcome, isSimpleAllocation);
-  const {allocationItems: appFunding} = checkThat(app.supported.outcome, isSimpleAllocation);
-  const targetFunding = appFunding.map(a => a.amount).reduce(BN.add, BN.from(0));
-
-  return _.some(
-    ledgerFunding,
-    ({destination, amount}) => destination === app.channelId && amount === targetFunding
-  );
-}
-
-function isFunded(ps: ProtocolState): boolean {
-  const {fundingStrategy, directFundingStatus} = ps.app;
-
-  switch (fundingStrategy) {
-    case 'Fake':
-      return true;
-
-    case 'Direct': {
-      return directFundingStatus === 'Funded';
+    channel: Channel,
+    response: WalletResponse,
+    tx: Transaction
+  ): Promise<boolean> {
+    const strategy = objective.data.fundingStrategy;
+    switch (strategy) {
+      case 'Direct':
+        return this.directFunder.crank(objective, channel, response, tx);
+      case 'Fake':
+        return true;
+      case 'Ledger':
+        return this.ledgerFunder.crank(objective, channel, response, tx);
+      case 'Virtual':
+        return false;
+      case 'Unknown':
+        return false;
+      default:
+        unreachable(strategy);
     }
+  }
 
-    case 'Ledger': {
-      if (ps.type !== 'LedgerFundingProtocolState') return false;
-      if (!ps.ledger) return false;
-      if (!isRunning(ps.ledger.latest)) return false;
-      // TODO: in the future check "funding table"
-      if (!isFunded({type: 'DirectFundingProtocolState', app: ps.ledger})) return false;
-      return ledgerFundedThisChannel(ps.ledger, ps.app);
-    }
+  private get directFunder(): DirectFunder {
+    return DirectFunder.create(this.store, this.chainService, this.logger, this.timingMetrics);
+  }
 
-    default:
-      throw new Error('isFunded: Undeterminable... unimplemented funding strategy');
+  private get ledgerFunder(): LedgerFunder {
+    return LedgerFunder.create(this.store, this.chainService, this.logger, this.timingMetrics);
   }
 }
-
-function myPostfundTurnNumber({app}: ProtocolState): number {
-  return app.participants.length + app.myIndex;
-}
-
-const requestFundChannelIfMyTurn = ({app}: ProtocolState): FundChannel | false => {
-  /**
-   * The below logic assumes:
-   *  1. Each destination occurs at most once.
-   *  2. We only care about a single destination.
-   * One reason to drop (2), for instance, is to support ledger top-ups with as few state updates as possible.
-   */
-
-  if (!app.supported) return false;
-  const existingRequest = app.chainServiceRequests.find(csr => csr.request === 'fund');
-  if (existingRequest?.isValid()) {
-    return false;
-  }
-  if (app.directFundingStatus !== 'ReadyToFund') return false;
-
-  const myDestination = app.participants[app.myIndex].destination;
-  const {allocationItems, assetHolderAddress} = checkThat(
-    app.supported?.outcome,
-    isSimpleAllocation
-  );
-
-  const currentFunding = app.funding(assetHolderAddress)?.amount;
-  if (!currentFunding) {
-    // this is a developer error, so throw
-    throw new Error(
-      `Funding not loaded from db. Make sure you use .withGraphJoined('funding') when fetching the channel.`
-    );
-  }
-
-  const allocationsBeforeMe = _.takeWhile(allocationItems, a => a.destination !== myDestination);
-  const targetBeforeMyDeposit = allocationsBeforeMe.map(a => a.amount).reduce(BN.add, BN.from(0));
-  if (BN.lt(currentFunding, targetBeforeMyDeposit)) return false;
-
-  const myAllocationItem = _.find(allocationItems, ai => ai.destination === myDestination);
-  if (!myAllocationItem) {
-    throw new Error(`My destination ${myDestination} is not in allocations ${allocationItems}`);
-  }
-  if (BN.eq(myAllocationItem.amount, 0)) return false;
-  const targetAfterMyDeposit = BN.add(targetBeforeMyDeposit, myAllocationItem.amount);
-  if (BN.gte(currentFunding, targetAfterMyDeposit)) return false;
-  const amountToDeposit = BN.sub(targetAfterMyDeposit, currentFunding); // previous line implies this is >0
-
-  return requestFundChannel({
-    channelId: app.channelId,
-    assetHolderAddress: assetHolderAddress,
-    expectedHeld: currentFunding,
-    amount: amountToDeposit,
-  });
-};
-
-const requestLedgerFunding = ({app}: ProtocolState): RequestLedgerFunding | false => {
-  if (!app.supported) return false;
-  const {assetHolderAddress} = checkThat(app.supported.outcome, isSimpleAllocation);
-  return requestLedgerFundingAction({
-    channelId: app.channelId,
-    assetHolderAddress,
-  });
-};
-
-const isFakeFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Fake';
-const isDirectlyFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Direct';
-const isLedgerFunded = ({fundingStrategy}: ChannelState): boolean => fundingStrategy === 'Ledger';
-
-const fundDirectly = (ps: ProtocolState): FundChannel | false => {
-  return (
-    ps.type === 'DirectFundingProtocolState' &&
-    isDirectlyFunded(ps.app) &&
-    requestFundChannelIfMyTurn(ps)
-  );
-};
-
-const fundViaLedger = (ps: ProtocolState): RequestLedgerFunding | false => {
-  return (
-    ps.type === 'LedgerFundingProtocolState' &&
-    isLedgerFunded(ps.app) &&
-    !ps.ledgerFundingRequested &&
-    requestLedgerFunding(ps)
-  );
-};
-
-const fundChannel = (ps: ProtocolState): OpenChannelProtocolResult | false =>
-  isPrefundSetup(ps.app.supported) &&
-  isPrefundSetup(ps.app.latestSignedByMe) &&
-  (fundDirectly(ps) || fundViaLedger(ps));
-
-const signPreFundSetup = (ps: ProtocolState): SignState | false =>
-  !ps.app.latestSignedByMe &&
-  !!ps.app.latest &&
-  ps.app.latest.turnNum < ps.app.participants.length &&
-  signState({
-    ...ps.app.latest,
-    channelId: ps.app.channelId,
-    turnNum: ps.app.myIndex,
-  });
-
-const signPostFundSetup = (ps: ProtocolState): SignState | undefined | false =>
-  ps.app.supported &&
-  ps.app.latestSignedByMe &&
-  ps.app.latestSignedByMe.turnNum < ps.app.participants.length &&
-  (isFunded(ps) || isFakeFunded(ps.app)) &&
-  signState({
-    ...ps.app.latestSignedByMe,
-    channelId: ps.app.channelId,
-    turnNum: myPostfundTurnNumber(ps),
-  });
-
-const completeOpenChannel = (ps: ProtocolState): CompleteObjective | false =>
-  (ps.app.supported?.turnNum === ps.app.participants.length * 2 - 1 ||
-    isRunning(ps.app.supported)) &&
-  completeObjective({channelId: ps.app.channelId});
-
-/**
- * Helper method to retrieve scoped data needed for OpenChannel protocol.
- */
-export const getOpenChannelProtocolState = async (
-  store: Store,
-  channelId: Bytes32,
-  tx: Transaction
-): Promise<ProtocolState> => {
-  const app = await store.getChannelState(channelId, tx);
-  switch (app.fundingStrategy) {
-    case 'Direct':
-    case 'Fake':
-      return {type: 'DirectFundingProtocolState', app};
-    case 'Ledger': {
-      const req = await store.getLedgerRequest(app.channelId, 'fund', tx);
-      return {
-        type: 'LedgerFundingProtocolState',
-        app,
-        ledgerFundingRequested: !!req,
-        ledger: req ? await store.getChannelState(req.ledgerChannelId, tx) : undefined,
-      };
-    }
-    case 'Unknown':
-    case 'Virtual':
-    default:
-      throw new Error('getOpenChannelProtocolState: Unimplemented funding strategy');
-  }
-};

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -79,12 +79,23 @@ export class TestChannel {
    * be the turnNum
    */
   public state(n: number, bals?: [number, number]): State {
+    if (n < 2) {
+      // in prefund setup, everyone signs state 0
+      n = 0;
+    } else if (n < 4) {
+      // postfund setup, everyone signs state 3
+      n = 3;
+    } else if (this.finalFrom && n > this.finalFrom) {
+      // when finalizing, everyone signs the final state
+      n = this.finalFrom;
+    }
+
     return {
       ...this.channelConstants,
       appData: '0x',
       isFinal: !!this.finalFrom && n >= this.finalFrom,
       // test channels adopt a countersigning strategy for final states, so the turn number doesn't progress after finalFrom.
-      turnNum: Math.min(n, this.finalFrom || n),
+      turnNum: n,
       outcome: bals ? this.toOutcome(bals) : this.startOutcome,
     };
   }

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -301,12 +301,12 @@ describe('when the application protocol returns an action', () => {
     });
     await expectResults(p, [{channelId, status: 'opening'}]);
     await expect(p).resolves.toMatchObject({
-      outbox: [{method: 'MessageQueued', params: {data: {signedStates: [{turnNum: 2}]}}}],
+      outbox: [{method: 'MessageQueued', params: {data: {signedStates: [{turnNum: 3}]}}}],
     });
 
     const updatedC = await Channel.forId(channelId, wallet.knex);
     expect(updatedC.protocolState).toMatchObject({
-      latestSignedByMe: {turnNum: 2},
+      latestSignedByMe: {turnNum: 3},
       supported: {turnNum: 0},
     });
   });

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -269,6 +269,13 @@ export class Store {
       .first();
   }
 
+  async getLockedChannel(channelId: Bytes32, tx: Transaction): Promise<Channel> {
+    return Channel.query(tx)
+      .where({channelId})
+      .forUpdate()
+      .first();
+  }
+
   async getStates(
     channelId: Bytes32,
     tx?: Transaction

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -50,6 +50,7 @@ import {defaultTestConfig} from '../config';
 import {createLogger} from '../logger';
 import {DBAdmin} from '../db-admin/db-admin';
 import {LedgerProposal} from '../models/ledger-proposal';
+import {ChainServiceRequest} from '../models/chain-service-request';
 
 const defaultLogger = createLogger(defaultTestConfig());
 
@@ -696,6 +697,26 @@ export class Store {
 
   async nextNonce(signingAddresses: Address[]): Promise<number> {
     return await Nonce.next(this.knex, signingAddresses);
+  }
+
+  async fundingRequestExists(channelId: string, tx: Transaction): Promise<boolean> {
+    const request = await ChainServiceRequest.query(tx)
+      .where({channelId, request: 'fund'})
+      .first();
+
+    return !!request && request.isValid();
+  }
+
+  async getFunding(
+    channelId: string,
+    assetHolder: Address,
+    tx: Transaction
+  ): Promise<Funding | undefined> {
+    const funding = Funding.query(tx)
+      .where({channelId, assetHolder})
+      .first();
+
+    return funding;
   }
 
   dbAdmin(): DBAdmin {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -269,7 +269,7 @@ export class Store {
       .first();
   }
 
-  async getLockedChannel(channelId: Bytes32, tx: Transaction): Promise<Channel> {
+  async getLockedChannel(channelId: Bytes32, tx: Transaction): Promise<Channel | undefined> {
     return Channel.query(tx)
       .where({channelId})
       .forUpdate()


### PR DESCRIPTION
This PR refactors the `OpenChannelProtocol`:

* The protocol is now implemented as a `ChannelOpener` object, which has a `crank` method
* That `crank` is an asynchronous method that runs a sequence of fetch/update operations, inside a transaction that it starts.
* It calls out to a funding utility class (`DirectFunder` or `LedgerFunder`) depending on the funding type
* These utility classes also have async `crank` methods, which behave similarly to the `ChannelOpener`, apart from accepting a transaction, instead of starting their own

In my eyes, these changes make the protocols clearer and the code easier to understand. As I'm probably not going to be doing a lot of work in the wallet anymore though, it more matters what other people think. We don't have to go down this route if the people who are going to do the majority of the work in future don't like it.

If we do want to go down this route, we'll need to perform a similar refactor on the close channel protocol.