### PR TITLE
Call register channel on wallet start up

### DIFF
--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -69,6 +69,7 @@
     "ts-node": "8.9.1",
     "typescript": "4.1.2",
     "unitimer": "3.13.0",
+    "wait-for-expect": "^3.0.2",
     "yargs": "15.4.1"
   },
   "gitHead": "89b158871f78cb256501a593c8ea36b24ad64226",

--- a/packages/server-wallet/src/wallet/__test__/restarting.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/restarting.test.ts
@@ -1,0 +1,45 @@
+import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/src/config';
+import waitForExpect from 'wait-for-expect';
+
+import {defaultTestConfig, Wallet} from '..';
+import {testKnex} from '../../../jest/knex-setup-teardown';
+import {DBAdmin} from '../../db-admin/db-admin';
+import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {Channel} from '../../models/channel';
+import {channel} from '../../models/__test__/fixtures/channel';
+
+import {alice, bob} from './fixtures/signing-wallets';
+import {stateWithHashSignedBy} from './fixtures/states';
+const registerChannelMock = jest.fn();
+// This is based on jest docs on mocking es6 class mocking:
+//https://jestjs.io/docs/en/es6-class-mocks
+jest.mock('../../chain-service/mock-chain-service', () => {
+  return {
+    MockChainService: jest.fn().mockImplementation(() => {
+      return {
+        registerChannel: registerChannelMock,
+      };
+    }),
+  };
+});
+
+test('the wallet registers existing channels with the chain service on starting up', async () => {
+  await new DBAdmin(testKnex).truncateDB();
+
+  await seedAlicesSigningWallet(testKnex);
+
+  const c = channel({
+    channelNonce: 1,
+    vars: [stateWithHashSignedBy([alice(), bob()])({turnNum: 1})],
+  });
+  await Channel.query(testKnex).withGraphFetched('signingWallet').insert(c);
+
+  const w = await Wallet.create(defaultTestConfig());
+
+  await waitForExpect(() => {
+    expect(registerChannelMock).toHaveBeenCalledWith(c.channelId, [ETH_ASSET_HOLDER_ADDRESS], w);
+  });
+
+  // We explicitly call destroy on knex to avoid triggering any destroy calls on our mocked out chain service
+  await w.knex.destroy();
+});

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -293,7 +293,7 @@ export class Store {
   /**
    * Returns all channels that are not finalized on chain
    */
-  async getActiveChannels(): Promise<ChannelState[]> {
+  async getNonFinalizedChannels(): Promise<ChannelState[]> {
     return (await Channel.query(this.knex))
       .filter(
         c => !c.challengeStatus || c.challengeStatus.toResult().status !== 'Challenge Finalized'

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -291,7 +291,7 @@ export class Store {
   }
 
   /**
-   * Returns all channels that are not finalized chain
+   * Returns all channels that are not finalized on chain
    */
   async getActiveChannels(): Promise<ChannelState[]> {
     return (await Channel.query(this.knex))

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -290,6 +290,17 @@ export class Store {
     return (await Channel.query(this.knex)).map(channel => channel.protocolState);
   }
 
+  /**
+   * Returns all channels that are not finalized chain
+   */
+  async getActiveChannels(): Promise<ChannelState[]> {
+    return (await Channel.query(this.knex))
+      .filter(
+        c => !c.challengeStatus || c.challengeStatus.toResult().status !== 'Challenge Finalized'
+      )
+      .map(channel => channel.protocolState);
+  }
+
   async getLedgerChannels(
     assetHolderAddress: string,
     participants: Participant[]

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -111,7 +111,7 @@ export class SingleThreadedWallet
    * so the chain service can alert us of any block chain events for existing channels
    */
   private async registerExistingChannelsWithChainService() {
-    const channelsToRegister = (await this.store.getChannels())
+    const channelsToRegister = (await this.store.getActiveChannels())
       .map(ChannelState.toChannelResult)
       .map(cr => ({
         assetHolderAddresses: cr.allocations.map(a => makeAddress(a.assetHolderAddress)),

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -111,7 +111,7 @@ export class SingleThreadedWallet
    * so the chain service can alert us of any block chain events for existing channels
    */
   private async registerExistingChannelsWithChainService() {
-    const channelsToRegister = (await this.store.getActiveChannels())
+    const channelsToRegister = (await this.store.getNonFinalizedChannels())
       .map(ChannelState.toChannelResult)
       .map(cr => ({
         assetHolderAddresses: cr.allocations.map(a => makeAddress(a.assetHolderAddress)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -23295,6 +23295,11 @@ wait-file@^1.0.5:
     fs-extra "^8.1.0"
     rx "^4.1.0"
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"


### PR DESCRIPTION
Fixes https://github.com/statechannels/project-management/issues/11

Changes the `wallet` to call `registerChannel` for existing channels on startup. Only channels that are not finalized on chain are called with `registerChannel`.


