### PR TITLE
build: do not use --scope with lerna when deciding whether to build the docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
           steps:
             - run:
                 name: build docs-website
-                command: yarn lerna run --scope docs-website build
+                command: yarn lerna run build-docs-website --stream
             - run:
                 name: deploy docs-website (production)
                 command: >
@@ -292,7 +292,7 @@ jobs:
           steps:
             - run:
                 name: build docs-website
-                command: yarn lerna run --scope docs-website --since $(git merge-base $CIRCLE_BRANCH origin/master) build
+                command: yarn lerna run --since $(git merge-base $CIRCLE_BRANCH origin/master) build-docs-website --stream
             - run:
                 name: deploy docs-website (preview)
                 command: >

--- a/packages/docs-website/package.json
+++ b/packages/docs-website/package.json
@@ -33,7 +33,7 @@
   "private": true,
   "scripts": {
     "api-documenter": "node scripts/api-documenter.js",
-    "build": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus build",
+    "build-docs-website": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus build",
     "start": "yarn trigger-api-generation && yarn api-documenter && docusaurus start",
     "trigger-api-generation": "yarn lerna run generate-api"
   }


### PR DESCRIPTION
It doesn't work quite the way I intended -- builds are not being triggered correctly at present.