### PR TITLE
chore: mergeMessages -> mergeOutputs

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -323,7 +323,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     // Warning: (ae-forgotten-export) The symbol "Output" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    mergeMessages(output: Output[]): MultipleChannelOutput;
+    static mergeOutputs(output: Output[]): MultipleChannelOutput;
     // Warning: (ae-forgotten-export) The symbol "ObjectiveManager" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -63,6 +63,4 @@ export type WalletInterface = {
   // Wallet <-> Wallet communication
   pushMessage(m: unknown): Promise<MultipleChannelOutput>;
   pushUpdate(m: unknown): Promise<SingleChannelOutput>;
-
-  mergeMessages(messages: Output[]): MultipleChannelOutput;
 };

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -215,7 +215,7 @@ export class SingleThreadedWallet
     );
   }
 
-  public mergeMessages(output: Output[]): MultipleChannelOutput {
+  public static mergeOutputs(output: Output[]): MultipleChannelOutput {
     return WalletResponse.mergeOutputs(output);
   }
 


### PR DESCRIPTION
...and make into a static method. It's just a wrapper for
a static mehod for another class.

This function is in use in just one place in one place in the graph presently:

https://github.com/statechannels/the-graph/blob/ec3007419ca2747f4ae444576d22ebb7842e4b3d/packages/receipt-manager/src/receipt-manager.ts#L100

But it should be an easy fix `this.wallet.mergeMessages(...) => Wallet.mergeOutputs(...)`