### PR TITLE
feat: handle Concluded event from adjudicator

### DIFF
--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -138,7 +138,7 @@ it('Create a directly funded channel between two wallets ', async () => {
     .toPromise();
 
   const channelClosedAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
-    .pipe(take(3))
+    .pipe(take(4))
     .toPromise();
 
   //        A <> B
@@ -239,7 +239,7 @@ it('Create a directly funded channel between two wallets ', async () => {
     fundingStatus: 'Funded',
   });
 
-  await mineBlocks(2);
+  await mineBlocks(5);
 
   const channelClosedA = await channelClosedAPromise;
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -343,6 +343,27 @@ describe('registerChannel', () => {
 });
 
 describe('concludeAndWithdraw', () => {
+  it('triggers a channel finalized event', async () => {
+    const {channelId, state, signatures} = await setUpConclude();
+
+    const p = new Promise<void>(resolve =>
+      chainService.registerChannel(channelId, [ethAssetHolderAddress], {
+        ...defaultNoopListeners,
+        channelFinalized: arg => {
+          expect(arg.channelId).toEqual(channelId);
+          resolve();
+        },
+      })
+    );
+
+    const transactionResponse = await chainService.concludeAndWithdraw([{...state, signatures}]);
+    if (!transactionResponse) throw 'Expected transaction response';
+    await transactionResponse.wait();
+
+    mineBlocks();
+    await p;
+  });
+
   it('Successful concludeAndWithdraw with eth allocation', async () => {
     const {channelId, aAddress, bAddress, state, signatures} = await setUpConclude();
 

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -43,6 +43,7 @@ import {
 const Deposited = 'Deposited' as const;
 const AllocationUpdated = 'AllocationUpdated';
 const ChallengeRegistered = 'ChallengeRegistered' as const;
+const Concluded = 'Concluded' as const;
 type DepositedEvent = {type: 'Deposited'; ethersEvent: Event} & HoldingUpdatedArg;
 type AllocationUpdatedEvent = {
   type: 'AllocationUpdated';
@@ -120,6 +121,10 @@ export class ChainService implements ChainServiceInterface {
           finalizesAt,
         })
       );
+    });
+
+    this.nitroAdjudicator.on(Concluded, (channelId, finalizesAtS) => {
+      this.addFinalizingChannel({channelId, finalizesAtS});
     });
 
     this.provider.on('block', async (blockTag: providers.BlockTag) =>


### PR DESCRIPTION
Fixes #3112.

The `chain-service` now detects the `Concluded` event from the adjudicator and dispatches a channel finalized event.

This PR also updates the `defund-channel` protocol to use the `holdings` table to determine if the outcome has been pushed or not.
