### PR TITLE
fix: make participants a required property of objectives

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -6,6 +6,7 @@ import {
   SharedObjective,
   SubmitChallenge,
   DefundChannel,
+  Participant,
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
@@ -42,6 +43,7 @@ export type DBCloseChannelObjective = CloseChannel & {
 };
 export type DBDefundChannelObjective = {
   type: 'DefundChannel';
+  participants: Participant[];
   objectiveId: string;
   status: ObjectiveStatus;
   data: {targetChannelId: string};
@@ -49,6 +51,7 @@ export type DBDefundChannelObjective = {
 
 export type DBSubmitChallengeObjective = {
   data: {targetChannelId: string};
+  participants: Participant[];
   objectiveId: string;
   status: ObjectiveStatus;
   type: 'SubmitChallenge';
@@ -81,7 +84,6 @@ export const toWireObjective = (dbObj: DBObjective): SharedObjective => {
   return {
     type: dbObj.type,
     data: dbObj.data,
-    // don't forget optional properties
     participants: dbObj.participants,
   };
 };

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -47,6 +47,7 @@ describe(`challenge-submitter`, () => {
     const obj: DBSubmitChallengeObjective = {
       type: 'SubmitChallenge',
       status: 'pending',
+      participants: [],
       objectiveId: ['SubmitChallenge', c.channelId].join('-'),
       data: {targetChannelId: c.channelId},
     };
@@ -65,6 +66,7 @@ describe(`challenge-submitter`, () => {
     const obj: DBSubmitChallengeObjective = {
       type: 'SubmitChallenge',
       status: 'pending',
+      participants: [],
       objectiveId: ['SubmitChallenge', c.channelId].join('-'),
       data: {targetChannelId: c.channelId},
     };
@@ -84,6 +86,7 @@ describe(`challenge-submitter`, () => {
     const obj: DBSubmitChallengeObjective = {
       type: 'SubmitChallenge',
       status: 'pending',
+      participants: [],
       objectiveId: ['SubmitChallenge', c.channelId].join('-'),
       data: {targetChannelId: c.channelId},
     };

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -242,6 +242,7 @@ function createPendingObjective(channelId: string): DBDefundChannelObjective {
   return {
     type: 'DefundChannel',
     status: 'pending',
+    participants: [],
     objectiveId: ['DefundChannel', channelId].join('-'),
     data: {targetChannelId: channelId},
   };

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -97,7 +97,7 @@ export function deserializeState(state: SignedStateWire): SignedState {
 }
 
 export function deserializeObjective(objective: ObjectiveWire): SharedObjective {
-  const participants = objective.participants?.map(p => ({
+  const participants = objective.participants.map(p => ({
     ...p,
     signingAddress: makeAddress(p.signingAddress),
     destination: makeDestination(p.destination)

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -89,7 +89,7 @@ export type SignedStateVariables = StateVariables & Signed;
 export type SignedStateVarsWithHash = SignedStateVariables & Hashed;
 
 type _Objective<Name, Data> = {
-  participants?: Participant[];
+  participants: Participant[];
   type: Name;
   data: Data;
 };

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -145,6 +145,7 @@
         }
       },
       "required": [
+        "participants",
         "type",
         "data"
       ],
@@ -177,6 +178,7 @@
         }
       },
       "required": [
+        "participants",
         "type",
         "data"
       ],
@@ -217,6 +219,7 @@
         }
       },
       "required": [
+        "participants",
         "type",
         "data"
       ],
@@ -249,6 +252,7 @@
         }
       },
       "required": [
+        "participants",
         "type",
         "data"
       ],
@@ -372,6 +376,7 @@
         }
       },
       "required": [
+        "participants",
         "type",
         "data"
       ],
@@ -534,6 +539,7 @@
         }
       },
       "required": [
+        "participants",
         "type",
         "data"
       ],

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -76,7 +76,7 @@ export interface SignedState {
 }
 
 type _Objective<Name, Data> = {
-  participants?: Participant[];
+  participants: Participant[];
   type: Name;
   data: Data;
 };


### PR DESCRIPTION
- it makes little sense to allow both undefined an an empty array
- greater certainty about properties makes type interconversion safer

I think there is a possibility that this property is entirely removed in future. This change will make that easier if we want to do it, and does not count as a vote for keeping the property. 

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
