### PR TITLE
Wallet emits 'objectiveStarted' & 'objectiveSucceeded' events

### DIFF
--- a/packages/server-wallet/e2e-test/challenge.test.ts
+++ b/packages/server-wallet/e2e-test/challenge.test.ts
@@ -104,6 +104,9 @@ test('the wallet handles the basic challenging v0 behavior', async () => {
   // We expect the channel to be marked as finalized
   expect(await getChannelMode(channelId)).toEqual('Finalized');
 
+  expect(events).toHaveLength(3);
+  expect(events).toContainObject({event: 'objectiveStarted', type: 'DefundChannel'});
+
   // We expect the balances to be updated based on the outcome
   const finalPayerBalance = await getBalance(payerClient.provider, payer);
   const finalReceiverBalance = await getBalance(payerClient.provider, receiver);

--- a/packages/server-wallet/e2e-test/challenge.test.ts
+++ b/packages/server-wallet/e2e-test/challenge.test.ts
@@ -104,8 +104,9 @@ test('the wallet handles the basic challenging v0 behavior', async () => {
   // We expect the channel to be marked as finalized
   expect(await getChannelMode(channelId)).toEqual('Finalized');
 
-  expect(events).toHaveLength(3);
+  expect(events).toHaveLength(4);
   expect(events).toContainObject({event: 'objectiveStarted', type: 'DefundChannel'});
+  expect(events).toContainObject({event: 'objectiveSucceeded', type: 'DefundChannel'});
 
   // We expect the balances to be updated based on the outcome
   const finalPayerBalance = await getBalance(payerClient.provider, payer);

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -85,7 +85,7 @@ describe('e2e', () => {
   });
 
   it('can create a channel, send signed state via http', async () => {
-    const channel = await payerClient.createPayerChannel(receiver);
+    const {channelResult: channel} = await payerClient.createPayerChannel(receiver);
 
     expect(channel.participants).toStrictEqual([payer, receiver]);
     expect(channel.status).toBe('running');

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -95,11 +95,16 @@ describe('e2e', () => {
       (await ChannelPayer.forId(channel.channelId, ChannelPayer.knex())).protocolState
     ).toMatchObject({supported: {turnNum: 3}});
 
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(2);
     expect(events).toContainObject({
       event: 'objectiveStarted',
       type: 'OpenChannel',
       status: 'pending',
+    });
+    expect(events).toContainObject({
+      event: 'objectiveSucceeded',
+      type: 'OpenChannel',
+      status: 'succeeded',
     });
   });
 });

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -96,7 +96,11 @@ describe('e2e', () => {
     ).toMatchObject({supported: {turnNum: 3}});
 
     expect(events).toHaveLength(1);
-    expect(events).toContainObject({type: 'OpenChannel', status: 'pending'});
+    expect(events).toContainObject({
+      event: 'objectiveStarted',
+      type: 'OpenChannel',
+      status: 'pending',
+    });
   });
 });
 

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -85,7 +85,7 @@ describe('e2e', () => {
   });
 
   it('can create a channel, send signed state via http', async () => {
-    const {channelResult: channel} = await payerClient.createPayerChannel(receiver);
+    const {channelResult: channel, events} = await payerClient.createPayerChannel(receiver);
 
     expect(channel.participants).toStrictEqual([payer, receiver]);
     expect(channel.status).toBe('running');
@@ -93,9 +93,10 @@ describe('e2e', () => {
 
     expect(
       (await ChannelPayer.forId(channel.channelId, ChannelPayer.knex())).protocolState
-    ).toMatchObject({
-      supported: {turnNum: 3},
-    });
+    ).toMatchObject({supported: {turnNum: 3}});
+
+    expect(events).toHaveLength(1);
+    expect(events).toContainObject({type: 'OpenChannel', status: 'pending'});
   });
 });
 

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -90,9 +90,9 @@ export default class PayerClient {
 
   public async createPayerChannel(receiver: Participant): Promise<TestChannelResult> {
     const events: WalletEvent[] = [];
-    this.wallet.on('channelUpdated', e => events.push(e));
-    this.wallet.on('objectiveStarted', o => events.push(o));
-    this.wallet.on('objectiveSucceeded', o => events.push(o));
+    const names = ['channelUpdated', 'objectiveStarted', 'objectiveSucceeded'] as const;
+    names.map(event => this.wallet.on(event, e => events.push({...e, event})));
+
     const {
       outbox: [{params}],
       channelResults: [{channelId}],

--- a/packages/server-wallet/jest/jest.e2e.config.js
+++ b/packages/server-wallet/jest/jest.e2e.config.js
@@ -1,7 +1,7 @@
 const config = require('./jest.config');
 config.testMatch = ['<rootDir>/e2e-test/*.test.ts?(x)'];
 // We don't want to use the default knex setup as we're using two DBs for the e2e test
-config.setupFilesAfterEnv = [];
+config.setupFilesAfterEnv = ['<rootDir>/jest/custom-matchers.ts'];
 config.globalSetup = '<rootDir>/jest/chain-setup.ts';
 config.globalTeardown = '<rootDir>/jest/test-teardown.ts';
 module.exports = config;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -356,9 +356,11 @@ export abstract class Wallet extends SingleThreadedWallet implements WalletInter
 }
 
 // Warning: (ae-forgotten-export) The symbol "ChannelUpdatedEvent" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ObjectiveStarted" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ObjectiveSucceeded" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type WalletEvent = ChannelUpdatedEvent;
+export type WalletEvent = ChannelUpdatedEvent | ObjectiveStarted | ObjectiveSucceeded;
 
 // @public (undocumented)
 export interface WalletInterface {

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -162,11 +162,19 @@ export class ObjectiveModel extends Model {
     await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'approved'});
   }
 
-  static async succeed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'succeeded'});
+  static async succeed(objectiveId: string, tx: TransactionOrKnex): Promise<ObjectiveModel> {
+    return ObjectiveModel.query(tx)
+      .findById(objectiveId)
+      .patch({status: 'succeeded'})
+      .returning('*')
+      .first();
   }
