### PR TITLE
refactor: make fundingStatus optional in the ChannelResult

### DIFF
--- a/packages/client-api-schema/src/data-types.ts
+++ b/packages/client-api-schema/src/data-types.ts
@@ -141,7 +141,7 @@ export interface ChannelResult {
   status: ChannelStatus;
   turnNum: Uint48;
   challengeExpirationTime?: number;
-  fundingStatus: FundingStatus;
+  fundingStatus?: FundingStatus;
 }
 
 /**

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -187,8 +187,7 @@
         "appDefinition",
         "channelId",
         "status",
-        "turnNum",
-        "fundingStatus"
+        "turnNum"
       ],
       "type": "object"
     },
@@ -387,7 +386,7 @@
       "$ref": "#/definitions/JsonRpcRequest%3C%22GetChannels%22%2Cstructure-1978982097-247-273-1978982097-217-274-1978982097-184-275-1978982097-0-344%3E"
     },
     "GetChannelsResponse": {
-      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src_data-types.ts-3375-3701-src_data-types.ts-0-4120%5B%5D%3E"
+      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src_data-types.ts-3375-3702-src_data-types.ts-0-4121%5B%5D%3E"
     },
     "GetStateError": {
       "$ref": "#/definitions/JsonRpcError%3C1200%2C%22Could%20not%20find%20channel%22%3E"
@@ -1679,7 +1678,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcResponse<def-interface-src_data-types.ts-3375-3701-src_data-types.ts-0-4120[]>": {
+    "JsonRpcResponse<def-interface-src_data-types.ts-3375-3702-src_data-types.ts-0-4121[]>": {
       "additionalProperties": false,
       "description": "Specifies response headers as per {@link https://www.jsonrpc.org/specification | JSON-RPC 2.0 Specification }",
       "properties": {

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -153,7 +153,6 @@ it('Create a directly funded channel between two wallets ', async () => {
   expect(getChannelResultFor(channelId, preFundA.channelResults)).toMatchObject({
     status: 'opening',
     turnNum: 0,
-    fundingStatus: 'Uncategorized',
   });
 
   const resultB0 = await b.pushMessage(getPayloadFor(participantB.participantId, preFundA.outbox));
@@ -161,14 +160,12 @@ it('Create a directly funded channel between two wallets ', async () => {
   expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
     status: 'proposed',
     turnNum: 0,
-    fundingStatus: 'Uncategorized',
   });
 
   const prefundB = await b.joinChannel({channelId});
   expect(getChannelResultFor(channelId, [prefundB.channelResult])).toMatchObject({
     status: 'opening',
     turnNum: 1,
-    fundingStatus: 'Uncategorized',
   });
 
   const resultA0 = await a.pushMessage(getPayloadFor(participantA.participantId, prefundB.outbox));

--- a/packages/server-wallet/src/__test__/test-helpers.ts
+++ b/packages/server-wallet/src/__test__/test-helpers.ts
@@ -44,12 +44,10 @@ export async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
 export async function interParticipantChannelResultsAreEqual(a: Wallet, b: Wallet): Promise<void> {
   const {channelResults: aChannelResults} = await a.getChannels();
   const {channelResults: bChannelResults, outbox: bOutbox} = await b.getChannels();
-  // The same channel state can map to a different ChannelResult fundingStatus for different participants
-  const bChannelResultsNoFunding = bChannelResults.map(cr => ({
-    ...cr,
-    fundingStatus: expect.anything(),
-  }));
-  expect(aChannelResults).toEqual(bChannelResultsNoFunding);
+
+  const nullifyFunding = (cr: ChannelResult) => ({...cr, fundingStatus: null});
+
+  expect(aChannelResults.map(nullifyFunding)).toEqual(bChannelResults.map(nullifyFunding));
   expect(bOutbox).toEqual([]);
 }
 

--- a/packages/server-wallet/src/protocols/open-channel.ts
+++ b/packages/server-wallet/src/protocols/open-channel.ts
@@ -236,7 +236,14 @@ const requestFundChannelIfMyTurn = ({app}: ProtocolState): FundChannel | false =
     isSimpleAllocation
   );
 
-  const currentFunding = app.funding(assetHolderAddress).amount;
+  const currentFunding = app.funding(assetHolderAddress)?.amount;
+  if (!currentFunding) {
+    // this is a developer error, so throw
+    throw new Error(
+      `Funding not loaded from db. Make sure you use .withGraphJoined('funding') when fetching the channel.`
+    );
+  }
+
   const allocationsBeforeMe = _.takeWhile(allocationItems, a => a.destination !== myDestination);
   const targetBeforeMyDeposit = allocationsBeforeMe.map(a => a.amount).reduce(BN.add, BN.from(0));
   if (BN.lt(currentFunding, targetBeforeMyDeposit)) return false;

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -40,11 +40,11 @@ export type ChannelState = {
   supported?: SignedStateWithHash;
   latest: SignedStateWithHash;
   latestSignedByMe?: SignedStateWithHash;
-  funding: (address: Address) => ChannelStateFunding;
+  funding: (address: Address) => ChannelStateFunding | undefined;
   chainServiceRequests: ChainServiceRequest[];
   fundingStrategy: FundingStrategy;
   fundingLedgerChannelId?: Bytes32; // only present if funding strategy is Ledger
-  directFundingStatus: FundingStatus;
+  directFundingStatus?: FundingStatus;
 };
 
 type WithSupported = {supported: SignedStateWithHash};
@@ -118,10 +118,10 @@ on ReadyToFund status as the sole criteria for determening if a channel is ready
 */
 export function directFundingStatus(
   supported: SignedStateVarsWithHash | undefined,
-  fundingFn: (address: Address) => ChannelStateFunding,
+  fundingFn: (address: Address) => ChannelStateFunding | undefined,
   myParticipant: Participant,
   fundingStrategy: FundingStrategy
-): FundingStatus {
+): FundingStatus | undefined {
   if (fundingStrategy !== 'Direct') {
     return 'Uncategorized';
   }
@@ -141,6 +141,7 @@ export function directFundingStatus(
     .reduce(BN.add, BN.from(0));
 
   const funding = fundingFn(assetHolderAddress);
+  if (!funding) return undefined;
 
   const amountTransferredToMe = funding.transferredOut
     .filter(tf => tf.toAddress === myDestination)


### PR DESCRIPTION
Currently the fundingStatus value is sometimes inaccurate. For example, it's possible to get 'Uncategorized' or 'ReadyToFund' when the channel is funded, but the funding hasn't been fetched from the db.

Fixing this would require always querying the db for funding, which might not be desirable for performance reasons. Instead, consumers will now receive `fundingStatus: undefined` if it hasn't be fetched.