### PR TITLE
test: enhance TestLedgerChannel

### DIFF
--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -41,7 +41,7 @@ interface TestChannelArgs {
   fundingStrategy?: FundingStrategy;
 }
 
-type Bals = [string, number][] | [number, number];
+export type Bals = [string, number][] | [number, number];
 
 /** A two-party channel between Alice and Bob, with state history. For testing purposes. */
 export class TestChannel {
@@ -98,7 +98,7 @@ export class TestChannel {
 
     return {
       ...this.channelConstants,
-      appData: '0x',
+      appData: '0x00',
       isFinal: !!this.finalFrom && n >= this.finalFrom,
       // test channels adopt a countersigning strategy for final states, so the turn number doesn't progress after finalFrom.
       turnNum: n,


### PR DESCRIPTION
This brings the `TestLedgerChannel` closer to how real ledger channels work, so it is pretty important IMO. 

- allow a non-mover to sign a state, but default to everyone signing every state.
(passing in an optional list of indices that defaults to everyone)
- force the appDefinition to be null