### PR TITLE
New objectives are returned in ChannelResults

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -164,6 +164,7 @@ export type MetricsConfiguration = {
 export type MultipleChannelOutput = {
     outbox: Outgoing[];
     channelResults: ChannelResult[];
+    newObjectives: DBObjective[];
 };
 
 // @public
@@ -255,6 +256,7 @@ export type ServerWalletConfig = RequiredServerWalletConfig & OptionalServerWall
 export type SingleChannelOutput = {
     outbox: Outgoing[];
     channelResult: ChannelResult;
+    newObjective: DBObjective | undefined;
 };
 
 // Warning: (ae-forgotten-export) The symbol "EventEmitterType" needs to be exported by the entry point index.d.ts
@@ -394,5 +396,9 @@ export interface WalletInterface {
     updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
 }
 
+
+// Warnings were encountered during analysis:
+//
+// src/wallet/types.ts:30:3 - (ae-forgotten-export) The symbol "DBObjective" needs to be exported by the entry point index.d.ts
 
 ```

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -386,7 +386,7 @@ describe('Funding multiple channels syncronously (in bulk)', () => {
 
     const {channelResults} = await a.getChannels();
 
-    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: []});
+    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: [], newObjectives: []});
 
     const ledger = getChannelResultFor(ledgerChannelId, channelResults);
 
@@ -478,7 +478,7 @@ describe('Funding multiple channels concurrently (in bulk)', () => {
 
     const {channelResults} = await a.getChannels();
 
-    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: []});
+    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: [], newObjectives: []});
 
     const ledger = getChannelResultFor(ledgerChannelId, channelResults);
 
@@ -561,7 +561,7 @@ describe('Funding multiple channels syncronously without enough funds', () => {
 
     const {channelResults} = await a.getChannels();
 
-    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: []});
+    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: [], newObjectives: []});
 
     const {
       allocations: [{allocationItems}],
@@ -914,7 +914,7 @@ describe('Automatic channel syncing on successive API calls', () => {
 
     const {channelResults} = await a.getChannels();
 
-    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: []});
+    await expect(b.getChannels()).resolves.toEqual({channelResults, outbox: [], newObjectives: []});
 
     const ledger = getChannelResultFor(ledgerChannelId, channelResults);
 

--- a/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/ledger-funding.test.ts
@@ -363,7 +363,7 @@ describe('Closing a ledger channel and preventing it from being used again', () 
   });
 });
 
-describe('Funding multiple channels syncronously (in bulk)', () => {
+describe('Funding multiple channels synchronously (in bulk)', () => {
   const N = 4;
   let ledgerChannelId: Bytes32;
   let appChannelIds: Bytes32[];

--- a/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/close-channel.test.ts
@@ -35,6 +35,7 @@ it("signs a final state when it's my turn", async () => {
   await expect(w.closeChannel({channelId})).resolves.toMatchObject({
     outbox: [{params: {recipient: 'bob', sender: 'alice', data: {signedStates: [closingState]}}}],
     channelResult: {channelId, status: 'closing', turnNum: turnNum + 1, appData},
+    newObjective: {type: 'CloseChannel', objectiveId: `CloseChannel-${channelId}`},
   });
 
   const updated = await Channel.forId(channelId, w.knex);
@@ -56,6 +57,7 @@ it("accepts and sends an objective when it isn't my turn", async () => {
   await expect(w.closeChannel({channelId})).resolves.toMatchObject({
     channelResult: {status: 'running'},
     outbox: [{method: 'MessageQueued', params: {data: {objectives: [{type: 'CloseChannel'}]}}}],
+    newObjective: {type: 'CloseChannel', objectiveId: `CloseChannel-${channelId}`},
   });
 });
 
@@ -80,6 +82,10 @@ it("signs a final state when it's my turn for many channels at once", async () =
       status: 'closing',
       turnNum: turnNum + 1,
       appData,
+    })),
+    newObjectives: channelIds.map(id => ({
+      type: 'CloseChannel',
+      objectiveId: `CloseChannel-${id}`,
     })),
   });
 });

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -25,7 +25,13 @@ describe('happy path', () => {
     const callback = jest.fn();
     w.once('objectiveStarted', callback);
     const createResult = await w.createChannels(createChannelArgs({appData}), 1);
-    expect(createResult).toMatchObject({channelResults: [{channelId: expect.any(String)}]});
+    const channelId = '0x4460dab6d4438f3bf1719720fcced4054a38baf60f315e49995eead80cfa498f';
+    expect(createResult).toMatchObject({channelResults: [{channelId}]});
+    expect(createResult.newObjectives).toHaveLength(1);
+    expect(createResult.newObjectives).toContainObject({
+      type: 'OpenChannel',
+      objectiveId: `OpenChannel-${channelId}`,
+    });
 
     expect(createResult).toMatchObject({
       outbox: [
@@ -51,7 +57,7 @@ describe('happy path', () => {
       channelResults: [{channelId: expect.any(String), turnNum: 0, appData}],
     });
     expect(callback).toHaveBeenCalledWith(expect.objectContaining({type: 'OpenChannel'}));
-    const {channelId} = createResult.channelResults[0];
+    expect(createResult.channelResults[0].channelId).toEqual(channelId);
     expect(await Channel.query(w.knex).resultSize()).toEqual(1);
 
     const updated = await Channel.forId(channelId, w.knex);
@@ -74,6 +80,7 @@ describe('happy path', () => {
 
     const result = await w.createChannels(createArgs, NUM_CHANNELS);
     expect(result.channelResults).toHaveLength(NUM_CHANNELS);
+    expect(result.newObjectives).toHaveLength(NUM_CHANNELS);
     expect(result.outbox).toHaveLength(1);
 
     expect(await Channel.query(w.knex).resultSize()).toEqual(NUM_CHANNELS);

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -22,6 +22,7 @@ export interface UpdateChannelFundingParams {
 export type SingleChannelOutput = {
   outbox: Outgoing[];
   channelResult: ChannelResult;
+  newObjective: DBObjective | undefined;
 };
 export type MultipleChannelOutput = {
   outbox: Outgoing[];

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -27,6 +27,7 @@ export type SingleChannelOutput = {
 export type MultipleChannelOutput = {
   outbox: Outgoing[];
   channelResults: ChannelResult[];
+  newObjectives: DBObjective[];
 };
 
 export type Output = SingleChannelOutput | MultipleChannelOutput;

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -252,12 +252,10 @@ export class WalletResponse {
     outputs: (SingleChannelOutput | MultipleChannelOutput)[]
   ): MultipleChannelOutput {
     const channelResults = mergeChannelResults(
-      outputs
-        .map(m => (isSingleChannelMessage(m) ? [m.channelResult] : m.channelResults))
-        .reduce((cr1, cr2) => cr1.concat(cr2))
+      outputs.flatMap(m => (isSingleChannelMessage(m) ? [m.channelResult] : m.channelResults))
     );
 
-    const outbox = mergeOutgoing(outputs.map(m => m.outbox).reduce((m1, m2) => m1.concat(m2)));
+    const outbox = mergeOutgoing(outputs.flatMap(m => m.outbox));
     const newObjectives = outputs.flatMap(m =>
       isSingleChannelMessage(m) ? (m.newObjective ? [m.newObjective] : []) : m.newObjectives
     );

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -20,6 +20,7 @@ export class WalletResponse {
   private queuedMessages: WireMessage[] = [];
   objectivesToSend: DBObjective[] = [];
   objectivesToApprove: DBObjective[] = [];
+  createdObjectives: DBObjective[] = [];
   succeededObjectives: DBObjective[] = [];
   requests: string[] = [];
 
@@ -76,13 +77,17 @@ export class WalletResponse {
   }
 
   /**
-   * Queues objectives for sending to opponent
+   * Queues objectives for
+   * - sending to opponent
+   * - notifying the app
    */
   queueCreatedObjective(
     objective: DBObjective,
     myIndex: number,
     participants: Participant[]
   ): void {
+    this.createdObjectives.push(objective);
+
     const myParticipantId = participants[myIndex].participantId;
     if (isSharedObjective(objective)) {
       participants.forEach((p, i) => {

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -212,6 +212,7 @@ export class WalletResponse {
     return {
       outbox: mergeOutgoing(this.outbox),
       channelResult: this.channelResults[0],
+      newObjective: this.createdObjectives[0],
       // objectivesToApprove: this.objectivesToApprove, // TODO: re-enable
     };
   }
@@ -226,6 +227,7 @@ export class WalletResponse {
       value: {
         channelResult,
         outbox: this.outbox, // TODO: doesn't seem like this should be on this event?
+        newObjective: this.createdObjectives[0], // TODO: This one neither?
       },
     }));
   }

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -189,7 +189,6 @@ export class WalletResponse {
       outbox: mergeOutgoing(this.outbox),
       channelResults: mergeChannelResults(this.channelResults),
       newObjectives: this.createdObjectives,
-      // objectivesToApprove: this.objectivesToApprove, // TODO: re-enable
     };
   }
 
@@ -214,7 +213,6 @@ export class WalletResponse {
       outbox: mergeOutgoing(this.outbox),
       channelResult: this.channelResults[0],
       newObjective: this.createdObjectives[0],
-      // objectivesToApprove: this.objectivesToApprove, // TODO: re-enable
     };
   }
 

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -188,6 +188,7 @@ export class WalletResponse {
     return {
       outbox: mergeOutgoing(this.outbox),
       channelResults: mergeChannelResults(this.channelResults),
+      newObjectives: this.createdObjectives,
       // objectivesToApprove: this.objectivesToApprove, // TODO: re-enable
     };
   }
@@ -257,7 +258,10 @@ export class WalletResponse {
     );
 
     const outbox = mergeOutgoing(outputs.map(m => m.outbox).reduce((m1, m2) => m1.concat(m2)));
-    return {channelResults, outbox};
+    const newObjectives = outputs.flatMap(m =>
+      isSingleChannelMessage(m) ? (m.newObjective ? [m.newObjective] : []) : m.newObjectives
+    );
+    return {channelResults, outbox, newObjectives};
   }
 
   // -------------------------------


### PR DESCRIPTION
## Description
createdObjectives are stored in a WalletResponse, and then returned in Single/MultipleChannelOutput to the app.

Fixes #3228, with a slightly expanded scope: it's important for the app to learn about objectives created as a direct result of an API call.


## Alternatives
I chose not to modify the wallet API, besides adding optional `newObjectives` to `Single/MultipleChannelResult`, because it seemed outside the scope of this PR.

### Code quality
9/9