### PR TITLE
fix: do not store constants in every vars

### DIFF
--- a/packages/server-wallet/src/state-utils.ts
+++ b/packages/server-wallet/src/state-utils.ts
@@ -85,6 +85,16 @@ export function clearOldStates(
   signedStates: SignedStateVarsWithHash[],
   support: SignedStateWithHash[] | undefined
 ): SignedStateVarsWithHash[] {
+  signedStates = signedStates.map(
+    ({turnNum, appData, signatures, stateHash, outcome, isFinal}) => ({
+      turnNum,
+      appData,
+      signatures,
+      stateHash,
+      outcome,
+      isFinal,
+    })
+  );
   let sorted = _.reverse(_.sortBy(signedStates, s => s.turnNum));
 
   // If we don't have a supported state we don't clean anything out


### PR DESCRIPTION
This should not be stored in the `vars` column of the DB:
```
[
  {
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007e1fb3bdad8c8939b218cc471e51d81ce52bdf90d9d673a67d9e5be7091aac59000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000",
    "chainId": "0x00",
    "isFinal": false,
    "outcome": {
      "type": "SimpleAllocation",
      "allocationItems": [
        {
          "amount": "0x02540be400",
          "destination": "0x00000000000000000000000011115FAf6f1BF263e81956F0Cc68aEc8426607cf"
        },
        {
          "amount": "0x00",
          "destination": "0x0000000000000000000000009F7ffcb016b0f7b142529bF27ef1eC5b0039C32C"
        }
      ],
      "assetHolderAddress": "0x0000000000000000000000000000000000000000"
    },
    "turnNum": 0,
    "stateHash": "0xe94ffb72d6edd40b5292cab7b89abe90668fbc971d5c56943e9a22cee7d5c65b",
    "signatures": [
      {
        "signer": "0xe252bA50dfC0Eb7705387acEd453c03963969092",
        "signature": "0x80295bb8356622ba8b8e0ae60b23fc65da36bf9954ffbf801a8d8751567c14a72408df6e72a2d35e88c319e4cbaf84174804c306c151b2ddd0a4710801e822e71c"
      },
      {
        "signer": "0x333356F625259653A2B6d7Da44162631DCbdF93F",
        "signature": "0x2adb475fc5dec52d2dc323945b3966ff84132fba96f9bdda25e69cc93a90ea1b03c064be47737ac03803f21584e933c486ecb0680ae6514a2a261385280180681b"
      }
    ],
    "channelNonce": 20,
    "participants": [
      {
        "destination": "0x00000000000000000000000011115FAf6f1BF263e81956F0Cc68aEc8426607cf",
        "participantId": "0xe252bA50dfC0Eb7705387acEd453c03963969092",
        "signingAddress": "0xe252bA50dfC0Eb7705387acEd453c03963969092"
      },
      {
        "destination": "0x0000000000000000000000009F7ffcb016b0f7b142529bF27ef1eC5b0039C32C",
        "participantId": "http://network-subgraph-indexer-1/",
        "signingAddress": "0x333356F625259653A2B6d7Da44162631DCbdF93F"
      }
    ],
    "appDefinition": "0x0000000000000000000000000000000000000000",
    "challengeDuration": 600000
  }
]
```