### PR TITLE
test: rewrite ledger-manager.test.ts (part 0)

### DIFF
--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -98,7 +98,7 @@ describe('not an app channel', () => {
   it(`errors if the channel is a ledger channel`, async () => {
     // want a running ledger channel
     const testLedger = TestLedgerChannel.create({aBal: 5, bBal: 5, channelNonce: 3});
-    await testLedger.insertIntoStore(store);
+    await testLedger.insertInto(store);
 
     await store.pushMessage(testLedger.wirePayload(5));
     await store.pushMessage(testLedger.wirePayload(6));

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
@@ -1,7 +1,5 @@
 import {SharedObjective} from '@statechannels/wallet-core';
 
-import {Store} from '../../store';
-
 import {TestChannel} from './test-channel';
 
 interface TestChannelArgs {
@@ -34,18 +32,5 @@ export class TestLedgerChannel extends TestChannel {
         fundingStrategy: 'Direct',
       },
     };
-  }
-
-  public async insertIntoStore(store: Store): Promise<void> {
-    await store.addSigningKey(this.signingKeyA);
-    // The only way the store currently knows the channel is a ledger is by the role
-    // passed in on the OpenChannel objective. So we need to push in that objective,
-    // and then approve it.
-    await store.pushMessage(this.openChannelPayload);
-    const objectives = await store.getObjectives([this.channelId]);
-    if (objectives.length !== 1) {
-      throw Error(`TestLedgerChannel expected 1 objective. Found ${objectives.length}`);
-    }
-    await store.approveObjective(objectives[0].objectiveId);
   }
 }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
@@ -1,5 +1,8 @@
 import {SharedObjective} from '@statechannels/wallet-core';
 
+import {LedgerRequest} from '../../../models/ledger-request';
+import {Store} from '../../store';
+
 import {TestChannel} from './test-channel';
 
 interface TestChannelArgs {
@@ -32,5 +35,17 @@ export class TestLedgerChannel extends TestChannel {
         fundingStrategy: 'Direct',
       },
     };
+  }
+
+  public async insertFundingRequest(store: Store, channelToBeFunded: string): Promise<void> {
+    return store.transaction(tx =>
+      LedgerRequest.requestLedgerFunding(channelToBeFunded, this.channelId, tx)
+    );
+  }
+
+  public async insertDefundingRequest(store: Store, channelToBeFunded: string): Promise<void> {
+    return store.transaction(tx =>
+      LedgerRequest.requestLedgerDefunding(channelToBeFunded, this.channelId, tx)
+    );
   }
 }


### PR DESCRIPTION
The aim here is to preserve the current test suite, but reach farther in to the store/database in the setup and assertions of each test. This has the (beneficial?) effect of integrating more code into the tests, but also bypassing some of the implementation details of the `LedgerManager`. 

Specifically, when the work on this branch is done we shall no longer have any dependence on the `protocol()` function in the tests, nor on any `ProtocolAction`s. This means that those concepts can safely be refactored away in separate PR. 

Performing the refactor in this order means that we will maintain full test coverage throughout the refactor. This is in line with similar refactors executed/planned in the `open-channel` / `close-channel` protocols. 

Because I am moving case by case, I am hoping to get a review + merge having only converted some of the cases over. The rest can be done in another PR. 