### PR TITLE
Drop non variables when updating channels

### DIFF
--- a/packages/server-wallet/src/state-utils.ts
+++ b/packages/server-wallet/src/state-utils.ts
@@ -67,7 +67,7 @@ export function addState(
   if (existing) {
     existing.signatures = _.uniqBy([...existing.signatures, ...signatures], 'signature');
   } else {
-    ret.push(signedState);
+    ret.push(dropNonVariables(signedState));
   }
 
   return ret;


### PR DESCRIPTION
# Description
Drop non variables in "vars" field when updating a channel

Fixes issue #3241

1. what is the problem being solved
As stated in issue https://github.com/statechannels/statechannels/pull/3151

2. why this is a good approach
Ensure non variables are dropped each time a new state is added

3. what are the shortcomings of this approach, if any
N/A

