### PR TITLE
build: throw error on broken links

### DIFF
--- a/packages/docs-website/docusaurus.config.js
+++ b/packages/docs-website/docusaurus.config.js
@@ -27,7 +27,7 @@ module.exports = {
     repoUrl: 'https://github.com/statechannels/statechannels',
     packageUrl: 'https://www.npmjs.com/package/@statechannels/nitro-protocol'
   },
-  onBrokenLinks: 'log',
+  onBrokenLinks: 'throw',
   presets: [
     [
       '@docusaurus/preset-classic',


### PR DESCRIPTION
This will prevent us from merging a change that results in a broken link on the docs website. 