### PR TITLE
Introduce Submit Challenge Protocol

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -48,6 +48,7 @@ import { SimpleAllocation } from '@statechannels/wallet-core';
 import { State } from '@statechannels/wallet-core';
 import { StateVariables } from '@statechannels/wallet-core';
 import { StateWithHash } from '@statechannels/wallet-core';
+import { SubmitChallenge } from '@statechannels/wallet-core';
 import { SyncChannelParams } from '@statechannels/client-api-schema';
 import { Transaction } from 'objection';
 import { TransactionOrKnex } from 'objection';

--- a/packages/server-wallet/src/models/challenge-status.ts
+++ b/packages/server-wallet/src/models/challenge-status.ts
@@ -1,4 +1,5 @@
 import Knex from 'knex';
+import _ from 'lodash';
 import {Model} from 'objection';
 
 import {Bytes32, Uint48} from '../type-aliases';
@@ -56,7 +57,7 @@ export class ChallengeStatus extends Model implements RequiredColumns {
     }
   }
   private static convertResult(result: ChallengeStatus | undefined): ChallengeStatusResult {
-    if (!result || result.finalizesAt === 0) {
+    if (!result || _.isEmpty(result) || result.finalizesAt === 0) {
       return {status: 'No Challenge Detected'};
     }
 

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -1,4 +1,12 @@
-import {objectiveId, Objective, OpenChannel, CloseChannel} from '@statechannels/wallet-core';
+import {
+  objectiveId,
+  Objective,
+  OpenChannel,
+  CloseChannel,
+  State,
+  SharedObjective,
+  SubmitChallenge,
+} from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
 
@@ -7,12 +15,14 @@ function extractReferencedChannels(objective: Objective): string[] {
     case 'OpenChannel':
     case 'CloseChannel':
     case 'VirtuallyFund':
+    case 'SubmitChallenge':
       return [objective.data.targetChannelId];
     case 'FundGuarantor':
       return [objective.data.guarantorId];
     case 'FundLedger':
     case 'CloseLedger':
       return [objective.data.ledgerId];
+
     default:
       return [];
   }
@@ -28,15 +38,34 @@ export type SupportedWireObjective = OpenChannel | CloseChannel;
 export type DBOpenChannelObjective = OpenChannel & {objectiveId: string; status: ObjectiveStatus};
 export type DBCloseChannelObjective = CloseChannel & {objectiveId: string; status: ObjectiveStatus};
 
+export type DBSubmitChallengeObjective = {
+  data: {targetChannelId: string; challengeState: State};
+  objectiveId: string;
+  status: ObjectiveStatus;
+  type: 'SubmitChallenge';
+};
+
+export function isDBSubmitChallengeObjective(
+  objective: DBObjective
+): objective is DBSubmitChallengeObjective {
+  return objective.type === 'SubmitChallenge';
+}
+
 /**
  * A DBObjective is a wire objective with a status and an objectiveId
  *
  * Limited to 'OpenChannel' and 'CloseChannel', which are the only objectives
  * that are currently supported by the server wallet
  */
-export type DBObjective = DBOpenChannelObjective | DBCloseChannelObjective;
+export type DBObjective =
+  | DBOpenChannelObjective
+  | DBCloseChannelObjective
+  | DBSubmitChallengeObjective;
 
-export const toWireObjective = (dbObj: DBObjective): Objective => {
+export const toWireObjective = (dbObj: DBObjective): SharedObjective => {
+  if (dbObj.type === 'SubmitChallenge') {
+    throw new Error('SubmitChallenge objectives are not supported as wire objectives');
+  }
   return _.omit(dbObj, ['objectiveId', 'status']);
 };
 
@@ -85,7 +114,7 @@ export class ObjectiveModel extends Model {
   }
 
   static async insert(
-    objectiveToBeStored: SupportedWireObjective & {
+    objectiveToBeStored: (SupportedWireObjective | SubmitChallenge) & {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
     },
     tx: TransactionOrKnex

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -45,10 +45,10 @@ export type DBSubmitChallengeObjective = {
   type: 'SubmitChallenge';
 };
 
-export function isDBSubmitChallengeObjective(
+export function isSharedObjective(
   objective: DBObjective
-): objective is DBSubmitChallengeObjective {
-  return objective.type === 'SubmitChallenge';
+): objective is DBOpenChannelObjective | DBCloseChannelObjective {
+  return objective.type === 'OpenChannel' || objective.type === 'CloseChannel';
 }
 
 /**

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -7,6 +7,7 @@ import {ChannelCloser} from '../protocols/close-channel';
 import {Store} from '../wallet/store';
 import {ChainServiceInterface} from '../chain-service';
 import {WalletResponse} from '../wallet/wallet-response';
+import {ChallengeSubmitter} from '../protocols/challenge-submitter';
 
 import {ObjectiveManagerParams} from './types';
 import {CloseChannelObjective} from './close-channel';
@@ -44,11 +45,20 @@ export class ObjectiveManager {
         return this.channelOpener.crank(objective, response);
       case 'CloseChannel':
         return this.channelCloser.crank(objective, response);
+      case 'SubmitChallenge':
+        return this.challengeSubmitter.crank(objective, response);
       default:
         unreachable(objective);
     }
   }
-
+  private get challengeSubmitter(): ChallengeSubmitter {
+    return ChallengeSubmitter.create(
+      this.store,
+      this.chainService,
+      this.logger,
+      this.timingMetrics
+    );
+  }
   private get channelOpener(): ChannelOpener {
     return ChannelOpener.create(this.store, this.chainService, this.logger, this.timingMetrics);
   }

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -1,0 +1,118 @@
+import {State} from '@statechannels/wallet-core';
+
+import {Store} from '../../wallet/store';
+import {testKnex as knex} from '../../../jest/knex-setup-teardown';
+import {defaultTestConfig} from '../../config';
+import {WalletResponse} from '../../wallet/wallet-response';
+import {MockChainService} from '../../chain-service';
+import {createLogger} from '../../logger';
+import {DBSubmitChallengeObjective} from '../../models/objective';
+import {ChallengeSubmitter} from '../challenge-submitter';
+import {stateVars} from '../../wallet/__test__/fixtures/state-vars';
+import {Channel} from '../../models/channel';
+import {channel} from '../../models/__test__/fixtures/channel';
+import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {ChallengeStatus} from '../../models/challenge-status';
+
+const logger = createLogger(defaultTestConfig());
+const timingMetrics = false;
+
+let store: Store;
+beforeEach(async () => {
+  store = new Store(
+    knex,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
+    '0'
+  );
+
+  await store.dbAdmin().truncateDB();
+  await seedAlicesSigningWallet(knex);
+});
+
+afterEach(async () => await store.dbAdmin().truncateDB());
+
+describe(`challenge-submitter`, () => {
+  it(`takes no action if there is an existing challenge`, async () => {
+    const c = channel();
+    await Channel.query(knex)
+      .withGraphFetched('signingWallet')
+      .insert(c);
+
+    await ChallengeStatus.updateChallengeStatus(knex, c.channelId, 100, 200);
+    const state: State = {...c.channelConstants, ...stateVars()};
+
+    const obj: DBSubmitChallengeObjective = {
+      type: 'SubmitChallenge',
+      status: 'pending',
+      objectiveId: ['SubmitChallenge', c.channelId].join('-'),
+      data: {challengeState: state, targetChannelId: c.channelId},
+    };
+
+    await knex.transaction(tx => store.ensureObjective(obj, tx));
+    await await crankAndAssert(obj, {callsChallenge: false, completesObj: false});
+  });
+
+  it(`calls challenge when no challenge exists`, async () => {
+    const c = channel();
+    await Channel.query(knex)
+      .withGraphFetched('signingWallet')
+      .insert(c);
+
+    const state: State = {...c.channelConstants, ...stateVars()};
+
+    const obj: DBSubmitChallengeObjective = {
+      type: 'SubmitChallenge',
+      status: 'pending',
+      objectiveId: ['SubmitChallenge', c.channelId].join('-'),
+      data: {challengeState: state, targetChannelId: c.channelId},
+    };
+
+    await knex.transaction(tx => store.ensureObjective(obj, tx));
+    await await crankAndAssert(obj, {
+      callsChallenge: true,
+      challengeState: state,
+      completesObj: true,
+    });
+  });
+});
+
+interface AssertionParams {
+  challengeState?: State;
+  callsChallenge?: boolean;
+  completesObj?: boolean;
+}
+
+const crankAndAssert = async (
+  objective: DBSubmitChallengeObjective,
+  args: AssertionParams
+): Promise<void> => {
+  const completesObj = args.completesObj || false;
+  const callsChallenge = args.callsChallenge || false;
+  const chainService = new MockChainService();
+  const challengeSubmitter = ChallengeSubmitter.create(store, chainService, logger, timingMetrics);
+  const response = WalletResponse.initialize();
+  const spy = jest.spyOn(chainService, 'challenge');
+  await challengeSubmitter.crank(objective, response);
+
+  if (callsChallenge) {
+    if (args.challengeState) {
+      expect(spy).toHaveBeenCalledWith(
+        [expect.objectContaining(args.challengeState)],
+        expect.anything()
+      );
+    } else {
+      expect(spy).toHaveBeenCalled();
+    }
+  } else {
+    expect(spy).not.toHaveBeenCalled();
+  }
+
+  const reloadedObjective = await store.getObjective(objective.objectiveId);
+
+  if (completesObj) {
+    expect(reloadedObjective.status).toEqual('succeeded');
+  } else {
+    expect(reloadedObjective.status).toEqual('pending');
+  }
+};

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -1,0 +1,58 @@
+import {Logger} from 'pino';
+
+import {ChainServiceInterface} from '../chain-service';
+import {ChainServiceRequest} from '../models/chain-service-request';
+import {DBSubmitChallengeObjective} from '../models/objective';
+import {Store} from '../wallet/store';
+import {WalletResponse} from '../wallet/wallet-response';
+
+export class ChallengeSubmitter {
+  constructor(
+    private store: Store,
+    private chainService: ChainServiceInterface,
+    private logger: Logger,
+    private timingMetrics = false
+  ) {}
+
+  public static create(
+    store: Store,
+    chainService: ChainServiceInterface,
+    logger: Logger,
+    timingMetrics = false
+  ): ChallengeSubmitter {
+    return new ChallengeSubmitter(store, chainService, logger, timingMetrics);
+  }
+  public async crank(
+    objective: DBSubmitChallengeObjective,
+    response: WalletResponse
+  ): Promise<void> {
+    const {targetChannelId: channelToLock, challengeState} = objective.data;
+
+    await this.store.transaction(async tx => {
+      const channel = await this.store.getLockedChannel(channelToLock, tx);
+      if (!channel) {
+        this.logger.warn(`No channel exists for channel ${channelToLock}`);
+        return false;
+      }
+
+      const {status} = channel.challengeStatus.toResult();
+      if (status !== 'No Challenge Detected') {
+        this.logger.warn('There is already a challange registered on chain');
+        return false;
+      }
+
+      if (!channel.signingWallet) {
+        throw new Error(`No signing wallet fetched for channel ${channelToLock}`);
+      }
+
+      await ChainServiceRequest.insertOrUpdate(channelToLock, 'challenge', tx);
+
+      const signedState = await this.store.signState(channel, challengeState, tx);
+
+      await this.chainService.challenge([signedState], channel.signingWallet.privateKey);
+
+      response.queueChannel(channel);
+      return true;
+    });
+  }
+}

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -50,6 +50,15 @@ export class ChallengeSubmitter {
         throw new Error(`No signing wallet fetched for channel ${channelToLock}`);
       }
 
+      const existingRequest = await ChainServiceRequest.query(tx)
+        .where({channelId: channelToLock, request: 'challenge'})
+        .first();
+
+      if (existingRequest) {
+        this.logger.warn('There is already an existing request', existingRequest);
+        return;
+      }
+
       await ChainServiceRequest.insertOrUpdate(channelToLock, 'challenge', tx);
 
       const signedState = await this.signState(channel, challengeState, tx);

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 
-import {defaultTestConfig, Wallet} from '../..';
-import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {ChallengeStatus} from '../../../models/challenge-status';
-import {Channel} from '../../../models/channel';
-import {channel} from '../../../models/__test__/fixtures/channel';
-import {alice, bob} from '../fixtures/signing-wallets';
-import {stateWithHashSignedBy} from '../fixtures/states';
+import {defaultTestConfig, Wallet} from '..';
+import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {ChallengeStatus} from '../../models/challenge-status';
+import {Channel} from '../../models/channel';
+import {channel} from '../../models/__test__/fixtures/channel';
+
+import {alice, bob} from './fixtures/signing-wallets';
+import {stateWithHashSignedBy} from './fixtures/states';
 
 let w: Wallet;
 beforeAll(async () => {

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -6,11 +6,11 @@ import {
   ChannelConstants,
   makeAddress,
   makePrivateKey,
-  Objective,
   Outcome,
   Participant,
   PrivateKey,
   serializeState,
+  SharedObjective,
   SignedStateWithHash,
   simpleEthAllocation,
   State,
@@ -155,7 +155,7 @@ export class TestChannel {
     return calculateChannelId(this.channelConstants);
   }
 
-  public get openChannelObjective(): Objective {
+  public get openChannelObjective(): SharedObjective {
     return {
       participants: this.participants,
       type: 'OpenChannel',
@@ -166,7 +166,7 @@ export class TestChannel {
     };
   }
 
-  public get closeChannelObjective(): Objective {
+  public get closeChannelObjective(): SharedObjective {
     return {
       participants: this.participants,
       type: 'CloseChannel',

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
@@ -1,4 +1,4 @@
-import {Objective} from '@statechannels/wallet-core';
+import {SharedObjective} from '@statechannels/wallet-core';
 
 import {Store} from '../../store';
 
@@ -24,7 +24,7 @@ export class TestLedgerChannel extends TestChannel {
     super(args);
   }
 
-  public get openChannelObjective(): Objective {
+  public get openChannelObjective(): SharedObjective {
     return {
       participants: this.participants,
       type: 'OpenChannel',

--- a/packages/server-wallet/src/wallet/__test__/integration/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/challenge.test.ts
@@ -1,0 +1,41 @@
+import _ from 'lodash';
+
+import {defaultTestConfig, Wallet} from '../..';
+import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
+import {ChallengeStatus} from '../../../models/challenge-status';
+import {Channel} from '../../../models/channel';
+import {channel} from '../../../models/__test__/fixtures/channel';
+import {alice, bob} from '../fixtures/signing-wallets';
+import {stateWithHashSignedBy} from '../fixtures/states';
+
+let w: Wallet;
+beforeAll(async () => {
+  w = Wallet.create(defaultTestConfig());
+
+  await seedAlicesSigningWallet(w.knex);
+});
+
+it('submits a challenge when no challenge exists for a channel', async () => {
+  const spy = jest.spyOn(w.chainService, 'challenge');
+  const c = channel({
+    channelNonce: 1,
+    vars: [stateWithHashSignedBy([alice(), bob()])({turnNum: 1})],
+  });
+  await Channel.query(w.knex).insert(c);
+
+  const {channelId} = c;
+
+  const current = await ChallengeStatus.getChallengeStatus(w.knex, channelId);
+
+  expect(current.status).toEqual('No Challenge Detected');
+  const challengeState = {
+    ...c.channelConstants,
+    ..._.pick(c.latest, ['turnNum', 'outcome', 'appData', 'isFinal']),
+  };
+  await w.challenge(challengeState);
+  expect(spy).toHaveBeenCalledWith([expect.objectContaining(challengeState)], alice().privateKey);
+});
+
+afterAll(async () => {
+  await w.destroy();
+});

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -278,7 +278,7 @@ export class Store {
   async getLockedChannel(channelId: Bytes32, tx: Transaction): Promise<Channel | undefined> {
     return Channel.query(tx)
       .where({channelId})
-      .withGraphJoined('challengingStatus')
+      .withGraphJoined('challengeStatus')
       .withGraphFetched('signingWallet')
       .forUpdate()
       .first();

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -414,6 +414,7 @@ export class Store {
     } catch (e) {
       if (e.name !== 'UniqueViolationError') throw e;
     }
+
     return {...objective, status: 'pending', objectiveId: objectiveId(objective)};
   }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -383,6 +383,10 @@ export class Store {
     return await ObjectiveModel.forId(objectiveId, tx);
   }
 
+  /**
+   * Ensure the provided objective is stored in the database.
+   * Returns the objective as a DBObjective
+   */
   async ensureObjective(objective: Objective, tx: Transaction): Promise<DBObjective> {
     switch (objective.type) {
       case 'OpenChannel':
@@ -412,6 +416,7 @@ export class Store {
     try {
       await ObjectiveModel.insert({...objective, status: 'pending'}, tx);
     } catch (e) {
+      // If the objective exists our job is done
       if (e.name !== 'UniqueViolationError') throw e;
     }
 
@@ -458,6 +463,7 @@ export class Store {
     try {
       await ObjectiveModel.insert(objectiveToBeStored, tx);
     } catch (e) {
+      // If the objective exists our job is done
       if (e.name !== 'UniqueViolationError') throw e;
     }
 
@@ -499,6 +505,7 @@ export class Store {
     try {
       await ObjectiveModel.insert(objectiveToBeStored, tx);
     } catch (e) {
+      // If the objective exists our job is done
       if (e.name !== 'UniqueViolationError') throw e;
     }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -23,6 +23,8 @@ import {
   Address,
   Destination,
   PrivateKey,
+  SubmitChallenge,
+  isSubmitChallenge,
 } from '@statechannels/wallet-core';
 import {Payload as WirePayload, SignedState as WireSignedState} from '@statechannels/wire-format';
 import _ from 'lodash';
@@ -276,6 +278,8 @@ export class Store {
   async getLockedChannel(channelId: Bytes32, tx: Transaction): Promise<Channel | undefined> {
     return Channel.query(tx)
       .where({channelId})
+      .withGraphJoined('challengingStatus')
+      .withGraphFetched('signingWallet')
       .forUpdate()
       .first();
   }
@@ -329,7 +333,10 @@ export class Store {
       }
 
       const objectiveChannelIds = storedObjectives
-        .filter(objective => isOpenChannel(objective) || isCloseChannel(objective))
+        .filter(
+          objective =>
+            isSubmitChallenge(objective) || isOpenChannel(objective) || isCloseChannel(objective)
+        )
         .map(objective => objective.data.targetChannelId);
 
       return {
@@ -382,9 +389,32 @@ export class Store {
         return this.ensureOpenChannelObjective(objective, tx);
       case 'CloseChannel':
         return this.ensureCloseChannelObjective(objective, tx);
+
+      case 'SubmitChallenge':
+        return this.ensureSubmitChallengeObjective(objective, tx);
       default:
         throw new StoreError(StoreError.reasons.unimplementedObjective);
     }
+  }
+
+  private async ensureSubmitChallengeObjective(
+    objective: SubmitChallenge,
+    tx: Transaction
+  ): Promise<DBObjective> {
+    const {data} = objective;
+    const {targetChannelId} = data;
+    // fetch the channel to make sure the channel exists
+    const channel = await this.getChannelState(targetChannelId, tx);
+    if (!channel) {
+      throw new StoreError(StoreError.reasons.channelMissing, {channelId: targetChannelId});
+    }
+
+    try {
+      await ObjectiveModel.insert({...objective, status: 'pending'}, tx);
+    } catch (e) {
+      if (e.name !== 'UniqueViolationError') throw e;
+    }
+    return {...objective, status: 'pending', objectiveId: objectiveId(objective)};
   }
 
   private async ensureOpenChannelObjective(

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -7,7 +7,7 @@ import {
   ChannelId,
   ChannelResult,
 } from '@statechannels/client-api-schema';
-import {Participant, Address as CoreAddress} from '@statechannels/wallet-core';
+import {Participant, Address as CoreAddress, State} from '@statechannels/wallet-core';
 
 import {Outgoing} from '../protocols/actions';
 import {Bytes32, Uint256} from '../type-aliases';
@@ -63,4 +63,6 @@ export type WalletInterface = {
   pushUpdate(m: unknown): Promise<SingleChannelOutput>;
 
   mergeMessages(messages: Output[]): MultipleChannelOutput;
+
+  challenge(challengeState: State): Promise<SingleChannelOutput>;
 };

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -57,12 +57,12 @@ export type WalletInterface = {
   syncChannels(chanelIds: Bytes32[]): Promise<MultipleChannelOutput>;
   syncChannel(args: SyncChannelParams): Promise<SingleChannelOutput>;
 
+  challenge(challengeState: State): Promise<SingleChannelOutput>;
+
   updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
   // Wallet <-> Wallet communication
   pushMessage(m: unknown): Promise<MultipleChannelOutput>;
   pushUpdate(m: unknown): Promise<SingleChannelOutput>;
 
   mergeMessages(messages: Output[]): MultipleChannelOutput;
-
-  challenge(challengeState: State): Promise<SingleChannelOutput>;
 };

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -5,7 +5,7 @@ import {Message as WireMessage, SignedState as WireState} from '@statechannels/w
 
 import {Notice, Outgoing} from '../protocols/actions';
 import {Channel} from '../models/channel';
-import {DBObjective, isDBSubmitChallengeObjective, toWireObjective} from '../models/objective';
+import {DBObjective, isSharedObjective, toWireObjective} from '../models/objective';
 import {WALLET_VERSION} from '../version';
 import {ChannelState, toChannelResult} from '../protocols/state';
 
@@ -84,7 +84,7 @@ export class WalletResponse {
     participants: Participant[]
   ): void {
     const myParticipantId = participants[myIndex].participantId;
-    if (!isDBSubmitChallengeObjective(objective)) {
+    if (isSharedObjective(objective)) {
       participants.forEach((p, i) => {
         if (i !== myIndex) {
           this.queuedMessages.push(

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -5,7 +5,7 @@ import {Message as WireMessage, SignedState as WireState} from '@statechannels/w
 
 import {Notice, Outgoing} from '../protocols/actions';
 import {Channel} from '../models/channel';
-import {DBObjective, toWireObjective} from '../models/objective';
+import {DBObjective, isDBSubmitChallengeObjective, toWireObjective} from '../models/objective';
 import {WALLET_VERSION} from '../version';
 import {ChannelState, toChannelResult} from '../protocols/state';
 
@@ -84,22 +84,23 @@ export class WalletResponse {
     participants: Participant[]
   ): void {
     const myParticipantId = participants[myIndex].participantId;
-
-    participants.forEach((p, i) => {
-      if (i !== myIndex) {
-        this.queuedMessages.push(
-          serializeMessage(
-            WALLET_VERSION,
-            {
-              walletVersion: WALLET_VERSION,
-              objectives: [toWireObjective(objective)],
-            },
-            p.participantId,
-            myParticipantId
-          )
-        );
-      }
-    });
+    if (!isDBSubmitChallengeObjective(objective)) {
+      participants.forEach((p, i) => {
+        if (i !== myIndex) {
+          this.queuedMessages.push(
+            serializeMessage(
+              WALLET_VERSION,
+              {
+                walletVersion: WALLET_VERSION,
+                objectives: [toWireObjective(objective)],
+              },
+              p.participantId,
+              myParticipantId
+            )
+          );
+        }
+      });
+    }
   }
 
   /**

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -246,7 +246,8 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
     });
 
     await this.takeActions([channelId], response);
-
+    // TODO: In v0 of challenging the challengeStatus on the channel will not be updated
+    // We return a single channel result anwyays in case there are messages in the outbox
     return response.singleChannelOutput();
   }
 

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -16,11 +16,11 @@ import {
   Outcome,
   AllocationItem,
   SimpleAllocation,
-  Objective,
   Participant,
   makeAddress,
   Payload,
-  ChannelRequest
+  ChannelRequest,
+  SharedObjective
 } from '../../types';
 import {BN} from '../../bignumber';
 import {makeDestination} from '../../utils';
@@ -96,7 +96,7 @@ export function deserializeState(state: SignedStateWire): SignedState {
   };
 }
 
-export function deserializeObjective(objective: ObjectiveWire): Objective {
+export function deserializeObjective(objective: ObjectiveWire): SharedObjective {
   const participants = objective.participants?.map(p => ({
     ...p,
     signingAddress: makeAddress(p.signingAddress),

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -137,13 +137,23 @@ export type CloseLedger = _Objective<
   }
 >;
 
-export type Objective =
+export type SubmitChallenge = _Objective<
+  'SubmitChallenge',
+  {
+    targetChannelId: string;
+    challengeState: State;
+  }
+>;
+
+export type SharedObjective =
   | OpenChannel
   | CloseChannel
   | VirtuallyFund
   | FundGuarantor
   | FundLedger
   | CloseLedger;
+
+export type Objective = SharedObjective | SubmitChallenge;
 
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;
@@ -153,12 +163,14 @@ export const isVirtuallyFund = guard<VirtuallyFund>('VirtuallyFund');
 export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');
 export const isFundLedger = guard<FundLedger>('FundLedger');
 export const isCloseLedger = guard<CloseLedger>('CloseLedger');
+export const isSubmitChallenge = guard<SubmitChallenge>('SubmitChallenge');
 
 export function objectiveId(objective: Objective): string {
   switch (objective.type) {
     case 'OpenChannel':
     case 'CloseChannel':
     case 'VirtuallyFund':
+    case 'SubmitChallenge':
       return [objective.type, objective.data.targetChannelId].join('-');
     case 'FundGuarantor':
       return [objective.type, objective.data.guarantorId].join('-');
@@ -181,7 +193,7 @@ export type ChannelRequest = GetChannel | ProposeLedgerUpdate;
 export interface Payload {
   walletVersion: string;
   signedStates?: SignedState[];
-  objectives?: Objective[];
+  objectives?: SharedObjective[];
   requests?: ChannelRequest[];
 }
 


### PR DESCRIPTION
Fixes #3078 

Introduces a new `challenge-submitter` protocol that is responsible for submitting a challenge transaction using the `chain-service`.

I've added `SubmitChallenge` as an `Objective` in `wallet-core`.  For now, it's a completely internal objective so I've defined `Objective = SharedObjective | SubmitChallenge`. (Sidenote: I find having objectives also defined in `wallet-core` slightly annoying and I'd rather just have them live only in `server-wallet`)

TODO:

- [x] Add test for `wallet.challenge`
- [x] Add transaction retry/failure logic (added same `chainRequest` logic as in other protocols.)