### PR TITLE
ci: introduce a branch that runs all tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - run:
           name: test
           command: |
-            if [ "${CIRCLE_BRANCH}" = "master" ]
+            if [ "${CIRCLE_BRANCH}" = "master" ] || [ "${CIRCLE_BRANCH}" = "test-ci" ]
             then
               yarn test:ci
             else


### PR DESCRIPTION
in addition to master. This provides a utility for running all of the tests, as they do on master, to test/anticipate problems that don't arise when making changes to a feature branch. For example: changes that slow the tests down enough to trigger jest timeouts, but only when run alongside tests from other packages (which are usually skipped on feature branches). 

To do so, just reset the `test-ci` branch to the commit you want to run all of the tests on. 