### PR TITLE
chore: improve e2e logging

### DIFF
--- a/packages/server-wallet/e2e-test/e2e-utils.ts
+++ b/packages/server-wallet/e2e-test/e2e-utils.ts
@@ -17,16 +17,20 @@ import {
   defaultTestConfig,
 } from '../src/config';
 
-export const payerConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
-  defaultTestConfig(),
-  {database: 'server_wallet_payer'}
-);
-export const receiverConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(
-  defaultTestConfig(),
-  {database: 'server_wallet_receiver'}
-);
-
 import {PerformanceTimer} from './payer/timers';
+import {LOG_PATH} from './logger';
+
+const config: ServerWalletConfig = {
+  ...defaultTestConfig(),
+  loggingConfiguration: {logLevel: 'trace', logDestination: LOG_PATH},
+};
+
+export const payerConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(config, {
+  database: 'server_wallet_payer',
+});
+export const receiverConfig: ServerWalletConfig = overwriteConfigWithDatabaseConnection(config, {
+  database: 'server_wallet_receiver',
+});
 
 export type E2EServer = {
   url: string;

--- a/packages/server-wallet/e2e-test/logger.ts
+++ b/packages/server-wallet/e2e-test/logger.ts
@@ -5,11 +5,12 @@ import pino from 'pino';
 
 const ARTIFACTS_DIR = '../../artifacts';
 
+export const LOG_PATH = path.join(ARTIFACTS_DIR, 'e2e.log');
 try {
   fs.mkdirSync(ARTIFACTS_DIR);
 } catch (err) {
   if (err.message !== "EEXIST: file already exists, mkdir '../../artifacts'") throw err;
 }
 
-const destination = pino.destination(path.join(ARTIFACTS_DIR, 'e2e.log'));
+const destination = pino.destination(LOG_PATH);
 export const logger = pino({}, destination);

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -3,6 +3,7 @@ import {ChannelResult, Participant} from '@statechannels/client-api-schema';
 import {Wallet, constants} from 'ethers';
 const {AddressZero} = constants;
 import {makeDestination, BN, Address, Destination, makeAddress} from '@statechannels/wallet-core';
+import _ from 'lodash';
 
 import {Wallet as ServerWallet} from '../../src';
 import {Bytes32} from '../../src/type-aliases';
@@ -26,7 +27,7 @@ export default class PayerClient {
     config?: ServerWalletConfig
   ): Promise<PayerClient> {
     const wallet = recordFunctionMetrics(
-      await ServerWallet.create(config ?? payerConfig),
+      await ServerWallet.create(_.assign(payerConfig, config)),
       payerConfig.metricsConfiguration.timingMetrics
     );
     return new PayerClient(pk, receiverHttpServerURL, wallet);

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -26,8 +26,9 @@ export default class PayerClient {
     receiverHttpServerURL: string,
     config?: ServerWalletConfig
   ): Promise<PayerClient> {
+    const mergedConfig = _.assign(payerConfig, config);
     const wallet = recordFunctionMetrics(
-      await ServerWallet.create(_.assign(payerConfig, config)),
+      await ServerWallet.create(mergedConfig),
       payerConfig.metricsConfiguration.timingMetrics
     );
     return new PayerClient(pk, receiverHttpServerURL, wallet);

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -62,7 +62,7 @@ import { ValidationErrorItem } from 'joi';
 // @public
 export type ChainServiceConfiguration = {
     attachChainService: boolean;
-} & Partial<ChainServiceArgs>;
+} & Partial<Exclude<ChainServiceArgs, 'logger'>>;
 
 // @public
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -53,7 +53,10 @@ export type MetricsConfiguration = {timingMetrics: boolean; metricsOutputFile?: 
 /**
  * Chain service configuration options
  */
-export type ChainServiceConfiguration = {attachChainService: boolean} & Partial<ChainServiceArgs>;
+export type ChainServiceConfiguration = {
+  attachChainService: boolean;
+  // We don't want to accept a complex object like the logger in the configuration object
+} & Partial<Exclude<ChainServiceArgs, 'logger'>>;
 
 /**
  * The minimum required configuration to use the server wallet.

--- a/packages/server-wallet/src/logger.ts
+++ b/packages/server-wallet/src/logger.ts
@@ -5,10 +5,10 @@ import {WALLET_VERSION} from './version';
 
 export function createLogger(config: ServerWalletConfig): pino.Logger {
   const destination =
-    config.loggingConfiguration.logLevel &&
-    config.loggingConfiguration.logDestination.toLocaleLowerCase() !== 'console'
+    config.loggingConfiguration.logDestination?.toLocaleLowerCase() !== 'console'
       ? pino.destination(config.loggingConfiguration.logDestination)
       : undefined;
+
   return (destination
     ? pino({level: config.loggingConfiguration.logLevel}, destination)
     : pino({level: config.loggingConfiguration.logLevel})

--- a/packages/server-wallet/src/logger.ts
+++ b/packages/server-wallet/src/logger.ts
@@ -5,7 +5,8 @@ import {WALLET_VERSION} from './version';
 
 export function createLogger(config: ServerWalletConfig): pino.Logger {
   const destination =
-    config.loggingConfiguration.logDestination?.toLocaleLowerCase() !== 'console'
+    config.loggingConfiguration.logDestination &&
+    config.loggingConfiguration.logDestination.toLocaleLowerCase() !== 'console'
       ? pino.destination(config.loggingConfiguration.logDestination)
       : undefined;
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -136,6 +136,8 @@ export class SingleThreadedWallet
     // This allows us to log out any config validation errors
     this.logger = createLogger(populatedConfig);
 
+    this.logger.trace({walletConfig: populatedConfig}, 'Wallet initializing');
+
     const {errors, valid} = validateServerWalletConfig(populatedConfig);
 
     if (!valid) {
@@ -163,7 +165,10 @@ export class SingleThreadedWallet
     }
 
     if (this.walletConfig.chainServiceConfiguration.attachChainService) {
-      this.chainService = new ChainService(this.walletConfig.chainServiceConfiguration);
+      this.chainService = new ChainService({
+        ...this.walletConfig.chainServiceConfiguration,
+        logger: this.logger,
+      });
     } else {
       this.chainService = new MockChainService();
     }


### PR DESCRIPTION
# Description
Improve E2E logging by ensuring that we log to the same file.

Fixes a few things and sets a few defaults so that we can expect everything to log to the same file in the e2e test.

## Changes
- The payer and receiver wallet now log to the `../../artifiacts/e2e.log` with a `logLevel` of `trace`
- The chain service will now log to the same logger as it's wallet (instead of always defaulting to console/info)
- Fixed a check in `createLogger` that was checking `logLevel` instead of `logDestination`


# How Has This Been Tested?
Verified that a [new wallet init trace log](https://github.com/statechannels/statechannels/blob/5b38e59388edeb0009d4cce900d7cdc41be07acb/packages/server-wallet/src/wallet/wallet.ts#L139) shows up in the [e2e logs on CI.](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5d85227bbc97ad5ba7cf4fb2/600f1e413cd3110dc326e5b9-0-build/artifacts/home/circleci/project/artifacts/e2e.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210125T194207Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20210125%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=91c8bffb142831d9c77e81836e3a3168f934320577a22936c5a134f8a0368483)

# Checklist:

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://github.com/statechannels/statechannels/issues/3177)
- [x] I have linked to relevant issues
- [x] I have added dependent tickets
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline
