### PR TITLE
test: prefer nullish coallescing operator ?? to ||

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -65,8 +65,8 @@ export class TestChannel {
 
   protected constructor(args: TestChannelArgs) {
     this.fundingStrategy = args.fundingStrategy || 'Direct';
-    this.startBals = [args.aBal || 5, args.bBal || 5];
-    this.channelNonce = args.channelNonce || 5;
+    this.startBals = [args.aBal ?? 5, args.bBal ?? 5];
+    this.channelNonce = args.channelNonce ?? 5;
     this.finalFrom = args.finalFrom;
   }
 


### PR DESCRIPTION
I discovered this bug while trying to write a test for ledger funding, where I spin up several application channels with various nonces. Unexpected results ensued. 

As in my case, a test author may often wish to pass `channelNonce: 0` or `bBal: 0`, to the `TestChannel` constructor, but the current implementation will silently and surprisingly override those values if they do. The intention was likely more to have
defaults set when the passed values are undefined (rather than 0). Hence this change https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator.

Side remark: I'm not sure why `channelNonce` defaults to 5. I think 0 would be less magic?