### PR TITLE
feat: store challenge state

### DIFF
--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -42,6 +42,12 @@ const chainId = process.env.CHAIN_NETWORK_ID || '9002';
 /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 const provider: providers.JsonRpcProvider = new providers.JsonRpcProvider(rpcEndpoint);
 
+const defaultNoopListeners = {
+  holdingUpdated: _.noop,
+  assetOutcomeUpdated: _.noop,
+  channelFinalized: _.noop,
+  challengeRegistered: _.noop,
+};
 let chainService: ChainService;
 let channelNonce = 0;
 async function mineBlock(timestamp?: number) {
@@ -223,13 +229,11 @@ describe('registerChannel', () => {
     const channelFinalizedHandler = jest.fn();
     const channelFinalizedPromise = new Promise<void>(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
-        holdingUpdated: _.noop,
-        assetOutcomeUpdated: _.noop,
+        ...defaultNoopListeners,
         channelFinalized: arg => {
           channelFinalizedHandler(arg);
           resolve();
         },
-        challengeRegistered: _.noop,
       })
     );
 
@@ -277,10 +281,8 @@ describe('registerChannel', () => {
     };
 
     chainService.registerChannel(channelId, [ethAssetHolderAddress], {
+      ...defaultNoopListeners,
       holdingUpdated,
-      assetOutcomeUpdated: _.noop,
-      channelFinalized: _.noop,
-      challengeRegistered: _.noop,
     });
     await p;
   });
@@ -291,6 +293,7 @@ describe('registerChannel', () => {
 
     await new Promise(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
+        ...defaultNoopListeners,
         holdingUpdated: arg => {
           expect(arg).toMatchObject({
             channelId,
@@ -299,9 +302,6 @@ describe('registerChannel', () => {
           });
           resolve(true);
         },
-        assetOutcomeUpdated: _.noop,
-        channelFinalized: _.noop,
-        challengeRegistered: _.noop,
       })
     );
   });
