### PR TITLE
chore: export SingleThreadedWallet class from pkg, disable removeComments in tsconfig

### DIFF
--- a/packages/docs-website/package.json
+++ b/packages/docs-website/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "api-documenter": "node scripts/api-documenter.js",
     "build-docs-website": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus build",
-    "start": "yarn trigger-api-generation && yarn api-documenter && docusaurus start",
+    "start": "yarn trigger-api-generation && yarn api-documenter && yarn docusaurus start",
     "trigger-api-generation": "yarn lerna run generate-api"
   }
 }

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -155,6 +155,23 @@ export type MultipleChannelOutput = {
 };
 
 // @public (undocumented)
+export class MultiThreadedWallet extends SingleThreadedWallet {
+    protected constructor(walletConfig: IncomingServerWalletConfig);
+    // (undocumented)
+    static create(walletConfig: IncomingServerWalletConfig): MultiThreadedWallet;
+    // (undocumented)
+    destroy(): Promise<void>;
+    // (undocumented)
+    pushMessage(rawPayload: unknown): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput>;
+    // (undocumented)
+    updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    warmUpThreads(): Promise<void>;
+    }
+
+// @public (undocumented)
 export type NetworkConfiguration = {
     chainNetworkID: number;
 };
@@ -225,6 +242,117 @@ export type SingleChannelOutput = {
     channelResult: ChannelResult;
 };
 
