### PR TITLE
Do not rely on directFundingStatus internally

### DIFF
--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -424,7 +424,7 @@ export class Channel extends Model implements RequiredColumns {
   }
 
   // Does the channel have any funds that I can claim?
-  public get isPartlyDirectlyFunded(): boolean {
+  public get isPartlyDirectFunded(): boolean {
     return this.isDirectFunded();
   }
 

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -100,7 +100,7 @@ export class ChannelCloser {
 
     switch (ps.fundingStrategy) {
       case 'Direct':
-        if (!c.isPartlyDirectlyFunded) {
+        if (!c.isPartlyDirectFunded) {
           return true;
         }
         if (!c.chainServiceRequests.find(csr => csr.request === 'withdraw')?.isValid()) {

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -100,7 +100,7 @@ export class ChannelCloser {
 
     switch (ps.fundingStrategy) {
       case 'Direct':
-        if (c.protocolState.directFundingStatus === 'Defunded') {
+        if (!c.isPartlyDirectlyFunded) {
           return true;
         }
         if (!c.chainServiceRequests.find(csr => csr.request === 'withdraw')?.isValid()) {

--- a/packages/server-wallet/src/protocols/direct-funder.ts
+++ b/packages/server-wallet/src/protocols/direct-funder.ts
@@ -1,4 +1,4 @@
-import {Address, BN, checkThat, isSimpleAllocation, Uint256} from '@statechannels/wallet-core';
+import {Address, BN, checkThat, isSimpleAllocation} from '@statechannels/wallet-core';
 import _ from 'lodash';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
@@ -39,7 +39,7 @@ export class DirectFunder {
     tx: Transaction
   ): Promise<boolean> {
     const assetHolderAddress = this.assetHolder(channel);
-    const [targetBefore, targetAfter, targetTotal] = this.fundingMilestones(channel);
+    const [targetBefore, targetAfter, targetTotal] = channel.fundingMilestones;
 
     const currentFunding = await this.store.getFunding(channel.channelId, assetHolderAddress, tx);
     const currentAmount = currentFunding?.amount || 0;
@@ -78,43 +78,5 @@ export class DirectFunder {
     const {assetHolderAddress} = checkThat(supported?.outcome, isSimpleAllocation);
 
     return assetHolderAddress;
-  }
-
-  /**
-   * Returns a triple of balance [targetBefore, targetAfter, targetTotal], where
-   *  - targetBefore is the balance where I should start depositing
-   *  - targetAfter should be the balance where I stop depositing
-   *  - targetTotal is the total amount that should be in the channel
-   *
-   * @param channel
-   */
-  private fundingMilestones(channel: Channel): [Uint256, Uint256, Uint256] {
-    /**
-     * The below logic assumes:
-     *  1. Each destination occurs at most once.
-     *  2. We only care about a single destination.
-     * One reason to drop (2), for instance, is to support ledger top-ups with as few state updates as possible.
-     */
-    const supported = channel.supported;
-    if (!supported) {
-      throw new Error(`Channel passed to DriectFunder has no supported state`);
-    }
-
-    const myDestination = channel.participants[channel.myIndex].destination;
-    const {allocationItems} = checkThat(supported.outcome, isSimpleAllocation);
-
-    const myAllocationItem = _.find(allocationItems, ai => ai.destination === myDestination);
-    if (!myAllocationItem) {
-      throw new Error(`My destination ${myDestination} is not in allocations ${allocationItems}`);
-    }
-
-    const allocationsBefore = _.takeWhile(allocationItems, a => a.destination !== myDestination);
-    const targetBefore = allocationsBefore.map(a => a.amount).reduce(BN.add, BN.from(0));
-
-    const targetAfter = BN.add(targetBefore, myAllocationItem.amount);
-
-    const total = allocationItems.map(a => a.amount).reduce(BN.add, BN.from(0));
-
-    return [targetBefore, targetAfter, total];
   }
 }

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -65,7 +65,7 @@ export class LedgerFunder {
   ): Promise<boolean> {
     // for time being ledger must be a direct channel
     // TODO: in the future check "funding table"
-    if (!ledger.isDirectFunded) return false;
+    if (!ledger.isFullyDirectFunded) return false;
 
     // ledger is running
     if (!ledger.isRunning) return false;


### PR DESCRIPTION
`directFundingStatus` of `ChannelState` has likely outlived its usefulness. The original intention with `directFundingStatus` was to create a function that maps a channel + funding database state to a channel funding string.

We are seeing the channel opener and defunding protocols reimplement parts of the `directFundingStatus`. That's probably the right approach. This way we can build up smaller functions that can answer specific questions such as:
- Is this directly funded channel fully funded?
- Do I have any funds in this channel that I can claim?

This PR is working toward addressing https://github.com/statechannels/statechannels/issues/3124.

This PR is a refactor, so no additional tests have been added.