### PR TITLE
chore: remove format on save vscode setting

### DIFF
--- a/packages/server-wallet/.vscode/settings.json
+++ b/packages/server-wallet/.vscode/settings.json
@@ -4,5 +4,6 @@
     "javascriptreact",
     "typescript",
     "typescriptreact"
-  ]
+  ],
+  "editor.codeActionsOnSave": {"source.fixAll.eslint": true}
 }

--- a/packages/server-wallet/.vscode/settings.json
+++ b/packages/server-wallet/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
-  "editor.formatOnSave": true
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
 }


### PR DESCRIPTION
The below vscode settings take effect when vscode is opened in the `packages/server-wallet` directory. This is my preferred way of working on the server wallet package.

Recently, I started to experience the following behaviour:
1. Save a typescript file.
2. Observe the eslint plugin reformat the file on-save to adhere to the eslint rules.
3. Observe vscode editor reformat the file to adhere to some other rules. See eslint warnings. Note, I do *not* have the prettier plugin installed.

It seems to me that the way to avoid the behavior above is to:
1. Disable formatOnSave
2. Use [editor.codeActionsOnSave](https://github.com/microsoft/vscode-eslint) which are enabled for in my User settings. Perhaps this should be enabled in the Workspace settings as well?