### PR TITLE
chore: remove no-op method from SingleThreadedWallet

### DIFF
--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -4,7 +4,7 @@ import {Wallet, constants} from 'ethers';
 const {AddressZero} = constants;
 import {makeDestination, BN, Address, Destination, makeAddress} from '@statechannels/wallet-core';
 
-import {Wallet as ServerWallet} from '../../src';
+import {MultiThreadedWallet, Wallet as ServerWallet} from '../../src';
 import {Bytes32} from '../../src/type-aliases';
 import {recordFunctionMetrics, timerFactory} from '../../src/metrics';
 import {payerConfig} from '../e2e-utils';
@@ -33,7 +33,7 @@ export default class PayerClient {
   }
 
   public async warmup(): Promise<void> {
-    await this.wallet.warmUpThreads();
+    this.wallet instanceof MultiThreadedWallet && (await this.wallet.warmUpThreads());
   }
   public async destroy(): Promise<void> {
     await this.wallet.destroy();

--- a/packages/server-wallet/e2e-test/receiver/controller.ts
+++ b/packages/server-wallet/e2e-test/receiver/controller.ts
@@ -2,7 +2,7 @@ import {makeDestination} from '@statechannels/wallet-core';
 import {Participant} from '@statechannels/client-api-schema';
 
 import {bob} from '../../src/wallet/__test__/fixtures/signing-wallets';
-import {Wallet, Message as Payload} from '../../src';
+import {Wallet, Message as Payload, MultiThreadedWallet} from '../../src';
 import {timerFactory, recordFunctionMetrics} from '../../src/metrics';
 import {receiverConfig} from '../e2e-utils';
 import {defaultConfig} from '../../src/config';
@@ -20,7 +20,7 @@ export default class ReceiverController {
   private constructor(private readonly wallet: Wallet) {}
 
   public async warmup(): Promise<void> {
-    this.wallet.warmUpThreads();
+    this.wallet instanceof MultiThreadedWallet && (await this.wallet.warmUpThreads());
   }
 
   private readonly myParticipantID: string = 'receiver';

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -353,8 +353,6 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     readonly walletConfig: ServerWalletConfig;
-    // (undocumented)
-    warmUpThreads(): Promise<void>;
 }
 
 // @public (undocumented)

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -800,10 +800,6 @@ export class SingleThreadedWallet
     );
     this.chainService.registerChannel(channelId, assetHolderAddresses, this);
   }
-
-  async warmUpThreads(): Promise<void> {
-    // no-op for single-threaded-wallet
-  }
 }
 
 // TODO: This should be removed, and not used externally.


### PR DESCRIPTION
This method is a no-op, and it unnecessarily bloats the wallet API. This change restores a more usual approach to class inheritance.

Consumers will now need to be sure they have a `MultiThreadedWallet` before calling `warmUpThreads`. This is easy and this PR makes such a change by way of example. 

## Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] I have scoped this change as narrowly as possible
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
## Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [ ] I have linked to relevant issues
- [ ] I have added dependent tickets
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate pipeline
