### PR TITLE
test: complete refactor of ledger-manager tests

### DIFF
--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -9,13 +9,9 @@ import {
   simpleEthAllocation as coreSimpleEthAllocation,
 } from '@statechannels/wallet-core';
 
-import {channel} from '../../models/__test__/fixtures/channel';
 import {alice, bob} from '../../wallet/__test__/fixtures/participants';
-import {alice as aliceSW, bob as bobSW} from '../../wallet/__test__/fixtures/signing-wallets';
-import {stateSignedBy} from '../../wallet/__test__/fixtures/states';
 import {Fixture} from '../../wallet/__test__/fixtures/utils';
-import {ChannelStateWithSupported} from '../state';
-import {LedgerManager, protocol, ProtocolState} from '../ledger-manager';
+import {LedgerManager} from '../ledger-manager';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
 import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
@@ -26,6 +22,7 @@ import {createLogger} from '../../logger';
 import {LedgerRequestType} from '../../models/ledger-request';
 import {getPayloadFor} from '../../__test__/test-helpers';
 import {ProposeLedgerUpdate} from '../actions';
+import {LedgerProposal} from '../../models/ledger-proposal';
 
 // TEST HELPERS
 // There are many test cases in this file. These helpers make the tests cases more readable.
@@ -44,47 +41,7 @@ function allocationItem(preAllocationItem: PreAllocationItem): AllocationItem {
 function simpleEthAllocation(...items: PreAllocationItem[]): SimpleAllocation {
   return coreSimpleEthAllocation(items.map(allocationItem));
 }
-
-let i = 0;
-const prefundChannelWithAllocations = (...allocations: PreAllocationItem[]) =>
-  channel({
-    channelNonce: i++, // Unique channel id each time this fixture is used
-    fundingStrategy: 'Ledger',
-    vars: [
-      stateSignedBy([aliceSW(), bobSW()])({
-        turnNum: 1,
-        outcome: simpleEthAllocation(...allocations),
-      }),
-    ],
-  });
-
-const ledgerChannelWithAllocations = (...allocations: PreAllocationItem[]) =>
-  channel({
-    vars: [
-      stateSignedBy([aliceSW(), bobSW()])({
-        turnNum: 3,
-        outcome: simpleEthAllocation(...allocations),
-      }),
-    ],
-  }).protocolState as ChannelStateWithSupported;
 // END TEST HELPERS
-
-const defaultLedgerChannel = ledgerChannelWithAllocations([alice, 10], [bob, 10]);
-
-// const unfundedLedgerChannel = ledgerChannelWithAllocations([]);
-
-const processLedgerQueueProtocolState = (args: Partial<ProtocolState> = {}) => ({
-  fundingChannel: defaultLedgerChannel,
-
-  channelsRequestingFunds: [],
-  channelsReturningFunds: [],
-
-  theirLedgerProposal: {proposal: null, nonce: 0},
-
-  myLedgerProposal: {proposal: null, nonce: 0},
-
-  ...args,
-});
 
 let store: Store;
 let ledgerManager: LedgerManager;
@@ -110,10 +67,6 @@ afterEach(async () => {
 });
 
 describe('marking ledger requests as complete', () => {
-  it('takes no action if there are no ledger requests', () => {
-    expect(protocol(processLedgerQueueProtocolState())).toBeUndefined();
-  });
-
   it('detects completed funding requests from the outcome of supported state', async () => {
     // create an application channel
     const appChannel = TestChannel.create({aBal: 5, bBal: 5});
@@ -581,104 +534,174 @@ describe('exchanging signed ledger state updates', () => {
           },
         ],
       });
-
-      const requestChannel = prefundChannelWithAllocations([alice, 1]);
-      const protocolArgs = {
-        fundingChannel: defaultLedgerChannel,
-        channelsRequestingFunds: [requestChannel.protocolState],
-        myLedgerProposal: {proposal, nonce: 0},
-        theirLedgerProposal: {proposal, nonce: 0},
-      };
-      expect(protocol(processLedgerQueueProtocolState(protocolArgs))).toMatchObject({
-        type: 'SignLedgerUpdate',
-        channelId: protocolArgs.fundingChannel.channelId,
-        stateToSign: {
-          outcome: proposal,
-          turnNum: 4,
-        },
-      });
     });
 
-    it('generates signed ledger update when proposals were not identical but overlapped', () => {
-      const requestChannel1 = prefundChannelWithAllocations([alice, 1]);
-      const requestChannel2 = prefundChannelWithAllocations([alice, 1]);
-      const requestChannel3 = prefundChannelWithAllocations([alice, 1]);
+    it('generates signed ledger update when proposals were not identical but overlapped', async () => {
+      const ledgerChannel = TestLedgerChannel.create({});
+      await ledgerChannel.insertInto(store, {
+        states: [4, 5],
+        bals: [10, 10],
+      });
+
+      // create three application channels
+      const appChannels = [0, 1, 2].map(() => TestChannel.create({aBal: 1, bBal: 0}));
+      for await (const appChannel of appChannels) {
+        // for each one, insert the channel and a ledger funding request
+        await appChannel.insertInto(store, {states: [0, 1]});
+        await ledgerChannel.insertFundingRequest(store, appChannel.channelId);
+      }
+
       const proposal1 = simpleEthAllocation(
         [alice, 8],
         [bob, 10],
-        [requestChannel1.channelId, 1],
-        [requestChannel2.channelId, 1]
+        [appChannels[0].channelId, 1],
+        [appChannels[1].channelId, 1]
       );
       const proposal2 = simpleEthAllocation(
         [alice, 8],
         [bob, 10],
-        [requestChannel2.channelId, 1],
-        [requestChannel3.channelId, 1]
+        [appChannels[1].channelId, 1],
+        [appChannels[2].channelId, 1]
       );
-      const expectedMerged = simpleEthAllocation(
-        [alice, 9],
-        [bob, 10],
-        [requestChannel2.channelId, 1]
+
+      await ledgerChannel.insertProposal(
+        store,
+        proposal1,
+        ledgerChannel.participantA.signingAddress,
+        0
       );
-      const protocolArgs = {
-        fundingChannel: defaultLedgerChannel,
-        channelsRequestingFunds: [
-          requestChannel1.protocolState,
-          requestChannel2.protocolState,
-          requestChannel3.protocolState,
+
+      await ledgerChannel.insertProposal(
+        store,
+        proposal2,
+        ledgerChannel.participantB.signingAddress,
+        1
+      );
+
+      // crank the ledger manager
+      const response = new WalletResponse();
+      await ledgerManager.crank(ledgerChannel.channelId, response);
+
+      // assert that there is a signedState in the outbox
+      const payload = getPayloadFor(
+        ledgerChannel.participantB.participantId,
+        response.multipleChannelOutput().outbox
+      );
+
+      expect(payload).toMatchObject({
+        signedStates: [
+          {
+            ...ledgerChannel.wireState(
+              6,
+              [
+                [alice().destination, 9],
+                [bob().destination, 10],
+                [appChannels[1].channelId, 1], // the intersection of the proposals
+              ],
+              [0]
+            ),
+          },
         ],
-        myLedgerProposal: {proposal: proposal1, nonce: 0},
-        theirLedgerProposal: {proposal: proposal2, nonce: 0},
-      };
-      expect(protocol(processLedgerQueueProtocolState(protocolArgs))).toMatchObject({
-        type: 'SignLedgerUpdate',
-        channelId: protocolArgs.fundingChannel.channelId,
-        stateToSign: {
-          outcome: expectedMerged,
-          turnNum: 4,
-        },
       });
     });
 
-    it('dismisses proposals when the intersected result is identical to supported', () => {
-      const requestChannel1 = prefundChannelWithAllocations([alice, 1]);
-      const requestChannel2 = prefundChannelWithAllocations([alice, 1]);
-      const proposal1 = simpleEthAllocation([alice, 9], [bob, 10], [requestChannel1.channelId, 1]);
-      const proposal2 = simpleEthAllocation([alice, 9], [bob, 10], [requestChannel2.channelId, 1]);
-      const protocolArgs = {
-        fundingChannel: defaultLedgerChannel,
-        channelsRequestingFunds: [requestChannel1.protocolState, requestChannel2.protocolState],
-        myLedgerProposal: {proposal: proposal1, nonce: 0},
-        theirLedgerProposal: {proposal: proposal2, nonce: 0},
-      };
-      expect(protocol(processLedgerQueueProtocolState(protocolArgs))).toMatchObject({
-        type: 'DismissLedgerProposals',
-        channelId: protocolArgs.fundingChannel.channelId,
+    it('dismisses proposals when the intersected result is identical to supported', async () => {
+      const ledgerChannel = TestLedgerChannel.create({});
+      await ledgerChannel.insertInto(store, {
+        states: [4, 5],
+        bals: [10, 10],
+      });
+
+      // create three application channels
+      const appChannels = [0, 1].map(() => TestChannel.create({aBal: 1, bBal: 0}));
+      for await (const appChannel of appChannels) {
+        // for each one, insert the channel and a ledger funding request
+        await appChannel.insertInto(store, {states: [0, 1]});
+        await ledgerChannel.insertFundingRequest(store, appChannel.channelId);
+      }
+
+      const proposal1 = simpleEthAllocation([alice, 9], [bob, 10], [appChannels[0].channelId, 1]);
+      const proposal2 = simpleEthAllocation([alice, 9], [bob, 10], [appChannels[1].channelId, 1]);
+
+      await ledgerChannel.insertProposal(
+        store,
+        proposal1,
+        ledgerChannel.participantA.signingAddress,
+        0
+      );
+
+      await ledgerChannel.insertProposal(
+        store,
+        proposal2,
+        ledgerChannel.participantB.signingAddress,
+        0
+      );
+
+      let ledgerProposals = await store.getLedgerProposals(ledgerChannel.channelId);
+      console.log(ledgerProposals);
+
+      // crank the ledger manager
+      const response = new WalletResponse();
+      await ledgerManager.crank(ledgerChannel.channelId, response); // This can result in several "actions" happening, in the old language
+      // in fact, we get a DismissLedgerProposals, then a ProposeLedgerUpdate, then an undefined
+      // The later actions overwrite changes to the store that we might intend to assert on after a single action is processed
+      // (see below)
+
+      // assert that the ledger proposals were dismissed
+      ledgerProposals = await store.getLedgerProposals(ledgerChannel.channelId);
+
+      // This assertion will fail because subsequent "actions" reintroduce a non-null proposal
+      // expect(ledgerProposals).toContainObject({
+      //   nonce: 0,
+      //   proposal: null,
+      //   signgingAddress: ledgerChannel.participantA.signingAddress,
+      // });
+      expect(ledgerProposals).toContainObject<Partial<LedgerProposal>>({
+        nonce: 0,
+        proposal: null,
+        signingAddress: ledgerChannel.participantB.signingAddress,
       });
     });
   });
 
   describe('as responding signer', () => {
-    it('throws an error if counterparty signed update does not follow protocol', () => {
-      const requestChannel = prefundChannelWithAllocations([alice, 1]);
-      const proposal = simpleEthAllocation([alice, 9], [bob, 10], [requestChannel.channelId, 1]);
-      const unexpectedOutcome = simpleEthAllocation([bob, 1337]);
-      const fundingChannel = channel({
-        vars: [
-          stateSignedBy([bobSW()])({
-            turnNum: 4,
-            outcome: unexpectedOutcome,
-          }),
-          defaultLedgerChannel.latest,
-        ],
-      }).protocolState as ChannelStateWithSupported;
-      const protocolArgs = {
-        fundingChannel,
-        channelsRequestingFunds: [requestChannel.protocolState],
-        myLedgerProposal: {proposal, nonce: 0},
-        theirLedgerProposal: {proposal, nonce: 0},
-      };
-      expect(() => protocol(processLedgerQueueProtocolState(protocolArgs))).toThrow(
+    it('throws an error if counterparty signed update does not follow protocol', async () => {
+      // create an application channel
+      const appChannel = TestChannel.create({aBal: 1, bBal: 0});
+      await appChannel.insertInto(store, {states: [0, 1]});
+
+      // create and insert a funded ledger channel that already funds the appChannel
+      const ledgerChannel = TestLedgerChannel.create({});
+      await ledgerChannel.insertInto(store, {
+        states: [3],
+      });
+
+      // create a ledger request for the ledger to fund the channel
+      await ledgerChannel.insertFundingRequest(store, appChannel.channelId);
+
+      // add a proposal from each of alice and bob (into Alice's store)
+      const proposal = simpleEthAllocation([alice, 9], [bob, 10], [appChannel.channelId, 1]);
+      await ledgerChannel.insertProposal(
+        store,
+        proposal,
+        ledgerChannel.participantA.signingAddress,
+        0
+      );
+      await ledgerChannel.insertProposal(
+        store,
+        proposal,
+        ledgerChannel.participantB.signingAddress,
+        0
+      );
+
+      // protocol deviation:
+      const stateWithUnexpectedOutcome = ledgerChannel.wirePayload(4, [0, 1337], [1]); // signed by Bob only
+      store.pushMessage(stateWithUnexpectedOutcome);
+
+      // crank the ledger manager
+      const response = new WalletResponse();
+      expect.assertions(1);
+      await expect(ledgerManager.crank(ledgerChannel.channelId, response)).rejects.toThrow(
         'received a signed reveal that is _not_ what we agreed on :/'
       );
     });

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
@@ -7,10 +7,11 @@ import {
   SignedStateWithHash,
   SimpleAllocation,
 } from '@statechannels/wallet-core';
-import {SignedState as WireState} from '@statechannels/wire-format';
+import {Payload, SignedState as WireState} from '@statechannels/wire-format';
 
 import {LedgerProposal} from '../../../models/ledger-proposal';
 import {LedgerRequest} from '../../../models/ledger-request';
+import {WALLET_VERSION} from '../../../version';
 import {Store} from '../../store';
 
 import {stateWithHashSignedBy} from './states';
@@ -55,6 +56,16 @@ export class TestLedgerChannel extends TestChannel {
       channelNonce: this.channelNonce,
       chainId: '0x01',
       challengeDuration: 9001,
+    };
+  }
+
+  /**
+   * Gives the nth state in the history, signed by the provided participant(s) -- default is both
+   */
+  public wirePayload(n: number, bals?: Bals, signerIndices: number[] = [n % 1, n % 2]): Payload {
+    return {
+      walletVersion: WALLET_VERSION,
+      signedStates: [this.wireState(n, bals, signerIndices)],
     };
   }
 


### PR DESCRIPTION
Of the remaining test cases that reference the `protocol()` function (etc), one is removed and the rest are converted over to a "manipulate the store" style. 

Relevant to https://github.com/statechannels/project-management/issues/22

Continuation of #3136

A subtlety I encountered was that as we now test `crank` (instead of `protocol`), we are testing the  *net* side effects of (potentially) several state-machine transitions in series. This means the intermediate states are not really available to assert on, and the tests need to be altered accordingly. 