### PR TITLE
test: add missing tables to truncateDB()

### DIFF
--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -12,6 +12,9 @@ import {ObjectiveModel, ObjectiveChannelModel} from '../models/objective';
 import {Funding} from '../models/funding';
 import {AppBytecode} from '../models/app-bytecode';
 import {LedgerRequest} from '../models/ledger-request';
+import {LedgerProposal} from '../models/ledger-proposal';
+import {ChallengeStatus} from '../models/challenge-status';
+import {ChainServiceRequest} from '../models/chain-service-request';
 
 export class DBAdmin {
   knex: Knex;
@@ -45,6 +48,10 @@ export class DBAdmin {
       Funding.tableName,
       AppBytecode.tableName,
       LedgerRequest.tableName,
+      LedgerProposal.tableName,
+      Funding.tableName,
+      ChallengeStatus.tableName,
+      ChainServiceRequest.tableName,
     ]
   ): Promise<void> {
     // eslint-disable-next-line no-process-env


### PR DESCRIPTION
When testing, one expects that `truncateDB()` truncates the entire DB.

We often run this function in a `beforeAll()` block to get a
clean DB state for each test case.

Therefore we need to have all table names in this function.