### PR TITLE
build: docs on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,32 @@ jobs:
             cp /home/circleci/project/packages/server-wallet/metrics.log  /home/circleci/project/artifacts
       - upload_artifacts
 
+  deploy-docs-website:
+    <<: *defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci/project
+      - run: 
+          name: build docs-website
+          command: yarn lerna run --scope docs-website build
+      - when:
+          condition:
+            equal: [ master, << pipeline.git.branch >> ]
+          steps:
+            - run: 
+                name: deploy docs-website (production)
+                command: |
+                  npx -p netlify-cli -c 'netlify deploy --site $NITRO_PROTOCOL_NETLIFY_ID --dir=/home/circleci/project/packages/docs-website/build --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) --prod' 
+      - when:
+          condition:
+            -not: 
+              equal: [ master, << pipeline.git.branch >> ]
+          steps:
+            - run: 
+                name: deploy docs-website (preview)
+                command: |
+                  npx -p netlify-cli -c 'netlify deploy --site $NITRO_PROTOCOL_NETLIFY_ID --dir=/home/circleci/project/packages/docs-website/build --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD)' 
 workflows:
   statechannels:
     jobs:
@@ -282,5 +308,8 @@ workflows:
             - prepare
 
       - server-wallet-e2e-test:
+          requires:
+            - prepare
+      - deploy-docs-website:
           requires:
             - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,17 +268,16 @@ jobs:
       - checkout
       - attach_workspace:
           at: /home/circleci/project
-      - run:
-          name: build docs-website
-          command: yarn lerna run --scope docs-website --since $(git merge-base $CIRCLE_BRANCH origin/master) build
       - when:
           condition:
             equal: [master, << pipeline.git.branch >>]
           steps:
             - run:
+                name: build docs-website
+                command: yarn lerna run --scope docs-website build
+            - run:
                 name: deploy docs-website (production)
                 command: >
-                  test -d "/home/circleci/project/packages/docs-website/build" && \
                   npx -p netlify-cli \
                   -c 'netlify deploy \
                   --site $NITRO_PROTOCOL_NETLIFY_ID \
@@ -291,6 +290,9 @@ jobs:
             -not:
               equal: [master, << pipeline.git.branch >>]
           steps:
+            - run:
+                name: build docs-website
+                command: yarn lerna run --scope docs-website --since $(git merge-base $CIRCLE_BRANCH origin/master) build
             - run:
                 name: deploy docs-website (preview)
                 command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,11 +278,11 @@ jobs:
             - run:
                 name: deploy docs-website (production)
                 command: >
-                  npx -p netlify-cli \
-                  -c 'netlify deploy \
-                  --site $NITRO_PROTOCOL_NETLIFY_ID \
-                  --dir=/home/circleci/project/packages/docs-website/build \
-                  --auth $NETLIFY_ACCESS_TOKEN \
+                  npx -p netlify-cli
+                  -c 'netlify deploy
+                  --site $NITRO_PROTOCOL_NETLIFY_ID
+                  --dir=/home/circleci/project/packages/docs-website/build
+                  --auth $NETLIFY_ACCESS_TOKEN
                   --message $(git rev-parse --short HEAD)'
                   --prod
       - when:
@@ -296,12 +296,12 @@ jobs:
             - run:
                 name: deploy docs-website (preview)
                 command: >
-                  test -d "/home/circleci/project/packages/docs-website/build" && \
-                  npx -p netlify-cli \
-                  -c 'netlify deploy \
-                  --site $NITRO_PROTOCOL_NETLIFY_ID \
-                  --dir=/home/circleci/project/packages/docs-website/build \
-                  --auth $NETLIFY_ACCESS_TOKEN \
+                  test -d "/home/circleci/project/packages/docs-website/build" && 
+                  npx -p netlify-cli 
+                  -c 'netlify deploy 
+                  --site $NITRO_PROTOCOL_NETLIFY_ID 
+                  --dir=/home/circleci/project/packages/docs-website/build 
+                  --auth $NETLIFY_ACCESS_TOKEN 
                   --message $(git rev-parse --short HEAD)'
 workflows:
   statechannels:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,26 +268,39 @@ jobs:
       - checkout
       - attach_workspace:
           at: /home/circleci/project
-      - run: 
+      - run:
           name: build docs-website
-          command: yarn lerna run --scope docs-website build
+          command: yarn lerna run --scope docs-website --since $(git merge-base $CIRCLE_BRANCH origin/master) build
       - when:
           condition:
-            equal: [ master, << pipeline.git.branch >> ]
+            equal: [master, << pipeline.git.branch >>]
           steps:
-            - run: 
+            - run:
                 name: deploy docs-website (production)
-                command: |
-                  npx -p netlify-cli -c 'netlify deploy --site $NITRO_PROTOCOL_NETLIFY_ID --dir=/home/circleci/project/packages/docs-website/build --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) --prod' 
+                command: >
+                  test -d "/home/circleci/project/packages/docs-website/build" && \
+                  npx -p netlify-cli \
+                  -c 'netlify deploy \
+                  --site $NITRO_PROTOCOL_NETLIFY_ID \
+                  --dir=/home/circleci/project/packages/docs-website/build \
+                  --auth $NETLIFY_ACCESS_TOKEN \
+                  --message $(git rev-parse --short HEAD)'
+                  --prod
       - when:
           condition:
-            -not: 
-              equal: [ master, << pipeline.git.branch >> ]
+            -not:
+              equal: [master, << pipeline.git.branch >>]
           steps:
-            - run: 
+            - run:
                 name: deploy docs-website (preview)
-                command: |
-                  npx -p netlify-cli -c 'netlify deploy --site $NITRO_PROTOCOL_NETLIFY_ID --dir=/home/circleci/project/packages/docs-website/build --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD)' 
+                command: >
+                  test -d "/home/circleci/project/packages/docs-website/build" && \
+                  npx -p netlify-cli \
+                  -c 'netlify deploy \
+                  --site $NITRO_PROTOCOL_NETLIFY_ID \
+                  --dir=/home/circleci/project/packages/docs-website/build \
+                  --auth $NETLIFY_ACCESS_TOKEN \
+                  --message $(git rev-parse --short HEAD)'
 workflows:
   statechannels:
     jobs:

--- a/packages/docs-website/package.json
+++ b/packages/docs-website/package.json
@@ -34,14 +34,7 @@
   "scripts": {
     "api-documenter": "node scripts/api-documenter.js",
     "build": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus build",
-    "deploy": "docusaurus deploy",
-    "docusaurus": "docusaurus",
-    "examples": "docusaurus-examples",
-    "publish-gh-pages": "docusaurus-publish",
-    "rename-version": "docusaurus-rename-version",
     "start": "yarn trigger-api-generation && yarn api-documenter && docusaurus start",
-    "swizzle": "docusaurus swizzle",
-    "trigger-api-generation": "yarn lerna run generate-api",
-    "write-translations": "docusaurus-write-translations"
+    "trigger-api-generation": "yarn lerna run generate-api"
   }
 }


### PR DESCRIPTION
- No need to add to our dev dependencies, because here we install netlify-cli using `npx`. 
- It's 3 minutes extra (concurrently) on circle, rather than 10 minutes on netlify (which I will disable when this PR is merged). 
- ~For now this will build on *every* circle run~ should skip on non-master branches if `docs-website` has not changed.

Closes #3096 