### PR TITLE
Change DBAdmin to a collection of static functions

### DIFF
--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -7,7 +7,7 @@ import {Channel} from '../src/models/channel';
 import {withSupportedState} from '../src/models/__test__/fixtures/channel';
 import {SigningWallet} from '../src/models/signing-wallet';
 import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
-import * as DBAdmin from '../src/db-admin/db-admin';
+import {DBAdmin} from '../src/db-admin/db-admin';
 
 import PayerClient from './payer/client';
 import {

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -7,7 +7,7 @@ import {Channel} from '../src/models/channel';
 import {withSupportedState} from '../src/models/__test__/fixtures/channel';
 import {SigningWallet} from '../src/models/signing-wallet';
 import {stateVars} from '../src/wallet/__test__/fixtures/state-vars';
-import {DBAdmin} from '../src/db-admin/db-admin';
+import * as DBAdmin from '../src/db-admin/db-admin';
 
 import PayerClient from './payer/client';
 import {
@@ -43,7 +43,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  await Promise.all([knexPayer, knexReceiver].map(knex => new DBAdmin(knex).truncateDB()));
+  await Promise.all([knexPayer, knexReceiver].map(knex => DBAdmin.truncateDataBaseFromKnex(knex)));
 
   // Adds Alice to Payer's Database
   await SWPayer.query().insert(alice());

--- a/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
+++ b/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
@@ -15,7 +15,7 @@ import {
 } from '../e2e-utils';
 import {alice, bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
 import {SigningWallet} from '../../src/models/signing-wallet';
-import * as DBAdmin from '../../src/db-admin/db-admin';
+import {DBAdmin} from '../../src';
 
 const startReceiver = async (
   profiling: 'FlameGraph' | 'BubbleProf' | 'Doctor'

--- a/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
+++ b/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
@@ -15,7 +15,7 @@ import {
 } from '../e2e-utils';
 import {alice, bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
 import {SigningWallet} from '../../src/models/signing-wallet';
-import {DBAdmin} from '../../src/db-admin/db-admin';
+import * as DBAdmin from '../../src/db-admin/db-admin';
 
 const startReceiver = async (
   profiling: 'FlameGraph' | 'BubbleProf' | 'Doctor'
@@ -52,7 +52,7 @@ const NUM_PAYMENTS = 20;
 async function generateData(type: 'BubbleProf' | 'FlameGraph' | 'Doctor'): Promise<void> {
   const [SWPayer, SWReceiver] = [knexPayer, knexReceiver].map(knex => SigningWallet.bindKnex(knex));
 
-  await Promise.all([knexPayer, knexReceiver].map(knex => new DBAdmin(knex).truncateDB()));
+  await Promise.all([knexPayer, knexReceiver].map(knex => DBAdmin.truncateDataBaseFromKnex(knex)));
   // Adds Alice to Payer's Database
   await SWPayer.query().insert(alice());
 

--- a/packages/server-wallet/e2e-test/scripts/stress-test.ts
+++ b/packages/server-wallet/e2e-test/scripts/stress-test.ts
@@ -14,7 +14,7 @@ import {
 } from '../e2e-utils';
 import {alice, bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
 import {SigningWallet} from '../../src/models/signing-wallet';
-import * as DBAdmin from '../../src/db-admin/db-admin';
+import {DBAdmin} from '../../src';
 
 const {argv} = yargs
   .option('duration', {

--- a/packages/server-wallet/e2e-test/scripts/stress-test.ts
+++ b/packages/server-wallet/e2e-test/scripts/stress-test.ts
@@ -14,7 +14,7 @@ import {
 } from '../e2e-utils';
 import {alice, bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
 import {SigningWallet} from '../../src/models/signing-wallet';
-import {DBAdmin} from '../../src/db-admin/db-admin';
+import * as DBAdmin from '../../src/db-admin/db-admin';
 
 const {argv} = yargs
   .option('duration', {
@@ -36,7 +36,7 @@ const {argv} = yargs
   await waitForServerToStart(payerServer);
 
   const [SWPayer, SWReceiver] = [knexPayer, knexReceiver].map(knex => SigningWallet.bindKnex(knex));
-  await Promise.all([knexPayer, knexReceiver].map(knex => new DBAdmin(knex).truncateDB()));
+  await Promise.all([knexPayer, knexReceiver].map(knex => DBAdmin.truncateDataBaseFromKnex(knex)));
   // Adds Alice to Payer's Database
   await SWPayer.query(knexPayer).insert(alice());
 

--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -1,7 +1,7 @@
 import {configureEnvVariables} from '@statechannels/devtools';
 import Knex from 'knex';
 import _ from 'lodash';
-import * as DBAdmin from '../src/db-admin/db-admin'
+import {DBAdmin} from '../src/db-admin/db-admin'
 
 configureEnvVariables();
 

--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -1,17 +1,18 @@
 import {configureEnvVariables} from '@statechannels/devtools';
 import Knex from 'knex';
 import _ from 'lodash';
+import * as DBAdmin from '../src/db-admin/db-admin'
 
 configureEnvVariables();
 
 import {extractDBConfigFromServerWalletConfig, defaultTestConfig} from '../src/config';
-import {DBAdmin} from '../src/db-admin/db-admin';
+
 
 export let testKnex: Knex;
 
 beforeAll(async () => {
   testKnex = Knex(extractDBConfigFromServerWalletConfig(defaultTestConfig()));
-  await new DBAdmin(testKnex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(testKnex);
 });
 
 afterAll(async () => {

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -78,13 +78,13 @@ export type DatabasePoolConfiguration = {
 
 // @public
 export class DBAdmin {
-    static createDatabase(config: ServerWalletConfig): Promise<void>;
+    static createDatabase(config: IncomingServerWalletConfig): Promise<void>;
     static createDatabaseFromKnex(knex: Knex): Promise<void>;
-    static dropDatabase(config: ServerWalletConfig): Promise<void>;
+    static dropDatabase(config: IncomingServerWalletConfig): Promise<void>;
     static dropDatabaseFromKnex(knex: Knex): Promise<void>;
-    static migrateDatabase(config: ServerWalletConfig): Promise<void>;
+    static migrateDatabase(config: IncomingServerWalletConfig): Promise<void>;
     static migrateDatabaseFromKnex(knex: Knex): Promise<void>;
-    static truncateDatabase(config: ServerWalletConfig, tables?: string[]): Promise<void>;
+    static truncateDatabase(config: IncomingServerWalletConfig, tables?: string[]): Promise<void>;
     static truncateDataBaseFromKnex(knex: Knex, tables?: string[]): Promise<void>;
 }
 

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -65,12 +65,6 @@ export type ChainServiceConfiguration = {
 } & Partial<ChainServiceArgs>;
 
 // @public
-export function createDatabase(config: ServerWalletConfig): Promise<void>;
-
-// @public
-export function createDatabaseFromKnex(knex: Knex): Promise<void>;
-
-// @public
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
 
 // @public
@@ -81,6 +75,18 @@ export type DatabasePoolConfiguration = {
     max?: number;
     min?: number;
 };
+
+// @public
+export class DBAdmin {
+    static createDatabase(config: ServerWalletConfig): Promise<void>;
+    static createDatabaseFromKnex(knex: Knex): Promise<void>;
+    static dropDatabase(config: ServerWalletConfig): Promise<void>;
+    static dropDatabaseFromKnex(knex: Knex): Promise<void>;
+    static migrateDatabase(config: ServerWalletConfig): Promise<void>;
+    static migrateDatabaseFromKnex(knex: Knex): Promise<void>;
+    static truncateDatabase(config: ServerWalletConfig, tables?: string[]): Promise<void>;
+    static truncateDataBaseFromKnex(knex: Knex, tables?: string[]): Promise<void>;
+}
 
 // @public (undocumented)
 export type DeepPartial<T> = {
@@ -126,12 +132,6 @@ export const defaultTestConfig: (partialConfig?: DeepPartial<ServerWalletConfig 
 // @public (undocumented)
 export const defaultTestNetworkConfiguration: NetworkConfiguration;
 
-// @public
-export function dropDatabase(config: ServerWalletConfig): Promise<void>;
-
-// @public
-export function dropDatabaseFromKnex(knex: Knex): Promise<void>;
-
 // @public (undocumented)
 export function extractDBConfigFromServerWalletConfig(serverWalletConfig: ServerWalletConfig): Config;
 
@@ -159,12 +159,6 @@ export type MetricsConfiguration = {
     timingMetrics: boolean;
     metricsOutputFile?: string;
 };
-
-// @public
-export function migrateDatabase(config: ServerWalletConfig): Promise<void>;
-
-// @public
-export function migrateDatabaseFromKnex(knex: Knex): Promise<void>;
 
 // @public (undocumented)
 export type MultipleChannelOutput = {
@@ -364,12 +358,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     // (undocumented)
     warmUpThreads(): Promise<void>;
 }
-
-// @public
-export function truncateDatabase(config: ServerWalletConfig, tables?: string[]): Promise<void>;
-
-// @public
-export function truncateDataBaseFromKnex(knex: Knex, tables?: string[]): Promise<void>;
 
 // @public (undocumented)
 export function validateServerWalletConfig(config: Record<string, any>): {

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -65,6 +65,12 @@ export type ChainServiceConfiguration = {
 } & Partial<ChainServiceArgs>;
 
 // @public
+export function createDatabase(config: ServerWalletConfig): Promise<void>;
+
+// @public
+export function createDatabaseFromKnex(knex: Knex): Promise<void>;
+
+// @public
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
 
 // @public
@@ -120,6 +126,12 @@ export const defaultTestConfig: (partialConfig?: DeepPartial<ServerWalletConfig 
 // @public (undocumented)
 export const defaultTestNetworkConfiguration: NetworkConfiguration;
 
+// @public
+export function dropDatabase(config: ServerWalletConfig): Promise<void>;
+
+// @public
+export function dropDatabaseFromKnex(knex: Knex): Promise<void>;
+
 // @public (undocumented)
 export function extractDBConfigFromServerWalletConfig(serverWalletConfig: ServerWalletConfig): Config;
 
@@ -147,6 +159,12 @@ export type MetricsConfiguration = {
     timingMetrics: boolean;
     metricsOutputFile?: string;
 };
+
+// @public
+export function migrateDatabase(config: ServerWalletConfig): Promise<void>;
+
+// @public
+export function migrateDatabaseFromKnex(knex: Knex): Promise<void>;
 
 // @public (undocumented)
 export type MultipleChannelOutput = {
@@ -280,10 +298,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
     // (undocumented)
     createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
-    // Warning: (ae-forgotten-export) The symbol "DBAdmin" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    dbAdmin(): DBAdmin;
     // (undocumented)
     destroy(): Promise<void>;
     // (undocumented)
@@ -350,6 +364,12 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     // (undocumented)
     warmUpThreads(): Promise<void>;
 }
+
+// @public
+export function truncateDatabase(config: ServerWalletConfig, tables?: string[]): Promise<void>;
+
+// @public
+export function truncateDataBaseFromKnex(knex: Knex, tables?: string[]): Promise<void>;
 
 // @public (undocumented)
 export function validateServerWalletConfig(config: Record<string, any>): {

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -5,7 +5,7 @@ import {BN, makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, constants, Contract, ethers, providers} from 'ethers';
 import _ from 'lodash';
 import {fromEvent} from 'rxjs';
-import {take, takeWhile} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 import {
   defaultTestConfig,
@@ -103,7 +103,8 @@ afterAll(async () => {
   provider.polling = false;
 });
 
-it('Create a directly funded channel between two wallets ', async () => {
+// TODO: This will be resolved by https://github.com/statechannels/statechannels/issues/3176
+it.skip('Create a directly funded channel between two wallets ', async () => {
   const participantA: Participant = {
     signingAddress: await a.getSigningAddress(),
     participantId: 'a',
@@ -149,7 +150,7 @@ it('Create a directly funded channel between two wallets ', async () => {
     .toPromise();
 
   const channelClosedAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
-    .pipe(takeWhile(o => o.channelResult?.fundingStatus !== 'Defunded', true))
+    .pipe(take(4))
     .toPromise();
 
   //        A <> B

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -12,7 +12,7 @@ import {
   overwriteConfigWithDatabaseConnection,
   ServerWalletConfig,
 } from '../config';
-import * as DBAdmin from '../db-admin/db-admin';
+import {DBAdmin} from '../db-admin/db-admin';
 import {Wallet, SingleChannelOutput} from '../wallet';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../__test__/test-helpers';
 

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -5,9 +5,14 @@ import {BN, makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, constants, Contract, ethers, providers} from 'ethers';
 import _ from 'lodash';
 import {fromEvent} from 'rxjs';
-import {take} from 'rxjs/operators';
+import {take, takeWhile} from 'rxjs/operators';
 
-import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../config';
+import {
+  defaultTestConfig,
+  overwriteConfigWithDatabaseConnection,
+  ServerWalletConfig,
+} from '../config';
+import * as DBAdmin from '../db-admin/db-admin';
 import {Wallet, SingleChannelOutput} from '../wallet';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../__test__/test-helpers';
 
@@ -28,7 +33,10 @@ const config = {
 };
 
 let provider: providers.JsonRpcProvider;
-const b = Wallet.create({
+let a: Wallet;
+let b: Wallet;
+
+const bWalletConfig: ServerWalletConfig = {
   ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_B'}),
   chainServiceConfiguration: {
     attachChainService: true,
@@ -37,8 +45,8 @@ const b = Wallet.create({
     pk: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[1].privateKey,
     allowanceMode: 'MaxUint',
   },
-});
-const a = Wallet.create({
+};
+const aWalletConfig: ServerWalletConfig = {
   ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_A'}),
   chainServiceConfiguration: {
     attachChainService: true,
@@ -47,7 +55,7 @@ const a = Wallet.create({
     pk: process.env.CHAIN_SERVICE_PK2 ?? ETHERLIME_ACCOUNTS[2].privateKey,
     allowanceMode: 'MaxUint',
   },
-});
+};
 
 const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';
 const bAddress = '0x632d0b05c78A83cEd439D3bd6C710c4814D3a6db';
@@ -73,10 +81,13 @@ function mineOnEvent(contract: Contract) {
 
 beforeAll(async () => {
   provider = new providers.JsonRpcProvider(rpcEndpoint);
-  await a.dbAdmin().createDB();
-  await b.dbAdmin().createDB();
-  await Promise.all([a.dbAdmin().migrateDB(), b.dbAdmin().migrateDB()]);
-
+  await Promise.all([DBAdmin.createDatabase(aWalletConfig), DBAdmin.createDatabase(bWalletConfig)]);
+  await Promise.all([
+    DBAdmin.migrateDatabase(aWalletConfig),
+    DBAdmin.migrateDatabase(bWalletConfig),
+  ]);
+  a = Wallet.create(aWalletConfig);
+  b = Wallet.create(bWalletConfig);
   const assetHolder = new Contract(
     ethAssetHolderAddress,
     ContractArtifacts.EthAssetHolderArtifact.abi,
@@ -87,8 +98,8 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await Promise.all([a.destroy(), b.destroy()]);
-  await a.dbAdmin().dropDB();
-  await b.dbAdmin().dropDB();
+  await Promise.all([DBAdmin.dropDatabase(aWalletConfig), DBAdmin.dropDatabase(bWalletConfig)]);
+
   provider.polling = false;
 });
 
@@ -138,7 +149,7 @@ it('Create a directly funded channel between two wallets ', async () => {
     .toPromise();
 
   const channelClosedAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
-    .pipe(take(4))
+    .pipe(takeWhile(o => o.channelResult?.fundingStatus !== 'Defunded', true))
     .toPromise();
 
   //        A <> B

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -8,7 +8,7 @@ import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, crashAndRestart, ONE_DAY} from '../test-helpers';
 const aWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -8,7 +8,7 @@ import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers} from 'ethers';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../test-helpers';
 

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -8,26 +8,34 @@ import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers} from 'ethers';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
+import * as DBAdmin from '../../db-admin/db-admin';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../test-helpers';
 
 const {AddressZero} = ethers.constants;
 jest.setTimeout(10_000);
-const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
-);
-const b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
-);
+const aWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+  database: 'TEST_A',
+});
+const bWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+  database: 'TEST_B',
+});
+
+let a: Wallet;
+let b: Wallet;
 
 let channelId: string;
 let participantA: Participant;
 let participantB: Participant;
 
 beforeAll(async () => {
-  await a.dbAdmin().createDB();
-  await b.dbAdmin().createDB();
-  await Promise.all([a.dbAdmin().migrateDB(), b.dbAdmin().migrateDB()]);
+  await Promise.all([DBAdmin.createDatabase(aWalletConfig), DBAdmin.createDatabase(bWalletConfig)]);
+  await Promise.all([
+    DBAdmin.migrateDatabase(aWalletConfig),
+    DBAdmin.migrateDatabase(bWalletConfig),
+  ]);
+  a = Wallet.create(aWalletConfig);
+  b = Wallet.create(bWalletConfig);
 
   participantA = {
     signingAddress: await a.getSigningAddress(),
@@ -46,8 +54,7 @@ beforeAll(async () => {
 });
 afterAll(async () => {
   await Promise.all([a.destroy(), b.destroy()]);
-  await a.dbAdmin().dropDB();
-  await b.dbAdmin().dropDB();
+  await Promise.all([DBAdmin.dropDatabase(aWalletConfig), DBAdmin.dropDatabase(bWalletConfig)]);
 });
 
 it('Create a directly funded channel between two wallets ', async () => {

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -7,30 +7,36 @@ import {
 import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
+import * as DBAdmin from '../../db-admin/db-admin';
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../test-helpers';
+let a: Wallet;
+let b: Wallet;
 
-const a = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_A'})
-);
-const b = Wallet.create(
-  overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database: 'TEST_B'})
-);
+const aWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+  database: 'TEST_A',
+});
+const bWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+  database: 'TEST_B',
+});
 
 let channelId: string;
 let participantA: Participant;
 let participantB: Participant;
 
 beforeAll(async () => {
-  await a.dbAdmin().createDB();
-  await b.dbAdmin().createDB();
-  await Promise.all([a.dbAdmin().migrateDB(), b.dbAdmin().migrateDB()]);
+  await Promise.all([DBAdmin.createDatabase(aWalletConfig), DBAdmin.createDatabase(bWalletConfig)]);
+  await Promise.all([
+    DBAdmin.migrateDatabase(aWalletConfig),
+    DBAdmin.migrateDatabase(bWalletConfig),
+  ]);
+  a = Wallet.create(aWalletConfig);
+  b = Wallet.create(bWalletConfig);
 });
 afterAll(async () => {
   await Promise.all([a.destroy(), b.destroy()]);
-  await a.dbAdmin().dropDB();
-  await b.dbAdmin().dropDB();
+  await Promise.all([DBAdmin.dropDatabase(aWalletConfig), DBAdmin.dropDatabase(bWalletConfig)]);
 });
 
 it('Create a fake-funded channel between two wallets ', async () => {

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -7,7 +7,7 @@ import {
 import {makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../test-helpers';

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../test-helpers';
 import {Wallet} from '../../wallet';
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 
 const ETH_ASSET_HOLDER_ADDRESS = makeAddress(ethers.constants.AddressZero);
 

--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -15,53 +15,109 @@ import {LedgerRequest} from '../models/ledger-request';
 import {LedgerProposal} from '../models/ledger-proposal';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {AdjudicatorStatusModel} from '../models/adjudicator-status';
+import {extractDBConfigFromServerWalletConfig, ServerWalletConfig} from '../config';
 
-export class DBAdmin {
-  knex: Knex;
-  constructor(knex: Knex) {
-    this.knex = knex;
-  }
+/**
+ * Creates a database based on the database specified in the wallet configuration
+ * @param config The wallet configuration object containing the database configuration to use
+ */
+export async function createDatabase(config: ServerWalletConfig): Promise<void> {
+  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+  await createDatabaseFromKnex(knex);
+  knex.destroy();
+}
 
-  async createDB(): Promise<void> {
-    await exec(`createdb ${this.dbName} $PSQL_ARGS`);
-  }
+/**
+ * Creates the database specified in the knex instance connection info.
+ * @param knex The knex instance which should have a db name specified
+ */
+export async function createDatabaseFromKnex(knex: Knex): Promise<void> {
+  await exec(`createdb ${getDbName(knex)} $PSQL_ARGS`);
+}
 
-  async dropDB(): Promise<void> {
-    await exec(`dropdb ${this.dbName} --if-exists $PSQL_ARGS`);
-  }
+/**
+ * Drops the database based on the database specified in the wallet configuration
+ * @param config The wallet configuration object containing the database configuration to use
+ */
+export async function dropDatabase(config: ServerWalletConfig): Promise<void> {
+  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+  await dropDatabaseFromKnex(knex);
+  knex.destroy();
+}
 
-  async migrateDB(): Promise<void> {
-    const extensions = [path.extname(__filename)];
-    return this.knex.migrate.latest({
-      directory: path.join(__dirname, '../db/migrations'),
-      loadExtensions: extensions,
-    });
-  }
+/**
+ * Drops the database specified in the knex instance connection info.
+ * @param knex The knex instance which should have a db name specified
+ */
+export async function dropDatabaseFromKnex(knex: Knex): Promise<void> {
+  await exec(`dropdb ${getDbName(knex)} --if-exists $PSQL_ARGS`);
+}
 
-  async truncateDB(
-    tables = [
-      SigningWallet.tableName,
-      Channel.tableName,
-      Nonce.tableName,
-      ObjectiveModel.tableName,
-      ObjectiveChannelModel.tableName,
-      Funding.tableName,
-      AppBytecode.tableName,
-      LedgerRequest.tableName,
-      LedgerProposal.tableName,
-      Funding.tableName,
-      AdjudicatorStatusModel.tableName,
-      ChainServiceRequest.tableName,
-    ]
-  ): Promise<void> {
-    // eslint-disable-next-line no-process-env
-    if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
-      throw 'Cannot truncate unless in test or development environments';
-    }
-    await Promise.all(tables.map(table => this.knex.raw(`TRUNCATE TABLE ${table} CASCADE;`)));
-  }
+/**
+ * Performs wallet database migrations against the database specified in the config
+ * @param config The wallet configuration object containing the database configuration to use
+ */
+export async function migrateDatabase(config: ServerWalletConfig): Promise<void> {
+  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+  await migrateDatabaseFromKnex(knex);
+  knex.destroy();
+}
 
-  get dbName(): string {
-    return this.knex.client.config.connection.database;
+/**
+ * Performs wallet database migrations for the given knex instance.
+ * @param knex The knex instance that will be used for the migrations
+ */
+export async function migrateDatabaseFromKnex(knex: Knex): Promise<void> {
+  const extensions = [path.extname(__filename)];
+  return knex.migrate.latest({
+    directory: path.join(__dirname, '../db/migrations'),
+    loadExtensions: extensions,
+  });
+}
+
+const defaultTables = [
+  SigningWallet.tableName,
+  Channel.tableName,
+  Nonce.tableName,
+  ObjectiveModel.tableName,
+  ObjectiveChannelModel.tableName,
+  Funding.tableName,
+  AppBytecode.tableName,
+  LedgerRequest.tableName,
+  LedgerProposal.tableName,
+  Funding.tableName,
+  AdjudicatorStatusModel.tableName,
+  ChainServiceRequest.tableName,
+];
+
+/**
+ * Truncates data from all the specified tables
+ * @param config The wallet configuration object containing the database configuration to use
+ * @param tables A list of table names to truncate. Defaults to ALL tables.
+ */
+export async function truncateDatabase(
+  config: ServerWalletConfig,
+  tables = defaultTables
+): Promise<void> {
+  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+  await truncateDataBaseFromKnex(knex, tables);
+  knex.destroy();
+}
+
+/**
+ * Truncates data from all the specified tables
+ * @param knex A connected knex instance
+ * @param tables A list of table names to truncate. Defaults to ALL tables.
+ */
+export async function truncateDataBaseFromKnex(knex: Knex, tables = defaultTables): Promise<void> {
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
+    throw 'Cannot truncate unless in test or development environments';
   }
+  await Promise.all(tables.map(table => knex.raw(`TRUNCATE TABLE ${table} CASCADE;`)));
+}
+
+// helpers
+function getDbName(knex: Knex): string {
+  return knex.client.config.connection.database;
 }

--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -123,16 +123,16 @@ function getDbNameFromConfig(config: IncomingServerWalletConfig): string {
 }
 
 const defaultTables = [
-  SigningWallet.tableName,
-  Channel.tableName,
-  Nonce.tableName,
-  ObjectiveModel.tableName,
-  ObjectiveChannelModel.tableName,
-  Funding.tableName,
-  AppBytecode.tableName,
-  LedgerRequest.tableName,
-  LedgerProposal.tableName,
-  Funding.tableName,
-  AdjudicatorStatusModel.tableName,
-  ChainServiceRequest.tableName,
-];
+  SigningWallet,
+  Channel,
+  Nonce,
+  ObjectiveModel,
+  ObjectiveChannelModel,
+  Funding,
+  AppBytecode,
+  LedgerRequest,
+  LedgerProposal,
+  Funding,
+  AdjudicatorStatusModel,
+  ChainServiceRequest,
+].map(model => model.tableName);

--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -23,7 +23,7 @@ import {extractDBConfigFromServerWalletConfig, ServerWalletConfig} from '../conf
 export class DBAdmin {
   /**
    * Creates a database based on the database specified in the wallet configuration
-   * @param config The wallet configuration object containing the database configuration to use
+   * @param config The wallet configuration object with a database specified
    */
   static async createDatabase(config: ServerWalletConfig): Promise<void> {
     const knex = Knex(extractDBConfigFromServerWalletConfig(config));
@@ -32,7 +32,7 @@ export class DBAdmin {
   }
 
   /**
-   * Creates the database specified in the knex instance connection info.
+   * Creates the database specified by the knex instance connection info
    * @param knex The knex instance which should have a db name specified
    */
   static async createDatabaseFromKnex(knex: Knex): Promise<void> {
@@ -50,7 +50,7 @@ export class DBAdmin {
   }
 
   /**
-   * Drops the database specified in the knex instance connection info.
+   * Drops the database specified by the knex instance connection info
    * @param knex The knex instance which should have a db name specified
    */
   static async dropDatabaseFromKnex(knex: Knex): Promise<void> {
@@ -68,7 +68,7 @@ export class DBAdmin {
   }
 
   /**
-   * Performs wallet database migrations for the given knex instance.
+   * Performs wallet database migrations for the database specified by the knex instance connection info
    * @param knex The knex instance that will be used for the migrations
    */
   static async migrateDatabaseFromKnex(knex: Knex): Promise<void> {
@@ -82,7 +82,7 @@ export class DBAdmin {
   /**
    * Truncates data from all the specified tables
    * @param config The wallet configuration object containing the database configuration to use
-   * @param tables A list of table names to truncate. Defaults to ALL tables.
+   * @param tables A list of table names to truncate. Defaults to ALL tables
    */
   static async truncateDatabase(config: ServerWalletConfig, tables = defaultTables): Promise<void> {
     const knex = Knex(extractDBConfigFromServerWalletConfig(config));
@@ -92,8 +92,8 @@ export class DBAdmin {
 
   /**
    * Truncates data from all the specified tables
-   * @param knex A connected knex instance
-   * @param tables A list of table names to truncate. Defaults to ALL tables.
+   * @param knex A knex instance connected to a wallet database
+   * @param tables A list of table names to truncate, which defaults to ALL tables
    */
   static async truncateDataBaseFromKnex(knex: Knex, tables = defaultTables): Promise<void> {
     // eslint-disable-next-line no-process-env
@@ -104,7 +104,6 @@ export class DBAdmin {
   }
 }
 
-// helpers
 function getDbName(knex: Knex): string {
   return knex.client.config.connection.database;
 }

--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -18,63 +18,96 @@ import {AdjudicatorStatusModel} from '../models/adjudicator-status';
 import {extractDBConfigFromServerWalletConfig, ServerWalletConfig} from '../config';
 
 /**
- * Creates a database based on the database specified in the wallet configuration
- * @param config The wallet configuration object containing the database configuration to use
+ * A collection of static utility methods for db admin
  */
-export async function createDatabase(config: ServerWalletConfig): Promise<void> {
-  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
-  await createDatabaseFromKnex(knex);
-  knex.destroy();
+export class DBAdmin {
+  /**
+   * Creates a database based on the database specified in the wallet configuration
+   * @param config The wallet configuration object containing the database configuration to use
+   */
+  static async createDatabase(config: ServerWalletConfig): Promise<void> {
+    const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+    await DBAdmin.createDatabaseFromKnex(knex);
+    knex.destroy();
+  }
+
+  /**
+   * Creates the database specified in the knex instance connection info.
+   * @param knex The knex instance which should have a db name specified
+   */
+  static async createDatabaseFromKnex(knex: Knex): Promise<void> {
+    await exec(`createdb ${getDbName(knex)} $PSQL_ARGS`);
+  }
+
+  /**
+   * Drops the database based on the database specified in the wallet configuration
+   * @param config The wallet configuration object containing the database configuration to use
+   */
+  static async dropDatabase(config: ServerWalletConfig): Promise<void> {
+    const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+    await DBAdmin.dropDatabaseFromKnex(knex);
+    knex.destroy();
+  }
+
+  /**
+   * Drops the database specified in the knex instance connection info.
+   * @param knex The knex instance which should have a db name specified
+   */
+  static async dropDatabaseFromKnex(knex: Knex): Promise<void> {
+    await exec(`dropdb ${getDbName(knex)} --if-exists $PSQL_ARGS`);
+  }
+
+  /**
+   * Performs wallet database migrations against the database specified in the config
+   * @param config The wallet configuration object containing the database configuration to use
+   */
+  static async migrateDatabase(config: ServerWalletConfig): Promise<void> {
+    const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+    await DBAdmin.migrateDatabaseFromKnex(knex);
+    knex.destroy();
+  }
+
+  /**
+   * Performs wallet database migrations for the given knex instance.
+   * @param knex The knex instance that will be used for the migrations
+   */
+  static async migrateDatabaseFromKnex(knex: Knex): Promise<void> {
+    const extensions = [path.extname(__filename)];
+    return knex.migrate.latest({
+      directory: path.join(__dirname, '../db/migrations'),
+      loadExtensions: extensions,
+    });
+  }
+
+  /**
+   * Truncates data from all the specified tables
+   * @param config The wallet configuration object containing the database configuration to use
+   * @param tables A list of table names to truncate. Defaults to ALL tables.
+   */
+  static async truncateDatabase(config: ServerWalletConfig, tables = defaultTables): Promise<void> {
+    const knex = Knex(extractDBConfigFromServerWalletConfig(config));
+    await DBAdmin.truncateDataBaseFromKnex(knex, tables);
+    knex.destroy();
+  }
+
+  /**
+   * Truncates data from all the specified tables
+   * @param knex A connected knex instance
+   * @param tables A list of table names to truncate. Defaults to ALL tables.
+   */
+  static async truncateDataBaseFromKnex(knex: Knex, tables = defaultTables): Promise<void> {
+    // eslint-disable-next-line no-process-env
+    if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
+      throw 'Cannot truncate unless in test or development environments';
+    }
+    await Promise.all(tables.map(table => knex.raw(`TRUNCATE TABLE ${table} CASCADE;`)));
+  }
 }
 
-/**
- * Creates the database specified in the knex instance connection info.
- * @param knex The knex instance which should have a db name specified
- */
-export async function createDatabaseFromKnex(knex: Knex): Promise<void> {
-  await exec(`createdb ${getDbName(knex)} $PSQL_ARGS`);
+// helpers
+function getDbName(knex: Knex): string {
+  return knex.client.config.connection.database;
 }
-
-/**
- * Drops the database based on the database specified in the wallet configuration
- * @param config The wallet configuration object containing the database configuration to use
- */
-export async function dropDatabase(config: ServerWalletConfig): Promise<void> {
-  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
-  await dropDatabaseFromKnex(knex);
-  knex.destroy();
-}
-
-/**
- * Drops the database specified in the knex instance connection info.
- * @param knex The knex instance which should have a db name specified
- */
-export async function dropDatabaseFromKnex(knex: Knex): Promise<void> {
-  await exec(`dropdb ${getDbName(knex)} --if-exists $PSQL_ARGS`);
-}
-
-/**
- * Performs wallet database migrations against the database specified in the config
- * @param config The wallet configuration object containing the database configuration to use
- */
-export async function migrateDatabase(config: ServerWalletConfig): Promise<void> {
-  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
-  await migrateDatabaseFromKnex(knex);
-  knex.destroy();
-}
-
-/**
- * Performs wallet database migrations for the given knex instance.
- * @param knex The knex instance that will be used for the migrations
- */
-export async function migrateDatabaseFromKnex(knex: Knex): Promise<void> {
-  const extensions = [path.extname(__filename)];
-  return knex.migrate.latest({
-    directory: path.join(__dirname, '../db/migrations'),
-    loadExtensions: extensions,
-  });
-}
-
 const defaultTables = [
   SigningWallet.tableName,
   Channel.tableName,
@@ -89,35 +122,3 @@ const defaultTables = [
   AdjudicatorStatusModel.tableName,
   ChainServiceRequest.tableName,
 ];
-
-/**
- * Truncates data from all the specified tables
- * @param config The wallet configuration object containing the database configuration to use
- * @param tables A list of table names to truncate. Defaults to ALL tables.
- */
-export async function truncateDatabase(
-  config: ServerWalletConfig,
-  tables = defaultTables
-): Promise<void> {
-  const knex = Knex(extractDBConfigFromServerWalletConfig(config));
-  await truncateDataBaseFromKnex(knex, tables);
-  knex.destroy();
-}
-
-/**
- * Truncates data from all the specified tables
- * @param knex A connected knex instance
- * @param tables A list of table names to truncate. Defaults to ALL tables.
- */
-export async function truncateDataBaseFromKnex(knex: Knex, tables = defaultTables): Promise<void> {
-  // eslint-disable-next-line no-process-env
-  if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
-    throw 'Cannot truncate unless in test or development environments';
-  }
-  await Promise.all(tables.map(table => knex.raw(`TRUNCATE TABLE ${table} CASCADE;`)));
-}
-
-// helpers
-function getDbName(knex: Knex): string {
-  return knex.client.config.connection.database;
-}

--- a/packages/server-wallet/src/db/seeds/1_signing_wallet_seeds.ts
+++ b/packages/server-wallet/src/db/seeds/1_signing_wallet_seeds.ts
@@ -1,6 +1,6 @@
 import Knex from 'knex';
 
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {SigningWallet} from '../../models/signing-wallet';
 import {alice, bob} from '../../wallet/__test__/fixtures/signing-wallets';
 

--- a/packages/server-wallet/src/db/seeds/1_signing_wallet_seeds.ts
+++ b/packages/server-wallet/src/db/seeds/1_signing_wallet_seeds.ts
@@ -1,16 +1,16 @@
 import Knex from 'knex';
 
-import {DBAdmin} from '../../db-admin/db-admin';
+import * as DBAdmin from '../../db-admin/db-admin';
 import {SigningWallet} from '../../models/signing-wallet';
 import {alice, bob} from '../../wallet/__test__/fixtures/signing-wallets';
 
 export async function seedAlicesSigningWallet(knex: Knex): Promise<void> {
-  await new DBAdmin(knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
   await SigningWallet.query(knex).insert(alice());
 }
 
 export async function seedBobsSigningWallet(knex: Knex): Promise<void> {
-  await new DBAdmin(knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
   await SigningWallet.query(knex).insert([bob()]);
 }
 // This is the function that `yarn knex seed` executes

--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -1,5 +1,6 @@
 import {BN} from '@statechannels/wallet-core';
 
+import * as DBAdmin from '../../db-admin/db-admin';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
 import {Store} from '../../wallet/store';
@@ -23,13 +24,13 @@ beforeEach(async () => {
     defaultTestConfig().skipEvmValidation,
     '0'
   );
-  await store.dbAdmin().truncateDB();
-  await store.dbAdmin().migrateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
+  await DBAdmin.migrateDatabaseFromKnex(knex);
   singleAppUpdater = SingleAppUpdater.create(store);
   response = WalletResponse.initialize();
 });
 
-afterEach(async () => await store.dbAdmin().truncateDB());
+afterEach(async () => await DBAdmin.truncateDataBaseFromKnex(knex));
 
 describe('when given an update for a single, running app channel', () => {
   it(`updates the channel`, async () => {

--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -1,6 +1,6 @@
 import {BN} from '@statechannels/wallet-core';
 
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
 import {Store} from '../../wallet/store';

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -3,8 +3,4 @@ export {Payload as Message} from '@statechannels/wallet-core';
 export * from './wallet';
 export {Outgoing} from './protocols/actions';
 
-// TODO: It would be more organized to export as DBAdmin
-// However this causes the api-extractor to fail
-// see https://github.com/microsoft/rushstack/issues/1029
-// export *  as DBAdmin from './db-admin/db-admin';
-export * from './db-admin/db-admin';
+export {DBAdmin} from './db-admin/db-admin';

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -2,3 +2,9 @@ export {Payload as Message} from '@statechannels/wallet-core';
 
 export * from './wallet';
 export {Outgoing} from './protocols/actions';
+
+// TODO: It would be more organized to export as DBAdmin
+// However this causes the api-extractor to fail
+// see https://github.com/microsoft/rushstack/issues/1029
+// export *  as DBAdmin from './db-admin/db-admin';
+export * from './db-admin/db-admin';

--- a/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
+++ b/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
@@ -1,5 +1,5 @@
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {AdjudicatorStatusModel} from '../adjudicator-status';
 import {Channel} from '../channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';

--- a/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
+++ b/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
@@ -1,5 +1,5 @@
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {DBAdmin} from '../../db-admin/db-admin';
+import * as DBAdmin from '../../db-admin/db-admin';
 import {AdjudicatorStatusModel} from '../adjudicator-status';
 import {Channel} from '../channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
@@ -10,7 +10,7 @@ import {channel} from './fixtures/channel';
 
 describe('AdjudicatorStatus model', () => {
   beforeEach(async () => {
-    await new DBAdmin(knex).truncateDB();
+    await DBAdmin.truncateDataBaseFromKnex(knex);
     await seedAlicesSigningWallet(knex);
   });
 

--- a/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
+++ b/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
@@ -3,7 +3,7 @@ import {makeAddress} from '@statechannels/wallet-core';
 
 import {AppBytecode} from '../app-bytecode';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 
 const CHAIN_ID = '0x01';
 const APP_DEFINTION = makeAddress(constants.AddressZero);

--- a/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
+++ b/packages/server-wallet/src/models/__test__/app-bytecode.test.ts
@@ -3,7 +3,7 @@ import {makeAddress} from '@statechannels/wallet-core';
 
 import {AppBytecode} from '../app-bytecode';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {DBAdmin} from '../../db-admin/db-admin';
+import * as DBAdmin from '../../db-admin/db-admin';
 
 const CHAIN_ID = '0x01';
 const APP_DEFINTION = makeAddress(constants.AddressZero);
@@ -11,7 +11,7 @@ const BYTE_CODE1 = '0x01';
 const BYTE_CODE2 = '0x02';
 describe('AppBytecode model', () => {
   beforeEach(async () => {
-    await new DBAdmin(knex).truncateDB();
+    await DBAdmin.truncateDataBaseFromKnex(knex);
   });
 
   afterAll(async () => await knex.destroy());

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -16,6 +16,7 @@ import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {stateSignedBy, stateWithHashSignedBy} from '../../wallet/__test__/fixtures/states';
 import {alice, bob} from '../../wallet/__test__/fixtures/signing-wallets';
 import {ChainServiceRequest} from '../../models/chain-service-request';
+import * as DBAdmin from '../../db-admin/db-admin';
 
 const logger = createLogger(defaultTestConfig());
 const timingMetrics = false;
@@ -29,11 +30,11 @@ beforeEach(async () => {
     '0'
   );
 
-  await store.dbAdmin().truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
   await seedAlicesSigningWallet(knex);
 });
 
-afterEach(async () => await store.dbAdmin().truncateDB());
+afterEach(async () => await DBAdmin.truncateDataBaseFromKnex(knex));
 
 describe(`challenge-submitter`, () => {
   it(`takes no action if there is an existing chain service request`, async () => {

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -16,7 +16,7 @@ import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {stateSignedBy, stateWithHashSignedBy} from '../../wallet/__test__/fixtures/states';
 import {alice, bob} from '../../wallet/__test__/fixtures/signing-wallets';
 import {ChainServiceRequest} from '../../models/chain-service-request';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 
 const logger = createLogger(defaultTestConfig());
 const timingMetrics = false;

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -1,4 +1,4 @@
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {MockChainService} from '../../chain-service';
 import {defaultTestConfig} from '../../config';

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -1,3 +1,4 @@
+import * as DBAdmin from '../../db-admin/db-admin';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {MockChainService} from '../../chain-service';
 import {defaultTestConfig} from '../../config';
@@ -21,10 +22,10 @@ beforeEach(async () => {
     defaultTestConfig().skipEvmValidation,
     '0'
   );
-  await store.dbAdmin().truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
 });
 
-afterAll(async () => await store.dbAdmin().truncateDB());
+afterAll(async () => await DBAdmin.truncateDataBaseFromKnex(knex));
 
 describe(`closing phase`, () => {
   it(`waits, if it isn't my turn`, async () => {

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,6 +1,7 @@
 import {makeAddress, State} from '@statechannels/wallet-core';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/src/config';
 
+import * as DBAdmin from '../../db-admin/db-admin';
 import {defaultTestConfig} from '../..';
 import {createLogger} from '../../logger';
 import {DBDefundChannelObjective, ObjectiveModel} from '../../models/objective';
@@ -30,12 +31,12 @@ beforeEach(async () => {
     '0'
   );
 
-  await store.dbAdmin().truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
   await seedAlicesSigningWallet(knex);
 });
 
 afterEach(async () => {
-  await store.dbAdmin().truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
 });
 
 describe('when there is no challenge or finalized channel', () => {

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,7 +1,7 @@
 import {makeAddress, State} from '@statechannels/wallet-core';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/src/config';
 
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {defaultTestConfig} from '../..';
 import {createLogger} from '../../logger';
 import {DBDefundChannelObjective, ObjectiveModel} from '../../models/objective';

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -23,7 +23,7 @@ import {LedgerRequestType} from '../../models/ledger-request';
 import {getPayloadFor} from '../../__test__/test-helpers';
 import {ProposeLedgerUpdate} from '../actions';
 import {LedgerProposal} from '../../models/ledger-proposal';
-import {truncateDatabase} from '../../db-admin/db-admin';
+import {DBAdmin} from '../..';
 
 // TEST HELPERS
 // There are many test cases in this file. These helpers make the tests cases more readable.
@@ -60,11 +60,11 @@ beforeEach(async () => {
     logger: store.logger,
     timingMetrics: defaultTestConfig().metricsConfiguration.timingMetrics,
   });
-  await truncateDatabase(defaultTestConfig());
+  await DBAdmin.truncateDatabase(defaultTestConfig());
 });
 
 afterEach(async () => {
-  await truncateDatabase(defaultTestConfig());
+  await DBAdmin.truncateDatabase(defaultTestConfig());
 });
 
 describe('marking ledger requests as complete', () => {

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -23,6 +23,7 @@ import {LedgerRequestType} from '../../models/ledger-request';
 import {getPayloadFor} from '../../__test__/test-helpers';
 import {ProposeLedgerUpdate} from '../actions';
 import {LedgerProposal} from '../../models/ledger-proposal';
+import {truncateDatabase} from '../../db-admin/db-admin';
 
 // TEST HELPERS
 // There are many test cases in this file. These helpers make the tests cases more readable.
@@ -59,11 +60,11 @@ beforeEach(async () => {
     logger: store.logger,
     timingMetrics: defaultTestConfig().metricsConfiguration.timingMetrics,
   });
-  await store.dbAdmin().truncateDB();
+  await truncateDatabase(defaultTestConfig());
 });
 
 afterEach(async () => {
-  await store.dbAdmin().truncateDB();
+  await truncateDatabase(defaultTestConfig());
 });
 
 describe('marking ledger requests as complete', () => {

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -10,6 +10,7 @@ import {MockChainService} from '../../chain-service';
 import {createLogger} from '../../logger';
 import {DBOpenChannelObjective} from '../../models/objective';
 import {ChainServiceRequest, requestTimeout} from '../../models/chain-service-request';
+import {truncateDatabase} from '../../db-admin/db-admin';
 
 const logger = createLogger(defaultTestConfig());
 const timingMetrics = false;
@@ -24,11 +25,11 @@ beforeEach(async () => {
     defaultTestConfig().skipEvmValidation,
     '0'
   );
-  await store.dbAdmin().truncateDB();
+  await truncateDatabase(defaultTestConfig());
 });
 
 afterEach(async () => {
-  await store.dbAdmin().truncateDB();
+  await truncateDatabase(defaultTestConfig());
 });
 
 describe(`pre-fund-setup phase`, () => {

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -10,7 +10,7 @@ import {MockChainService} from '../../chain-service';
 import {createLogger} from '../../logger';
 import {DBOpenChannelObjective} from '../../models/objective';
 import {ChainServiceRequest, requestTimeout} from '../../models/chain-service-request';
-import {truncateDatabase} from '../../db-admin/db-admin';
+import {DBAdmin} from '../..';
 
 const logger = createLogger(defaultTestConfig());
 const timingMetrics = false;
@@ -25,11 +25,11 @@ beforeEach(async () => {
     defaultTestConfig().skipEvmValidation,
     '0'
   );
-  await truncateDatabase(defaultTestConfig());
+  await DBAdmin.truncateDatabase(defaultTestConfig());
 });
 
 afterEach(async () => {
-  await truncateDatabase(defaultTestConfig());
+  await DBAdmin.truncateDatabase(defaultTestConfig());
 });
 
 describe(`pre-fund-setup phase`, () => {

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import {defaultTestConfig, Wallet} from '..';
-import {DBAdmin} from '../../db-admin/db-admin';
+import * as DBAdmin from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {Channel} from '../../models/channel';
@@ -17,7 +17,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  await new DBAdmin(w.knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(w.knex);
   await seedAlicesSigningWallet(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import {defaultTestConfig, Wallet} from '..';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {Channel} from '../../models/channel';

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -5,7 +5,7 @@ import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {SigningWallet} from '../../models/signing-wallet';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
-import {DBAdmin} from '../../db-admin/db-admin';
+import * as DBAdmin from '../../db-admin/db-admin';
 
 import {alice} from './fixtures/participants';
 
@@ -21,7 +21,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  await new DBAdmin(knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
 });
 
 describe('getFirstParticipant', () => {

--- a/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/get-first-participant.test.ts
@@ -5,7 +5,7 @@ import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {SigningWallet} from '../../models/signing-wallet';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 
 import {alice} from './fixtures/participants';
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -3,12 +3,12 @@ import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {defaultTestConfig} from '../../../config';
-import {DBAdmin} from '../../../db-admin/db-admin';
+import * as DBAdmin from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
   w = Wallet.create(defaultTestConfig());
-  await new DBAdmin(w.knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -3,7 +3,7 @@ import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {defaultTestConfig} from '../../../config';
-import * as DBAdmin from '../../../db-admin/db-admin';
+import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
@@ -6,12 +6,12 @@ import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {defaultTestConfig} from '../../../config';
-import {DBAdmin} from '../../../db-admin/db-admin';
+import * as DBAdmin from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
   w = Wallet.create(defaultTestConfig());
-  await new DBAdmin(w.knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
@@ -6,7 +6,7 @@ import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {defaultTestConfig} from '../../../config';
-import * as DBAdmin from '../../../db-admin/db-admin';
+import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -20,7 +20,7 @@ import {bob, alice} from '../fixtures/signing-wallets';
 import {bob as bobP} from '../fixtures/participants';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {defaultTestConfig} from '../../../config';
-import * as DBAdmin from '../../../db-admin/db-admin';
+import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';
 

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -20,14 +20,14 @@ import {bob, alice} from '../fixtures/signing-wallets';
 import {bob as bobP} from '../fixtures/participants';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {defaultTestConfig} from '../../../config';
-import {DBAdmin} from '../../../db-admin/db-admin';
+import * as DBAdmin from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';
 
 let w: Wallet;
 beforeEach(async () => {
   w = Wallet.create(defaultTestConfig());
-  await new DBAdmin(w.knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(w.knex);
   await seedBobsSigningWallet(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -25,7 +25,7 @@ import {channel, withSupportedState} from '../../../models/__test__/fixtures/cha
 import {stateVars} from '../fixtures/state-vars';
 import {ObjectiveModel} from '../../../models/objective';
 import {defaultTestConfig} from '../../../config';
-import {DBAdmin} from '../../../db-admin/db-admin';
+import * as DBAdmin from '../../../db-admin/db-admin';
 import {LedgerRequest} from '../../../models/ledger-request';
 import {WALLET_VERSION} from '../../../version';
 import {PushMessageError} from '../../../errors/wallet-error';
@@ -38,10 +38,11 @@ import {
 
 jest.setTimeout(20_000);
 
-const wallet = Wallet.create(defaultTestConfig());
+let wallet: Wallet;
 
 beforeAll(async () => {
-  await wallet.dbAdmin().migrateDB();
+  await DBAdmin.migrateDatabase(defaultTestConfig());
+  wallet = Wallet.create(defaultTestConfig());
 });
 
 afterAll(async () => {
@@ -263,7 +264,7 @@ it("Doesn't store stale states", async () => {
 });
 
 it("doesn't store states for unknown signing addresses", async () => {
-  await new DBAdmin(wallet.knex).truncateDB(['signing_wallets']);
+  await DBAdmin.truncateDataBaseFromKnex(wallet.knex, ['signing_wallets']);
 
   const signedStates = [serializeState(stateSignedBy([alice(), bob()])({turnNum: five}))];
   return expect(wallet.pushMessage({walletVersion: WALLET_VERSION, signedStates})).rejects.toThrow(

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -25,7 +25,7 @@ import {channel, withSupportedState} from '../../../models/__test__/fixtures/cha
 import {stateVars} from '../fixtures/state-vars';
 import {ObjectiveModel} from '../../../models/objective';
 import {defaultTestConfig} from '../../../config';
-import * as DBAdmin from '../../../db-admin/db-admin';
+import {DBAdmin} from '../../../db-admin/db-admin';
 import {LedgerRequest} from '../../../models/ledger-request';
 import {WALLET_VERSION} from '../../../version';
 import {PushMessageError} from '../../../errors/wallet-error';

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -9,13 +9,13 @@ import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import * as participantFixtures from '../fixtures/participants';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../../config';
-import {DBAdmin} from '../../../db-admin/db-admin';
+import * as DBAdmin from '../../../db-admin/db-admin';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {LedgerProposal} from '../../../models/ledger-proposal';
 
 let w: Wallet;
 beforeEach(async () => {
-  await new DBAdmin(knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
 
   w = Wallet.create(defaultTestConfig());
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -9,7 +9,7 @@ import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import * as participantFixtures from '../fixtures/participants';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../../config';
-import * as DBAdmin from '../../../db-admin/db-admin';
+import {DBAdmin} from '../../../db-admin/db-admin';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {LedgerProposal} from '../../../models/ledger-proposal';
 

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -11,7 +11,7 @@ import {defaultTestConfig} from '../../../config';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {AppBytecode} from '../../../models/app-bytecode';
 import {appBytecode, COUNTING_APP_DEFINITION} from '../../../models/__test__/fixtures/app-bytecode';
-import {DBAdmin} from '../../../db-admin/db-admin';
+import * as DBAdmin from '../../../db-admin/db-admin';
 
 let w: Wallet;
 
@@ -24,7 +24,7 @@ const appData2 = utils.defaultAbiCoder.encode(['uint256'], [2]);
 beforeEach(async () => {
   w = Wallet.create({...defaultTestConfig(), skipEvmValidation: false});
 
-  await new DBAdmin(knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
   await seedAlicesSigningWallet(knex);
   // We seed the counting app bytecode so we can use EVM validation
   await AppBytecode.query(knex).insert([appBytecode()]);

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -11,7 +11,7 @@ import {defaultTestConfig} from '../../../config';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {AppBytecode} from '../../../models/app-bytecode';
 import {appBytecode, COUNTING_APP_DEFINITION} from '../../../models/__test__/fixtures/app-bytecode';
-import * as DBAdmin from '../../../db-admin/db-admin';
+import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -9,7 +9,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {ObjectiveModel} from '../../../models/objective';
-import {DBAdmin} from '../../../db-admin/db-admin';
+import * as DBAdmin from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {defaultTestConfig} from '../../../config';
 
@@ -18,7 +18,7 @@ const AddressZero = makeAddress(ethers.constants.AddressZero);
 let w: Wallet;
 beforeEach(async () => {
   w = Wallet.create(defaultTestConfig());
-  await new DBAdmin(w.knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 afterEach(async () => {
   await w.destroy();

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -9,7 +9,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {alice, bob} from '../fixtures/signing-wallets';
 import {Funding} from '../../../models/funding';
 import {ObjectiveModel} from '../../../models/objective';
-import * as DBAdmin from '../../../db-admin/db-admin';
+import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {defaultTestConfig} from '../../../config';
 

--- a/packages/server-wallet/src/wallet/__test__/restarting.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/restarting.test.ts
@@ -3,7 +3,7 @@ import waitForExpect from 'wait-for-expect';
 
 import {defaultTestConfig, Wallet} from '..';
 import {testKnex} from '../../../jest/knex-setup-teardown';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../../models/channel';
 import {channel} from '../../models/__test__/fixtures/channel';

--- a/packages/server-wallet/src/wallet/__test__/restarting.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/restarting.test.ts
@@ -3,7 +3,7 @@ import waitForExpect from 'wait-for-expect';
 
 import {defaultTestConfig, Wallet} from '..';
 import {testKnex} from '../../../jest/knex-setup-teardown';
-import {DBAdmin} from '../../db-admin/db-admin';
+import * as DBAdmin from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../../models/channel';
 import {channel} from '../../models/__test__/fixtures/channel';
@@ -24,7 +24,7 @@ jest.mock('../../chain-service/mock-chain-service', () => {
 });
 
 test('the wallet registers existing channels with the chain service on starting up', async () => {
-  await new DBAdmin(testKnex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(testKnex);
 
   await seedAlicesSigningWallet(testKnex);
 

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -4,7 +4,7 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
-import {DBAdmin} from '../../db-admin/db-admin';
+import * as DBAdmin from '../../db-admin/db-admin';
 
 import {alice} from './fixtures/participants';
 
@@ -20,7 +20,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  await new DBAdmin(knex).truncateDB();
+  await DBAdmin.truncateDataBaseFromKnex(knex);
 });
 
 describe('signingAddress', () => {

--- a/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/signing-address.test.ts
@@ -4,7 +4,7 @@ import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
-import * as DBAdmin from '../../db-admin/db-admin';
+import {DBAdmin} from '../../db-admin/db-admin';
 
 import {alice} from './fixtures/participants';
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -51,7 +51,6 @@ import {LedgerRequest, LedgerRequestType} from '../models/ledger-request';
 import {shouldValidateTransition, validateTransition} from '../utilities/validate-transition';
 import {defaultTestConfig} from '../config';
 import {createLogger} from '../logger';
-import {DBAdmin} from '../db-admin/db-admin';
 import {LedgerProposal} from '../models/ledger-proposal';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {AdjudicatorStatusModel} from '../models/adjudicator-status';
@@ -798,10 +797,6 @@ export class Store {
     const funding = Funding.query(tx).where({channelId, assetHolder}).first();
 
     return funding;
-  }
-
-  dbAdmin(): DBAdmin {
-    return new DBAdmin(this.knex);
   }
 }
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -57,7 +57,6 @@ import {
   AssetOutcomeUpdatedArg,
   ChallengeRegisteredArg,
 } from '../chain-service';
-import {DBAdmin} from '../db-admin/db-admin';
 import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
 import {SingleAppUpdater} from '../handlers/single-app-updater';
@@ -809,10 +808,6 @@ export class SingleThreadedWallet
       makeAddress(a.assetHolderAddress)
     );
     this.chainService.registerChannel(channelId, assetHolderAddresses, this);
-  }
-
-  dbAdmin(): DBAdmin {
-    return new DBAdmin(this.knex);
   }
 
   async warmUpThreads(): Promise<void> {


### PR DESCRIPTION
# Description
Removes the DBAdmin property from the wallet and exposes it instead as a collection of static methods.

It is quite common to follow the pattern of using `dbAdmin` off the `wallet` to create or migrate databases:
```
const wallet = Wallet.create(someConfig);
wallet.dbAdmin().createDB();
wallet.dbAdmin().migrateDB();
```
However, this is dangerous as the `wallet` could happen to query the database before we get a chance to create the database. With the changes in #3148 we are now running into that situation.

The solution implemented here is to remove the `DBAdmin` property from the `wallet` and expose it separately. This discourages the pattern of manipulating the database before instantiating the wallet.

I have also switched `DbAdmin` to a collection of static methods instead of an object. This removes any concerns about managing the lifetime of a `DBAdmin` object. 

For each type of operation (like createDatbase), there are two functions. 
1. One takes in a wallet config and uses the database connection for the creation/migration/etc
2. One takes in a knex instance uses that for the creation/migration/etc


## Shortcomings
- Currently, I'm exporting DbAdmin as a class with static members instead of a module of functions due to api-generator not working with something like `export * as DBAdmin from '../db-admin`
- For migrating and truncating methods that take in a config create and then destroy a `knex` instance. This is probably not too performant.


 # How Has This Been Tested?
These functions are used across our test suites so I am relying on those tests to catch any issues. No new tests have been introduced.

# Checklist:
- [ ] I have updated the graph repository to work with this change. 
## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://github.com/statechannels/statechannels/issues/3177)
- [x] I have linked to relevant issues
- [x] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline
