### PR TITLE
build: generate api report during prepare

### DIFF
--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -110,13 +110,13 @@ export type ChannelProposedNotification = JsonRpcNotification<'ChannelProposed',
 // @public (undocumented)
 export interface ChannelResult {
     // (undocumented)
+    adjudicatorStatus: 'Challenge' | 'Open' | 'Finalized';
+    // (undocumented)
     allocations: Allocation[];
     // (undocumented)
     appData: string;
     // (undocumented)
     appDefinition: Address;
-    // (undocumented)
-    challengeStatus: 'Challenge Finalized' | 'Challenge Active' | 'No Challenge Detected';
     // (undocumented)
     channelId: ChannelId;
     // (undocumented)

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -48,7 +48,7 @@
     "generate-api": "yarn api-extractor run --local",
     "lint:check": "eslint \"src/**/*.ts\" --cache",
     "lint:write": "eslint \"src/**/*.ts\" --fix",
-    "prepare": "yarn build:generate-schema && yarn build:typescript",
+    "prepare": "yarn build:generate-schema && yarn build:typescript && yarn generate-api",
     "test": "yarn jest",
     "test:ci": "yarn test --ci --runInBand"
   }


### PR DESCRIPTION
The api report checked in for the client-api-schema package is out of sync with the source code. This PR hooks report generation into the prepare lifecycle, as it is for the server-wallet. If the API of that package changes, Circle will now fail unless the report is regenerated and checked in. 

Additionally, if running the docs-website locally, the correct report _is_ generated, which dirties your working directory if the report is out of sync. This change will prevent that issue. 

Shortcomings: `prepare` will take a little longer. PRs may unexpectedly fail, it may not be clear why or how to fix. 


# [Optional] :warn: Does this require multiple approvals?
Please explain which reason, if any, why this requires more than one approval.
- [x] Is it a significant process change? Arguably, yes. Although it is really an aligning of several processes already in play. 

# Checklist:

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [ ] I have linked to relevant issues
- [ ] I have added dependent tickets
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate pipeline
