### PR TITLE
refactor: remove succeeded and failed objective statuses; do garbage collection

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -156,6 +156,7 @@ export class ObjectiveModel extends Model {
 
   static async forId(objectiveId: string, tx: TransactionOrKnex): Promise<DBObjective> {
     const model = await ObjectiveModel.query(tx).findById(objectiveId);
+    if (!model) throw new Error('Objective does not exist in database');
     return model.toObjective();
   }
 

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -29,7 +29,7 @@ function extractReferencedChannels(objective: Objective): string[] {
   }
 }
 
-type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+type ObjectiveStatus = 'pending' | 'approved' | 'rejected';
 
 /**
  * Objectives that are currently supported by the server wallet (wire format)
@@ -128,7 +128,7 @@ export class ObjectiveModel extends Model {
 
   static async insert(
     objectiveToBeStored: (SupportedWireObjective | SubmitChallenge | DefundChannel) & {
-      status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+      status: 'pending' | 'approved' | 'rejected';
     },
     tx: TransactionOrKnex
   ): Promise<ObjectiveModel> {
@@ -163,11 +163,9 @@ export class ObjectiveModel extends Model {
     await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'approved'});
   }
 
-  static async succeed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'succeeded'});
-  }
-  static async failed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'failed'});
+  static async delete(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
+    await ObjectiveChannelModel.query(tx).where({objectiveId}).delete();
+    await ObjectiveModel.query(tx).deleteById(objectiveId);
   }
 
   static async forChannelIds(

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -146,7 +146,9 @@ const crankAndAssert = async (
   }
 
   if (completesObj) {
-    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow(
+      'Objective does not exist in database'
+    );
   } else {
     const reloadedObjective = await store.getObjective(objective.objectiveId);
     expect(reloadedObjective.status).toEqual('pending');

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -145,11 +145,10 @@ const crankAndAssert = async (
     expect(spy).not.toHaveBeenCalled();
   }
 
-  const reloadedObjective = await store.getObjective(objective.objectiveId);
-
   if (completesObj) {
-    expect(reloadedObjective.status).toEqual('succeeded');
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
   } else {
+    const reloadedObjective = await store.getObjective(objective.objectiveId);
     expect(reloadedObjective.status).toEqual('pending');
   }
 };

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -142,7 +142,9 @@ const crankAndAssert = async (
   }
 
   if (completesObj) {
-    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow(
+      'Objective does not exist in database'
+    );
   } else {
     const reloadedObjective = await store.getObjective(objective.objectiveId);
     expect(reloadedObjective.status).toEqual('approved');

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -141,10 +141,10 @@ const crankAndAssert = async (
     expect(spy).not.toHaveBeenCalled();
   }
 
-  const reloadedObjective = await store.getObjective(objective.objectiveId);
   if (completesObj) {
-    expect(reloadedObjective.status).toEqual('succeeded');
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
   } else {
+    const reloadedObjective = await store.getObjective(objective.objectiveId);
     expect(reloadedObjective.status).toEqual('approved');
   }
 };

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -86,7 +86,9 @@ describe('when there is an active challenge', () => {
     await channelDefunder.crank(objective, WalletResponse.initialize());
 
     // Check the results
-    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow(
+      'Objective does not exist in database'
+    );
 
     expect(concludeSpy).toHaveBeenCalled();
   });
@@ -142,7 +144,9 @@ describe('when the channel is finalized on chain', () => {
     expect(pushSpy).toHaveBeenCalledWith(expect.objectContaining(challengeState), c.myAddress);
 
     // Check the results
-    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow(
+      'Objective does not exist in database'
+    );
   });
 
   it('does nothing if the on-chain state is final', async () => {
@@ -184,7 +188,9 @@ it('should fail the objective when the channel does not exist', async () => {
   await channelDefunder.crank(objective, WalletResponse.initialize());
 
   // Check the results
-  await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
+  await expect(store.getObjective(objective.objectiveId)).rejects.toThrow(
+    'Objective does not exist in database'
+  );
 });
 
 it('should fail when using non-direct funding', async () => {
@@ -203,7 +209,9 @@ it('should fail when using non-direct funding', async () => {
   await channelDefunder.crank(obj, WalletResponse.initialize());
 
   // Check the results
-  await expect(store.getObjective(obj.objectiveId)).rejects.toThrow();
+  await expect(store.getObjective(obj.objectiveId)).rejects.toThrow(
+    'Objective does not exist in database'
+  );
 });
 
 // Helpers

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -86,9 +86,8 @@ describe('when there is an active challenge', () => {
     await channelDefunder.crank(objective, WalletResponse.initialize());
 
     // Check the results
-    const reloadedObjective = await store.getObjective(objective.objectiveId);
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
 
-    expect(reloadedObjective.status).toEqual('succeeded');
     expect(concludeSpy).toHaveBeenCalled();
   });
 
@@ -141,8 +140,9 @@ describe('when the channel is finalized on chain', () => {
 
     // Check the results
     expect(pushSpy).toHaveBeenCalledWith(expect.objectContaining(challengeState), c.myAddress);
-    const reloadedObjective = await store.getObjective(objective.objectiveId);
-    expect(reloadedObjective.status).toEqual('succeeded');
+
+    // Check the results
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
   });
 
   it('does nothing if the on-chain state is final', async () => {
@@ -182,9 +182,9 @@ it('should fail the objective when the channel does not exist', async () => {
 
   // Crank the protocol
   await channelDefunder.crank(objective, WalletResponse.initialize());
+
   // Check the results
-  const reloadedObjective = await store.getObjective(objective.objectiveId);
-  expect(reloadedObjective.status).toEqual('failed');
+  await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
 });
 
 it('should fail when using non-direct funding', async () => {
@@ -203,8 +203,7 @@ it('should fail when using non-direct funding', async () => {
   await channelDefunder.crank(obj, WalletResponse.initialize());
 
   // Check the results
-  const reloadedObjective = await store.getObjective(obj.objectiveId);
-  expect(reloadedObjective.status).toEqual('failed');
+  await expect(store.getObjective(obj.objectiveId)).rejects.toThrow();
 });
 
 // Helpers

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -188,7 +188,9 @@ const crankAndAssert = async (
   }
 
   if (completesObj) {
-    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow(
+      'Objective does not exist in database'
+    );
   } else {
     const reloadedObjective = await store.getObjective(objective.objectiveId);
     expect(reloadedObjective.status).toEqual('approved');

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -187,10 +187,10 @@ const crankAndAssert = async (
     expect(spy).not.toHaveBeenCalled();
   }
 
-  const reloadedObjective = await store.getObjective(objective.objectiveId);
   if (completesObj) {
-    expect(reloadedObjective.status).toEqual('succeeded');
+    await expect(store.getObjective(objective.objectiveId)).rejects.toThrow();
   } else {
+    const reloadedObjective = await store.getObjective(objective.objectiveId);
     expect(reloadedObjective.status).toEqual('approved');
   }
 };

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -65,7 +65,8 @@ export class ChallengeSubmitter {
 
       await this.chainService.challenge([signedState], channel.signingWallet.privateKey);
 
-      await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+      await this.store.removeObjective(objective.objectiveId, tx);
+
       response.queueChannel(channel);
     });
   }

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -60,7 +60,7 @@ export class ChannelOpener {
       }
 
       if (channel.postfundSupported) {
-        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+        await this.store.removeObjective(objective.objectiveId, tx);
 
         response.queueSucceededObjective(objective);
       }

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -107,7 +107,7 @@ export class ChannelCloser {
     tx: Transaction,
     response: WalletResponse
   ): Promise<void> {
-    await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+    await this.store.removeObjective(objective.objectiveId, tx);
 
     response.queueChannelState(protocolState.app);
     response.queueSucceededObjective(objective);

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -33,14 +33,14 @@ export class ChannelDefunder {
 
       if (!channel) {
         this.logger.error(`No channel found for channel id ${channelId}`);
-        await this.store.markObjectiveStatus(objective, 'failed', tx);
+        await this.store.removeObjective(objective.objectiveId, tx);
         return;
       }
 
       if (channel.fundingStrategy !== 'Direct') {
         // TODO: https://github.com/statechannels/statechannels/issues/3124
         this.logger.error(`Only direct funding is currently supported.`);
-        await this.store.markObjectiveStatus(objective, 'failed', tx);
+        await this.store.removeObjective(objective.objectiveId, tx);
         return;
       }
 
@@ -56,12 +56,12 @@ export class ChannelDefunder {
         } else {
           await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
           this.chainService.pushOutcomeAndWithdraw(result.challengeState, channel.myAddress);
-          await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+          await this.store.removeObjective(objective.objectiveId, tx);
         }
       } else if (channel.hasConclusionProof) {
         await ChainServiceRequest.insertOrUpdate(channelId, 'withdraw', tx);
         this.chainService.concludeAndWithdraw(channel.support);
-        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+        await this.store.removeObjective(objective.objectiveId, tx);
         return;
       }
     });

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -345,16 +345,8 @@ export class Store {
     await ObjectiveModel.approve(objectiveId, tx || this.knex);
   }
 
-  async markObjectiveStatus(
-    objective: DBObjective,
-    status: 'succeeded' | 'failed',
-    tx?: Transaction
-  ): Promise<void> {
-    if (status === 'succeeded') {
-      await ObjectiveModel.succeed(objective.objectiveId, tx || this.knex);
-    } else {
-      await ObjectiveModel.failed(objective.objectiveId, tx || this.knex);
-    }
+  async removeObjective(objectiveId: string, tx?: Transaction): Promise<void> {
+    await ObjectiveModel.delete(objectiveId, tx || this.knex);
   }
 
   private bytecodeCache: Record<string, string | undefined> = {};


### PR DESCRIPTION
Presently, objectives can pile up and there is no mechanism for removing them. This PR removes them after they have succeeded. 