-  static async failed(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'failed'});
+  static async failed(objectiveId: string, tx: TransactionOrKnex): Promise<ObjectiveModel> {
+    return ObjectiveModel.query(tx)
+      .findById(objectiveId)
+      .patch({status: 'failed'})
+      .returning('*')
+      .first();
   }
 
   static async forChannelIds(

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -63,7 +63,7 @@ export function isSharedObjective(
 /**
  * A DBObjective is a wire objective with a status and an objectiveId
  *
- * Limited to 'OpenChannel' and 'CloseChannel', which are the only objectives
+ * Limited to 'OpenChannel', 'CloseChannel', 'SubmitChallenge' and 'DefundChannel' which are the only objectives
  * that are currently supported by the server wallet
  */
 export type DBObjective =

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -72,8 +72,9 @@ export class ChallengeSubmitter {
 
       await this.chainService.challenge(channel.initialSupport, channel.signingWallet.privateKey);
 
-      await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+      objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
       response.queueChannel(channel);
+      response.queueSucceededObjective(objective);
     });
   }
 

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -133,7 +133,7 @@ export class ChannelCloser {
     tx: Transaction,
     response: WalletResponse
   ): Promise<void> {
-    await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+    objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
     response.queueChannelState(protocolState.app);
     response.queueSucceededObjective(objective);
   }

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -60,7 +60,7 @@ export class ChannelOpener {
       }
 
       if (channel.postfundSupported) {
-        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+        objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
 
         response.queueSucceededObjective(objective);
       }

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -25,10 +25,7 @@ export class ChannelDefunder {
     return new ChannelDefunder(store, chainService, logger, timingMetrics);
   }
 
-  public async crank(
-    objective: DBDefundChannelObjective,
-    _response: WalletResponse
-  ): Promise<void> {
+  public async crank(objective: DBDefundChannelObjective, response: WalletResponse): Promise<void> {
     const {targetChannelId: channelId} = objective.data;
     await this.store.transaction(async tx => {
       const channel = await this.store.getAndLockChannel(channelId, tx);
@@ -64,7 +61,8 @@ export class ChannelDefunder {
       } else if (channel.hasConclusionProof) {
         await ChainServiceRequest.insertOrUpdate(channelId, 'withdraw', tx);
         await this.chainService.concludeAndWithdraw(channel.support);
-        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+        objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+        response.queueSucceededObjective(objective);
         return;
       }
     });

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -55,6 +55,7 @@ export class ChannelDefunder {
           await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
           await this.chainService.pushOutcomeAndWithdraw(result.states[0], channel.myAddress);
           await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+          response.queueSucceededObjective(objective);
         } else {
           this.logger.trace('Outcome already pushed, doing nothing');
         }

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -37,7 +37,7 @@ it('throws an error when challenging with a non ledger channel', async () => {
 it('submits a challenge when no challenge exists for a channel', async () => {
   const spy = jest.spyOn(w.chainService, 'challenge');
   const callback = jest.fn();
-  w.once('operationStarted', callback);
+  w.once('objectiveStarted', callback);
   const c = channel({
     channelNonce: 1,
     // Set a random address so this will be a "ledger" channel

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -36,6 +36,8 @@ it('throws an error when challenging with a non ledger channel', async () => {
 });
 it('submits a challenge when no challenge exists for a channel', async () => {
   const spy = jest.spyOn(w.chainService, 'challenge');
+  const callback = jest.fn();
+  w.once('operationStarted', callback);
   const c = channel({
     channelNonce: 1,
     // Set a random address so this will be a "ledger" channel
@@ -54,6 +56,7 @@ it('submits a challenge when no challenge exists for a channel', async () => {
 
   await w.challenge(channelId);
   expect(spy).toHaveBeenCalledWith(c.initialSupport, alice().privateKey);
+  expect(callback).toHaveBeenCalledWith(expect.objectContaining({type: 'SubmitChallenge'}));
 });
 
 it('stores the challenge state on the challenge created event', async () => {

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -24,11 +24,10 @@ describe('happy path', () => {
     const appData = '0xaf00';
     const callback = jest.fn();
     w.once('objectiveStarted', callback);
-    const createPromise = w.createChannels(createChannelArgs({appData}), 1);
-    await expect(createPromise).resolves.toMatchObject({
-      channelResults: [{channelId: expect.any(String)}],
-    });
-    await expect(createPromise).resolves.toMatchObject({
+    const createResult = await w.createChannels(createChannelArgs({appData}), 1);
+    expect(createResult).toMatchObject({channelResults: [{channelId: expect.any(String)}]});
+
+    expect(createResult).toMatchObject({
       outbox: [
         {
           params: {
@@ -52,7 +51,7 @@ describe('happy path', () => {
       channelResults: [{channelId: expect.any(String), turnNum: 0, appData}],
     });
     expect(callback).toHaveBeenCalledWith(expect.objectContaining({type: 'OpenChannel'}));
-    const {channelId} = (await createPromise).channelResults[0];
+    const {channelId} = createResult.channelResults[0];
     expect(await Channel.query(w.knex).resultSize()).toEqual(1);
 
     const updated = await Channel.forId(channelId, w.knex);

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -18,12 +18,12 @@ afterEach(async () => {
 describe('happy path', () => {
   beforeEach(async () => seedAlicesSigningWallet(w.knex));
 
-  it('creates a channel and emits an OperationStarted event', async () => {
+  it('creates a channel and emits an ObjectiveStarted event', async () => {
     expect(await Channel.query(w.knex).resultSize()).toEqual(0);
 
     const appData = '0xaf00';
     const callback = jest.fn();
-    w.once('operationStarted', callback);
+    w.once('objectiveStarted', callback);
     const createPromise = w.createChannels(createChannelArgs({appData}), 1);
     await expect(createPromise).resolves.toMatchObject({
       channelResults: [{channelId: expect.any(String)}],

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -340,15 +340,19 @@ export class Store {
     await ObjectiveModel.approve(objectiveId, tx || this.knex);
   }
 
-  async markObjectiveStatus(
-    objective: DBObjective,
+  async markObjectiveStatus<O extends DBObjective>(
+    objective: O,
     status: 'succeeded' | 'failed',
     tx?: Transaction
-  ): Promise<void> {
+  ): Promise<O> {
     if (status === 'succeeded') {
-      await ObjectiveModel.succeed(objective.objectiveId, tx || this.knex);
+      return (
+        await ObjectiveModel.succeed(objective.objectiveId, tx || this.knex)
+      ).toObjective() as O;
     } else {
-      await ObjectiveModel.failed(objective.objectiveId, tx || this.knex);
+      return (
+        await ObjectiveModel.failed(objective.objectiveId, tx || this.knex)
+      ).toObjective() as O;
     }
   }
 

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -29,9 +29,8 @@ export type MultipleChannelOutput = {
 
 export type Output = SingleChannelOutput | MultipleChannelOutput;
 
-type ChannelUpdatedEventName = 'channelUpdated';
 type ChannelUpdatedEvent = {
-  type: ChannelUpdatedEventName;
+  type: 'channelUpdated';
   value: SingleChannelOutput;
 };
 

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -35,16 +35,16 @@ type ChannelUpdatedEvent = {
   value: SingleChannelOutput;
 };
 
-type OperationStarted = {
-  type: 'operationStarted';
+type ObjectiveStarted = {
+  type: 'objectiveStarted';
   value: DBObjective;
 };
-type OperationSucceeded = {
-  type: 'operationSucceeded';
+type ObjectiveSucceeded = {
+  type: 'objectiveSucceeded';
   value: DBObjective;
 };
 
-export type WalletEvent = ChannelUpdatedEvent | OperationStarted | OperationSucceeded;
+export type WalletEvent = ChannelUpdatedEvent | ObjectiveStarted | ObjectiveSucceeded;
 
 export interface WalletInterface {
   // App utilities

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -9,6 +9,7 @@ import {
 } from '@statechannels/client-api-schema';
 import {Address as CoreAddress} from '@statechannels/wallet-core';
 
+import {DBObjective} from '../models/objective';
 import {Outgoing} from '../protocols/actions';
 import {Bytes32, Uint256} from '../type-aliases';
 
@@ -34,7 +35,16 @@ type ChannelUpdatedEvent = {
   value: SingleChannelOutput;
 };
 
-export type WalletEvent = ChannelUpdatedEvent;
+type OperationStarted = {
+  type: 'operationStarted';
+  value: DBObjective;
+};
+type OperationSucceeded = {
+  type: 'operationSucceeded';
+  value: DBObjective;
+};
+
+export type WalletEvent = ChannelUpdatedEvent | OperationStarted | OperationSucceeded;
 
 export interface WalletInterface {
   // App utilities

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -354,7 +354,7 @@ export class SingleThreadedWallet
         },
         tx
       );
-      this.emit('operationStarted', objective);
+      this.emit('objectiveStarted', objective);
 
       await this.store.approveObjective(objective.objectiveId, tx);
 
@@ -524,7 +524,7 @@ export class SingleThreadedWallet
       fundingLedgerChannelId
     );
 
-    this.emit('operationStarted', objective);
+    this.emit('objectiveStarted', objective);
     response.queueState(signedState, channel.myIndex, channel.channelId);
     response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
     response.queueChannelState(channel);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -886,6 +886,8 @@ export class SingleThreadedWallet
       await this.crankUntilIdle(channels, response);
       needToCrank = await this.processLedgerQueue(channels, response);
     }
+
+    response.succeededObjectives.map(o => this.emit('objectiveSucceeded', o));
   }
 
   private async processLedgerQueue(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -346,7 +346,7 @@ export class SingleThreadedWallet
       }
       // END CHALLENGING_V0
 
-      const {objectiveId} = await this.store.ensureObjective(
+      const objective = await this.store.ensureObjective(
         {
           type: 'SubmitChallenge',
           participants: [],
@@ -354,8 +354,9 @@ export class SingleThreadedWallet
         },
         tx
       );
+      this.emit('operationStarted', objective);
 
-      await this.store.approveObjective(objectiveId, tx);
+      await this.store.approveObjective(objective.objectiveId, tx);
 
       response.queueChannel(channel);
     });
@@ -367,7 +368,7 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Update the wallets knowledge about the funding for some channels
+   * Update the wallet's knowledge about the funding for some channels
    *
    * @param args - A list of objects, each specifying the channelId, asset holder address and amount.
    * @returns A promise that resolves to a channel output.
@@ -523,6 +524,7 @@ export class SingleThreadedWallet
       fundingLedgerChannelId
     );
 
+    this.emit('operationStarted', objective);
     response.queueState(signedState, channel.myIndex, channel.channelId);
     response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
     response.queueChannelState(channel);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -881,16 +881,14 @@ export class SingleThreadedWallet
   }
 
   /**
-   *
-   * @param channels channels touched by the caller
-   * @param response WalletResponse that is modified in place while cranking objectives
-   *
-   * EMITS: 'objectiveSucceded' for objectives that succeed
-   *
    * Active objectives for the "touched" channels are cranked. Theoretically, this may touch other
    * channels, resulting in a cascade of cranked objectives.
    *
+   * @remarks
+   * Emits an 'objectiveSucceded' event for objectives that succeed.
    *
+   * @param channels channels touched by the caller
+   * @param response WalletResponse that is modified in place while cranking objectives
    */
   private async takeActions(channels: Bytes32[], response: WalletResponse): Promise<void> {
     let needToCrank = true;

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -880,6 +880,18 @@ export class SingleThreadedWallet
     await this.takeActions(channelIds, response);
   }
 
+  /**
+   *
+   * @param channels channels touched by the caller
+   * @param response WalletResponse that is modified in place while cranking objectives
+   *
+   * EMITS: 'objectiveSucceded' for objectives that succeed
+   *
+   * Active objectives for the "touched" channels are cranked. Theoretically, this may touch other
+   * channels, resulting in a cascade of cranked objectives.
+   *
+   *
+   */
   private async takeActions(channels: Bytes32[], response: WalletResponse): Promise<void> {
     let needToCrank = true;
     while (needToCrank) {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -1001,7 +1001,7 @@ export class SingleThreadedWallet
       arg.blockTimestamp
     );
     await this.knex.transaction(async tx => {
-      const {objectiveId} = await this.store.ensureObjective(
+      const objective = await this.store.ensureObjective(
         {
           type: 'DefundChannel',
           participants: [],
@@ -1009,7 +1009,8 @@ export class SingleThreadedWallet
         },
         tx
       );
-      await this.store.approveObjective(objectiveId, tx);
+      this.emit('objectiveStarted', objective);
+      await this.store.approveObjective(objective.objectiveId, tx);
     });
 
     await this.takeActions([arg.channelId], response);


### PR DESCRIPTION
Wallet emits 'objectiveStarted' & 'objectiveSucceeded' events, allowing applications to learn when API calls succeed.

See the RFC [here](https://www.notion.so/RCF-1-First-class-objectives-2a26247ce3244b8aafa4f9397df8465f#187917c1a0d54dd3bf9715f8415f65f2).

## Drawbacks
As the WalletResponse model already stores `succeededObjectives`, I opted to emit them at the end of a crank. I believe this increases the susceptibility of crashes, since the implementation follows the following story:
1. An objective might succeed
2. This might trigger other objectives to be cranked
3. Finally, `'objectiveSucceeded'` is emitted.

If the wallet crashes during (2), then the objective would succeed, but the app would never know.

## Alternative?
We could emit `objectiveSucceeded` right away, when the objective succeeds. In this case, the risk is only reduced, not fully eliminated. Therefore, an app (eg. a ChannelManager) must periodically check the status of ongoing objectives anyway. During this monitoring, the app would learn that the objective succeeded.

Therefore I opted for emitting within `takeActions` for simplicity.

### TODO
I don't know the wallet well enough to answer these questions yet. I'd like them answered, by me or someone else, before marking as "ready". I would appreciate input from more familiar devs.

- [x] Are all objectives included in this changeset?
  - [x] When started?
  - [x] When succeeded?
- [x] Are there enough tests in this PR? Where else should assertions be made?

## Additional Changes 

1. e2e test uses custom matchers
2. e2e test asserts on emitted events
3. I attempted to describe what `takeActions` does
4. `ObjectiveManager.succeed/fail` returns objectives (so that `succeededObjectives` does not contain stale data)

## :warning: Does this require multiple approvals? [Optional]
> Is it a significant change to architectural, design?

Even if this is true, because we've done an RFC for this, that it doesn't require multiple approvals.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
