### PR TITLE
chore: remove console.log

### DIFF
--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -639,7 +639,6 @@ describe('exchanging signed ledger state updates', () => {
       );
 
       let ledgerProposals = await store.getLedgerProposals(ledgerChannel.channelId);
-      console.log(ledgerProposals);
 
       // crank the ledger manager
       const response = new WalletResponse();


### PR DESCRIPTION
I am assuming `console.log` was left behind accidentally?