### PR TITLE
Defund Channel Protocol

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -14,6 +14,7 @@ import { CloseChannel } from '@statechannels/wallet-core';
 import { CloseChannelParams } from '@statechannels/client-api-schema';
 import { Config } from 'knex';
 import { CreateChannelParams } from '@statechannels/client-api-schema';
+import { DefundChannel } from '@statechannels/wallet-core';
 import { Destination } from '@statechannels/wallet-core';
 import { ethers } from 'ethers';
 import EventEmitter from 'eventemitter3';

--- a/packages/server-wallet/src/db/migrations/20210112164123_add_push_outcome_status.ts
+++ b/packages/server-wallet/src/db/migrations/20210112164123_add_push_outcome_status.ts
@@ -1,0 +1,32 @@
+import * as Knex from 'knex';
+
+import {chainServiceRequests} from './20200915140300_chain_service';
+
+const requestsConstraint = `valid_requests`;
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`\
+    ALTER TABLE ${chainServiceRequests}
+    DROP CONSTRAINT ${requestsConstraint}
+    `);
+  await knex.raw(`\
+    ALTER TABLE ${chainServiceRequests}
+    ADD CONSTRAINT ${requestsConstraint}
+    CHECK (
+      array_position (ARRAY['fund', 'withdraw', 'challenge','pushOutcome']::VARCHAR[], request ) IS NOT NULL
+    )
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`\
+    ALTER TABLE ${chainServiceRequests}
+    DROP CONSTRAINT ${requestsConstraint}
+    `);
+  await knex.raw(`\
+    ALTER TABLE ${chainServiceRequests}
+    ADD CONSTRAINT ${requestsConstraint}
+    CHECK (
+      array_position (ARRAY['fund', 'withdraw', 'challenge']::VARCHAR[], request ) IS NOT NULL
+    )
+  `);
+}

--- a/packages/server-wallet/src/models/chain-service-request.ts
+++ b/packages/server-wallet/src/models/chain-service-request.ts
@@ -8,7 +8,7 @@ export const requestTimeout = 10 * 60 * 1_000;
 const ID_COLUMN = ['channelId', 'request'] as const;
 const REQUIRED_COLUMNS = [...ID_COLUMN, 'timestamp'] as const;
 
-type Request = 'fund' | 'withdraw' | 'challenge';
+type Request = 'fund' | 'withdraw' | 'challenge' | 'pushOutcome';
 
 interface RequiredColumns {
   readonly channelId: Bytes32;

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -170,6 +170,11 @@ export class ObjectiveModel extends Model {
       .findById(objectiveId)
       .patch({status: 'succeeded'});
   }
+  static async failed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
+    await ObjectiveModel.query(tx)
+      .findById(objectiveId)
+      .patch({status: 'failed'});
+  }
 
   static async forChannelIds(
     targetChannelIds: string[],

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -160,20 +160,14 @@ export class ObjectiveModel extends Model {
   }
 
   static async approve(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx)
-      .findById(objectiveId)
-      .patch({status: 'approved'});
+    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'approved'});
   }
 
   static async succeed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx)
-      .findById(objectiveId)
-      .patch({status: 'succeeded'});
+    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'succeeded'});
   }
   static async failed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx)
-      .findById(objectiveId)
-      .patch({status: 'failed'});
+    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'failed'});
   }
 
   static async forChannelIds(

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -8,6 +8,7 @@ import {Store} from '../wallet/store';
 import {ChainServiceInterface} from '../chain-service';
 import {WalletResponse} from '../wallet/wallet-response';
 import {ChallengeSubmitter} from '../protocols/challenge-submitter';
+import {ChannelDefunder} from '../protocols/defund-channel';
 
 import {ObjectiveManagerParams} from './types';
 import {CloseChannelObjective} from './close-channel';
@@ -47,10 +48,17 @@ export class ObjectiveManager {
         return this.channelCloser.crank(objective, response);
       case 'SubmitChallenge':
         return this.challengeSubmitter.crank(objective, response);
+      case 'DefundChannel':
+        return this.channelDefunder.crank(objective, response);
       default:
         unreachable(objective);
     }
   }
+
+  private get channelDefunder(): ChannelDefunder {
+    return ChannelDefunder.create(this.store, this.chainService, this.logger, this.timingMetrics);
+  }
+
   private get challengeSubmitter(): ChallengeSubmitter {
     return ChallengeSubmitter.create(
       this.store,

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -72,6 +72,7 @@ test('when the channel does not exist it should fail the objective', async () =>
   const reloadedObjective = await store.getObjective(obj.objectiveId);
   expect(reloadedObjective.status).toEqual('failed');
 });
+
 test('when using non-direct funding it fails', async () => {
   const chainService = new MockChainService();
   const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,0 +1,127 @@
+import {State} from '@statechannels/wallet-core';
+
+import {defaultTestConfig} from '../..';
+import {createLogger} from '../../logger';
+import {DBDefundChannelObjective} from '../../models/objective';
+import {Store} from '../../wallet/store';
+import {testKnex as knex} from '../../../jest/knex-setup-teardown';
+import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {channel} from '../../models/__test__/fixtures/channel';
+import {Channel} from '../../models/channel';
+import {MockChainService} from '../../chain-service';
+import {WalletResponse} from '../../wallet/wallet-response';
+import {ChannelDefunder} from '../defund-channel';
+import {ChallengeStatus} from '../../models/challenge-status';
+import {stateVars} from '../../wallet/__test__/fixtures/state-vars';
+import {stateWithHashSignedBy} from '../../wallet/__test__/fixtures/states';
+import {alice, bob} from '../../wallet/__test__/fixtures/signing-wallets';
+
+const logger = createLogger(defaultTestConfig());
+const timingMetrics = false;
+
+let store: Store;
+beforeEach(async () => {
+  store = new Store(
+    knex,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
+    '0'
+  );
+
+  await store.dbAdmin().truncateDB();
+  await seedAlicesSigningWallet(knex);
+});
+
+describe('when a channel is finalized on chain', () => {
+  it('defunds the channel by calling pushOutcomeAndWithdraw', async () => {
+    const c = channel();
+
+    await Channel.query(knex)
+      .withGraphFetched('signingWallet')
+      .insert(c);
+    await ChallengeStatus.insertChallengeStatus(knex, c.channelId, 100, {
+      ...c.channelConstants,
+      ...stateVars(),
+    });
+    await ChallengeStatus.setFinalized(knex, c.channelId, 200);
+    const obj: DBDefundChannelObjective = {
+      type: 'DefundChannel',
+      status: 'pending',
+      objectiveId: ['DefundChannel', c.channelId].join('-'),
+      data: {targetChannelId: c.channelId},
+    };
+
+    await knex.transaction(tx => store.ensureObjective(obj, tx));
+    await await crankAndAssert(obj, {calls: 'pushOutcomeAndWithdraw', completesObj: true});
+  });
+  it('if the channel has not been concluded on chain it should call withdrawAndPushOutcome', async () => {
+    const c = channel({
+      channelNonce: 1,
+      vars: [stateWithHashSignedBy([alice(), bob()])({isFinal: true})],
+    });
+
+    await Channel.query(knex)
+      .withGraphFetched('signingWallet')
+      .insert(c);
+
+    await ChallengeStatus.setFinalized(knex, c.channelId, 200);
+    const obj: DBDefundChannelObjective = {
+      type: 'DefundChannel',
+      status: 'pending',
+      objectiveId: ['DefundChannel', c.channelId].join('-'),
+      data: {targetChannelId: c.channelId},
+    };
+
+    await knex.transaction(tx => store.ensureObjective(obj, tx));
+    await await crankAndAssert(obj, {completesObj: true, calls: 'concludeAndWithdraw'});
+  });
+});
+afterEach(async () => {
+  await store.dbAdmin().truncateDB();
+});
+
+interface AssertionParams {
+  challengeState?: State;
+  calls: 'pushOutcomeAndWithdraw' | 'concludeAndWithdraw' | 'none';
+  completesObj?: boolean;
+}
+
+const crankAndAssert = async (
+  objective: DBDefundChannelObjective,
+  args: AssertionParams
+): Promise<void> => {
+  const completesObj = args.completesObj || false;
+
+  const chainService = new MockChainService();
+  const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);
+  const response = WalletResponse.initialize();
+  const pushSpy = jest.spyOn(chainService, 'pushOutcomeAndWithdraw');
+  const withdrawSpy = jest.spyOn(chainService, 'concludeAndWithdraw');
+  await channelDefunder.crank(objective, response);
+
+  if (args.calls === 'none') {
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(withdrawSpy).not.toHaveBeenCalled();
+  } else if (args.calls === 'pushOutcomeAndWithdraw') {
+    if (args.challengeState) {
+      expect(pushSpy).toHaveBeenCalledWith(
+        expect.objectContaining(args.challengeState),
+        expect.anything()
+      );
+    } else {
+      expect(pushSpy).toHaveBeenCalled();
+    }
+    expect(withdrawSpy).not.toHaveBeenCalled();
+  } else {
+    expect(withdrawSpy).toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+  }
+
+  const reloadedObjective = await store.getObjective(objective.objectiveId);
+
+  if (completesObj) {
+    expect(reloadedObjective.status).toEqual('succeeded');
+  } else {
+    expect(reloadedObjective.status).toEqual('pending');
+  }
+};

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,8 +1,6 @@
-import {State} from '@statechannels/wallet-core';
-
 import {defaultTestConfig} from '../..';
 import {createLogger} from '../../logger';
-import {DBDefundChannelObjective} from '../../models/objective';
+import {DBDefundChannelObjective, ObjectiveModel} from '../../models/objective';
 import {Store} from '../../wallet/store';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
@@ -32,96 +30,133 @@ beforeEach(async () => {
   await seedAlicesSigningWallet(knex);
 });
 
-describe('when a channel is finalized on chain', () => {
-  it('defunds the channel by calling pushOutcomeAndWithdraw', async () => {
-    const c = channel();
+test('when the channel does not exist it should fail the objective', async () => {
+  const chainService = new MockChainService();
+  const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);
+  const c = channel();
 
-    await Channel.query(knex)
-      .withGraphFetched('signingWallet')
-      .insert(c);
-    await ChallengeStatus.insertChallengeStatus(knex, c.channelId, 100, {
-      ...c.channelConstants,
-      ...stateVars(),
-    });
-    await ChallengeStatus.setFinalized(knex, c.channelId, 200);
-    const obj: DBDefundChannelObjective = {
-      type: 'DefundChannel',
-      status: 'pending',
-      objectiveId: ['DefundChannel', c.channelId].join('-'),
-      data: {targetChannelId: c.channelId},
-    };
+  const obj: DBDefundChannelObjective = {
+    type: 'DefundChannel',
+    status: 'pending',
+    objectiveId: ['DefundChannel', c.channelId].join('-'),
+    data: {targetChannelId: c.channelId},
+  };
 
-    await knex.transaction(tx => store.ensureObjective(obj, tx));
-    await await crankAndAssert(obj, {calls: 'pushOutcomeAndWithdraw', completesObj: true});
-  });
-  it('if the channel has not been concluded on chain it should call withdrawAndPushOutcome', async () => {
-    const c = channel({
-      channelNonce: 1,
-      vars: [stateWithHashSignedBy([alice(), bob()])({isFinal: true})],
-    });
+  await knex.transaction(tx => ObjectiveModel.insert(obj, tx));
+  const response = WalletResponse.initialize();
 
-    await Channel.query(knex)
-      .withGraphFetched('signingWallet')
-      .insert(c);
+  await channelDefunder.crank(obj, response);
 
-    await ChallengeStatus.setFinalized(knex, c.channelId, 200);
-    const obj: DBDefundChannelObjective = {
-      type: 'DefundChannel',
-      status: 'pending',
-      objectiveId: ['DefundChannel', c.channelId].join('-'),
-      data: {targetChannelId: c.channelId},
-    };
-
-    await knex.transaction(tx => store.ensureObjective(obj, tx));
-    await await crankAndAssert(obj, {completesObj: true, calls: 'concludeAndWithdraw'});
-  });
+  const reloadedObjective = await store.getObjective(obj.objectiveId);
+  expect(reloadedObjective.status).toEqual('failed');
 });
+
+test('when using non-direct funding it fails', async () => {
+  const chainService = new MockChainService();
+  const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);
+
+  const c = channel({fundingStrategy: 'Fake'});
+
+  await Channel.query(knex)
+    .withGraphFetched('signingWallet')
+    .insert(c);
+
+  const obj = createPendingObjective(c.channelId);
+  await knex.transaction(tx => store.ensureObjective(obj, tx));
+  const response = WalletResponse.initialize();
+
+  await channelDefunder.crank(obj, response);
+
+  const reloadedObjective = await store.getObjective(obj.objectiveId);
+  expect(reloadedObjective.status).toEqual('failed');
+});
+
+test('when there is an active challenge it should do nothing', async () => {
+  const chainService = new MockChainService();
+  const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);
+
+  const c = channel();
+  const challengeState = {
+    ...c.channelConstants,
+    ...stateVars(),
+  };
+  await Channel.query(knex)
+    .withGraphFetched('signingWallet')
+    .insert(c);
+  await ChallengeStatus.insertChallengeStatus(knex, c.channelId, 100, challengeState);
+
+  const obj = createPendingObjective(c.channelId);
+  await knex.transaction(tx => store.ensureObjective(obj, tx));
+  const response = WalletResponse.initialize();
+
+  await channelDefunder.crank(obj, response);
+
+  const reloadedObjective = await store.getObjective(obj.objectiveId);
+  expect(reloadedObjective.status).toEqual('pending');
+});
+
+test('when the channel is not finalized it defunds the channel by calling pushOutcomeAndWithdraw', async () => {
+  const chainService = new MockChainService();
+  const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);
+  const c = channel();
+  const challengeState = {
+    ...c.channelConstants,
+    ...stateVars(),
+  };
+  await Channel.query(knex)
+    .withGraphFetched('signingWallet')
+    .insert(c);
+  await ChallengeStatus.insertChallengeStatus(knex, c.channelId, 100, challengeState);
+  await ChallengeStatus.setFinalized(knex, c.channelId, 200);
+  const obj = createPendingObjective(c.channelId);
+
+  await knex.transaction(tx => store.ensureObjective(obj, tx));
+  const response = WalletResponse.initialize();
+  const pushSpy = jest.spyOn(chainService, 'pushOutcomeAndWithdraw');
+
+  await channelDefunder.crank(obj, response);
+
+  expect(pushSpy).toHaveBeenCalledWith(challengeState, c.myAddress);
+  const reloadedObjective = await store.getObjective(obj.objectiveId);
+  expect(reloadedObjective.status).toEqual('succeeded');
+});
+
+test('when the channel has not been concluded on chain it should call withdrawAndPushOutcome', async () => {
+  const chainService = new MockChainService();
+  const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);
+  const c = channel({
+    channelNonce: 1,
+    vars: [stateWithHashSignedBy([alice(), bob()])({isFinal: true})],
+  });
+
+  await Channel.query(knex)
+    .withGraphFetched('signingWallet')
+    .insert(c);
+
+  await ChallengeStatus.setFinalized(knex, c.channelId, 200);
+  const obj = createPendingObjective(c.channelId);
+
+  await knex.transaction(tx => store.ensureObjective(obj, tx));
+  const response = WalletResponse.initialize();
+  const withdrawSpy = jest.spyOn(chainService, 'concludeAndWithdraw');
+
+  await channelDefunder.crank(obj, response);
+
+  expect(withdrawSpy).toHaveBeenCalledWith(c.support);
+
+  const reloadedObjective = await store.getObjective(obj.objectiveId);
+  expect(reloadedObjective.status).toEqual('succeeded');
+});
+
 afterEach(async () => {
   await store.dbAdmin().truncateDB();
 });
 
-interface AssertionParams {
-  challengeState?: State;
-  calls: 'pushOutcomeAndWithdraw' | 'concludeAndWithdraw' | 'none';
-  completesObj?: boolean;
+function createPendingObjective(channelId: string): DBDefundChannelObjective {
+  return {
+    type: 'DefundChannel',
+    status: 'pending',
+    objectiveId: ['DefundChannel', channelId].join('-'),
+    data: {targetChannelId: channelId},
+  };
 }
-
-const crankAndAssert = async (
-  objective: DBDefundChannelObjective,
-  args: AssertionParams
-): Promise<void> => {
-  const completesObj = args.completesObj || false;
-
-  const chainService = new MockChainService();
-  const channelDefunder = ChannelDefunder.create(store, chainService, logger, timingMetrics);
-  const response = WalletResponse.initialize();
-  const pushSpy = jest.spyOn(chainService, 'pushOutcomeAndWithdraw');
-  const withdrawSpy = jest.spyOn(chainService, 'concludeAndWithdraw');
-  await channelDefunder.crank(objective, response);
-
-  if (args.calls === 'none') {
-    expect(pushSpy).not.toHaveBeenCalled();
-    expect(withdrawSpy).not.toHaveBeenCalled();
-  } else if (args.calls === 'pushOutcomeAndWithdraw') {
-    if (args.challengeState) {
-      expect(pushSpy).toHaveBeenCalledWith(
-        expect.objectContaining(args.challengeState),
-        expect.anything()
-      );
-    } else {
-      expect(pushSpy).toHaveBeenCalled();
-    }
-    expect(withdrawSpy).not.toHaveBeenCalled();
-  } else {
-    expect(withdrawSpy).toHaveBeenCalled();
-    expect(pushSpy).not.toHaveBeenCalled();
-  }
-
-  const reloadedObjective = await store.getObjective(objective.objectiveId);
-
-  if (completesObj) {
-    expect(reloadedObjective.status).toEqual('succeeded');
-  } else {
-    expect(reloadedObjective.status).toEqual('pending');
-  }
-};

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -65,7 +65,7 @@ export class ChallengeSubmitter {
 
       await this.chainService.challenge([signedState], channel.signingWallet.privateKey);
 
-      await this.store.markObjectiveStatus(objective, 'succeed', tx);
+      await this.store.markObjectiveStatus(objective, 'succeeded', tx);
       response.queueChannel(channel);
     });
   }

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -65,7 +65,7 @@ export class ChallengeSubmitter {
 
       await this.chainService.challenge([signedState], channel.signingWallet.privateKey);
 
-      await this.store.markObjectiveAsSucceeded(objective, tx);
+      await this.store.markObjectiveStatus(objective, 'succeed', tx);
       response.queueChannel(channel);
     });
   }

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -60,7 +60,7 @@ export class ChannelOpener {
       }
 
       if (channel.postfundSupported) {
-        await this.store.markObjectiveAsSucceeded(objective, tx);
+        await this.store.markObjectiveStatus(objective, 'succeed', tx);
 
         response.queueSucceededObjective(objective);
       }

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -60,7 +60,7 @@ export class ChannelOpener {
       }
 
       if (channel.postfundSupported) {
-        await this.store.markObjectiveStatus(objective, 'succeed', tx);
+        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
 
         response.queueSucceededObjective(objective);
       }

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -107,7 +107,7 @@ export class ChannelCloser {
     tx: Transaction,
     response: WalletResponse
   ): Promise<void> {
-    await this.store.markObjectiveAsSucceeded(objective, tx);
+    await this.store.markObjectiveStatus(objective, 'succeed', tx);
 
     response.queueChannelState(protocolState.app);
     response.queueSucceededObjective(objective);

--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -107,7 +107,7 @@ export class ChannelCloser {
     tx: Transaction,
     response: WalletResponse
   ): Promise<void> {
-    await this.store.markObjectiveStatus(objective, 'succeed', tx);
+    await this.store.markObjectiveStatus(objective, 'succeeded', tx);
 
     response.queueChannelState(protocolState.app);
     response.queueSucceededObjective(objective);

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -1,0 +1,59 @@
+import {Logger} from 'pino';
+
+import {ChainServiceInterface} from '../chain-service';
+import {ChallengeStatus} from '../models/challenge-status';
+import {DBDefundChannelObjective} from '../models/objective';
+import {Store} from '../wallet/store';
+import {WalletResponse} from '../wallet/wallet-response';
+
+export class ChannelDefunder {
+  constructor(
+    private store: Store,
+    private chainService: ChainServiceInterface,
+    logger: Logger,
+    _timingMetrics = false
+  ) {}
+  public static create(
+    store: Store,
+    chainService: ChainServiceInterface,
+    logger: Logger,
+    timingMetrics = false
+  ): ChannelDefunder {
+    return new ChannelDefunder(store, chainService, logger, timingMetrics);
+  }
+  public async crank(
+    objective: DBDefundChannelObjective,
+    _response: WalletResponse
+  ): Promise<void> {
+    const {targetChannelId: channelId} = objective.data;
+    await this.store.transaction(async tx => {
+      const channel = await this.store.getAndLockChannel(channelId, tx);
+      if (!channel) {
+        throw new Error(`No channel found for channel id ${channelId}`);
+      }
+
+      if (channel.fundingStrategy !== 'Direct') {
+        // TODO: https://github.com/statechannels/statechannels/issues/3124
+        throw new Error('Only direct funding is currently supported.');
+      }
+
+      const result = await ChallengeStatus.getChallengeStatus(tx, channelId);
+
+      if (result.status === 'Challenge Active') {
+        throw new Error('Cannot defund a channel with an active challenge');
+        // TODO: We might want to refactor challengeStatus to something that
+        // applies to both co-operatively concluding or challenging
+      } else if (result.status === 'Challenge Finalized') {
+        this.chainService.pushOutcomeAndWithdraw(result.challengeState, channel.myAddress);
+      } else {
+        // No challenge found so we must need to call concludeAndWithdraw
+        if (!channel.hasConclusionProof) {
+          throw new Error('The support is not a valid conclusion proof.');
+        }
+        this.chainService.concludeAndWithdraw(channel.support);
+      }
+
+      await this.store.markObjectiveAsSucceeded(objective, tx);
+    });
+  }
+}

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -50,11 +50,14 @@ export class ChannelDefunder {
       // applies to both co-operatively concluding or challenging
       // see https://github.com/statechannels/statechannels/issues/3132
       if (result.status === 'Challenge Finalized') {
-        await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
-        this.chainService.pushOutcomeAndWithdraw(result.challengeState, channel.myAddress);
-        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
-
-        return;
+        if (result.challengeState.isFinal) {
+          // We should handle this in https://github.com/statechannels/statechannels/issues/3112
+          this.logger.warn('TODO: Currently do not support defunding concluded channels');
+        } else {
+          await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
+          this.chainService.pushOutcomeAndWithdraw(result.challengeState, channel.myAddress);
+          await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+        }
       } else if (channel.hasConclusionProof) {
         await ChainServiceRequest.insertOrUpdate(channelId, 'withdraw', tx);
         this.chainService.concludeAndWithdraw(channel.support);

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -46,11 +46,6 @@ export class ChannelDefunder {
 
       const result = await ChallengeStatus.getChallengeStatus(tx, channelId);
 
-      if (result.status === 'Challenge Active') {
-        this.logger.warn('There is a challenge active so cannot defund the channel');
-        return;
-      }
-
       // TODO: We might want to refactor challengeStatus to something that
       // applies to both co-operatively concluding or challenging
       // see https://github.com/statechannels/statechannels/issues/3132

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -54,11 +54,11 @@ export class ChannelDefunder {
       // applies to both co-operatively concluding or challenging
       if (result.status === 'Challenge Finalized') {
         this.chainService.pushOutcomeAndWithdraw(result.challengeState, channel.myAddress);
-        await this.store.markObjectiveStatus(objective, 'succeed', tx);
+        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
         return;
       } else if (channel.hasConclusionProof) {
         this.chainService.concludeAndWithdraw(channel.support);
-        await this.store.markObjectiveStatus(objective, 'succeed', tx);
+        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
         return;
       }
     });

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -53,6 +53,7 @@ export class ChannelDefunder {
 
       // TODO: We might want to refactor challengeStatus to something that
       // applies to both co-operatively concluding or challenging
+      // see https://github.com/statechannels/statechannels/issues/3132
       if (result.status === 'Challenge Finalized') {
         await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
         this.chainService.pushOutcomeAndWithdraw(result.challengeState, channel.myAddress);

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -353,8 +353,16 @@ export class Store {
     await ObjectiveModel.approve(objectiveId, tx || this.knex);
   }
 
-  async markObjectiveAsSucceeded(objective: DBObjective, tx?: Transaction): Promise<void> {
-    await ObjectiveModel.succeed(objective.objectiveId, tx || this.knex);
+  async markObjectiveStatus(
+    objective: DBObjective,
+    status: 'succeed' | 'failed',
+    tx?: Transaction
+  ): Promise<void> {
+    if (status === 'succeed') {
+      await ObjectiveModel.succeed(objective.objectiveId, tx || this.knex);
+    } else {
+      await ObjectiveModel.failed(objective.objectiveId, tx || this.knex);
+    }
   }
 
   private bytecodeCache: Record<string, string | undefined> = {};

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -355,10 +355,10 @@ export class Store {
 
   async markObjectiveStatus(
     objective: DBObjective,
-    status: 'succeed' | 'failed',
+    status: 'succeeded' | 'failed',
     tx?: Transaction
   ): Promise<void> {
-    if (status === 'succeed') {
+    if (status === 'succeeded') {
       await ObjectiveModel.succeed(objective.objectiveId, tx || this.knex);
     } else {
       await ObjectiveModel.failed(objective.objectiveId, tx || this.knex);

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -145,6 +145,13 @@ export type SubmitChallenge = _Objective<
   }
 >;
 
+export type DefundChannel = _Objective<
+  'DefundChannel',
+  {
+    targetChannelId: string;
+  }
+>;
+
 export type SharedObjective =
   | OpenChannel
   | CloseChannel
@@ -153,7 +160,7 @@ export type SharedObjective =
   | FundLedger
   | CloseLedger;
 
-export type Objective = SharedObjective | SubmitChallenge;
+export type Objective = SharedObjective | SubmitChallenge | DefundChannel;
 
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;
@@ -164,6 +171,7 @@ export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');
 export const isFundLedger = guard<FundLedger>('FundLedger');
 export const isCloseLedger = guard<CloseLedger>('CloseLedger');
 export const isSubmitChallenge = guard<SubmitChallenge>('SubmitChallenge');
+export const isDefundChannel = guard<DefundChannel>('DefundChannel');
 
 export function objectiveId(objective: Objective): string {
   switch (objective.type) {
@@ -171,6 +179,7 @@ export function objectiveId(objective: Objective): string {
     case 'CloseChannel':
     case 'VirtuallyFund':
     case 'SubmitChallenge':
+    case 'DefundChannel':
       return [objective.type, objective.data.targetChannelId].join('-');
     case 'FundGuarantor':
       return [objective.type, objective.data.guarantorId].join('-');


### PR DESCRIPTION
Fixes #3113 

Introduces a `DefundChannel` protocol that is responsible for defunding a channel by calling either `pushOutcomeAndTransferAll` or `concludePushOutcomeAndTransferAll` on chain.

A `DefundChannel` objective now gets added when a channel is finalized.

The `DefundChannel` protocol is pretty simple and does the following:
- Checks if the channel is finalized on chain (by consulting the `ChallengeStatus` table) 
- If so it calls `pushOutcomeAndTransferAll`
- If not check if the channel has a conclusion proof
- If so it calls `concludePushOutcomeAndTransferAll`
- If not do nothing

