### PR TITLE
Chain service bug fix and test cleanups

### DIFF
--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -243,7 +243,7 @@ describe('registerChannel', () => {
     let resolve: (value: unknown) => void;
     const p = new Promise(r => (resolve = r));
 
-    const holdingUpdated = (arg: HoldingUpdatedArg): void => {
+    const holdingUpdated = async (arg: HoldingUpdatedArg): Promise<void> => {
       switch (counter) {
         case 0:
           expect(arg).toMatchObject({
@@ -252,7 +252,10 @@ describe('registerChannel', () => {
             amount: BN.from(0),
           });
           counter++;
-          fundChannel(0, 5, wrongChannelId);
+          // wait for the transaction to be mined.
+          // Otherwise, it is possibleble for the correct channel funding transaction to be mined first.
+          // In which case, this test might pass even if the holdingUpdated callback is fired for the wrongChannelId.
+          await (await fundChannel(0, 5, wrongChannelId).request).wait();
           fundChannelAndMineBlocks(0, 5, channelId);
           break;
         case 1:

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -47,7 +47,7 @@ async function mineBlock(timestamp?: number) {
   await provider.send('evm_mine', param);
 }
 async function mineBlocks() {
-  for (const _i in _.range(5)) {
+  for (const _i of _.range(5)) {
     await mineBlock();
   }
 }

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -211,17 +211,13 @@ describe('fundChannel', () => {
 describe('registerChannel', () => {
   it('registers a channel in the finalizing channel list and fires an event when that channel is finalized', async () => {
     const channelId = randomChannelId();
-    // We use large values so we don't have to worry about ganache
-    // mining a block with the current timestamp setting off the expiry
-    const CURRENT_TIME = 2_000_000_000;
-    const CHALLENGE_EXPIRE_TIME = 2_000_400_000;
-    const FUTURE_TIME = 2_000_800_000;
+    const currentTime = (await provider.getBlock(provider.getBlockNumber())).timestamp;
 
     const tx = await testAdjudicator.setChannelStorageHash(
       channelId,
       channelDataToChannelStorageHash({
         turnNumRecord: 0,
-        finalizesAt: CHALLENGE_EXPIRE_TIME,
+        finalizesAt: currentTime + 2,
       })
     );
     await tx.wait();
@@ -238,9 +234,8 @@ describe('registerChannel', () => {
       })
     );
 
-    await mineBlock(CURRENT_TIME);
-
-    await mineBlock(FUTURE_TIME);
+    await mineBlock(currentTime + 1);
+    await mineBlock(currentTime + 2);
     await channelFinalizedPromise;
     expect(channelFinalizedHandler).toHaveBeenCalledWith({channelId});
   });

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -493,12 +493,11 @@ describe('challenge', () => {
     const currentTime = (await provider.getBlock(provider.getBlockNumber())).timestamp;
     // The longest challenge duration is 3 seconds.
     // Lets mine a few blocks up to challenge expiration
-    const blockDeltas = _.range(0, 3.5, 0.5).map(Math.floor);
+    const blockDeltas = [0, 1, 2, 3];
     for (const blockDelta of blockDeltas) {
       await mineBlock(currentTime + blockDelta);
     }
 
-    //await mineBlockPeriodically(20);
     await Promise.all(channelsFinalized);
     await Promise.all(
       state1s.map(

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -253,7 +253,7 @@ describe('registerChannel', () => {
           });
           counter++;
           // wait for the transaction to be mined.
-          // Otherwise, it is possibleble for the correct channel funding transaction to be mined first.
+          // Otherwise, it is possible for the correct channel funding transaction to be mined first.
           // In which case, this test might pass even if the holdingUpdated callback is fired for the wrongChannelId.
           await (await fundChannel(0, 5, wrongChannelId).request).wait();
           fundChannelAndMineBlocks(0, 5, channelId);


### PR DESCRIPTION
Chain service tests [recently started logging lines like the following after completion](https://app.circleci.com/pipelines/github/statechannels/statechannels/11097/workflows/e99a2892-2bb2-48a1-8bab-b33f7bf821c7/jobs/54160):
```
@statechannels/server-wallet: (node:3543) UnhandledPromiseRejectionWarning: Error: missing response (requestBody="{\"method\":\"eth_call\",\"params\":[{\"from\":\"0xd9995bae12fee327256ffec1e3184d492bd94c31\",\"to\":\"0xc9707e1e496c12f1fa83afbba8735da697cdbf64\",\"data\":\"0xfe9e5db9008070d7208570cdbc4d1657dbe98a29d15365084fb3ded89f5b4b4236e02e69\"},\"latest\"],\"id\":3639,\"jsonrpc\":\"2.0\"}", requestMethod="POST", serverError={"code":"ECONNRESET"}, url="http://0.0.0.0:8545", code=SERVER_ERROR, version=web/5.0.7)
```

While seemingly harmless, the log lines were a symptom of a serious bug where a finalized channel was never properly removed from the finalizing channels list. This PR:
- fixes the bug.
- Removes a redundant chain service test case.
- Each test only mines enough blocks for the test to pass. This approach helps write tests that do not affect tests that follow.
- A few minor cleanups.