### PR TITLE
ci: inject date into canary preid

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -32,4 +32,4 @@ jobs:
           git config --global user.email "github-actions@users.noreply.github.com"
 
       - name: publish packages to npm
-        run: yarn run lerna publish --canary --force-publish --exact --preid next.$(git rev-parse --short HEAD) --dist-tag next --yes
+        run: yarn run lerna publish --canary --force-publish --exact --preid next.$(git rev-parse --short HEAD).$(date +%Y-%m-%d) --dist-tag next --yes


### PR DESCRIPTION
Prevents the github action from failing when there have been no commits made between runs (avoids tag collisions between nightly builds, even when they run on the same commit). 

Fixes #3190 

Shortcomings: long version numbers getting longer. Does nothing to address existing shortcoming (generation and release of at least 1 new version per day / hundreds per year). 

Alternatives considered: 
- reduce frequency of this github action to weekly (very likely a commit has been made; side effect of reducing number of published versions; we only learn about breaking changes relatively slowly)
- ignore the failed github actions (nothing bad really happened)
- "catch" the error and report success from the GH action.

### [Optional] How Has This Been Tested?
By manually running `echo next.$(git rev-parse --short HEAD).$(date +%Y-%m-%d)`. 

In terms of version numbers, this means that: 
`1.14.2-next.2522b345b` will become `1.14.2-next.2522b345b.2021-01-25`


## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary
- [x] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://github.com/statechannels/statechannels/issues/3177)
- [x] I have linked to relevant issues
- [ ] I have added dependent tickets
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate pipeline
