### PR TITLE
docs: remove comment

### DIFF
--- a/packages/docs-website/docs/docs/overview.md
+++ b/packages/docs-website/docs/docs/overview.md
@@ -4,8 +4,6 @@ title: statechannels docs
 slug: /
 ---
 
-[//]: # 'THIS PAGE WILL BE SERVED AT /, SO LINKS SHOULD BE ABSOLUTE'
-
 Welcome to the statechannels documentation site!
 
 :::important


### PR DESCRIPTION
The comment shows up in the metadata of the webpage, which is very much unintended.

We don't really need this comment, as the docs website is checked for broken links automatically on circleCI.