### PR TITLE
[nitro-protocol] remove transferAll from AssetHolder 

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -41,19 +41,6 @@ contract AssetHolder is IAssetHolder {
     }
 
     /**
-     * @notice Transfers the funds escrowed against `channelId` to the beneficiaries of that channel. Checks against the storage in this contract.
-     * @dev Transfers the funds escrowed against `channelId` and transfers them to the beneficiaries of that channel. Checks against the storage in this contract.
-     * @param channelId Unique identifier for a state channel.
-     * @param allocationBytes The abi.encode of AssetOutcome.Allocation
-     */
-    function transferAll(bytes32 channelId, bytes calldata allocationBytes) external {
-        // checks
-        _requireCorrectAllocationHash(channelId, allocationBytes);
-        // effects and interactions
-        _transfer(channelId, allocationBytes, new uint256[](0));
-    }
-
-    /**
      * @notice Transfers as many funds escrowed against `guarantorChannelId` as can be afforded for a specific destination in the beneficiaries of the __target__ of that channel. Checks against the storage in this contract.
      * @dev Transfers as many funds escrowed against `guarantorChannelId` as can be afforded for a specific destination in the beneficiaries of the __target__ of that channel. Checks against the storage in this contract.
      * @param guarantorChannelId Unique identifier for a guarantor state channel.

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -592,7 +592,7 @@ contract AssetHolder is IAssetHolder {
     }
 
     function _requireIncreasingIndices(uint256[] memory indices) internal pure {
-        for (uint256 i = 0; i < indices.length - 1; i++) {
+        for (uint256 i = 0; i + 1 < indices.length; i++) {
             require(indices[i] < indices[i + 1], 'Indices must be sorted');
         }
     }

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -13,6 +13,7 @@ import {
   writeGasConsumption,
 } from '../../test-helpers';
 import {encodeAllocation} from '../../../src/contract/outcome';
+import {defaultAbiCoder} from 'ethers/lib/utils';
 
 const provider = getTestProvider();
 
@@ -39,7 +40,7 @@ beforeAll(async () => {
 const reason0 = 'h(allocation)!=assetOutcomeHash';
 
 // c is the channel we are transferring from.
-describe('transferAll', () => {
+describe('transferAll (using transfer and empty indices array)', () => {
   it.each`
     name                              | heldBefore | setOutcome      | newOutcome      | heldAfter             | payouts         | reason
     ${' 0. outcome not set         '} | ${{c: 1}}  | ${{}}           | ${{}}           | ${{}}                 | ${{A: 1}}       | ${reason0}
@@ -91,7 +92,8 @@ describe('transferAll', () => {
       ).wait();
       expect(await AssetHolder.assetOutcomeHashes(channelId)).toBe(assetOutcomeHash);
 
-      const tx = AssetHolder.transferAll(channelId, encodeAllocation(allocation));
+      const emptyArray = [];
+      const tx = AssetHolder.transfer(channelId, encodeAllocation(allocation), emptyArray);
 
       // Call method in a slightly different way if expecting a revert
       if (reason) {


### PR DESCRIPTION
Closes #3047 .
On the way uncovered a pretty serious underflow bug 🐛 .