+// Warning: (ae-forgotten-export) The symbol "EventEmitterType" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "WalletInterface" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ChainEventSubscriberInterface" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export class SingleThreadedWallet extends EventEmitter<EventEmitterType> implements WalletInterface, ChainEventSubscriberInterface {
+    protected constructor(walletConfig: IncomingServerWalletConfig);
+    // (undocumented)
+    addSigningKey(privateKey: PrivateKey): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "AssetOutcomeUpdatedArg" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    assetOutcomeUpdated({ channelId, assetHolderAddress, externalPayouts, }: AssetOutcomeUpdatedArg): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "ChainServiceInterface" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    chainService: ChainServiceInterface;
+    // (undocumented)
+    challenge(challengeState: State): Promise<SingleChannelOutput>;
+    // Warning: (ae-forgotten-export) The symbol "ChallengeRegisteredArg" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    challengeRegistered(arg: ChallengeRegisteredArg): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "ChannelFinalizedArg" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    channelFinalized(arg: ChannelFinalizedArg): Promise<void>;
+    // (undocumented)
+    closeChannel({ channelId }: CloseChannelParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    static create(walletConfig: IncomingServerWalletConfig): SingleThreadedWallet;
+    // (undocumented)
+    createChannel(args: CreateChannelParams): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
+    // Warning: (ae-forgotten-export) The symbol "DBAdmin" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    dbAdmin(): DBAdmin;
+    // (undocumented)
+    destroy(): Promise<void>;
+    // (undocumented)
+    getChannels(): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    getParticipant(): Promise<Participant | undefined>;
+    // (undocumented)
+    getSigningAddress(): Promise<Address>;
+    // (undocumented)
+    getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;
+    // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    holdingUpdated({ channelId, amount, assetHolderAddress }: HoldingUpdatedArg): Promise<void>;
+    // (undocumented)
+    joinChannel({ channelId }: JoinChannelParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    joinChannels(channelIds: ChannelId[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    knex: Knex;
+    // Warning: (ae-forgotten-export) The symbol "LedgerManager" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    ledgerManager: LedgerManager;
+    // (undocumented)
+    logger: Logger;
+    // Warning: (ae-forgotten-export) The symbol "Output" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    mergeMessages(output: Output[]): MultipleChannelOutput;
+    // Warning: (ae-forgotten-export) The symbol "ObjectiveManager" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    objectiveManager: ObjectiveManager;
+    // (undocumented)
+    pushMessage(rawPayload: unknown): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput>;
+    // (undocumented)
+    registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;
+    // (undocumented)
+    registerAppDefinition(appDefinition: string): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "Store" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    store: Store;
+    // (undocumented)
+    syncChannel({ channelId }: SyncChannelParams): Promise<SingleChannelOutput>;
+    // Warning: (ae-forgotten-export) The symbol "Bytes32" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    syncChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    updateChannel({ channelId, allocations, appData, }: UpdateChannelParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    updateChannelFunding(args: UpdateChannelFundingParams): Promise<SingleChannelOutput>;
+    // Warning: (ae-forgotten-export) The symbol "UpdateChannelFundingParams" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    readonly walletConfig: ServerWalletConfig;
+    // (undocumented)
+    warmUpThreads(): Promise<void>;
+}
+
 // @public (undocumented)
 export function validateServerWalletConfig(config: Record<string, any>): {
     valid: boolean;
@@ -232,12 +360,8 @@ export function validateServerWalletConfig(config: Record<string, any>): {
     errors: ValidationErrorItem[];
 };
 
-// Warning: (ae-forgotten-export) The symbol "SingleThreadedWallet" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export abstract class Wallet extends SingleThreadedWallet {
-    // Warning: (ae-forgotten-export) The symbol "MultiThreadedWallet" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     static create(walletConfig: IncomingServerWalletConfig): SingleThreadedWallet | MultiThreadedWallet;
 }

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -59,18 +59,18 @@ import { ValidationErrorItem } from 'joi';
 
 // Warning: (ae-forgotten-export) The symbol "ChainServiceArgs" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public
 export type ChainServiceConfiguration = {
     attachChainService: boolean;
 } & Partial<ChainServiceArgs>;
 
-// @public (undocumented)
+// @public
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
 
-// @public (undocumented)
+// @public
 export type DatabaseConnectionConfiguration = RequiredConnectionConfiguration & Partial<OptionalConnectionConfiguration>;
 
-// @public (undocumented)
+// @public
 export type DatabasePoolConfiguration = {
     max?: number;
     min?: number;
@@ -92,7 +92,7 @@ export const defaultChainServiceConfiguration: {
     attachChainService: boolean;
 };
 
-// @public (undocumented)
+// @public
 export const defaultConfig: OptionalServerWalletConfig;
 
 // @public (undocumented)
@@ -104,7 +104,7 @@ export const defaultDatabaseConfiguration: OptionalDatabaseConfiguration & {
     };
 };
 
-// @public (undocumented)
+// @public
 export const defaultLoggingConfiguration: LoggingConfiguration;
 
 // @public (undocumented)
@@ -131,10 +131,10 @@ export function getDatabaseConnectionConfig(config: ServerWalletConfig): Databas
     port: number;
 };
 
-// @public (undocumented)
+// @public
 export type IncomingServerWalletConfig = RequiredServerWalletConfig & Partial<OptionalServerWalletConfig>;
 
-// @public (undocumented)
+// @public
 export type LoggingConfiguration = {
     logLevel: Level;
     logDestination: string;
@@ -142,7 +142,7 @@ export type LoggingConfiguration = {
 
 export { Message }
 
-// @public (undocumented)
+// @public
 export type MetricsConfiguration = {
     timingMetrics: boolean;
     metricsOutputFile?: string;
@@ -171,12 +171,12 @@ export class MultiThreadedWallet extends SingleThreadedWallet {
     warmUpThreads(): Promise<void>;
     }
 
-// @public (undocumented)
+// @public
 export type NetworkConfiguration = {
     chainNetworkID: number;
 };
 
-// @public (undocumented)
+// @public
 export type OptionalConnectionConfiguration = {
     port: number;
 } | string;
@@ -188,7 +188,7 @@ export type OptionalDatabaseConfiguration = {
     connection: OptionalConnectionConfiguration;
 };
 
-// @public (undocumented)
+// @public
 export interface OptionalServerWalletConfig {
     // (undocumented)
     chainServiceConfiguration: ChainServiceConfiguration;
@@ -214,7 +214,7 @@ export type Outgoing = Notice;
 // @public (undocumented)
 export function overwriteConfigWithDatabaseConnection(config: ServerWalletConfig, databaseConnectionConfig: PartialConfigObject | string): ServerWalletConfig;
 
-// @public (undocumented)
+// @public
 export type RequiredConnectionConfiguration = {
     database: string;
     host: string;
@@ -222,18 +222,18 @@ export type RequiredConnectionConfiguration = {
     password?: string;
 } | string;
 
-// @public (undocumented)
+// @public
 export type RequiredDatabaseConfiguration = {
     connection: RequiredConnectionConfiguration;
 };
 
-// @public (undocumented)
+// @public
 export type RequiredServerWalletConfig = {
     databaseConfiguration: RequiredDatabaseConfiguration;
     networkConfiguration: NetworkConfiguration;
 };
 
-// @public (undocumented)
+// @public
 export type ServerWalletConfig = RequiredServerWalletConfig & OptionalServerWalletConfig;
 
 // @public (undocumented)
@@ -323,7 +323,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     objectiveManager: ObjectiveManager;
     // (undocumented)
     pushMessage(rawPayload: unknown): Promise<MultipleChannelOutput>;
-    // (undocumented)
     pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput>;
     // (undocumented)
     registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -17,3 +17,4 @@ export abstract class Wallet extends SingleThreadedWallet {
 }
 
 export * from '../config';
+export {SingleThreadedWallet, MultiThreadedWallet};

--- a/packages/server-wallet/tsconfig.json
+++ b/packages/server-wallet/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "lib",
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "allowJs": true // We want to include loader.js to load worker threads
+    "allowJs": true, // We want to include loader.js to load worker threads
+    "removeComments": false
   },
   "references": [
     {


### PR DESCRIPTION
# Description

https://github.com/statechannels/project-management/issues/28 calls for documenation of the server wallet design, mostly from an internal-developer perspective. I consider the API of the `Wallet` class as an important part of that documentation, as well as for public-facing documentation. I think it will be very useful for "App developers" (currently these are chiefly other members of our core team) to understand the purpose and responsibility of each API call they may want to make. 

This change is preparatory work for actually documenting the API using [TSDoc](https://tsdoc.org/). Some of this documentation is in place already, but very patchy.  This change will:
- Spur on a more comprehensive set of TSDoc comments, which have the advantage of enhancing[ intellisence in VSCode](https://code.visualstudio.com/docs/nodejs/working-with-javascript). I believe this has the potential to greatly reduce confusion, duplication and regressions in our code-base, by disseminating knowledge and design principles throughout the codebase. As an example, see #3180 . I can churn out a lot more, but will wait until the overall approach has the green light.
- Cause [this page to appear](https://6009614b7f8fd5c2c94b0585--nitro-protocol.netlify.app/typescript-api/server-wallet.singlethreadedwallet) in our docs website. It's automatically generated and reasonably pretty, and very easy to "show off" to those who are unfamiliar with the codebase
- Quiet a warning from the [`api-extractor`](https://api-extractor.com/) tool that is hooked into the `prepare` lifecycle of this package. I believe this is a great tool to help us "build better typescript packages", and we should mostly do what it recommends us to do :-). The recommendation has a good [justification](https://api-extractor.com/pages/messages/ae-forgotten-export/)

## [Optional] Changes
1. I also inserted `yarn` keyword in `docs-website`. This isn't really necessary so I can rewrite history to drop that commit. 

# How Has This Been Tested?
This change is tested via CI. The docs website successfully got built: meaning that the server-wallet package was successfully compiled, had it's api successfully extracted and documented, and the result was successfully included in a draft build of our docs website (see link above). 

# Checklist:

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [ ] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [ ] I have applied the [appropriate labels](https://github.com/statechannels/statechannels/issues/3177)
- [x] I have linked to relevant issues
- [ ] I have added dependent tickets
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate pipeline
