### PR TITLE
refactor: make toWireObjective type safe / more robust

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -78,7 +78,12 @@ export const toWireObjective = (dbObj: DBObjective): SharedObjective => {
       'SubmitChallenge and DefundChannel objectives are not supported as wire objectives'
     );
   }
-  return _.omit(dbObj, ['objectiveId', 'status']);
+  return {
+    type: dbObj.type,
+    data: dbObj.data,
+    // don't forget optional properties
+    participants: dbObj.participants,
+  };
 };
 
 export class ObjectiveChannelModel extends Model {


### PR DESCRIPTION
The lodash utility currently in use does not provide type safety. For example, if we add properties to `dbObj: DBObjective`, they will not be omitted unless we update this function, and this will lead to a runtime error when we try to validate the objective coming over the wire, due to pollutant properties.

Here, any required properties will be checked by the TS compiler. Optional properties are still a bit of a risk -- I will tackle that in another PR  #3251 

(Extra context: we may well add new properties to objectives, soon. See #3230). 

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
