### PR TITLE
chore: fix all eslint errors in codeActionsOnSave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,11 @@
   ],
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.wordWrapColumn": 100,
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.formatOnSave": true
+  ,"editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
 }
 
 


### PR DESCRIPTION
# Description
This makes vscode-eslint actually format on save with the default VS Code settings.

## How Has This Been Tested?
1. I reset my vscode user settings to the default.
2. I opened the repository from the monorepo root
3. I added some whitespace to a file, saved it, and observed vs-code eslint apply the prettier changes.

## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x]  I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [ ] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
