### PR TITLE
refactor: decouple logger from evm transition validation

### DIFF
--- a/packages/server-wallet/src/__test__/evm-validator.test.ts
+++ b/packages/server-wallet/src/__test__/evm-validator.test.ts
@@ -20,7 +20,9 @@ it('returns true for a valid transition', () => {
       appData: utils.defaultAbiCoder.encode(['uint256'], [2]),
     })
   );
-  expect(validateAppTransitionWithEVM(fromState, toState, appBytecode().appBytecode)).toBe(true);
+  expect(
+    validateAppTransitionWithEVM(fromState, toState, appBytecode().appBytecode)
+  ).toMatchObject({success: true});
 });
 
 it('returns false for an invalid transition', () => {
@@ -36,7 +38,9 @@ it('returns false for an invalid transition', () => {
       appData: utils.defaultAbiCoder.encode(['uint256'], [1]),
     })
   );
-  expect(validateAppTransitionWithEVM(fromState, toState, appBytecode().appBytecode)).toBe(false);
+  expect(
+    validateAppTransitionWithEVM(fromState, toState, appBytecode().appBytecode)
+  ).toMatchObject({success: false});
 });
 
 it('returns false when no byte code exists for the app definition', () => {
@@ -45,5 +49,5 @@ it('returns false when no byte code exists for the app definition', () => {
       appDefinition: UNDEFINED_APP_DEFINITION,
     })
   );
-  expect(validateAppTransitionWithEVM(state, state, '0x')).toBe(false);
+  expect(validateAppTransitionWithEVM(state, state, '0x')).toMatchObject({success: false});
 });

--- a/packages/server-wallet/src/utilities/validate-transition.ts
+++ b/packages/server-wallet/src/utilities/validate-transition.ts
@@ -39,11 +39,17 @@ export function validateTransition(
     switch (status) {
       case Status.True:
         return true;
-      case Status.NeedToCheckApp:
-        return (
-          skipAppTransitionCheck || // TODO this should be removed as soon as possible
-          validateAppTransitionWithEVM(toNitroState(fromState), toNitroState(toState), bytecode)
+      case Status.NeedToCheckApp: {
+        if (skipAppTransitionCheck) return true; // TODO: remove this possibility
+        if (!bytecode) return false;
+        const {success, revertReason} = validateAppTransitionWithEVM(
+          toNitroState(fromState),
+          toNitroState(toState),
+          bytecode
         );
+        if (!success) logger.error(`EVM transition validation failed`, {result: revertReason});
+        return success;
+      }
       default:
         return unreachable(status);
     }


### PR DESCRIPTION
Attempting to remove all instances of `createLogger` in places where it is unnecessary
