### PR TITLE
test: move custom matchers to setup file and add an additional toContainObject matcher

### DIFF
--- a/packages/server-wallet/jest/custom-matchers.ts
+++ b/packages/server-wallet/jest/custom-matchers.ts
@@ -1,0 +1,53 @@
+import { AllocationItem, areAllocationItemsEqual } from "@statechannels/wallet-core";
+
+expect.extend({
+    toContainAllocationItem(received: AllocationItem[], argument: AllocationItem) {
+      const pass = received.some(areAllocationItemsEqual.bind(null, argument));
+      if (pass) {
+        return {
+          pass: true,
+          message: () =>
+            `expected ${JSON.stringify(received, null, 2)} to not contain ${JSON.stringify(
+              argument,
+              null,
+              2
+            )}`,
+        };
+      } else {
+        return {
+          pass: false,
+          message: () =>
+            `expected ${JSON.stringify(received, null, 2)} to contain ${JSON.stringify(
+              argument,
+              null,
+              2
+            )}`,
+        };
+      }
+    },
+  });
+
+// https://medium.com/@andrei.pfeiffer/jest-matching-objects-in-array-50fe2f4d6b98
+expect.extend({
+  toContainObject(received, argument) {
+    const pass = this.equals(received, expect.arrayContaining([expect.objectContaining(argument)]));
+
+    if (pass) {
+      return {
+        message: () =>
+          `expected ${this.utils.printReceived(
+            received
+          )} not to contain object ${this.utils.printExpected(argument)}`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () =>
+          `expected ${this.utils.printReceived(
+            received
+          )} to contain object ${this.utils.printExpected(argument)}`,
+        pass: false,
+      };
+    }
+  },
+});

--- a/packages/server-wallet/jest/jest.config.js
+++ b/packages/server-wallet/jest/jest.config.js
@@ -4,7 +4,7 @@ const root = resolve(__dirname, '../');
 module.exports = {
   rootDir: root,
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  setupFilesAfterEnv: ['./jest/knex-setup-teardown.ts'],
+  setupFilesAfterEnv: ['./jest/custom-matchers.ts','./jest/knex-setup-teardown.ts'],
   testMatch: ['<rootDir>/**/__test__/**/?(*.)(spec|test).ts'],
   testEnvironment: 'node',
   testURL: 'http://localhost',

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -1,12 +1,5 @@
 import {CreateChannelParams} from '@statechannels/client-api-schema';
-import {
-  AllocationItem,
-  areAllocationItemsEqual,
-  BN,
-  makeAddress,
-  makeDestination,
-  Participant,
-} from '@statechannels/wallet-core';
+import {BN, makeAddress, makeDestination, Participant} from '@statechannels/wallet-core';
 import {ethers} from 'ethers';
 
 import {Outgoing} from '../..';
@@ -24,38 +17,6 @@ import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../co
 const ETH_ASSET_HOLDER_ADDRESS = makeAddress(ethers.constants.AddressZero);
 
 const tablesUsingLedgerChannels = ['channels', 'ledger_requests', 'ledger_proposals'];
-
-// TODO: Extending expect should be probably done in a setup file
-// This is probably fine for now since we only use toContainAllocationItem in these tests
-// This was moved from test-helpers.ts where it was a bit of footgun.
-// If you loaded the test-helpers.ts for any reason it would try to extend expect
-// which blows up if there is no expect defined
-expect.extend({
-  toContainAllocationItem(received: AllocationItem[], argument: AllocationItem) {
-    const pass = received.some(areAllocationItemsEqual.bind(null, argument));
-    if (pass) {
-      return {
-        pass: true,
-        message: () =>
-          `expected ${JSON.stringify(received, null, 2)} to not contain ${JSON.stringify(
-            argument,
-            null,
-            2
-          )}`,
-      };
-    } else {
-      return {
-        pass: false,
-        message: () =>
-          `expected ${JSON.stringify(received, null, 2)} to contain ${JSON.stringify(
-            argument,
-            null,
-            2
-          )}`,
-      };
-    }
-  },
-});
 
 let a = Wallet.create(
   overwriteConfigWithDatabaseConnection(defaultTestConfig(), {

--- a/packages/server-wallet/src/__test__/globals.d.ts
+++ b/packages/server-wallet/src/__test__/globals.d.ts
@@ -3,7 +3,7 @@ declare global {
   namespace jest {
     interface Matchers</* eslint-disable-line */ R> {
       toContainAllocationItem<R>(received: {amount: string; destination: string}): R;
-      toContainObject<R>(argument: unknown): R;
+      toContainObject<R>(argument: R): R;
     }
   }
 }

--- a/packages/server-wallet/src/__test__/globals.d.ts
+++ b/packages/server-wallet/src/__test__/globals.d.ts
@@ -3,6 +3,7 @@ declare global {
   namespace jest {
     interface Matchers</* eslint-disable-line */ R> {
       toContainAllocationItem<R>(received: {amount: string; destination: string}): R;
+      toContainObject<R>(argument: unknown): R;
     }
   }
 }


### PR DESCRIPTION
Establishes a more scalable pattern for extending `jest.expect`. 

1. Moves the existing  `toContainAllocationItem` matcher to a location where it may be more easily re-used (it's currently declared as a global variable, but is not guaranteed to be available in all tests). 
2. Adds a `toContainObject` matcher following this blog post https://medium.com/@andrei.pfeiffer/jest-matching-objects-in-array-50fe2f4d6b98. I anticipate this will be very useful when inspecting objects that contain arrays of objects with many keys besides the ones of interest, and where the position of those objects in the array is not important. 