### PR TITLE
fix: support fake funding in directFundingStatus

### DIFF
--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -109,7 +109,6 @@ export function directFundingStatus(
   if (fundingStrategy === 'Fake') {
     if (!supported) return 'Uncategorized';
     if (supported.turnNum < 3) return 'ReadyToFund';
-    if (supported.isFinal) return 'Defunded';
     return 'Funded';
   }
 

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -106,6 +106,13 @@ export function directFundingStatus(
   myParticipant: Participant,
   fundingStrategy: FundingStrategy
 ): FundingStatus | undefined {
+  if (fundingStrategy === 'Fake') {
+    if (!supported) return 'Uncategorized';
+    if (supported.turnNum < 3) return 'ReadyToFund';
+    if (supported.isFinal) return 'Defunded';
+    return 'Funded';
+  }
+
   if (fundingStrategy !== 'Direct') {
     return 'Uncategorized';
   }


### PR DESCRIPTION
If a ledger channel is funding a payment channel, when the payment channel checks to see if its parent is funded it will not work if the parent is fake funded.

https://github.com/statechannels/statechannels/blob/f2b0d6b919ecb4eeaf2a86f5ef41c32e7ad97d43/packages/server-wallet/src/protocols/ledger-funder.ts#L66-L68

This makes this function above return `true`