### PR TITLE
ci: remove api-extractor step from prepare lifecycle script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           file: prepare-stats
       - <<: *restore_dep
       - run: yarn --cache-folder ~.cache/yarn
-      - run: git diff --exit-code # Fails the job if you forgot to check in tracked installation and/or preparation artifacts (e.g. yarn.lock or api-reports)
+      - run: git diff --exit-code # Fails the job if you forgot to check in tracked installation and/or preparation artifacts (e.g. yarn.lock)
       - run: yarn lint:check
       - <<: *save_dep
 
@@ -275,6 +275,9 @@ jobs:
             - run:
                 name: build docs-website
                 command: yarn lerna run build-docs-website --stream
+            - run: 
+                name: ensure api-reports checked in
+                command: git diff --exit-code
             - run:
                 name: deploy docs-website (production)
                 command: >
@@ -293,6 +296,9 @@ jobs:
             - run:
                 name: build docs-website
                 command: yarn lerna run --since $(git merge-base $CIRCLE_BRANCH origin/master) build-docs-website --stream
+            - run: 
+                name: ensure api-reports checked in
+                command: git diff --exit-code
             - run:
                 name: deploy docs-website (preview)
                 command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
                 name: build docs-website
                 command: yarn lerna run build-docs-website --stream
             - run: 
-                name: ensure api-reports checked in
+                name: ensure api-reports checked in (yarn lerna run generate-api)
                 command: git diff --exit-code
             - run:
                 name: deploy docs-website (production)
@@ -297,7 +297,7 @@ jobs:
                 name: build docs-website
                 command: yarn lerna run --since $(git merge-base $CIRCLE_BRANCH origin/master) build-docs-website --stream
             - run: 
-                name: ensure api-reports checked in
+                name: ensure api-reports checked in (yarn lerna run generate-api)
                 command: git diff --exit-code
             - run:
                 name: deploy docs-website (preview)

--- a/packages/client-api-schema/client-api-schema.api.md
+++ b/packages/client-api-schema/client-api-schema.api.md
@@ -110,13 +110,13 @@ export type ChannelProposedNotification = JsonRpcNotification<'ChannelProposed',
 // @public (undocumented)
 export interface ChannelResult {
     // (undocumented)
+    adjudicatorStatus: 'Challenge' | 'Open' | 'Finalized';
+    // (undocumented)
     allocations: Allocation[];
     // (undocumented)
     appData: string;
     // (undocumented)
     appDefinition: Address;
-    // (undocumented)
-    challengeStatus: 'Challenge Finalized' | 'Challenge Active' | 'No Challenge Detected';
     // (undocumented)
     channelId: ChannelId;
     // (undocumented)

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -91,7 +91,7 @@
     "lint:check": "eslint \"*/**/*.{js,ts}\" --cache",
     "lint:write": "eslint \"*/**/*.{js,ts}\" --fix",
     "precommit": "lint-staged --quiet",
-    "prepare": "rm -rf lib; tsc -b . && node ./scripts/inject-wallet-version.js && yarn generate-api",
+    "prepare": "rm -rf lib; tsc -b . && node ./scripts/inject-wallet-version.js",
     "prestart": "yarn prepare && npm run db:rollback && npm run db:migrate && npm run db:seed",
     "prettier:check": "npx prettier --check 'src/**/*.{ts,tsx}'",
     "prettier:write": "npx prettier --write 'src/**/*.{ts,tsx}'",


### PR DESCRIPTION
We want both to 
- have `prepare` complete as fast as possible, and to only perform tasks necessary to prepare a package for use / consumption by other packages
- enforce that the reports generated by api-extractor are checked in when the API of a package (currently, `server-wallet` and `client-api-schema`) changes. These reports provide a valuable spotlight on such changes.

This approach moves the api-extractor step out of `prepare` and into the dedicated circle job that handles the `docs-website`, (which was running the extractor anyway). So it achieves both goals.

## How Has This Been Tested? 
Existing CI suite.
---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
