### PR TITLE
test: default to a random channel nonce if none is provided.

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -72,7 +72,8 @@ export class TestChannel {
       ['a', args.aBal ?? 5],
       ['b', args.bBal ?? 5],
     ];
-    this.channelNonce = args.channelNonce ?? Math.ceil(Math.random() * 1e12);
+    const MAX_INTEGER_POSTGRES = 2147483647;
+    this.channelNonce = args.channelNonce ?? Math.floor(Math.random() * MAX_INTEGER_POSTGRES);
     this.finalFrom = args.finalFrom;
   }
 

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -72,7 +72,7 @@ export class TestChannel {
       ['a', args.aBal ?? 5],
       ['b', args.bBal ?? 5],
     ];
-    this.channelNonce = args.channelNonce ?? 5;
+    this.channelNonce = args.channelNonce ?? Math.ceil(Math.random() * 1e12);
     this.finalFrom = args.finalFrom;
   }
 


### PR DESCRIPTION
This issue is scoped purely to _test_ code, and concerns the behaviour of the `TestChannel` class in use in many of our suites.

There are obviously several approaches here

a) make `channelNonce` random (this proposal). Nonce collisions are made very unlikely automatically.
b) make `channelNonce` a required parameter, at least things are then very explicit in our tests. The test author has to take care to avoid nonce collisions (this is laborious but very easy typically).
c) implement a method to ensure `channelNonce` increments each time a new instance is created (similar to how our store does it):

```ts
class TestChannel {
    static overallNonce = 0;
    public nonce: number;
    constructor(providedNonce?:number ) {
        this.nonce = providedNonce ?? TestChannel.overallNonce++;
    }
}
```
(although in this case, it might be better to disallow `providedNonce` altogether). This might be overengineering. The main thing is to have it not default to 5 (current behaviour).

Note: our on-chain code stipulates that `channelNonce` is a `uint48`. Our DB schema in the server wallet, the `value` column of the `nonces` table is an `integer` (32 bit). We might consider using `bigint` instead (64 bit), but this may affect performance. Here, I constrain test channel nonces to be small enough to not cause problems. 