### PR TITLE
Wallet.Create is now async

### DIFF
--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -66,7 +66,7 @@ describe('e2e', () => {
 
   beforeAll(async () => {
     // Create actors
-    payerClient = new PayerClient(alice().privateKey, `http://127.0.0.1:65535`);
+    payerClient = await PayerClient.create(alice().privateKey, `http://127.0.0.1:65535`);
 
     // Gets participant info for testing convenience
     payer = payerClient.me;
@@ -134,8 +134,8 @@ describe('payments', () => {
   describe('syncing', () => {
     let payerClient: PayerClient;
 
-    beforeAll(() => {
-      payerClient = new PayerClient(alice().privateKey, `http://127.0.0.1:65535`);
+    beforeAll(async () => {
+      payerClient = await PayerClient.create(alice().privateKey, `http://127.0.0.1:65535`);
     });
 
     afterAll(async () => {

--- a/packages/server-wallet/e2e-test/payer/app.ts
+++ b/packages/server-wallet/e2e-test/payer/app.ts
@@ -7,7 +7,7 @@ import {RECEIVER_PORT} from '../e2e-utils';
 
 import PayerClient from './client';
 export async function startApp(): Promise<express.Application> {
-  const client = new PayerClient(alice().privateKey, `http://127.0.0.1:${RECEIVER_PORT}`);
+  const client = await PayerClient.create(alice().privateKey, `http://127.0.0.1:${RECEIVER_PORT}`);
   await client.warmup();
   const app = express();
 

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -12,17 +12,26 @@ import {defaultConfig, ServerWalletConfig} from '../../src/config';
 import {ONE_DAY} from '../../src/__test__/test-helpers';
 
 export default class PayerClient {
-  private readonly wallet: ServerWallet;
-  constructor(
+  readonly config: ServerWalletConfig;
+  private constructor(
     private readonly pk: Bytes32,
     private readonly receiverHttpServerURL: string,
-    readonly config?: ServerWalletConfig
+    private readonly wallet: ServerWallet
   ) {
-    this.wallet = recordFunctionMetrics(
-      ServerWallet.create(this.config || payerConfig),
+    this.config = wallet.walletConfig;
+  }
+  public static async create(
+    pk: Bytes32,
+    receiverHttpServerURL: string,
+    config?: ServerWalletConfig
+  ): Promise<PayerClient> {
+    const wallet = await recordFunctionMetrics(
+      ServerWallet.create(config ?? payerConfig),
       payerConfig.metricsConfiguration.timingMetrics
     );
+    return new PayerClient(pk, receiverHttpServerURL, wallet);
   }
+
   public async warmup(): Promise<void> {
     await this.wallet.warmUpThreads();
   }

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -25,8 +25,8 @@ export default class PayerClient {
     receiverHttpServerURL: string,
     config?: ServerWalletConfig
   ): Promise<PayerClient> {
-    const wallet = await recordFunctionMetrics(
-      ServerWallet.create(config ?? payerConfig),
+    const wallet = recordFunctionMetrics(
+      await ServerWallet.create(config ?? payerConfig),
       payerConfig.metricsConfiguration.timingMetrics
     );
     return new PayerClient(pk, receiverHttpServerURL, wallet);

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -40,8 +40,8 @@ export default {
   handler: async (argv: {[key: string]: any} & Argv['argv']): Promise<void> => {
     const {database, numPayments, channels} = argv;
 
-    const payerClient = await recordFunctionMetrics(
-      PayerClient.create(
+    const payerClient = recordFunctionMetrics(
+      await PayerClient.create(
         alice().privateKey,
         `http://127.0.0.1:65535`,
         overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database})

--- a/packages/server-wallet/e2e-test/payer/start.ts
+++ b/packages/server-wallet/e2e-test/payer/start.ts
@@ -40,8 +40,8 @@ export default {
   handler: async (argv: {[key: string]: any} & Argv['argv']): Promise<void> => {
     const {database, numPayments, channels} = argv;
 
-    const payerClient = recordFunctionMetrics(
-      new PayerClient(
+    const payerClient = await recordFunctionMetrics(
+      PayerClient.create(
         alice().privateKey,
         `http://127.0.0.1:65535`,
         overwriteConfigWithDatabaseConnection(defaultTestConfig(), {database})

--- a/packages/server-wallet/e2e-test/receiver/app.ts
+++ b/packages/server-wallet/e2e-test/receiver/app.ts
@@ -7,7 +7,7 @@ import {logger} from '../logger';
 
 import ReceiverController from './controller';
 export async function startApp(): Promise<express.Application> {
-  const controller = new ReceiverController();
+  const controller = await ReceiverController.create();
   await controller.warmup();
   const app = express();
 

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -10,8 +10,8 @@ import {WALLET_VERSION} from '../../src/version';
 
 export default class ReceiverController {
   static async create(): Promise<ReceiverController> {
-    const wallet = await recordFunctionMetrics(
-      Wallet.create(receiverConfig),
+    const wallet = recordFunctionMetrics(
+      await Wallet.create(receiverConfig),
       defaultConfig.metricsConfiguration.timingMetrics
     );
     return new ReceiverController(wallet);

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -9,10 +9,15 @@ import {defaultConfig} from '../../src/config';
 import {WALLET_VERSION} from '../../src/version';
 
 export default class ReceiverController {
-  private readonly wallet: Wallet = recordFunctionMetrics(
-    Wallet.create(receiverConfig),
-    defaultConfig.metricsConfiguration.timingMetrics
-  );
+  static async create(): Promise<ReceiverController> {
+    const wallet = await recordFunctionMetrics(
+      Wallet.create(receiverConfig),
+      defaultConfig.metricsConfiguration.timingMetrics
+    );
+    return new ReceiverController(wallet);
+  }
+
+  private constructor(private readonly wallet: Wallet) {}
 
   public async warmup(): Promise<void> {
     this.wallet.warmUpThreads();

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -170,7 +170,7 @@ export type MultipleChannelOutput = {
 export class MultiThreadedWallet extends SingleThreadedWallet {
     protected constructor(walletConfig: IncomingServerWalletConfig);
     // (undocumented)
-    static create(walletConfig: IncomingServerWalletConfig): MultiThreadedWallet;
+    static create(walletConfig: IncomingServerWalletConfig): Promise<MultiThreadedWallet>;
     // (undocumented)
     destroy(): Promise<void>;
     // (undocumented)
@@ -285,7 +285,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     // (undocumented)
     closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     // (undocumented)
-    static create(walletConfig: IncomingServerWalletConfig): SingleThreadedWallet;
+    static create(walletConfig: IncomingServerWalletConfig): Promise<SingleThreadedWallet>;
     // (undocumented)
     createChannel(args: CreateChannelParams): Promise<MultipleChannelOutput>;
     // (undocumented)

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -369,7 +369,7 @@ export function validateServerWalletConfig(config: Record<string, any>): {
 // @public (undocumented)
 export abstract class Wallet extends SingleThreadedWallet {
     // (undocumented)
-    static create(walletConfig: IncomingServerWalletConfig): SingleThreadedWallet | MultiThreadedWallet;
+    static create(walletConfig: IncomingServerWalletConfig): Promise<SingleThreadedWallet | MultiThreadedWallet>;
 }
 
 

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -86,8 +86,8 @@ beforeAll(async () => {
     DBAdmin.migrateDatabase(aWalletConfig),
     DBAdmin.migrateDatabase(bWalletConfig),
   ]);
-  a = Wallet.create(aWalletConfig);
-  b = Wallet.create(bWalletConfig);
+  a = await Wallet.create(aWalletConfig);
+  b = await Wallet.create(bWalletConfig);
   const assetHolder = new Contract(
     ethAssetHolderAddress,
     ContractArtifacts.EthAssetHolderArtifact.abi,

--- a/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test__/crash-tolerance/crash-tolerance.test.ts
@@ -32,8 +32,8 @@ beforeAll(async () => {
     DBAdmin.migrateDatabase(aWalletConfig),
     DBAdmin.migrateDatabase(bWalletConfig),
   ]);
-  a = Wallet.create(aWalletConfig);
-  b = Wallet.create(bWalletConfig); // Wallet that will "crash"
+  a = await Wallet.create(aWalletConfig);
+  b = await Wallet.create(bWalletConfig); // Wallet that will "crash"
 
   participantA = {
     signingAddress: await a.getSigningAddress(),

--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -34,8 +34,8 @@ beforeAll(async () => {
     DBAdmin.migrateDatabase(aWalletConfig),
     DBAdmin.migrateDatabase(bWalletConfig),
   ]);
-  a = Wallet.create(aWalletConfig);
-  b = Wallet.create(bWalletConfig);
+  a = await Wallet.create(aWalletConfig);
+  b = await Wallet.create(bWalletConfig);
 
   participantA = {
     signingAddress: await a.getSigningAddress(),

--- a/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/fake-funding.test.ts
@@ -31,8 +31,8 @@ beforeAll(async () => {
     DBAdmin.migrateDatabase(aWalletConfig),
     DBAdmin.migrateDatabase(bWalletConfig),
   ]);
-  a = Wallet.create(aWalletConfig);
-  b = Wallet.create(bWalletConfig);
+  a = await Wallet.create(aWalletConfig);
+  b = await Wallet.create(bWalletConfig);
 });
 afterAll(async () => {
   await Promise.all([a.destroy(), b.destroy()]);

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -39,8 +39,8 @@ beforeAll(async () => {
     DBAdmin.migrateDatabase(aWalletConfig),
     DBAdmin.migrateDatabase(bWalletConfig),
   ]);
-  a = Wallet.create(aWalletConfig);
-  b = Wallet.create(bWalletConfig);
+  a = await Wallet.create(aWalletConfig);
+  b = await Wallet.create(bWalletConfig);
 
   participantA = {
     signingAddress: await a.getSigningAddress(),

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -13,7 +13,7 @@ import {stateWithHashSignedBy} from './fixtures/states';
 
 let w: Wallet;
 beforeAll(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = await Wallet.create(defaultTestConfig());
 });
 
 beforeEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -9,7 +9,7 @@ import {Bytes32} from '../../../type-aliases';
 
 let w: Wallet;
 beforeAll(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = await Wallet.create(defaultTestConfig());
   await seedAlicesSigningWallet(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -7,7 +7,7 @@ import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = await Wallet.create(defaultTestConfig());
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-ledger-channel.test.ts
@@ -10,7 +10,7 @@ import {DBAdmin} from '../../../db-admin/db-admin';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = await Wallet.create(defaultTestConfig());
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -26,7 +26,7 @@ import {ObjectiveModel} from '../../../models/objective';
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = await Wallet.create(defaultTestConfig());
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
   await seedBobsSigningWallet(w.knex);
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -42,7 +42,7 @@ let wallet: Wallet;
 
 beforeAll(async () => {
   await DBAdmin.migrateDatabase(defaultTestConfig());
-  wallet = Wallet.create(defaultTestConfig());
+  wallet = await Wallet.create(defaultTestConfig());
 });
 
 afterAll(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/sync-channel.test.ts
@@ -17,7 +17,7 @@ let w: Wallet;
 beforeEach(async () => {
   await DBAdmin.truncateDataBaseFromKnex(knex);
 
-  w = Wallet.create(defaultTestConfig());
+  w = await Wallet.create(defaultTestConfig());
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-channel.test.ts
@@ -22,7 +22,7 @@ afterEach(async () => {
 const appData1 = utils.defaultAbiCoder.encode(['uint256'], [1]);
 const appData2 = utils.defaultAbiCoder.encode(['uint256'], [2]);
 beforeEach(async () => {
-  w = Wallet.create({...defaultTestConfig(), skipEvmValidation: false});
+  w = await Wallet.create({...defaultTestConfig(), skipEvmValidation: false});
 
   await DBAdmin.truncateDataBaseFromKnex(knex);
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -17,7 +17,7 @@ const AddressZero = makeAddress(ethers.constants.AddressZero);
 
 let w: Wallet;
 beforeEach(async () => {
-  w = Wallet.create(defaultTestConfig());
+  w = await Wallet.create(defaultTestConfig());
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 afterEach(async () => {

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -5,9 +5,9 @@ import {MultiThreadedWallet} from './multi-threaded-wallet';
 import {SingleThreadedWallet} from './wallet';
 
 export abstract class Wallet extends SingleThreadedWallet {
-  static create(
+  static async create(
     walletConfig: IncomingServerWalletConfig
-  ): SingleThreadedWallet | MultiThreadedWallet {
+  ): Promise<SingleThreadedWallet | MultiThreadedWallet> {
     if (walletConfig?.workerThreadAmount && walletConfig.workerThreadAmount > 0) {
       return MultiThreadedWallet.create(walletConfig);
     } else {

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
@@ -9,7 +9,9 @@ import {WorkerManager} from './manager';
 export class MultiThreadedWallet extends SingleThreadedWallet {
   private workerManager: WorkerManager;
 
-  public static create(walletConfig: IncomingServerWalletConfig): MultiThreadedWallet {
+  public static async create(
+    walletConfig: IncomingServerWalletConfig
+  ): Promise<MultiThreadedWallet> {
     return new this(walletConfig);
   }
 

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
@@ -22,45 +22,46 @@ const walletConfig: ServerWalletConfig = {
 const logger = createLogger(walletConfig);
 
 logger.debug(`Worker %o starting`, threadId);
-const wallet = Wallet.create(walletConfig);
-parentPort?.on('message', async (message: any) => {
-  if (isMainThread) {
-    parentPort?.postMessage(
-      left(new Error('Attempting to execute worker thread script on the main thread'))
-    );
-  }
-
-  if (!isStateChannelWorkerData(message)) {
-    parentPort?.postMessage(left(new Error('Incorrect worker data')));
-  }
-
-  const timer = timerFactory(
-    walletConfig.metricsConfiguration?.timingMetrics || false,
-    `Thread ${threadId}`
-  );
-  try {
-    switch (message.operation) {
-      case 'UpdateChannel':
-        logger.debug(`Worker-%o handling UpdateChannel`, threadId);
-        return parentPort?.postMessage(
-          right(await timer('UpdateChannel', () => wallet.updateChannel(message.args)))
-        );
-      case 'PushMessage':
-        logger.debug(`Worker-%o handling PushMessage`, threadId);
-        return parentPort?.postMessage(
-          right(await timer('PushMessage', () => wallet.pushMessage(message.args)))
-        );
-      case 'PushUpdate':
-        logger.debug(`Worker-%o handling PushUpdate`, threadId);
-        return parentPort?.postMessage(
-          right(await timer('PushUpdate', () => wallet.pushUpdate(message.args)))
-        );
-      default:
-        return parentPort?.postMessage(left(new Error('Unknown message type')));
+Wallet.create(walletConfig).then(wallet => {
+  parentPort?.on('message', async (message: any) => {
+    if (isMainThread) {
+      parentPort?.postMessage(
+        left(new Error('Attempting to execute worker thread script on the main thread'))
+      );
     }
-  } catch (error) {
-    logger.error(error);
-    return parentPort?.postMessage(left(error));
-  }
+
+    if (!isStateChannelWorkerData(message)) {
+      parentPort?.postMessage(left(new Error('Incorrect worker data')));
+    }
+
+    const timer = timerFactory(
+      walletConfig.metricsConfiguration?.timingMetrics || false,
+      `Thread ${threadId}`
+    );
+    try {
+      switch (message.operation) {
+        case 'UpdateChannel':
+          logger.debug(`Worker-%o handling UpdateChannel`, threadId);
+          return parentPort?.postMessage(
+            right(await timer('UpdateChannel', () => wallet.updateChannel(message.args)))
+          );
+        case 'PushMessage':
+          logger.debug(`Worker-%o handling PushMessage`, threadId);
+          return parentPort?.postMessage(
+            right(await timer('PushMessage', () => wallet.pushMessage(message.args)))
+          );
+        case 'PushUpdate':
+          logger.debug(`Worker-%o handling PushUpdate`, threadId);
+          return parentPort?.postMessage(
+            right(await timer('PushUpdate', () => wallet.pushUpdate(message.args)))
+          );
+        default:
+          return parentPort?.postMessage(left(new Error('Unknown message type')));
+      }
+    } catch (error) {
+      logger.error(error);
+      return parentPort?.postMessage(left(error));
+    }
+  });
+  logger.info(`Thread %o started`, threadId);
 });
-logger.info(`Thread %o started`, threadId);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -102,10 +102,12 @@ export class SingleThreadedWallet
 
   readonly walletConfig: ServerWalletConfig;
 
-  public static create(walletConfig: IncomingServerWalletConfig): SingleThreadedWallet {
+  public static async create(
+    walletConfig: IncomingServerWalletConfig
+  ): Promise<SingleThreadedWallet> {
     const wallet = new SingleThreadedWallet(walletConfig);
-    // This is an async method so it could continue executing after this method returns
-    wallet.registerExistingChannelsWithChainService();
+
+    await wallet.registerExistingChannelsWithChainService();
     return wallet;
   }
 


### PR DESCRIPTION
# Description
Updates the `Wallet.create` method to be `async`.

In #3148 an async function  `registerExistingChannelsWithChainService` is called in the constructor. Since it is async it can fail after the constructor has finished executing, causing issue with the tests.

The solution implemented is to change the `Wallet.Create` method to be async. This allows us to perform the registration or any other initialization logic before returning the `wallet`.  


#  How Has This Been Tested?
 These methods are using throughout our tests so I am relying on existing test coverage.

# Checklist:
- [ ] Update graph repo to work with changes.
## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://github.com/statechannels/statechannels/issues/3177)
- [x] I have linked to relevant issues
- [x] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline
