### PR TITLE
Refactor logic around computing 'status' of channel result

### DIFF
--- a/packages/server-wallet/src/protocols/close-channel.ts
+++ b/packages/server-wallet/src/protocols/close-channel.ts
@@ -1,4 +1,4 @@
-import {checkThat, isSimpleAllocation, State, unreachable} from '@statechannels/wallet-core';
+import {checkThat, isSimpleAllocation, unreachable} from '@statechannels/wallet-core';
 import {Transaction} from 'knex';
 import {Logger} from 'pino';
 import {isExternalDestination} from '@statechannels/nitro-protocol';

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -69,12 +69,12 @@ export const status = (channelState: ChannelState): ChannelStatus => {
     return 'opening';
   }
 
-  if (supported.turnNum < 2 * participants.length - 1) return 'opening';
-
   if (supported.isFinal) {
     if (_.every(support, 'isFinal')) return 'closed';
     return 'closing';
   }
+
+  if (supported.turnNum < 2 * participants.length - 1) return 'opening';
 
   return 'running';
 };

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -3,7 +3,6 @@ import {
   serializeAllocation,
   checkThat,
   isAllocation,
-  State,
   Participant,
   Address,
   Destination,
@@ -55,62 +54,54 @@ type SignedByMe = {latestSignedByMe: SignedStateWithHash};
 export type ChannelStateWithMe = ChannelState & SignedByMe;
 export type ChannelStateWithSupported = ChannelState & SignedByMe & WithSupported;
 
-export type Stage = 'Missing' | 'PrefundSetup' | 'PostfundSetup' | 'Running' | 'Final';
 /**
- *
- * @param state: SignedStateWithHash | undefined
- * Returns stage of state.
- *
- * Useful for partitioning the protocol state to decide what action to next take.
+ * The definition of a ChannelStatus is still under debate, but for now
+ * this is what we have settled on. Future changes should include 'funding',
+ * 'defunding', and state related to challenging, probably. See this issue
+ * for more: https://github.com/statechannels/statechannels/issues/2509
  */
-export const stage = (state: State | undefined): Stage =>
-  !state
-    ? 'Missing'
-    : state.isFinal
-    ? 'Final'
-    : state.turnNum <= state.participants.length - 1
-    ? 'PrefundSetup'
-    : state.turnNum <= state.participants.length * 2 - 1
-    ? 'PostfundSetup'
-    : 'Running';
+export const status = (channelState: ChannelState): ChannelStatus => {
+  const {supported, latest, latestSignedByMe, support} = channelState;
+  const {participants} = supported ?? latest;
+  if (supported?.isFinal) {
+    if (support?.every(s => s.isFinal)) {
+      return 'closed'; // the entire support chain isFinal
+    } else {
+      return 'closing'; // at least one isFinal state proposed
+    }
+  } else {
+    if (latest.turnNum >= participants.length * 2) {
+      return 'running'; // unambiguously running e.g., 4, 5, 6, ...
+    } else {
+      if (latest.turnNum < participants.length) {
+        if (latestSignedByMe) {
+          return 'opening'; // 0 or 1 signed by me
+        } else {
+          return 'proposed'; // 0 or 1 signed, but not by me
+        }
+      } else {
+        if (support?.every(s => s.turnNum >= participants.length)) {
+          return 'running'; // <-- e.g., 2 and 3 both signed
+        } else {
+          return 'opening'; // <-- debatebly this could be 'funding'
+        }
+      }
+    }
+  }
+};
 
 export const toChannelResult = (channelState: ChannelState): ChannelResult => {
-  const {
-    channelId,
-    supported,
-    latest,
-    latestSignedByMe,
-    support,
-    directFundingStatus,
-    challengeStatus,
-  } = channelState;
+  const {channelId, supported, latest, directFundingStatus, challengeStatus} = channelState;
 
   const {outcome, appData, turnNum, participants, appDefinition} = supported ?? latest;
-
-  const status: ChannelStatus = ((): ChannelStatus => {
-    switch (stage(supported)) {
-      case 'Missing':
-      case 'PrefundSetup':
-        return latestSignedByMe ? 'opening' : 'proposed';
-      case 'PostfundSetup':
-        return (supported?.turnNum || 0) < participants.length * 2 - 1 ? 'opening' : 'running';
-      case 'Running':
-        return 'running';
-      case 'Final':
-        return support?.find(s => !s.isFinal) ? 'closing' : 'closed';
-    }
-  })();
-
-  const allocations = serializeAllocation(checkThat(outcome, isAllocation));
-
   return {
     appData,
     appDefinition,
     channelId,
     participants,
     turnNum,
-    allocations,
-    status,
+    allocations: serializeAllocation(checkThat(outcome, isAllocation)),
+    status: status(channelState),
     fundingStatus: directFundingStatus,
     challengeStatus,
   };

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -64,18 +64,19 @@ export const status = (channelState: ChannelState): ChannelStatus => {
   const {supported, latest, latestSignedByMe, support} = channelState;
   const {participants} = supported ?? latest;
 
-  if (supported?.isFinal) {
-    if (support?.every(s => s.isFinal)) return 'closed'; // the entire support chain isFinal
-    return 'closing'; // the latest state, and possibly other states, are isFinal
+  if (!supported) {
+    if (!latestSignedByMe) return 'proposed';
+    return 'opening';
   }
 
-  if (latest.turnNum < 2 * participants.length) {
-    if (supported?.turnNum === participants.length - 1) return 'running'; // 3
-    if (latestSignedByMe) return 'opening'; // 0 or 1 signed by me
-    return 'proposed'; // 0 or 1 signed, but not by me
+  if (supported.turnNum < 2 * participants.length - 1) return 'opening';
+
+  if (supported.isFinal) {
+    if (_.every(support, 'isFinal')) return 'closed';
+    return 'closing';
   }
 
-  return 'running'; // unambiguously running e.g., 4, 5, 6, ...
+  return 'running';
 };
 
 export const toChannelResult = (channelState: ChannelState): ChannelResult => {

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -67,7 +67,7 @@ export const status = (channelState: ChannelState): ChannelStatus => {
     if (support?.every(s => s.isFinal)) {
       return 'closed'; // the entire support chain isFinal
     } else {
-      return 'closing'; // at least one isFinal state proposed
+      return 'closing'; // the latest state, and possibly other states, are isFinal
     }
   } else {
     if (latest.turnNum >= participants.length * 2) {

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -62,7 +62,7 @@ export type ChannelStateWithSupported = ChannelState & SignedByMe & WithSupporte
  */
 export const status = (channelState: ChannelState): ChannelStatus => {
   const {supported, latest, latestSignedByMe, support} = channelState;
-  const {participants} = supported ?? latest;
+  const {participants} = latest;
 
   if (!supported) {
     if (!latestSignedByMe) return 'proposed';

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -63,31 +63,19 @@ export type ChannelStateWithSupported = ChannelState & SignedByMe & WithSupporte
 export const status = (channelState: ChannelState): ChannelStatus => {
   const {supported, latest, latestSignedByMe, support} = channelState;
   const {participants} = supported ?? latest;
+
   if (supported?.isFinal) {
-    if (support?.every(s => s.isFinal)) {
-      return 'closed'; // the entire support chain isFinal
-    } else {
-      return 'closing'; // the latest state, and possibly other states, are isFinal
-    }
-  } else {
-    if (latest.turnNum >= participants.length * 2) {
-      return 'running'; // unambiguously running e.g., 4, 5, 6, ...
-    } else {
-      if (latest.turnNum < participants.length) {
-        if (latestSignedByMe) {
-          return 'opening'; // 0 or 1 signed by me
-        } else {
-          return 'proposed'; // 0 or 1 signed, but not by me
-        }
-      } else {
-        if (support?.every(s => s.turnNum >= participants.length)) {
-          return 'running'; // <-- e.g., 2 and 3 both signed
-        } else {
-          return 'opening'; // <-- debatebly this could be 'funding'
-        }
-      }
-    }
+    if (support?.every(s => s.isFinal)) return 'closed'; // the entire support chain isFinal
+    return 'closing'; // the latest state, and possibly other states, are isFinal
   }
+
+  if (latest.turnNum < 2 * participants.length) {
+    if (supported?.turnNum === participants.length - 1) return 'running'; // 3
+    if (latestSignedByMe) return 'opening'; // 0 or 1 signed by me
+    return 'proposed'; // 0 or 1 signed, but not by me
+  }
+
+  return 'running'; // unambiguously running e.g., 4, 5, 6, ...
 };
 
 export const toChannelResult = (channelState: ChannelState): ChannelResult => {


### PR DESCRIPTION
Simplifies the logic around `status` without changing any of the behaviour.
