### PR TITLE
build: trigger canary release on a schedule

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,7 +1,10 @@
 name: Publish Packages (canary)
 
 on:
-  workflow_dispatch:
+  schedule:
+    - cron:  '0 7 * * *'
+  # enable users to manually trigger with workflow_dispatch
+  workflow_dispatch: {}
 
 jobs:
   canary-publish:


### PR DESCRIPTION
Currently, it is easy to unwittingly break software that relies on the @statechhannels/* packages (e.g. TG), and not find out about it until some later point with an arbitrary delay. We would like a workflow that pushes changes out more predictably and frequently, so that we can pull in and test those changes more rapidly.

This PR triggers the current "canary" release workflow to be triggered at [7am UTC every day.](https://crontab.guru/#0_7_*_*_*). The schedule is easily altered if folks have other suggestions.

I went down this route, rather than making a brand new github action, because the idea of nightly builds is in fact what the [`--canary` flag](https://github.com/lerna/lerna/tree/main/commands/publish#--canary) was intended for. 

This work will only be completed when another automated process pulls in the changes that are published. Doing, e.g. `yarn add @statechannels/nitro-protocol@next` will bring in the latest canary release. 


