### PR TITLE
perf: remove claimAll from AssetHolder interface

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -26,7 +26,7 @@ contract AssetHolder is IAssetHolder {
      * @dev Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries.
      * @param fromChannelId Unique identifier for state channel to transfer funds *from*.
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
-     * @param indices Array with each entry denoting the index of a destination to transfer funds to.
+     * @param indices Array with each entry denoting the index of a destination to transfer funds to. An empty array indicates "all".
      */
     function transfer(
         bytes32 fromChannelId,
@@ -46,7 +46,7 @@ contract AssetHolder is IAssetHolder {
      * @param guarantorChannelId Unique identifier for a guarantor state channel.
      * @param guaranteeBytes The abi.encode of Outcome.Guarantee
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation for the __target__
-     * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order.
+     * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all".
      */
     function claim(
         bytes32 guarantorChannelId,
@@ -222,7 +222,7 @@ contract AssetHolder is IAssetHolder {
      * @dev Transfers as many funds escrowed against `channelId` as can be afforded for a specific destination. Assumes no repeated entries. Does not check allocationBytes against on chain storage.
      * @param fromChannelId Unique identifier for state channel to transfer funds *from*.
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation
-     * @param indices Array with each entry denoting the index of a destination to transfer funds to. Should be in increasing order.
+     * @param indices Array with each entry denoting the index of a destination to transfer funds to. Should be in increasing order. An empty array indicates "all".
      */
     function _transfer(
         bytes32 fromChannelId,
@@ -285,7 +285,7 @@ contract AssetHolder is IAssetHolder {
      * @param guarantorChannelId Unique identifier for a guarantor state channel.
      * @param guarantee The guarantee
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation for the __target__
-     * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to.
+     * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. An empty array indicates "all".
      */
     function _claim(
         bytes32 guarantorChannelId,

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -53,7 +53,7 @@ contract AssetHolder is IAssetHolder {
         bytes calldata guaranteeBytes,
         bytes calldata allocationBytes,
         uint256[] memory indices
-    ) external {
+    ) external override {
         // checks
         _requireIncreasingIndices(indices);
         _requireCorrectGuaranteeHash(guarantorChannelId, guaranteeBytes);

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -63,26 +63,6 @@ contract AssetHolder is IAssetHolder {
         _claim(guarantorChannelId, guarantee, allocationBytes, indices);
     }
 
-    /**
-     * @notice Transfers the funds escrowed against `guarantorChannelId` to the beneficiaries of the __target__ of that channel. Checks against the storage in this contract.
-     * @dev Transfers the funds escrowed against `guarantorChannelId` to the beneficiaries of the __target__ of that channel. Checks against the storage in this contract.
-     * @param guarantorChannelId Unique identifier for a guarantor state channel.
-     * @param guaranteeBytes The abi.encode of Outcome.Guarantee
-     * @param allocationBytes The abi.encode of AssetOutcome.Allocation for the __target__
-     */
-    function claimAll(
-        bytes32 guarantorChannelId,
-        bytes calldata guaranteeBytes,
-        bytes calldata allocationBytes
-    ) external override {
-        // checks
-        _requireCorrectGuaranteeHash(guarantorChannelId, guaranteeBytes);
-        Outcome.Guarantee memory guarantee = abi.decode(guaranteeBytes, (Outcome.Guarantee));
-        _requireCorrectAllocationHash(guarantee.targetChannelId, allocationBytes);
-        // effects and interactions
-        _claim(guarantorChannelId, guarantee, allocationBytes, new uint256[](0));
-    }
-
     // **************
     // Permissioned methods
     // **************

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -20,16 +20,18 @@ interface IAssetHolder {
     ) external;
 
     /**
-     * @notice Transfers the funds escrowed against `guarantorChannelId` to the beneficiaries of the __target__ of that channel.
-     * @dev Transfers the funds escrowed against `guarantorChannelId` to the beneficiaries of the __target__ of that channel.
+     * @notice Transfers as many funds escrowed against `guarantorChannelId` as can be afforded for a specific destination in the beneficiaries of the __target__ of that channel. Checks against the storage in this contract.
+     * @dev Transfers as many funds escrowed against `guarantorChannelId` as can be afforded for a specific destination in the beneficiaries of the __target__ of that channel. Checks against the storage in this contract.
      * @param guarantorChannelId Unique identifier for a guarantor state channel.
      * @param guaranteeBytes The abi.encode of Outcome.Guarantee
      * @param allocationBytes The abi.encode of AssetOutcome.Allocation for the __target__
+     * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all".
      */
-    function claimAll(
+    function claim(
         bytes32 guarantorChannelId,
         bytes calldata guaranteeBytes,
-        bytes calldata allocationBytes
+        bytes calldata allocationBytes,
+        uint256[] memory indices
     ) external;
 
     /**

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -48,7 +48,7 @@ const reason6 = 'h(guarantee)!=assetOutcomeHash';
 // 4. claim G2 (step 2 of alternative of figure 23 of nitro paper)
 
 // Amounts are valueString representations of wei
-describe('claimAll', () => {
+describe('claimAll (by passing [] as indices to claim)', () => {
   it.each`
     name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | tOutcomeAfter         | heldAfter | payouts         | reason
     ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
@@ -134,7 +134,7 @@ describe('claimAll', () => {
         expect(await AssetHolder.assetOutcomeHashes(guarantorId)).toBe(gOutcomeContentHash);
       }
 
-      const tx = AssetHolder.claimAll(...claimAllArgs(guarantorId, guarantee, allocation));
+      const tx = AssetHolder.claim(...claimAllArgs(guarantorId, guarantee, allocation), []);
 
       // Call method in a slightly different way if expecting a revert
       if (reason) {


### PR DESCRIPTION
It's just an alias for `claim(..,[])`