### PR TITLE
docs: enhance server-wallet tsdoc

### DIFF
--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -110,13 +110,13 @@ export type ChannelProposedNotification = JsonRpcNotification<'ChannelProposed',
 // @public (undocumented)
 export interface ChannelResult {
     // (undocumented)
+    adjudicatorStatus: 'Challenge' | 'Open' | 'Finalized';
+    // (undocumented)
     allocations: Allocation[];
     // (undocumented)
     appData: string;
     // (undocumented)
     appDefinition: Address;
-    // (undocumented)
-    challengeStatus: 'Challenge Finalized' | 'Challenge Active' | 'No Challenge Detected';
     // (undocumented)
     channelId: ChannelId;
     // (undocumented)

--- a/packages/docs-website/scripts/api-documenter.js
+++ b/packages/docs-website/scripts/api-documenter.js
@@ -1,7 +1,8 @@
-const {readdir, createReadStream, writeFile} = require('fs-extra');
 const {createInterface} = require('readline');
 const {join, parse} = require('path');
 const {exec} = require('child_process');
+
+const {readdir, createReadStream, writeFile} = require('fs-extra');
 
 // copied from https://github.com/faastjs/faast.js/blob/3f498554d5a662bb3f98beab7e6d7eeeb4505f9c/build/make-docs.js
 
@@ -68,6 +69,13 @@ async function main() {
         // So, remove:
         if (line.includes('<!-- -->')) {
           line = line.replace(/<!-- -->/g, '');
+        }
+        // For some reason <b> </b> tags break markdown links :shrug:
+        if (line.includes('<b>')) {
+          line = line.replace('<b>', '**');
+        }
+        if (line.includes('</b>')) {
+          line = line.replace('</b>', '**');
         }
         if (!skip) {
           output.push(line);

--- a/packages/docs-website/scripts/api-documenter.js
+++ b/packages/docs-website/scripts/api-documenter.js
@@ -62,6 +62,13 @@ async function main() {
         if (line.startsWith('|')) {
           line = line.replace(/\\\|/g, '&#124;');
         }
+
+        // I don't know why api-documenter wants to insert an html comment like this <!-- -->
+        // But it will upset docusaurus, and we don't need it.
+        // So, remove:
+        if (line.includes('<!-- -->')) {
+          line = line.replace(/<!-- -->/g, '');
+        }
         if (!skip) {
           output.push(line);
         }

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -286,11 +286,8 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     static create(walletConfig: IncomingServerWalletConfig): Promise<SingleThreadedWallet>;
-    // (undocumented)
     createChannel(args: CreateChannelParams): Promise<MultipleChannelOutput>;
-    // (undocumented)
     createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
-    // (undocumented)
     createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
     // (undocumented)
     destroy(): Promise<void>;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -221,6 +221,9 @@ export interface OptionalServerWalletConfig {
 // @public (undocumented)
 export type Outgoing = Notice;
 
+// @public (undocumented)
+export type Output = SingleChannelOutput | MultipleChannelOutput;
+
 // Warning: (ae-forgotten-export) The symbol "PartialConfigObject" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -255,7 +258,6 @@ export type SingleChannelOutput = {
 };
 
 // Warning: (ae-forgotten-export) The symbol "EventEmitterType" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "WalletInterface" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ChainEventSubscriberInterface" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -289,13 +291,10 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
     // (undocumented)
     destroy(): Promise<void>;
-    // (undocumented)
     getChannels(): Promise<MultipleChannelOutput>;
-    // (undocumented)
     getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     getSigningAddress(): Promise<Address>;
-    // (undocumented)
     getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts
     //
@@ -337,12 +336,21 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     updateChannel({ channelId, allocations, appData, }: UpdateChannelParams): Promise<SingleChannelOutput>;
     // (undocumented)
     updateChannelFunding(args: UpdateChannelFundingParams): Promise<SingleChannelOutput>;
-    // Warning: (ae-forgotten-export) The symbol "UpdateChannelFundingParams" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     readonly walletConfig: ServerWalletConfig;
+}
+
+// @public (undocumented)
+export interface UpdateChannelFundingParams {
+    // Warning: (ae-forgotten-export) The symbol "Uint256" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    amount: Uint256;
+    // (undocumented)
+    assetHolderAddress?: Address;
+    // (undocumented)
+    channelId: ChannelId;
 }
 
 // @public (undocumented)
@@ -357,6 +365,30 @@ export abstract class Wallet extends SingleThreadedWallet {
     // (undocumented)
     static create(walletConfig: IncomingServerWalletConfig): Promise<SingleThreadedWallet | MultiThreadedWallet>;
 }
+
+// Warning: (ae-forgotten-export) The symbol "ChannelUpdatedEvent" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type WalletEvent = ChannelUpdatedEvent;
+
+// @public (undocumented)
+export type WalletInterface = {
+    registerAppDefinition(appDefinition: string): Promise<void>;
+    registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;
+    createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
+    joinChannels(channelIds: ChannelId[]): Promise<MultipleChannelOutput>;
+    updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput>;
+    closeChannel(args: CloseChannelParams): Promise<SingleChannelOutput>;
+    getChannels(): Promise<MultipleChannelOutput>;
+    getState(args: GetStateParams): Promise<SingleChannelOutput>;
+    syncChannels(chanelIds: Bytes32[]): Promise<MultipleChannelOutput>;
+    syncChannel(args: SyncChannelParams): Promise<SingleChannelOutput>;
+    challenge(challengeState: State): Promise<SingleChannelOutput>;
+    updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
+    pushMessage(m: unknown): Promise<MultipleChannelOutput>;
+    pushUpdate(m: unknown): Promise<SingleChannelOutput>;
+    mergeMessages(messages: Output[]): MultipleChannelOutput;
+};
 
 
 ```

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -329,9 +329,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     // (undocumented)
     pushMessage(rawPayload: unknown): Promise<MultipleChannelOutput>;
     pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput>;
-    // (undocumented)
     registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;
-    // (undocumented)
     registerAppDefinition(appDefinition: string): Promise<void>;
     // Warning: (ae-forgotten-export) The symbol "Store" needs to be exported by the entry point index.d.ts
     //

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -272,7 +272,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     //
     // (undocumented)
     chainService: ChainServiceInterface;
-    // (undocumented)
     challenge(channelId: string): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "ChallengeRegisteredArg" needs to be exported by the entry point index.d.ts
     //
@@ -289,11 +288,9 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     createChannel(args: CreateChannelParams): Promise<MultipleChannelOutput>;
     createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
     createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
-    // (undocumented)
     destroy(): Promise<void>;
     getChannels(): Promise<MultipleChannelOutput>;
     getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
-    // (undocumented)
     getSigningAddress(): Promise<Address>;
     getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts
@@ -323,14 +320,10 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     //
     // (undocumented)
     store: Store;
-    // (undocumented)
     syncChannel({ channelId }: SyncChannelParams): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "Bytes32" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     syncChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     updateChannel({ channelId, allocations, appData, }: UpdateChannelParams): Promise<SingleChannelOutput>;
-    // (undocumented)
     updateChannelFunding(args: UpdateChannelFundingParams): Promise<SingleChannelOutput>;
     updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
     // (undocumented)
@@ -357,7 +350,7 @@ export function validateServerWalletConfig(config: Record<string, any>): {
 };
 
 // @public
-export abstract class Wallet extends SingleThreadedWallet {
+export abstract class Wallet extends SingleThreadedWallet implements WalletInterface {
     // (undocumented)
     static create(walletConfig: IncomingServerWalletConfig): Promise<SingleThreadedWallet | MultiThreadedWallet>;
 }
@@ -370,7 +363,7 @@ export type WalletEvent = ChannelUpdatedEvent;
 // @public (undocumented)
 export interface WalletInterface {
     // (undocumented)
-    challenge(challengeState: State): Promise<SingleChannelOutput>;
+    challenge(channelId: string): Promise<SingleChannelOutput>;
     // (undocumented)
     closeChannel(args: CloseChannelParams): Promise<SingleChannelOutput>;
     // (undocumented)

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -166,7 +166,7 @@ export type MultipleChannelOutput = {
     channelResults: ChannelResult[];
 };
 
-// @public (undocumented)
+// @public
 export class MultiThreadedWallet extends SingleThreadedWallet {
     protected constructor(walletConfig: IncomingServerWalletConfig);
     // (undocumented)
@@ -362,7 +362,7 @@ export function validateServerWalletConfig(config: Record<string, any>): {
     errors: ValidationErrorItem[];
 };
 
-// @public (undocumented)
+// @public
 export abstract class Wallet extends SingleThreadedWallet {
     // (undocumented)
     static create(walletConfig: IncomingServerWalletConfig): Promise<SingleThreadedWallet | MultiThreadedWallet>;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -303,9 +303,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     //
     // (undocumented)
     holdingUpdated({ channelId, amount, assetHolderAddress }: HoldingUpdatedArg): Promise<void>;
-    // (undocumented)
     joinChannel({ channelId }: JoinChannelParams): Promise<SingleChannelOutput>;
-    // (undocumented)
     joinChannels(channelIds: ChannelId[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     knex: Knex;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -280,9 +280,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     //
     // (undocumented)
     channelFinalized(arg: ChannelFinalizedArg): Promise<void>;
-    // (undocumented)
     closeChannel({ channelId }: CloseChannelParams): Promise<SingleChannelOutput>;
-    // (undocumented)
     closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     static create(walletConfig: IncomingServerWalletConfig): Promise<SingleThreadedWallet>;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -318,7 +318,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     //
     // (undocumented)
     objectiveManager: ObjectiveManager;
-    // (undocumented)
     pushMessage(rawPayload: unknown): Promise<MultipleChannelOutput>;
     pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput>;
     registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -310,9 +310,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     ledgerManager: LedgerManager;
     // (undocumented)
     logger: Logger;
-    // Warning: (ae-forgotten-export) The symbol "Output" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     static mergeOutputs(output: Output[]): MultipleChannelOutput;
     // Warning: (ae-forgotten-export) The symbol "ObjectiveManager" needs to be exported by the entry point index.d.ts
     //
@@ -371,23 +368,36 @@ export abstract class Wallet extends SingleThreadedWallet {
 export type WalletEvent = ChannelUpdatedEvent;
 
 // @public (undocumented)
-export type WalletInterface = {
-    registerAppDefinition(appDefinition: string): Promise<void>;
-    registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;
-    createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
-    joinChannels(channelIds: ChannelId[]): Promise<MultipleChannelOutput>;
-    updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput>;
-    closeChannel(args: CloseChannelParams): Promise<SingleChannelOutput>;
-    getChannels(): Promise<MultipleChannelOutput>;
-    getState(args: GetStateParams): Promise<SingleChannelOutput>;
-    syncChannels(chanelIds: Bytes32[]): Promise<MultipleChannelOutput>;
-    syncChannel(args: SyncChannelParams): Promise<SingleChannelOutput>;
+export interface WalletInterface {
+    // (undocumented)
     challenge(challengeState: State): Promise<SingleChannelOutput>;
-    updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    closeChannel(args: CloseChannelParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    getChannels(): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    getState(args: GetStateParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    joinChannels(channelIds: ChannelId[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
     pushMessage(m: unknown): Promise<MultipleChannelOutput>;
+    // (undocumented)
     pushUpdate(m: unknown): Promise<SingleChannelOutput>;
-    mergeMessages(messages: Output[]): MultipleChannelOutput;
-};
+    // (undocumented)
+    registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;
+    // (undocumented)
+    registerAppDefinition(appDefinition: string): Promise<void>;
+    // (undocumented)
+    syncChannel(args: SyncChannelParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    syncChannels(chanelIds: Bytes32[]): Promise<MultipleChannelOutput>;
+    // (undocumented)
+    updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput>;
+    // (undocumented)
+    updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
+}
 
 
 ```

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -369,6 +369,4 @@ export abstract class Wallet extends SingleThreadedWallet {
 }
 
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -336,7 +336,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     //
     // (undocumented)
     syncChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
-    // (undocumented)
     updateChannel({ channelId, allocations, appData, }: UpdateChannelParams): Promise<SingleChannelOutput>;
     // (undocumented)
     updateChannelFunding(args: UpdateChannelFundingParams): Promise<SingleChannelOutput>;

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -1,3 +1,25 @@
+/**
+ * @packageDocumentation Spin up Nitro wallets in a node-js environment
+ *
+ * @remarks
+ * To create an instance of the exported Wallet class, pass in a configuration object specifying a connection to a database.
+ * Then, use the API of this instance, along with your messaging system, to run state channels with counterparties running compatible wallets.
+ *
+ * Example usage:
+ * ```typescript
+ *  const wallet = Wallet.create(config);
+ *
+ *  const createChannelParams: CreateChannelParams = {
+ *      participants,
+ *      allocations,
+ *      appDefinition,
+ *      appData,
+ *      fundingStrategy,
+ *      challengeDuration: ONE_DAY,
+ *      };
+ *  await wallet.createChannel(createChannelArgs);
+ * ```
+ */
 export {Payload as Message} from '@statechannels/wallet-core';
 
 export * from './wallet';

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -1,6 +1,5 @@
 import {IncomingServerWalletConfig} from '../config';
 
-export {SingleChannelOutput, MultipleChannelOutput} from './types';
 import {MultiThreadedWallet} from './multi-threaded-wallet';
 import {WalletInterface} from './types';
 import {SingleThreadedWallet} from './wallet';
@@ -24,4 +23,5 @@ export abstract class Wallet extends SingleThreadedWallet implements WalletInter
 }
 
 export * from '../config';
+export * from './types';
 export {SingleThreadedWallet, MultiThreadedWallet};

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -4,6 +4,12 @@ export {SingleChannelOutput, MultipleChannelOutput} from './types';
 import {MultiThreadedWallet} from './multi-threaded-wallet';
 import {SingleThreadedWallet} from './wallet';
 
+/**
+ * A single- or multi-threaded Nitro wallet
+ *
+ * @remarks
+ * The number of threads is specified in the supplied {@link @statechannels/server-wallet#RequiredServerWalletConfig | configuration}.
+ */
 export abstract class Wallet extends SingleThreadedWallet {
   static async create(
     walletConfig: IncomingServerWalletConfig

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -2,6 +2,7 @@ import {IncomingServerWalletConfig} from '../config';
 
 export {SingleChannelOutput, MultipleChannelOutput} from './types';
 import {MultiThreadedWallet} from './multi-threaded-wallet';
+import {WalletInterface} from './types';
 import {SingleThreadedWallet} from './wallet';
 
 /**
@@ -10,7 +11,7 @@ import {SingleThreadedWallet} from './wallet';
  * @remarks
  * The number of threads is specified in the supplied {@link @statechannels/server-wallet#RequiredServerWalletConfig | configuration}.
  */
-export abstract class Wallet extends SingleThreadedWallet {
+export abstract class Wallet extends SingleThreadedWallet implements WalletInterface {
   static async create(
     walletConfig: IncomingServerWalletConfig
   ): Promise<SingleThreadedWallet | MultiThreadedWallet> {

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
@@ -6,6 +6,9 @@ import {SingleThreadedWallet} from '../wallet';
 
 import {WorkerManager} from './manager';
 
+/**
+ * A multi-threaded Nitro wallet
+ */
 export class MultiThreadedWallet extends SingleThreadedWallet {
   private workerManager: WorkerManager;
 

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -37,7 +37,7 @@ type ChannelUpdatedEvent = {
 
 export type WalletEvent = ChannelUpdatedEvent;
 
-export type WalletInterface = {
+export interface WalletInterface {
   // App utilities
   registerAppDefinition(appDefinition: string): Promise<void>;
   registerAppBytecode(appDefinition: string, bytecode: string): Promise<void>;
@@ -62,4 +62,4 @@ export type WalletInterface = {
   // Wallet <-> Wallet communication
   pushMessage(m: unknown): Promise<MultipleChannelOutput>;
   pushUpdate(m: unknown): Promise<SingleChannelOutput>;
-};
+}

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -532,6 +532,16 @@ export class SingleThreadedWallet
     return channel.channelId;
   }
 
+  /**
+   * Joins a list of channels.
+   *
+   * @remarks
+   * Approves an OpenChannel objective for each channel, if it exists, and cranks it.
+   * Registers each channel with the wallet's chain service.
+   *
+   * @param channelIds - The list of ids of the channels to join.
+   * @returns A promise that resolves to the channel output.
+   */
   async joinChannels(channelIds: ChannelId[]): Promise<MultipleChannelOutput> {
     const response = WalletResponse.initialize();
     const objectives = await this.store.getObjectives(channelIds);
@@ -550,6 +560,18 @@ export class SingleThreadedWallet
     return response.multipleChannelOutput();
   }
 
+  /**
+   * Joins a channel.
+   *
+   * @remarks
+   * Approves an OpenChannel objective for this channel, if it exists, and cranks it.
+   * Registers the channel with the wallet's chain service.
+   * Throws an error if the channel is not known to this wallet.
+   * Throws an error if no objectives are known that have this channel in scope.
+   *
+   * @param channelId - The id of the channel to join.
+   * @returns A promise that resolves to the channel output.
+   */
   async joinChannel({channelId}: JoinChannelParams): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
     const channel = await this.store.getChannelState(channelId);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -85,7 +85,7 @@ export class ConfigValidationError extends Error {
 }
 
 /**
- * A statechannels wallet
+ * A single-threaded Nitro wallet
  */
 export class SingleThreadedWallet
   extends EventEmitter<EventEmitterType>

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -383,7 +383,7 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Update the wallets knowledge about the funding for a channel.
+   * Update the wallet's knowledge about the funding for a channel.
    *
    * @param args - An object specifying the channelId, asset holder address and amount.
    * @returns A promise that resolves to a channel output.
@@ -411,6 +411,11 @@ export class SingleThreadedWallet
     await this.takeActions([channelId], response);
   }
 
+  /**
+   * Get the signing address for this wallet, or create it if it does not exist.
+   *
+   * @returns A promise that resolves to the address.
+   */
   public async getSigningAddress(): Promise<CoreAddress> {
     return await this.store.getOrCreateSigningAddress();
   }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -745,6 +745,7 @@ export class SingleThreadedWallet
   /**
    * Gets the latest {@link ChannelResult} for a channel.
    *
+   * @privateRemarks TODO: Consider renaming this to getChannel() to match getChannels()
    * @returns A promise that resolves to the channel output.
    */
   async getState({channelId}: GetStateParams): Promise<SingleChannelOutput> {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -273,6 +273,12 @@ export class SingleThreadedWallet
     this.chainService.destructor();
   }
 
+  /**
+   * Trigger a response containing a message for counterparties, with all stored states for each a set of channels.
+   *
+   * @param channelIds - List of channel ids to be sync'ed
+   * @returns A promise that resolves to an object containing the messages.
+   */
   public async syncChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput> {
     const response = WalletResponse.initialize();
 
@@ -281,6 +287,12 @@ export class SingleThreadedWallet
     return response.multipleChannelOutput();
   }
 
+  /**
+   * Trigger a response containing a message for all counterparties, with all stored states for a given channel.
+   *
+   * @param channelId - The channel id to be sync'ed
+   * @returns A promise that resolves to an object containing the messages.
+   */
   public async syncChannel({channelId}: SyncChannelParams): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
     await this._syncChannel(channelId, response);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -420,6 +420,14 @@ export class SingleThreadedWallet
     return await this.store.getOrCreateSigningAddress();
   }
 
+  /**
+   * Creates a ledger channel.
+   *
+   * @remarks
+   * The channel will have a null app definition and null app data. This method is otherwise identical to {@link SingleThreadedWallet.createChannel}.
+   *
+   * @returns A promise that resolves to the channel output.
+   */
   async createLedgerChannel(
     args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>,
     fundingStrategy: 'Direct' | 'Fake' = 'Direct'
@@ -439,7 +447,18 @@ export class SingleThreadedWallet
 
     return response.singleChannelOutput();
   }
-
+  /**
+   * Creates a channel.
+   *
+   * @remarks
+   * The channel's nonce will be automatically chosen.
+   * The channel will be registered with the wallet's chain service.
+   * The 0th state will be created and signed.
+   * An OpenChannel objective will be created and approved.
+   *
+   * @param args - Parameters to create the channel with.
+   * @returns A promise that resolves to the channel output.
+   */
   async createChannel(args: CreateChannelParams): Promise<MultipleChannelOutput> {
     const response = WalletResponse.initialize();
 
@@ -447,7 +466,13 @@ export class SingleThreadedWallet
 
     return response.multipleChannelOutput();
   }
-
+  /**
+   * Creates multiple channels with the same parameters. See {@link SingleThreadedWallet.createChannel}.
+   *
+   * @param args - Parameters to create the channels with.
+   * @param numberOfChannels - The number of desired channels.
+   * @returns A promise that resolves to the channel output.
+   */
   async createChannels(
     args: CreateChannelParams,
     numberOfChannels: number

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -187,10 +187,14 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Registers any channels existing in the database with the chain service
-   * so the chain service can alert us of any block chain events for existing channels
+   * Registers any channels existing in the database with the chain service.
+   *
+   * @remarks
+   * Enables the chain service to alert the wallet of of any blockchain events for existing channels.
+   *
+   * @returns A promise that resolves when the channels have been successfully registered.
    */
-  private async registerExistingChannelsWithChainService() {
+  private async registerExistingChannelsWithChainService(): Promise<void> {
     const channelsToRegister = (await this.store.getNonFinalizedChannels())
       .map(ChannelState.toChannelResult)
       .map(cr => ({
@@ -202,6 +206,16 @@ export class SingleThreadedWallet
       this.chainService.registerChannel(channelId, assetHolderAddresses, this);
     }
   }
+
+  /**
+   * Pulls and stores the ForceMoveApp definition bytecode at the supplied blockchain address.
+   *
+   * @remarks
+   * Storing the bytecode is necessary for the wallet to verify ForceMoveApp transitions.
+   *
+   * @param  appDefinition - An ethereum address where ForceMoveApp rules are deployed.
+   * @returns A promise that resolves when the bytecode has been successfully stored.
+   */
   public async registerAppDefinition(appDefinition: string): Promise<void> {
     const bytecode = await this.chainService.fetchBytecode(appDefinition);
     await this.store.upsertBytecode(
@@ -211,6 +225,16 @@ export class SingleThreadedWallet
     );
   }
 
+  /**
+   * Stores the supplied ForceMoveApp definition bytecode against the supplied blockchain address.
+   *
+   * @remarks
+   * Storing the bytecode is necessary for the wallet to verify ForceMoveApp transitions.
+   *
+   * @param  appDefinition - An ethereum address where ForceMoveApp rules are deployed.
+   * @param  bytecode - The bytecode at that address.
+   * @returns A promise that resolves when the bytecode has been successfully stored.
+   */
   public async registerAppBytecode(appDefinition: string, bytecode: string): Promise<void> {
     return this.store.upsertBytecode(
       utils.hexlify(this.walletConfig.networkConfiguration.chainNetworkID),

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -706,7 +706,7 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Gets the latest {@link ChannelResult} for each ledger channel in the wallet's store.
+   * Gets the latest state for each ledger channel in the wallet's store.
    *
    * @param assetHolderAddress - The on chain address of an asset holder contract funding the ledger channels (filters the query).
    * @param participants - The list of participants in the ledger channel (filters the query).
@@ -729,7 +729,7 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Gets the latest {@link ChannelResult} for each channel in the wallet's store.
+   * Gets the latest state for each channel in the wallet's store.
    *
    * @returns A promise that resolves to the channel output.
    */
@@ -743,7 +743,7 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Gets the latest {@link ChannelResult} for a channel.
+   * Gets the latest state for a channel.
    *
    * @privateRemarks TODO: Consider renaming this to getChannel() to match getChannels()
    * @returns A promise that resolves to the channel output.

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -243,6 +243,19 @@ export class SingleThreadedWallet
     );
   }
 
+  /**
+   * Streamlines wallet output messsages.
+   *
+   * @remarks
+   * Helps to enable more efficient messaging. Channel results are sorted and deduplicated. Messages to the same recipient are merged.
+   *
+   * @privateRemarks
+   * TODO: Consider whether we need to make this method public (at time of writing, it is used only once in consuming code)
+   * TODO: Is this method well named? "Merge" doesn't really do justice to what is going on. "Messages" is not in harmony with "Output[]".
+   *
+   * @param output - An array of output messages and channel results.
+   * @returns A streamlined output of messages.
+   */
   public static mergeOutputs(output: Output[]): MultipleChannelOutput {
     return WalletResponse.mergeOutputs(output);
   }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -260,6 +260,14 @@ export class SingleThreadedWallet
     return WalletResponse.mergeOutputs(output);
   }
 
+  /**
+   * Destroy this wallet instance
+   *
+   * @remarks
+   * Removes listeners from the chainService and destroys the wallet's database connection.
+   *
+   * @returns A promise that resolves when the wallet has been destroyed.
+   */
   public async destroy(): Promise<void> {
     await this.knex.destroy();
     this.chainService.destructor();

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -332,7 +332,7 @@ export class SingleThreadedWallet
    * @param challengeState - The state to raise the challenge with.
    * @returns A promise that resolves to a channel output.
    */
-  async challenge(channelId: string): Promise<SingleChannelOutput> {
+  public async challenge(channelId: string): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
 
     await this.knex.transaction(async tx => {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -382,7 +382,15 @@ export class SingleThreadedWallet
     return response.multipleChannelOutput();
   }
 
-  async updateChannelFunding(args: UpdateChannelFundingParams): Promise<SingleChannelOutput> {
+  /**
+   * Update the wallets knowledge about the funding for a channel.
+   *
+   * @param args - An object specifying the channelId, asset holder address and amount.
+   * @returns A promise that resolves to a channel output.
+   */
+  public async updateChannelFunding(
+    args: UpdateChannelFundingParams
+  ): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
 
     await this._updateChannelFunding(args, response);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -326,6 +326,12 @@ export class SingleThreadedWallet
     }
   }
 
+  /**
+   * Trigger an on-chain challenge.
+   *
+   * @param challengeState - The state to raise the challenge with.
+   * @returns A promise that resolves to a channel output.
+   */
   async challenge(channelId: string): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -109,23 +109,9 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Registers any channels existing in the database with the chain service
-   * so the chain service can alert us of any block chain events for existing channels
+   * Protected method. Initialize wallet via Wallet.create(..)
+   * @readonly
    */
-  private async registerExistingChannelsWithChainService() {
-    const channelsToRegister = (await this.store.getNonFinalizedChannels())
-      .map(ChannelState.toChannelResult)
-      .map(cr => ({
-        assetHolderAddresses: cr.allocations.map(a => makeAddress(a.assetHolderAddress)),
-        channelId: cr.channelId,
-      }));
-
-    for (const {channelId, assetHolderAddresses} of channelsToRegister) {
-      this.chainService.registerChannel(channelId, assetHolderAddresses, this);
-    }
-  }
-
-  // protected constructor to force consumers to initialize wallet via Wallet.create(..)
   protected constructor(walletConfig: IncomingServerWalletConfig) {
     super();
 
@@ -200,6 +186,22 @@ export class SingleThreadedWallet
     await this.store.addSigningKey(privateKey);
   }
 
+  /**
+   * Registers any channels existing in the database with the chain service
+   * so the chain service can alert us of any block chain events for existing channels
+   */
+  private async registerExistingChannelsWithChainService() {
+    const channelsToRegister = (await this.store.getNonFinalizedChannels())
+      .map(ChannelState.toChannelResult)
+      .map(cr => ({
+        assetHolderAddresses: cr.allocations.map(a => makeAddress(a.assetHolderAddress)),
+        channelId: cr.channelId,
+      }));
+
+    for (const {channelId, assetHolderAddresses} of channelsToRegister) {
+      this.chainService.registerChannel(channelId, assetHolderAddresses, this);
+    }
+  }
   public async registerAppDefinition(appDefinition: string): Promise<void> {
     const bytecode = await this.chainService.fetchBytecode(appDefinition);
     await this.store.upsertBytecode(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -599,6 +599,19 @@ export class SingleThreadedWallet
     return response.singleChannelOutput(false);
   }
 
+  /**
+   * Updates a channel with a new state.
+   *
+   * @remarks
+   * Signs and stores the new state, returns the result in a message for counterparties.
+   * Throws an error if the channel is not known to this wallet.
+   * Throws an error if no objectives are known that have this channel in scope.
+   *
+   * @param channelId - The id of the channel to update.
+   * @param allocations - New allocations describing a new outcome (distribution of assets) for the channel.
+   * @param appData - New application-specific data.
+   * @returns A promise that resolves to the channel output.
+   */
   async updateChannel({
     channelId,
     allocations,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -661,6 +661,16 @@ export class SingleThreadedWallet
     return this.store.lockApp(channelId, criticalCode, handleMissingChannel, true);
   }
 
+  /**
+   * Attempts to collaboratively close a list of channels.
+   *
+   * @remarks
+   * Signs, stores, and sends an isFinal=true state for each channel in the list.
+   * Creates, approves and cranks a CloseChannel objective for each channel in the list. See {@link SingleThreadedWallet.closeChannel}.
+   *
+   * @param channelId - The id of the channel to try and close.
+   * @returns A promise that resolves to the channel output.
+   */
   async closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput> {
     const response = WalletResponse.initialize();
 
@@ -671,6 +681,17 @@ export class SingleThreadedWallet
     return response.multipleChannelOutput();
   }
 
+  /**
+   * Attempts to collaboratively close a channel.
+   *
+   * @remarks
+   * Signs, stores, and sends an isFinal=true state.
+   * Creates, approves and cranks a CloseChannel objective for the supplied channel.
+   * This objective continues working after this call resolves, and will attempt to defund the channel.
+   *
+   * @param channelId - The id of the channel to try and close.
+   * @returns A promise that resolves to the channel output.
+   */
   async closeChannel({channelId}: CloseChannelParams): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -705,6 +705,13 @@ export class SingleThreadedWallet
     await this.objectiveManager.commenceCloseChannel(channelId, response);
   }
 
+  /**
+   * Gets the latest {@link ChannelResult} for each ledger channel in the wallet's store.
+   *
+   * @param assetHolderAddress - The on chain address of an asset holder contract funding the ledger channels (filters the query).
+   * @param participants - The list of participants in the ledger channel (filters the query).
+   * @returns A promise that resolves to the channel output.
+   */
   async getLedgerChannels(
     assetHolderAddress: string,
     participants: APIParticipant[]
@@ -721,6 +728,11 @@ export class SingleThreadedWallet
     return response.multipleChannelOutput();
   }
 
+  /**
+   * Gets the latest {@link ChannelResult} for each channel in the wallet's store.
+   *
+   * @returns A promise that resolves to the channel output.
+   */
   async getChannels(): Promise<MultipleChannelOutput> {
     const response = WalletResponse.initialize();
 
@@ -730,6 +742,11 @@ export class SingleThreadedWallet
     return response.multipleChannelOutput();
   }
 
+  /**
+   * Gets the latest {@link ChannelResult} for a channel.
+   *
+   * @returns A promise that resolves to the channel output.
+   */
   async getState({channelId}: GetStateParams): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -366,6 +366,12 @@ export class SingleThreadedWallet
     return response.singleChannelOutput();
   }
 
+  /**
+   * Update the wallets knowledge about the funding for some channels
+   *
+   * @param args - A list of objects, each specifying the channelId, asset holder address and amount.
+   * @returns A promise that resolves to a channel output.
+   */
   public async updateFundingForChannels(
     args: UpdateChannelFundingParams[]
   ): Promise<MultipleChannelOutput> {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -763,6 +763,17 @@ export class SingleThreadedWallet
     }
   }
 
+  /**
+   * Push a message from a counterparty into the wallet.
+   *
+   * @remarks
+   * Fresh states and Ledger Proposals will be stored.
+   * Requests will be handled.
+   * Objectives with updated channels in scope will be cranked.
+   *
+   * @param rawPayload - The message to be pushed. Will be validated against a schema.
+   * @returns A promise that resolves to the channel output.
+   */
   async pushMessage(rawPayload: unknown): Promise<MultipleChannelOutput> {
     const wirePayload = validatePayload(rawPayload);
 
@@ -783,7 +794,15 @@ export class SingleThreadedWallet
   }
 
   /**
-   * For pushing a message containing a single update to a running application channel
+   * Push a message containing a single update to a running application channel.
+   *
+   * @remarks
+   * A single fresh state will be stored.
+   * No fresh requests or objectives will stored.
+   * No objectives will be cranked.
+   *
+   * @param rawPayload - The message to be pushed. Will be validated against a schema.
+   * @returns A promise that resolves to the channel output.
    */
   async pushUpdate(rawPayload: unknown): Promise<SingleChannelOutput> {
     const wirePayload = validatePayload(rawPayload);


### PR DESCRIPTION
Adds explanations to our source code that will appear in our documentation website and intellisense in vscode. 

Towards https://github.com/statechannels/project-management/issues/28. In the mould of https://github.com/statechannels/statechannels/pull/3180. I think the motivation is self evident. 

# Changes
1. TSDoc annotations were added to all SingleThreadedWallet public methods, apart from the ChainServiceSubscriber part (because it is not clear whether this should be part of the public API: see #3203 and [this suggestion](https://github.com/statechannels/statechannels/pull/3116/commits/35abe36a7552663f569efb05a21e54dd19dcd81a)). 
2. Additional symbols are exported from `server-wallet` package, as per the recommendation of `api-extractor`. 
3. Some tweaks to our documentation generation pipeline. I only discovered the necessity for these after exporting additional types from the package
4. Some TSdoc was added elsewhere in the package, too

Although there are many changes, they have each been made in their own commit, which should make it easier for the reviewer. For this reason I have not split into may pull requests.
# Checklist:

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [ ] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://github.com/statechannels/statechannels/issues/3177)
- [x] I have linked to relevant issues
- [x] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline
