### PR TITLE
fix: await concludeAndWithdraw transaction submission

### DIFF
--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -78,3 +78,11 @@ export class MockChainService implements ChainServiceInterface {
     return;
   }
 }
+export class ErorringMockChainService extends MockChainService {
+  pushOutcomeAndWithdraw(
+    _state: State,
+    _challengerAddress: Address
+  ): Promise<providers.TransactionResponse> {
+    throw new Error('Failed to submit transaction');
+  }
+}

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -31,7 +31,6 @@ beforeEach(async () => {
     '0'
   );
 
-  await DBAdmin.truncateDataBaseFromKnex(knex);
   await seedAlicesSigningWallet(knex);
 });
 
@@ -46,7 +45,7 @@ describe('when there is no challenge or finalized channel', () => {
 
     // Create the channel in the database
     const c = channel();
-    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    await Channel.query(knex).insert(c);
 
     // Set the objective in the database
     const objective = await createPendingObjective(c.channelId);
@@ -74,7 +73,7 @@ describe('when there is an active challenge', () => {
       channelNonce: 1,
       vars: [stateWithHashSignedBy([alice(), bob()])({isFinal: true})],
     });
-    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    await Channel.query(knex).insert(c);
 
     await setChallengeStatus('active', c);
 
@@ -100,7 +99,7 @@ describe('when there is an active challenge', () => {
 
     // Setup a channel with no conclusion proof
     const c = channel();
-    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    await Channel.query(knex).insert(c);
 
     await setChallengeStatus('active', c);
 
@@ -126,7 +125,7 @@ describe('when the channel is finalized on chain', () => {
     const c = channel({
       assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
     });
-    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    await Channel.query(knex).insert(c);
 
     // If there is a funding entry that means the outcome has not been pushed
     await Funding.updateFunding(knex, c.channelId, '0x05', makeAddress(c.assetHolderAddress));
@@ -157,7 +156,7 @@ describe('when the channel is finalized on chain', () => {
     const c = channel({
       assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
     });
-    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    await Channel.query(knex).insert(c);
 
     // Set a finalized channel with a final state
     await setChallengeStatus('finalized', c);
@@ -199,7 +198,7 @@ it('should fail when using non-direct funding', async () => {
 
   // Create a channel with fake funding strategy
   const c = channel({fundingStrategy: 'Fake'});
-  await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+  await Channel.query(knex).insert(c);
 
   // Store the objective
   const obj = createPendingObjective(c.channelId);

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -24,6 +24,7 @@ const timingMetrics = false;
 let store: Store;
 
 beforeEach(async () => {
+  await DBAdmin.truncateDataBaseFromKnex(knex);
   store = new Store(
     knex,
     defaultTestConfig().metricsConfiguration.timingMetrics,
@@ -32,10 +33,6 @@ beforeEach(async () => {
   );
 
   await seedAlicesSigningWallet(knex);
-});
-
-afterEach(async () => {
-  await DBAdmin.truncateDataBaseFromKnex(knex);
 });
 
 describe('when there is no challenge or finalized channel', () => {

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -63,7 +63,7 @@ export class ChannelDefunder {
         }
       } else if (channel.hasConclusionProof) {
         await ChainServiceRequest.insertOrUpdate(channelId, 'withdraw', tx);
-        this.chainService.concludeAndWithdraw(channel.support);
+        await this.chainService.concludeAndWithdraw(channel.support);
         await this.store.markObjectiveStatus(objective, 'succeeded', tx);
         return;
       }

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -56,7 +56,7 @@ export class ChannelDefunder {
       if (result.channelMode === 'Finalized') {
         if (!outcomePushed) {
           await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
-          this.chainService.pushOutcomeAndWithdraw(result.states[0], channel.myAddress);
+          await this.chainService.pushOutcomeAndWithdraw(result.states[0], channel.myAddress);
           await this.store.markObjectiveStatus(objective, 'succeeded', tx);
         } else {
           this.logger.trace('Outcome already pushed, doing nothing');


### PR DESCRIPTION
Chain service APIs that result in transaction submission return a promise that resolves to [`ethers` `TransactionResponse`](https://docs.ethers.io/v5/single-page/#/v5/api/providers/types/-%23-providers-TransactionResponse). The heuristic thus far has been for the chain service API consumer to await these promises to ensure that a transaction is submitted properly.

Note that this does **not** await transaction mining.