### PR TITLE
perf: TestChannel nonce is incrementing, not random

### DIFF
--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -9,8 +9,8 @@ import {TestLedgerChannel} from '../../wallet/__test__/fixtures/test-ledger-chan
 import {SingleAppUpdater} from '../single-app-updater';
 
 const FINAL = 8;
-const testChan = TestChannel.create({channelNonce: 1, finalFrom: FINAL});
-const testChan2 = TestChannel.create({channelNonce: 2});
+const testChan = TestChannel.create({finalFrom: FINAL});
+const testChan2 = TestChannel.create({});
 
 let store: Store;
 let singleAppUpdater: SingleAppUpdater;

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -118,7 +118,7 @@ describe('marking ledger requests as complete', () => {
     // create an application channel
     const appChannel = TestChannel.create({aBal: 5, bBal: 5});
     await appChannel.insertInto(store, {states: [0, 1]});
-    // create a ledger channel that funds that channel. Note distinct channel nonce
+    // create a ledger channel that funds that channel.Note distinct channel nonce should be automatically ensured automatically
     const ledgerChannel = TestLedgerChannel.create({channelNonce: 1});
     await ledgerChannel.insertInto(store, {
       states: [4, 5],
@@ -144,8 +144,8 @@ describe('marking ledger requests as complete', () => {
     // create an application channel
     const appChannel = TestChannel.create({aBal: 5, bBal: 5});
     await appChannel.insertInto(store, {states: [0, 1]});
-    // create a ledger channel whose current state doesn't fund that channel. Note distinct channel nonce
-    const ledgerChannel = TestLedgerChannel.create({channelNonce: 1});
+    // create a ledger channel whose current state doesn't fund that channel. Note distinct channel nonce should be automatically ensuredd automatically
+    const ledgerChannel = TestLedgerChannel.create({});
     await ledgerChannel.insertInto(store, {
       states: [5, 6],
       bals: [
@@ -198,8 +198,8 @@ describe('exchanging ledger proposals', () => {
       // create an application channel
       const appChannel = TestChannel.create({aBal: 5, bBal: 5});
       await appChannel.insertInto(store, {states: [0, 1]});
-      // create a ledger channel whose current state doesn't fund that channel. Note distinct channel nonce
-      const ledgerChannel = TestLedgerChannel.create({channelNonce: 1});
+      // create a ledger channel whose current state doesn't fund that channel. Note distinct channel nonce should be automatically ensured automatically
+      const ledgerChannel = TestLedgerChannel.create({});
       await ledgerChannel.insertInto(store, {
         // Will be "fully funded" i.e. with 10 coins
         states: [4, 5],
@@ -233,17 +233,15 @@ describe('exchanging ledger proposals', () => {
     });
 
     it('proposes new outcome funding many channels', async () => {
-      // create and insert a funded ledger channel that doesn't fund any channels yet. Note distinct channel nonce
-      const ledgerChannel = TestLedgerChannel.create({channelNonce: 5});
+      // create and insert a funded ledger channel that doesn't fund any channels yet. Note distinct channel nonce should be automatically ensured automatically
+      const ledgerChannel = TestLedgerChannel.create({});
       await ledgerChannel.insertInto(store, {
         states: [4, 5],
         bals: [10, 10],
       });
 
       // create 5 application channels, each allocating 1 to Alice
-      const appChannels = [0, 1, 2, 3, 4].map(channelNonce =>
-        TestChannel.create({aBal: 1, bBal: 0, channelNonce})
-      );
+      const appChannels = [0, 1, 2, 3, 4].map(() => TestChannel.create({aBal: 1, bBal: 0}));
       for await (const appChannel of appChannels) {
         // for each one, insert the channel and a ledger funding request
         await appChannel.insertInto(store, {states: [0, 1]});
@@ -277,8 +275,8 @@ describe('exchanging ledger proposals', () => {
 
     it('proposes new outcome requiring defund before having sufficient funds', async () => {
       // setup a ledger channel funding an 'older' channel
-      const ledgerChannel = TestLedgerChannel.create({channelNonce: 0});
-      const olderChannel = TestChannel.create({aBal: 10, bBal: 0, channelNonce: 1});
+      const ledgerChannel = TestLedgerChannel.create({});
+      const olderChannel = TestChannel.create({aBal: 10, bBal: 0});
       await ledgerChannel.insertInto(store, {
         states: [4, 5],
         bals: [[olderChannel.channelId, 10]],
@@ -286,7 +284,7 @@ describe('exchanging ledger proposals', () => {
       await olderChannel.insertInto(store, {states: [0, 1]});
 
       // create a new channel
-      const newChannel = TestChannel.create({aBal: 10, bBal: 0, channelNonce: 2});
+      const newChannel = TestChannel.create({aBal: 10, bBal: 0});
       await newChannel.insertInto(store, {states: [0, 1]});
 
       // create a ledger request for the ledger to defund the older channel
@@ -319,8 +317,8 @@ describe('exchanging ledger proposals', () => {
       // create an application channel that allocates 200 coins
       const appChannel = TestChannel.create({aBal: 100, bBal: 100});
       await appChannel.insertInto(store, {states: [0, 1]});
-      // create a ledger channel whose current state doesn't fund that channel. Note distinct channel nonce
-      const ledgerChannel = TestLedgerChannel.create({channelNonce: 1});
+      // create a ledger channel whose current state doesn't fund that channel. Note distinct channel nonce should be automatically ensured automatically
+      const ledgerChannel = TestLedgerChannel.create({});
       await ledgerChannel.insertInto(store, {
         // Will be "fully funded" with 10 coins, but this is insufficient for the app channel
         states: [4, 5],
@@ -341,8 +339,8 @@ describe('exchanging ledger proposals', () => {
     });
 
     it('proposes outcome funding some channels, identifying insufficient funds for others', async () => {
-      // create and insert a funded ledger channel that doesn't fund any channels yet. Note distinct channel nonce
-      const ledgerChannel = TestLedgerChannel.create({channelNonce: 5});
+      // create and insert a funded ledger channel that doesn't fund any channels yet. Note distinct channel nonce should be automatically ensured automatically
+      const ledgerChannel = TestLedgerChannel.create({});
       await ledgerChannel.insertInto(store, {
         states: [4, 5],
         bals: [10, 10],
@@ -350,9 +348,7 @@ describe('exchanging ledger proposals', () => {
 
       // create 5 application channels, each allocating 5 to Alice
       // The ledger channel can only afford 2 of these
-      const appChannels = [0, 1, 2, 3, 4].map(channelNonce =>
-        TestChannel.create({aBal: 5, bBal: 0, channelNonce})
-      );
+      const appChannels = [0, 1, 2, 3, 4].map(() => TestChannel.create({aBal: 5, bBal: 0}));
       for await (const appChannel of appChannels) {
         // for each one, insert the channel and a ledger funding request
         await appChannel.insertInto(store, {states: [0, 1]});

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -36,7 +36,6 @@ import {stateWithHashSignedBy} from './states';
 interface TestChannelArgs {
   aBal?: number;
   bBal?: number;
-  channelNonce?: number;
   finalFrom?: number;
   fundingStrategy?: FundingStrategy;
 }
@@ -54,6 +53,7 @@ export class TestChannel {
   public channelNonce: number;
   public finalFrom?: number;
   public fundingStrategy: FundingStrategy;
+  static maximumNonce = 0;
 
   public get participants(): Participant[] {
     return [this.participantA, this.participantB];
@@ -72,9 +72,8 @@ export class TestChannel {
       ['a', args.aBal ?? 5],
       ['b', args.bBal ?? 5],
     ];
-    const MAX_INTEGER_POSTGRES = 2147483647;
-    this.channelNonce = args.channelNonce ?? Math.floor(Math.random() * MAX_INTEGER_POSTGRES);
     this.finalFrom = args.finalFrom;
+    this.channelNonce = TestChannel.maximumNonce++;
   }
 
   /**


### PR DESCRIPTION
A recent change #3152 caused the tests on master to fail with jest timeouts. My hypothesis is that the change introduced some inefficient code, namely generation of random integers, which made the difference for the timeouts.

This PR swaps out a random nonce for an incrementing nonce approach, which should be faster. 