@@ -333,10 +333,8 @@ describe('registerChannel', () => {
       if (!objectsToMatch.length) resolve(true);
     };
     chainService.registerChannel(channelId, [ethAssetHolderAddress, erc20AssetHolderAddress], {
+      ...defaultNoopListeners,
       holdingUpdated,
-      assetOutcomeUpdated: _.noop,
-      channelFinalized: _.noop,
-      challengeRegistered: _.noop,
     });
     fundChannelAndMineBlocks(0, 5, channelId, ethAssetHolderAddress);
     fundChannelAndMineBlocks(0, 5, channelId, erc20AssetHolderAddress);
@@ -368,13 +366,11 @@ describe('concludeAndWithdraw', () => {
 
     const p = new Promise<void>(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
-        holdingUpdated: _.noop,
+        ...defaultNoopListeners,
         assetOutcomeUpdated: arg => {
           expect(arg).toMatchObject(assetOutocomeUpdated);
           resolve();
         },
-        channelFinalized: _.noop,
-        challengeRegistered: _.noop,
       })
     );
 
@@ -411,13 +407,11 @@ describe('concludeAndWithdraw', () => {
 
     const p = new Promise<void>(resolve =>
       chainService.registerChannel(channelId, [erc20AssetHolderAddress], {
-        holdingUpdated: _.noop,
+        ...defaultNoopListeners,
         assetOutcomeUpdated: arg => {
           expect(arg).toMatchObject(assetOutocomeUpdated);
           resolve();
         },
-        channelFinalized: _.noop,
-        challengeRegistered: _.noop,
       })
     );
 
@@ -485,10 +479,8 @@ describe('challenge', () => {
       channelId =>
         new Promise(resolve =>
           chainService.registerChannel(channelId, [ethAssetHolderAddress], {
-            holdingUpdated: _.noop,
-            assetOutcomeUpdated: _.noop,
+            ...defaultNoopListeners,
             channelFinalized: resolve,
-            challengeRegistered: _.noop,
           })
         )
     );
@@ -558,9 +550,7 @@ describe('challenge', () => {
     });
     const challengeRegistered: Promise<ChallengeRegisteredArg> = new Promise(resolve =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
-        holdingUpdated: _.noop,
-        assetOutcomeUpdated: _.noop,
-        channelFinalized: _.noop,
+        ...defaultNoopListeners,
         challengeRegistered: arg => resolve(arg),
       })
     );

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -551,7 +551,7 @@ describe('challenge', () => {
     const challengeRegistered: Promise<ChallengeRegisteredArg> = new Promise(challengeRegistered =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         ...defaultNoopListeners,
-        challengeRegistered
+        challengeRegistered,
       })
     );
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -346,7 +346,7 @@ describe('concludeAndWithdraw', () => {
   it('Successful concludeAndWithdraw with eth allocation', async () => {
     const {channelId, aAddress, bAddress, state, signatures} = await setUpConclude();
 
-    const assetOutocomeUpdated: AssetOutcomeUpdatedArg = {
+    const assetOutcomeUpdated: AssetOutcomeUpdatedArg = {
       channelId,
       assetHolderAddress: ethAssetHolderAddress,
       newHoldings: '0x00' as Uint256,
@@ -368,7 +368,7 @@ describe('concludeAndWithdraw', () => {
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         ...defaultNoopListeners,
         assetOutcomeUpdated: arg => {
-          expect(arg).toMatchObject(assetOutocomeUpdated);
+          expect(arg).toMatchObject(assetOutcomeUpdated);
           resolve();
         },
       })
@@ -387,7 +387,7 @@ describe('concludeAndWithdraw', () => {
   it('Successful concludeAndWithdraw with erc20 allocation', async () => {
     const {channelId, aAddress, bAddress, state, signatures} = await setUpConclude(false);
 
-    const assetOutocomeUpdated: AssetOutcomeUpdatedArg = {
+    const assetOutcomeUpdated: AssetOutcomeUpdatedArg = {
       channelId,
       assetHolderAddress: erc20AssetHolderAddress,
       newHoldings: '0x00' as Uint256,
@@ -409,7 +409,7 @@ describe('concludeAndWithdraw', () => {
       chainService.registerChannel(channelId, [erc20AssetHolderAddress], {
         ...defaultNoopListeners,
         assetOutcomeUpdated: arg => {
-          expect(arg).toMatchObject(assetOutocomeUpdated);
+          expect(arg).toMatchObject(assetOutcomeUpdated);
           resolve();
         },
       })
@@ -436,17 +436,17 @@ describe('challenge', () => {
   it('two channels are challenged, funds are withdrawn -> final balances are correct', async () => {
     const aDestinationAddress = Wallet.createRandom().address;
     const bDestinationAddress = Wallet.createRandom().address;
-    const aDestintination = makeDestination(aDestinationAddress);
-    const bDestintination = makeDestination(bDestinationAddress);
+    const aDestination = makeDestination(aDestinationAddress);
+    const bDestination = makeDestination(bDestinationAddress);
     const channelNonces = [0, 1].map(getChannelNonce);
 
     const outcome = simpleEthAllocation([
       {
-        destination: aDestintination,
+        destination: aDestination,
         amount: BN.from(1),
       },
       {
-        destination: bDestintination,
+        destination: bDestination,
         amount: BN.from(3),
       },
     ]);
@@ -514,17 +514,17 @@ describe('challenge', () => {
   it('triggers challenge registered when a challenge is raised', async () => {
     const aDestinationAddress = Wallet.createRandom().address;
     const bDestinationAddress = Wallet.createRandom().address;
-    const aDestintination = makeDestination(aDestinationAddress);
-    const bDestintination = makeDestination(bDestinationAddress);
+    const aDestination = makeDestination(aDestinationAddress);
+    const bDestination = makeDestination(bDestinationAddress);
     const channelNonce = getChannelNonce();
 
     const outcome = simpleEthAllocation([
       {
-        destination: aDestintination,
+        destination: aDestination,
         amount: BN.from(1),
       },
       {
-        destination: bDestintination,
+        destination: bDestination,
         amount: BN.from(3),
       },
     ]);

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -548,10 +548,10 @@ describe('challenge', () => {
       chainId: state1.chainId,
       participants: [alice(), bob()].map(p => p.signingAddress),
     });
-    const challengeRegistered: Promise<ChallengeRegisteredArg> = new Promise(resolve =>
+    const challengeRegistered: Promise<ChallengeRegisteredArg> = new Promise(challengeRegistered =>
       chainService.registerChannel(channelId, [ethAssetHolderAddress], {
         ...defaultNoopListeners,
-        challengeRegistered: arg => resolve(arg),
+        challengeRegistered
       })
     );
 

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -10,6 +10,7 @@ import {
 import {
   Address,
   BN,
+  fromNitroState,
   makeAddress,
   PrivateKey,
   SignedState,
@@ -109,6 +110,16 @@ export class ChainService implements ChainServiceInterface {
     this.nitroAdjudicator.on(ChallengeRegistered, (...args) => {
       const event = getChallengeRegisteredEvent(args);
       this.addFinalizingChannel({channelId: event.channelId, finalizesAtS: event.finalizesAt});
+
+      const {channelId, challengeStates, finalizesAt} = event;
+
+      this.channelToSubscribers.get(event.channelId)?.map(subscriber =>
+        subscriber.challengeRegistered({
+          channelId,
+          challengeStates: challengeStates.map(s => fromNitroState(s.state)),
+          finalizesAt,
+        })
+      );
     });
 
     this.provider.on('block', async (blockTag: providers.BlockTag) =>

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -33,10 +33,17 @@ export type ChannelFinalizedArg = {
   finalizedAt: number;
 };
 
+export type ChallengeRegisteredArg = {
+  channelId: string;
+  finalizesAt: number;
+  challengeStates: State[];
+};
+
 export interface ChainEventSubscriberInterface {
   holdingUpdated(arg: HoldingUpdatedArg): void;
   assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg): void;
   channelFinalized(arg: ChannelFinalizedArg): void;
+  challengeRegistered(arg: ChallengeRegisteredArg): void;
 }
 
 interface ChainEventEmitterInterface {

--- a/packages/server-wallet/src/db/migrations/20210111135843_add_challenge_state.ts
+++ b/packages/server-wallet/src/db/migrations/20210111135843_add_challenge_state.ts
@@ -1,0 +1,10 @@
+import * as Knex from 'knex';
+
+const tableName = 'challenge_status';
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => table.jsonb('challenge_state').nullable());
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => table.dropColumn('challenge_state'));
+}

--- a/packages/server-wallet/src/models/__test__/challenge-status.test.ts
+++ b/packages/server-wallet/src/models/__test__/challenge-status.test.ts
@@ -3,6 +3,7 @@ import {DBAdmin} from '../../db-admin/db-admin';
 import {ChallengeStatus} from '../challenge-status';
 import {Channel} from '../channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {stateVars} from '../../wallet/__test__/fixtures/state-vars';
 
 import {channel} from './fixtures/channel';
 
@@ -16,15 +17,16 @@ describe('ChallengeStatus model', () => {
 
   it('returns an active challenge status when the challenge is not finalized (finalizesAt>blockNumber)', async () => {
     const c = channel();
+    const challengeState = {...stateVars(), ...c.channelConstants};
     await Channel.query(knex)
       .withGraphFetched('signingWallet')
       .insert(c);
 
-    await ChallengeStatus.updateChallengeStatus(knex, c.channelId, 5, 1);
+    await ChallengeStatus.insertChallengeStatus(knex, c.channelId, 5, challengeState);
 
     const result = await ChallengeStatus.getChallengeStatus(knex, c.channelId);
 
-    expect(result).toEqual({status: 'Challenge Active', finalizesAt: 5});
+    expect(result).toEqual({status: 'Challenge Active', finalizesAt: 5, challengeState});
   });
 
   it('returns no challenge when there is not an entry', async () => {
@@ -38,26 +40,15 @@ describe('ChallengeStatus model', () => {
     expect(result).toEqual({status: 'No Challenge Detected'});
   });
 
-  it('returns no challenge when finalizesAt is 0', async () => {
-    const c = channel();
-    await Channel.query(knex)
-      .withGraphFetched('signingWallet')
-      .insert(c);
-
-    await ChallengeStatus.updateChallengeStatus(knex, c.channelId, 0, 1);
-
-    const result = await ChallengeStatus.getChallengeStatus(knex, c.channelId);
-
-    expect(result).toEqual({status: 'No Challenge Detected'});
-  });
-
   it('returns channel finalized when the channel is finalized (finalizedAt<=blockNumber)', async () => {
     const c = channel();
+    const challengeState = {...stateVars(), ...c.channelConstants};
     await Channel.query(knex)
       .withGraphFetched('signingWallet')
       .insert(c);
 
-    await ChallengeStatus.updateChallengeStatus(knex, c.channelId, 5, 10);
+    await ChallengeStatus.insertChallengeStatus(knex, c.channelId, 5, challengeState);
+    await ChallengeStatus.setFinalized(knex, c.channelId, 10);
 
     const result = await ChallengeStatus.getChallengeStatus(knex, c.channelId);
 
@@ -65,6 +56,7 @@ describe('ChallengeStatus model', () => {
       status: 'Challenge Finalized',
       finalizedAt: 5,
       finalizedBlockNumber: 10,
+      challengeState,
     });
   });
 });

--- a/packages/server-wallet/src/models/challenge-status.ts
+++ b/packages/server-wallet/src/models/challenge-status.ts
@@ -1,3 +1,4 @@
+import {State} from '@statechannels/wallet-core';
 import Knex from 'knex';
 import _ from 'lodash';
 import {Model} from 'objection';
@@ -5,8 +6,13 @@ import {Model} from 'objection';
 import {Bytes32, Uint48} from '../type-aliases';
 
 export type ChallengeStatusResult =
-  | {status: 'Challenge Finalized'; finalizedAt: number; finalizedBlockNumber: number}
-  | {status: 'Challenge Active'; finalizesAt: number}
+  | {
+      status: 'Challenge Finalized';
+      finalizedAt: number;
+      challengeState: State;
+      finalizedBlockNumber: number;
+    }
+  | {status: 'Challenge Active'; finalizesAt: number; challengeState: State}
   | {status: 'No Challenge Detected'};
 
 interface RequiredColumns {
@@ -18,10 +24,12 @@ export class ChallengeStatus extends Model implements RequiredColumns {
   readonly channelId!: Bytes32;
   readonly finalizesAt!: Uint48;
   readonly blockNumber!: Uint48;
+  readonly challengeState!: State;
   static tableName = 'challenge_status';
   static get idColumn(): string[] {
     return ['channelId'];
   }
+
   static async getChallengeStatus(knex: Knex, channelId: Bytes32): Promise<ChallengeStatusResult> {
     const result = await ChallengeStatus.query(knex)
       .where({channelId})
@@ -30,45 +38,52 @@ export class ChallengeStatus extends Model implements RequiredColumns {
     return ChallengeStatus.convertResult(result);
   }
 
-  static async updateChallengeStatus(
+  static async setFinalized(
+    knex: Knex,
+    channelId: string,
+    blockNumber: number
+  ): Promise<ChallengeStatusResult> {
+    const existing = await ChallengeStatus.query(knex).where({channelId});
+    if (!existing) {
+      throw new Error('No existing challenge found to update');
+    }
+    const result = await ChallengeStatus.query(knex)
+      .patch({blockNumber})
+      .where({channelId})
+      .returning('*')
+      .first();
+
+    return ChallengeStatus.convertResult(result);
+  }
+  static async insertChallengeStatus(
     knex: Knex,
     channelId: string,
     finalizesAt: number,
-    blockNumber: number
+    challengeState: State
   ): Promise<ChallengeStatusResult> {
-    const existing = await ChallengeStatus.query(knex)
-      .where({channelId})
-      .first();
-
-    if (!existing) {
-      const result = await ChallengeStatus.query(knex).insert({
-        channelId,
-        finalizesAt,
-        blockNumber,
-      });
-      return ChallengeStatus.convertResult(result);
-    } else {
-      const result = await ChallengeStatus.query(knex)
-        .patch({finalizesAt, blockNumber})
-        .where({channelId})
-        .returning('*')
-        .first();
-      return ChallengeStatus.convertResult(result);
-    }
+    const result = await ChallengeStatus.query(knex).insert({
+      channelId,
+      finalizesAt,
+      blockNumber: 0,
+      challengeState,
+    });
+    return ChallengeStatus.convertResult(result);
   }
   private static convertResult(result: ChallengeStatus | undefined): ChallengeStatusResult {
-    if (!result || _.isEmpty(result) || result.finalizesAt === 0) {
+    if (!result || _.isEmpty(result)) {
       return {status: 'No Challenge Detected'};
     }
 
-    const {finalizesAt, blockNumber} = result;
+    const {finalizesAt, blockNumber, challengeState} = result;
+
     if (finalizesAt > blockNumber) {
-      return {status: 'Challenge Active', finalizesAt};
+      return {status: 'Challenge Active', finalizesAt, challengeState};
     } else {
       return {
         status: 'Challenge Finalized',
         finalizedAt: finalizesAt,
         finalizedBlockNumber: blockNumber,
+        challengeState,
       };
     }
   }

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -16,6 +16,7 @@ import {ChallengeStatus} from '../../models/challenge-status';
 import {stateWithHashSignedBy} from '../../wallet/__test__/fixtures/states';
 import {alice, bob} from '../../wallet/__test__/fixtures/signing-wallets';
 import {ChainServiceRequest} from '../../models/chain-service-request';
+import {stateVars} from '../../wallet/__test__/fixtures/state-vars';
 
 const logger = createLogger(defaultTestConfig());
 const timingMetrics = false;
@@ -68,7 +69,10 @@ describe(`challenge-submitter`, () => {
       .withGraphFetched('signingWallet')
       .insert(c);
 
-    await ChallengeStatus.updateChallengeStatus(knex, c.channelId, 100, 200);
+    await ChallengeStatus.insertChallengeStatus(knex, c.channelId, 100, {
+      ...stateVars(),
+      ...c.channelConstants,
+    });
 
     const challengeState = {
       ...c.channelConstants,

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -4,6 +4,7 @@ import {Logger} from 'pino';
 
 import {ChainServiceInterface} from '../chain-service';
 import {ChainServiceRequest} from '../models/chain-service-request';
+import {ChallengeStatus} from '../models/challenge-status';
 import {Channel} from '../models/channel';
 import {DBSubmitChallengeObjective} from '../models/objective';
 import {Store} from '../wallet/store';
@@ -64,7 +65,11 @@ export class ChallengeSubmitter {
       const signedState = await this.signState(channel, challengeState, tx);
 
       await this.chainService.challenge([signedState], channel.signingWallet.privateKey);
+      // TODO: Store the actual finalizesAt instead of 0
+      await this.store.insertChallengeStatus(channelToLock, 0, challengeState);
 
+      // TODO: Store the actual finalizesAt instead of 0
+      await ChallengeStatus.insertChallengeStatus(tx, channelToLock, 0, challengeState);
       await this.store.markObjectiveAsSucceeded(objective, tx);
       response.queueChannel(channel);
     });

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -4,7 +4,6 @@ import {Logger} from 'pino';
 
 import {ChainServiceInterface} from '../chain-service';
 import {ChainServiceRequest} from '../models/chain-service-request';
-import {ChallengeStatus} from '../models/challenge-status';
 import {Channel} from '../models/channel';
 import {DBSubmitChallengeObjective} from '../models/objective';
 import {Store} from '../wallet/store';
@@ -65,11 +64,7 @@ export class ChallengeSubmitter {
       const signedState = await this.signState(channel, challengeState, tx);
 
       await this.chainService.challenge([signedState], channel.signingWallet.privateKey);
-      // TODO: Store the actual finalizesAt instead of 0
-      await this.store.insertChallengeStatus(channelToLock, 0, challengeState);
 
-      // TODO: Store the actual finalizesAt instead of 0
-      await ChallengeStatus.insertChallengeStatus(tx, channelToLock, 0, challengeState);
       await this.store.markObjectiveAsSucceeded(objective, tx);
       response.queueChannel(channel);
     });

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import {defaultTestConfig, Wallet} from '..';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {ChallengeStatus} from '../../models/challenge-status';
 import {Channel} from '../../models/channel';
@@ -12,7 +13,10 @@ import {stateWithHashSignedBy} from './fixtures/states';
 let w: Wallet;
 beforeAll(async () => {
   w = Wallet.create(defaultTestConfig());
+});
 
+beforeEach(async () => {
+  await new DBAdmin(w.knex).truncateDB();
   await seedAlicesSigningWallet(w.knex);
 });
 
@@ -35,6 +39,27 @@ it('submits a challenge when no challenge exists for a channel', async () => {
   };
   await w.challenge(challengeState);
   expect(spy).toHaveBeenCalledWith([expect.objectContaining(challengeState)], alice().privateKey);
+});
+
+it('stores the challenge state on the challenge created event', async () => {
+  const c = channel({
+    channelNonce: 1,
+    vars: [stateWithHashSignedBy([alice(), bob()])({turnNum: 1})],
+  });
+  await Channel.query(w.knex).insert(c);
+  const current = await ChallengeStatus.getChallengeStatus(w.knex, c.channelId);
+
+  expect(current.status).toEqual('No Challenge Detected');
+  const challengeState = {
+    ...c.channelConstants,
+    ..._.pick(c.latest, ['turnNum', 'outcome', 'appData', 'isFinal']),
+  };
+  const {channelId} = c;
+  await w.challengeRegistered({channelId, finalizesAt: 200, challengeStates: [challengeState]});
+  const updated = await ChallengeStatus.getChallengeStatus(w.knex, c.channelId);
+
+  expect(updated.status).toEqual('Challenge Active');
+  expect((updated as any).challengeState).toMatchObject(challengeState);
 });
 
 afterAll(async () => {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -25,6 +25,7 @@ import {
   PrivateKey,
   SubmitChallenge,
   isSubmitChallenge,
+  State,
 } from '@statechannels/wallet-core';
 import {Payload as WirePayload, SignedState as WireSignedState} from '@statechannels/wire-format';
 import _ from 'lodash';
@@ -726,17 +727,16 @@ export class Store {
     await Funding.updateFunding(this.knex, channelId, fromAmount, assetHolderAddress);
   }
 
-  async updateFinalizationStatus(
+  async insertChallengeStatus(
     channelId: string,
     finalizedAt: number,
-    finalizedBlockNumber: number
+    challengeState: State
   ): Promise<void> {
-    await ChallengeStatus.updateChallengeStatus(
-      this.knex,
-      channelId,
-      finalizedAt,
-      finalizedBlockNumber
-    );
+    await ChallengeStatus.insertChallengeStatus(this.knex, channelId, finalizedAt, challengeState);
+  }
+
+  async setFinalizedChallengeStatus(channelId: string, blockNumber: number): Promise<void> {
+    await ChallengeStatus.setFinalized(this.knex, channelId, blockNumber);
   }
   async updateTransferredOut(
     channelId: string,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -55,6 +55,7 @@ import {
   MockChainService,
   ChannelFinalizedArg,
   AssetOutcomeUpdatedArg,
+  ChallengeRegisteredArg,
 } from '../chain-service';
 import {DBAdmin} from '../db-admin/db-admin';
 import {WALLET_VERSION} from '../version';
@@ -823,6 +824,15 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
     await this.takeActions([channelId], response);
 
+    response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));
+  }
+
+  async challengeRegistered(arg: ChallengeRegisteredArg): Promise<void> {
+    const response = WalletResponse.initialize();
+    const {channelId, finalizesAt: finalizedAt, challengeStates} = arg;
+
+    await this.store.insertChallengeStatus(channelId, finalizedAt, challengeStates.slice(-1)[0]);
+    await this.takeActions([arg.channelId], response);
     response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));
   }
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -828,7 +828,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType>
 
   async channelFinalized(arg: ChannelFinalizedArg): Promise<void> {
     const response = WalletResponse.initialize();
-    await this.store.updateFinalizationStatus(arg.channelId, arg.finalizedAt, arg.blockNumber);
+    await this.store.setFinalizedChallengeStatus(arg.channelId, arg.blockNumber);
 
     await this.takeActions([arg.channelId], response);
     response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));

--- a/packages/wallet-core/src/state-utils.ts
+++ b/packages/wallet-core/src/state-utils.ts
@@ -7,8 +7,7 @@ import {
   hashState as hashNitroState,
   getStateSignerAddress as getNitroSignerAddress,
   getChannelId,
-  convertAddressToBytes32,
-  convertBytes32ToAddress
+  convertAddressToBytes32
 } from '@statechannels/nitro-protocol';
 import * as _ from 'lodash';
 import {Wallet, utils} from 'ethers';
@@ -26,6 +25,8 @@ import {
   Address
 } from './types';
 import {BN} from './bignumber';
+
+import {makeDestination} from './';
 
 export function toNitroState(state: State): NitroState {
   const {channelNonce, participants, chainId} = state;
@@ -163,10 +164,7 @@ function convertToNitroAllocationItems(allocationItems: AllocationItem[]): Nitro
 function convertFromNitroAllocationItems(allocationItems: NitroAllocationItem[]): AllocationItem[] {
   return allocationItems.map(a => ({
     amount: BN.from(a.amount),
-    destination:
-      a.destination.substr(2, 22) === '00000000000000000000'
-        ? (convertBytes32ToAddress(a.destination) as Destination)
-        : (a.destination as Destination)
+    destination: makeDestination(a.destination)
   }));
 }
 


### PR DESCRIPTION
Fixes #3126 

This adds the `challenge-state` column to `ChallengeStatus` allowing us to store the state that was used to challenge.

We need to store the `challenge-state` so once the challenge expires we can call `PushOutcomeAndWithdraw` with that state.

It gets set when the `ChallengeRegistered` event is fired from the `chain-service`