### PR TITLE
refactor: wrap crank in a transaction

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -177,6 +177,7 @@ export class ObjectiveModel extends Model {
     const objectiveIds = (
       await ObjectiveChannelModel.query(tx)
         .column('objectiveId')
+        .forUpdate()
         .select()
         .whereIn('channelId', targetChannelIds)
     ).map(oc => oc.objectiveId);

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -1,5 +1,6 @@
 import {Logger} from 'pino';
 import {unreachable} from '@statechannels/wallet-core';
+import {Transaction} from 'objection';
 
 import {Bytes32} from '../type-aliases';
 import {ChannelOpener} from '../protocols/channel-opener';
@@ -38,18 +39,18 @@ export class ObjectiveManager {
    * @param objectiveId - id of objective to try to advance
    * @param response - response builder; will be modified by the method
    */
-  async crank(objectiveId: string, response: WalletResponse): Promise<void> {
-    const objective = await this.store.getObjective(objectiveId);
+  async crank(objectiveId: string, response: WalletResponse, tx: Transaction): Promise<void> {
+    const objective = await this.store.getObjective(objectiveId, tx);
 
     switch (objective.type) {
       case 'OpenChannel':
-        return this.channelOpener.crank(objective, response);
+        return this.channelOpener.crank(objective, response, tx);
       case 'CloseChannel':
-        return this.channelCloser.crank(objective, response);
+        return this.channelCloser.crank(objective, response, tx);
       case 'SubmitChallenge':
-        return this.challengeSubmitter.crank(objective, response);
+        return this.challengeSubmitter.crank(objective, response, tx);
       case 'DefundChannel':
-        return this.channelDefunder.crank(objective, response);
+        return this.channelDefunder.crank(objective, response, tx);
       default:
         unreachable(objective);
     }

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -122,7 +122,9 @@ const crankAndAssert = async (
   const challengeSubmitter = ChallengeSubmitter.create(store, chainService, logger, timingMetrics);
   const response = WalletResponse.initialize();
   const spy = jest.spyOn(chainService, 'challenge');
-  await challengeSubmitter.crank(objective, response);
+  await store.transaction(async tx => {
+    await challengeSubmitter.crank(objective, response, tx);
+  });
 
   if (callsChallenge) {
     if (args.challengeState) {

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -128,7 +128,9 @@ const crankAndAssert = async (
   const channelCloser = ChannelCloser.create(store, chainService, logger, timingMetrics);
   const response = WalletResponse.initialize();
   const spy = jest.spyOn(chainService, 'concludeAndWithdraw');
-  await channelCloser.crank(objective, response);
+  await store.transaction(async tx => {
+    await channelCloser.crank(objective, response, tx);
+  });
 
   // expect there to be an outgoing message in the response
   expect(response._signedStates).toMatchObject(

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -55,7 +55,9 @@ describe('when there is no challenge or finalized channel', () => {
     const withdrawSpy = jest.spyOn(chainService, 'concludeAndWithdraw');
 
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await store.transaction(tx =>
+      channelDefunder.crank(objective, WalletResponse.initialize(), tx)
+    );
 
     // Check the results
     expect(pushSpy).not.toHaveBeenCalled();
@@ -84,7 +86,9 @@ describe('when there is an active challenge', () => {
     const concludeSpy = jest.spyOn(chainService, 'concludeAndWithdraw');
 
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await store.transaction(tx =>
+      channelDefunder.crank(objective, WalletResponse.initialize(), tx)
+    );
 
     // Check the results
     const reloadedObjective = await store.getObjective(objective.objectiveId);
@@ -108,7 +112,9 @@ describe('when there is an active challenge', () => {
     await knex.transaction(tx => store.ensureObjective(objective, tx));
 
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await store.transaction(tx =>
+      channelDefunder.crank(objective, WalletResponse.initialize(), tx)
+    );
 
     // Check the results
     const reloadedObjective = await store.getObjective(objective.objectiveId);
@@ -140,7 +146,9 @@ describe('when the channel is finalized on chain', () => {
     const pushSpy = jest.spyOn(chainService, 'pushOutcomeAndWithdraw');
 
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await store.transaction(tx =>
+      channelDefunder.crank(objective, WalletResponse.initialize(), tx)
+    );
 
     // Check the results
     expect(pushSpy).toHaveBeenCalledWith(expect.objectContaining(challengeState), c.myAddress);
@@ -186,7 +194,8 @@ it('should fail the objective when the channel does not exist', async () => {
   await knex.transaction(tx => ObjectiveModel.insert(objective, tx));
 
   // Crank the protocol
-  await channelDefunder.crank(objective, WalletResponse.initialize());
+  await store.transaction(tx => channelDefunder.crank(objective, WalletResponse.initialize(), tx));
+
   // Check the results
   const reloadedObjective = await store.getObjective(objective.objectiveId);
   expect(reloadedObjective.status).toEqual('failed');

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -174,7 +174,9 @@ const crankAndAssert = async (
   const channelOpener = ChannelOpener.create(store, chainService, logger, timingMetrics);
   const response = WalletResponse.initialize();
   const spy = jest.spyOn(chainService, 'fundChannel');
-  await channelOpener.crank(objective, response);
+  await store.transaction(async tx => {
+    await channelOpener.crank(objective, response, tx);
+  });
 
   // expect there to be an outgoing message in the response
   expect(response._signedStates).toMatchObject(

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -29,44 +29,46 @@ export class ChannelOpener {
     return new ChannelOpener(store, chainService, logger, timingMetrics);
   }
 
-  public async crank(objective: DBOpenChannelObjective, response: WalletResponse): Promise<void> {
+  public async crank(
+    objective: DBOpenChannelObjective,
+    response: WalletResponse,
+    tx: Transaction
+  ): Promise<void> {
     const channelToLock = objective.data.targetChannelId;
 
-    await this.store.transaction(async tx => {
-      const channel = await this.store.getAndLockChannel(channelToLock, tx);
+    const channel = await this.store.getAndLockChannel(channelToLock, tx);
 
-      if (!channel) {
-        throw new Error(`ChannelOpener can't find channel with id ${channelToLock}`);
-      }
+    if (!channel) {
+      throw new Error(`ChannelOpener can't find channel with id ${channelToLock}`);
+    }
 
-      // if we haven't signed the pre-fund, sign it
-      if (!channel.prefundSigned) {
-        await this.signPrefundSetup(channel, response, tx);
-      }
+    // if we haven't signed the pre-fund, sign it
+    if (!channel.prefundSigned) {
+      await this.signPrefundSetup(channel, response, tx);
+    }
 
-      // if we don't have a supported preFundSetup, we're done for now
-      if (!channel.prefundSupported) {
-        response.queueChannel(channel); // always queue the channel if we've potentially touched it
-        return;
-      }
-
-      // if we have a full pre fund setup, delegate to the funding process to (a) see if
-      // the channel is funded, and (b) take action if not
-      const funded = await this.crankChannelFunder(objective, channel, response, tx);
-
-      // if the channel is funded and I haven't signed the post-fund, sign it
-      if (funded && !channel.postfundSigned) {
-        await this.signPostfundSetup(channel, response, tx);
-      }
-
-      if (channel.postfundSupported) {
-        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
-
-        response.queueSucceededObjective(objective);
-      }
-
+    // if we don't have a supported preFundSetup, we're done for now
+    if (!channel.prefundSupported) {
       response.queueChannel(channel); // always queue the channel if we've potentially touched it
-    });
+      return;
+    }
+
+    // if we have a full pre fund setup, delegate to the funding process to (a) see if
+    // the channel is funded, and (b) take action if not
+    const funded = await this.crankChannelFunder(objective, channel, response, tx);
+
+    // if the channel is funded and I haven't signed the post-fund, sign it
+    if (funded && !channel.postfundSigned) {
+      await this.signPostfundSetup(channel, response, tx);
+    }
+
+    if (channel.postfundSupported) {
+      await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+
+      response.queueSucceededObjective(objective);
+    }
+
+    response.queueChannel(channel); // always queue the channel if we've potentially touched it
   }
 
   private async crankChannelFunder(

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -1,6 +1,7 @@
 import {Logger} from 'pino';
 import {makeAddress} from '@statechannels/wallet-core';
 import {BigNumber} from 'ethers';
+import {Transaction} from 'knex';
 
 import {ChainServiceInterface} from '../chain-service';
 import {ChainServiceRequest} from '../models/chain-service-request';
@@ -27,46 +28,46 @@ export class ChannelDefunder {
 
   public async crank(
     objective: DBDefundChannelObjective,
-    _response: WalletResponse
+    _response: WalletResponse,
+    tx: Transaction
   ): Promise<void> {
     const {targetChannelId: channelId} = objective.data;
-    await this.store.transaction(async tx => {
-      const channel = await this.store.getAndLockChannel(channelId, tx);
 
-      if (!channel) {
-        this.logger.error(`No channel found for channel id ${channelId}`);
-        await this.store.markObjectiveStatus(objective, 'failed', tx);
-        return;
-      }
+    const channel = await this.store.getAndLockChannel(channelId, tx);
 
-      if (channel.fundingStrategy !== 'Direct') {
-        // TODO: https://github.com/statechannels/statechannels/issues/3124
-        this.logger.error(`Only direct funding is currently supported.`);
-        await this.store.markObjectiveStatus(objective, 'failed', tx);
-        return;
-      }
+    if (!channel) {
+      this.logger.error(`No channel found for channel id ${channelId}`);
+      await this.store.markObjectiveStatus(objective, 'failed', tx);
+      return;
+    }
 
-      const result = await AdjudicatorStatusModel.getAdjudicatorStatus(tx, channelId);
+    if (channel.fundingStrategy !== 'Direct') {
+      // TODO: https://github.com/statechannels/statechannels/issues/3124
+      this.logger.error(`Only direct funding is currently supported.`);
+      await this.store.markObjectiveStatus(objective, 'failed', tx);
+      return;
+    }
 
-      const channelHoldings =
-        channel.assetHolderAddress &&
-        (await this.store.getFunding(channelId, makeAddress(channel.assetHolderAddress), tx));
+    const result = await AdjudicatorStatusModel.getAdjudicatorStatus(tx, channelId);
 
-      const outcomePushed = !channelHoldings || BigNumber.from(channelHoldings.amount).isZero();
-      if (result.channelMode === 'Finalized') {
-        if (!outcomePushed) {
-          await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
-          this.chainService.pushOutcomeAndWithdraw(result.states[0], channel.myAddress);
-          await this.store.markObjectiveStatus(objective, 'succeeded', tx);
-        } else {
-          this.logger.trace('Outcome already pushed, doing nothing');
-        }
-      } else if (channel.hasConclusionProof) {
-        await ChainServiceRequest.insertOrUpdate(channelId, 'withdraw', tx);
-        this.chainService.concludeAndWithdraw(channel.support);
+    const channelHoldings =
+      channel.assetHolderAddress &&
+      (await this.store.getFunding(channelId, makeAddress(channel.assetHolderAddress), tx));
+
+    const outcomePushed = !channelHoldings || BigNumber.from(channelHoldings.amount).isZero();
+    if (result.channelMode === 'Finalized') {
+      if (!outcomePushed) {
+        await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
+        this.chainService.pushOutcomeAndWithdraw(result.states[0], channel.myAddress);
         await this.store.markObjectiveStatus(objective, 'succeeded', tx);
-        return;
+      } else {
+        this.logger.trace('Outcome already pushed, doing nothing');
       }
-    });
+    } else if (channel.hasConclusionProof) {
+      await ChainServiceRequest.insertOrUpdate(channelId, 'withdraw', tx);
+      this.chainService.concludeAndWithdraw(channel.support);
+      await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+      return;
+    }
   }
 }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -714,29 +714,26 @@ export class SingleThreadedWallet
 
   // todo(tom): change function to return a value instead of mutating input args
   private async crankUntilIdle(channels: Bytes32[], response: WalletResponse): Promise<void> {
-    await this.store.transaction(async tx => {
-      // Fetch channels related to the channels argument where related means, either:
-      // - The channel is in the channels array
-      // - The channel is being funded by one of the channels in the channels array
-      const channelsWithRelevantPendingReqs = await this.store.getChannelIdsPendingLedgerFundingFrom(
-        channels,
-        tx
-      );
+    // Fetch channels related to the channels argument where related means, either:
+    // - The channel is in the channels array
+    // - The channel is being funded by one of the channels in the channels array
+    const channelsWithRelevantPendingReqs = await this.store.getChannelIdsPendingLedgerFundingFrom(
+      channels
+    );
 
-      const objectives = (
-        await this.store.getObjectives(channels.concat(channelsWithRelevantPendingReqs), tx)
-      ).filter(objective => objective.status === 'approved');
+    const objectives = (
+      await this.store.getObjectives(channels.concat(channelsWithRelevantPendingReqs))
+    ).filter(objective => objective.status === 'approved');
 
-      // todo(tom): why isn't this just a for loop?
-      while (objectives.length) {
-        const [{objectiveId}] = objectives;
+    // todo(tom): why isn't this just a for loop?
+    while (objectives.length) {
+      const [{objectiveId}] = objectives;
 
-        await this.objectiveManager.crank(objectiveId, response, tx);
+      await this.objectiveManager.crank(objectiveId, response);
 
-        // remove objective from list
-        objectives.shift();
-      }
-    });
+      // remove objective from list
+      objectives.shift();
+    }
   }
 
   // ChainEventSubscriberInterface implementation


### PR DESCRIPTION
Wraps `crank` in a transaction as a means of ensuring a crank is done inside of a transaction. Enables the ability to provide `tx` object to `getObjectives` which enables usage of `.forUpdate` to avoid cranking the same objective in two threads or processes.

This pull request was inspired after noticing that #3109 appeared to [demonstrate a flickering test](https://app.circleci.com/pipelines/github/statechannels/statechannels/11244/workflows/8dd29206-1558-4bc9-92ec-3b1733ee98af/jobs/54895) that indicated an objective was being operated on despite having been deleted. The [server wallet architecture doc](https://www.notion.so/elfour/Server-wallet-updated-architecture-ad0372e611ac485aa16dc2c4df65a14f) implies that an objective ought to only ever be handled by a single process as there is always only one logical "crank" to be done with it. We have a partial implementation of that now as the _channel_ is locked within the execution of the crank, but the objective remains freely usable. It seems safe to wrap the crank as a whole inside a transaction to mitigate this risk. 