### PR TITLE
Unify defunding logic between Close and Defund protocols

### DIFF
--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -431,7 +431,7 @@ export class Channel extends Model implements RequiredColumns {
   private isDirectFunded(fully?: boolean): boolean {
     const outcome = this.supported?.outcome;
     if (!outcome) {
-      throw new Error(`Channel passed to isFullyDirectFunded has no supported state`);
+      throw new Error(`Channel passed to isDirectFunded has no supported state`);
     }
 
     const {assetHolderAddress, allocationItems} = checkThat(outcome, isSimpleAllocation);

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -29,6 +29,8 @@ import {Channel} from '../../models/channel';
 // TEST HELPERS
 // There are many test cases in this file. These helpers make the tests cases more readable.
 
+jest.setTimeout(10_000);
+
 type PreAllocationItem = [string | Fixture<Participant>, number];
 
 function allocationItem(preAllocationItem: PreAllocationItem): AllocationItem {

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -1,9 +1,4 @@
-import {
-  checkThat,
-  isSimpleAllocation,
-  StateVariables,
-  unreachable,
-} from '@statechannels/wallet-core';
+import {checkThat, isSimpleAllocation, StateVariables} from '@statechannels/wallet-core';
 import {Transaction} from 'knex';
 import {Logger} from 'pino';
 import {isExternalDestination} from '@statechannels/nitro-protocol';
@@ -15,6 +10,8 @@ import {WalletResponse} from '../wallet/wallet-response';
 import {Channel} from '../models/channel';
 import {LedgerRequest} from '../models/ledger-request';
 import {ChainServiceRequest} from '../models/chain-service-request';
+
+import {Defunder} from './defunder';
 
 export class ChannelCloser {
   constructor(
@@ -50,12 +47,19 @@ export class ChannelCloser {
           return;
         }
 
+        const defunder = Defunder.create(
+          this.store,
+          this.chainService,
+          this.logger,
+          this.timingMetrics
+        );
+
         if (!(await this.areAllFinalStatesSigned(channel, tx, response))) {
           response.queueChannel(channel);
           return;
         }
 
-        if (!(await this.isChannelDefunded(channel, tx))) {
+        if (!(await defunder.isChannelDefunded(channel, tx)).isChannelDefunded) {
           response.queueChannel(channel);
           return;
         }
@@ -93,38 +97,6 @@ export class ChannelCloser {
       return channel.hasConclusionProof;
     }
     return false;
-  }
-
-  private async isChannelDefunded(c: Channel, tx: Transaction): Promise<boolean> {
-    const {protocolState: ps} = c;
-
-    switch (ps.fundingStrategy) {
-      case 'Direct':
-        if (!c.isPartlyDirectFunded) {
-          return true;
-        }
-        if (!c.chainServiceRequests.find(csr => csr.request === 'withdraw')?.isValid()) {
-          await this.withdraw(c, tx);
-        }
-        return false;
-      case 'Ledger': {
-        const ledgerRequest = await this.store.getLedgerRequest(c.channelId, 'defund', tx);
-        if (ledgerRequest && ledgerRequest.status === 'succeeded') {
-          return true;
-        }
-        if (!ledgerRequest || ledgerRequest.status !== 'pending') {
-          await this.requestLedgerDefunding(c, tx);
-        }
-        return false;
-      }
-      case 'Unknown':
-      case 'Fake':
-        return true;
-      case 'Virtual':
-        throw new Error('Virtual channel defunding is not implemented');
-      default:
-        unreachable(ps.fundingStrategy);
-    }
   }
 
   private async signState(

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -57,7 +57,7 @@ export class ChannelCloser {
           return;
         }
 
-        if (!(await defunder.isChannelDefunded(channel, tx)).isChannelDefunded) {
+        if (!(await defunder.crank(channel, tx)).isChannelDefunded) {
           response.queueChannel(channel);
           return;
         }

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -8,8 +8,6 @@ import {ChainServiceInterface} from '../chain-service';
 import {DBCloseChannelObjective} from '../models/objective';
 import {WalletResponse} from '../wallet/wallet-response';
 import {Channel} from '../models/channel';
-import {LedgerRequest} from '../models/ledger-request';
-import {ChainServiceRequest} from '../models/chain-service-request';
 
 import {Defunder} from './defunder';
 
@@ -113,23 +111,6 @@ export class ChannelCloser {
     const vars: StateVariables = {...channel.supported, turnNum, isFinal: true};
     const signedState = await this.store.signState(channel, vars, tx);
     response.queueState(signedState, myIndex, channelId);
-  }
-
-  private async withdraw(channel: Channel, tx: Transaction): Promise<void> {
-    await ChainServiceRequest.insertOrUpdate(channel.channelId, 'withdraw', tx);
-
-    // supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
-    // Note, we are not awaiting transaction submission
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await this.chainService.concludeAndWithdraw([channel.supported!]);
-  }
-
-  private async requestLedgerDefunding(channel: Channel, tx: Transaction): Promise<void> {
-    await LedgerRequest.requestLedgerDefunding(
-      channel.channelId,
-      channel.fundingLedgerChannelId,
-      tx
-    );
   }
 
   private async completeObjective(

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -49,7 +49,7 @@ export class ChannelDefunder {
         this.chainService,
         this.logger,
         this.timingMetrics
-      ).isChannelDefunded(channel, tx);
+      ).crank(channel, tx);
 
       // A better methodology is likely to create a Challenge objective that succeeds after a
       // channel has been defunded (instead of succeeding an objective on transaction submission)

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -1,13 +1,11 @@
 import {Logger} from 'pino';
-import {makeAddress} from '@statechannels/wallet-core';
-import {BigNumber} from 'ethers';
 
 import {ChainServiceInterface} from '../chain-service';
-import {ChainServiceRequest} from '../models/chain-service-request';
-import {AdjudicatorStatusModel} from '../models/adjudicator-status';
 import {DBDefundChannelObjective} from '../models/objective';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
+
+import {Defunder} from './defunder';
 
 export class ChannelDefunder {
   constructor(
@@ -27,14 +25,15 @@ export class ChannelDefunder {
 
   public async crank(objective: DBDefundChannelObjective, response: WalletResponse): Promise<void> {
     const {targetChannelId: channelId} = objective.data;
-    await this.store.transaction(async tx => {
-      const channel = await this.store.getAndLockChannel(channelId, tx);
-
+    await this.store.lockApp(channelId, async (tx, channel) => {
       if (!channel) {
         this.logger.error(`No channel found for channel id ${channelId}`);
         await this.store.markObjectiveStatus(objective, 'failed', tx);
         return;
       }
+
+      await channel.$fetchGraph('funding', {transaction: tx});
+      await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
 
       if (channel.fundingStrategy !== 'Direct') {
         // TODO: https://github.com/statechannels/statechannels/issues/3124
@@ -43,28 +42,18 @@ export class ChannelDefunder {
         return;
       }
 
-      const result = await AdjudicatorStatusModel.getAdjudicatorStatus(tx, channelId);
+      const {didSubmitTransaction} = await Defunder.create(
+        this.store,
+        this.chainService,
+        this.logger,
+        this.timingMetrics
+      ).isChannelDefunded(channel, tx);
 
-      const channelHoldings =
-        channel.assetHolderAddress &&
-        (await this.store.getFunding(channelId, makeAddress(channel.assetHolderAddress), tx));
-
-      const outcomePushed = !channelHoldings || BigNumber.from(channelHoldings.amount).isZero();
-      if (result.channelMode === 'Finalized') {
-        if (!outcomePushed) {
-          await ChainServiceRequest.insertOrUpdate(channelId, 'pushOutcome', tx);
-          await this.chainService.pushOutcomeAndWithdraw(result.states[0], channel.myAddress);
-          await this.store.markObjectiveStatus(objective, 'succeeded', tx);
-          response.queueSucceededObjective(objective);
-        } else {
-          this.logger.trace('Outcome already pushed, doing nothing');
-        }
-      } else if (channel.hasConclusionProof) {
-        await ChainServiceRequest.insertOrUpdate(channelId, 'withdraw', tx);
-        await this.chainService.concludeAndWithdraw(channel.support);
-        objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+      // Note that that the objective succeeds regardless of whether the channel is defunded.
+      // This objetive will likey get replaced by a ChallengeObjective
+      if (didSubmitTransaction) {
+        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
         response.queueSucceededObjective(objective);
-        return;
       }
     });
   }

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -49,8 +49,8 @@ export class ChannelDefunder {
         this.timingMetrics
       ).isChannelDefunded(channel, tx);
 
-      // Note that that the objective succeeds regardless of whether the channel is defunded.
-      // This objetive will likey get replaced by a ChallengeObjective
+      // A better methodology is likely to create a Challenge objective that succeeds after a
+      // channel has been defunded (instead of succeeding an objective on transaction submission)
       if (didSubmitTransaction) {
         await this.store.markObjectiveStatus(objective, 'succeeded', tx);
         response.queueSucceededObjective(objective);

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -35,6 +35,8 @@ export class ChannelDefunder {
       await channel.$fetchGraph('funding', {transaction: tx});
       await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
 
+      // This if-statement should be removed and test cases should be added.
+      // Defund channel now (in theory) supports Ledger funded channels.
       if (channel.fundingStrategy !== 'Direct') {
         // TODO: https://github.com/statechannels/statechannels/issues/3124
         this.logger.error(`Only direct funding is currently supported.`);

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -67,9 +67,11 @@ export class Defunder {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'withdraw', tx);
 
       // supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
+      if (!channel.supported) {
+        throw new Error('channel.supported should be defined in directDefunder');
+      }
       // Note, we are not awaiting transaction submission
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      await this.chainService.concludeAndWithdraw([channel.supported!]);
+      await this.chainService.concludeAndWithdraw([channel.supported]);
       didSubmitTransaction = true;
     } else if (adjudicatorStatus.channelMode === 'Finalized') {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'pushOutcome', tx);

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -1,0 +1,101 @@
+import {unreachable} from '@statechannels/wallet-core';
+import {Transaction} from 'objection';
+import {Logger} from 'pino';
+
+import {ChainServiceInterface} from '../chain-service';
+import {AdjudicatorStatusModel} from '../models/adjudicator-status';
+import {ChainServiceRequest} from '../models/chain-service-request';
+import {Channel} from '../models/channel';
+import {LedgerRequest} from '../models/ledger-request';
+import {Store} from '../wallet/store';
+
+export type DefunderResult = {isChannelDefunded: boolean; didSubmitTransaction: boolean};
+
+export class Defunder {
+  constructor(
+    private store: Store,
+    private chainService: ChainServiceInterface,
+    private logger: Logger,
+    private timingMetrics = false
+  ) {}
+
+  public static create(
+    store: Store,
+    chainService: ChainServiceInterface,
+    logger: Logger,
+    timingMetrics = false
+  ): Defunder {
+    return new Defunder(store, chainService, logger, timingMetrics);
+  }
+
+  public async isChannelDefunded(channel: Channel, tx: Transaction): Promise<DefunderResult> {
+    const {protocolState: ps} = channel;
+
+    switch (ps.fundingStrategy) {
+      case 'Direct':
+        return await this.directDefunder(channel, tx);
+      case 'Ledger': {
+        const ledgerRequest = await this.store.getLedgerRequest(channel.channelId, 'defund', tx);
+        if (ledgerRequest && ledgerRequest.status === 'succeeded') {
+          return {isChannelDefunded: true, didSubmitTransaction: false};
+        }
+        if (!ledgerRequest || ledgerRequest.status !== 'pending') {
+          await this.requestLedgerDefunding(channel, tx);
+        }
+        return {isChannelDefunded: false, didSubmitTransaction: false};
+      }
+      case 'Unknown':
+      case 'Fake':
+        return {isChannelDefunded: true, didSubmitTransaction: false};
+      case 'Virtual':
+        throw new Error('Virtual channel defunding is not implemented');
+      default:
+        unreachable(ps.fundingStrategy);
+    }
+  }
+
+  private async directDefunder(channel: Channel, tx: Transaction): Promise<DefunderResult> {
+    if (channel.protocolState.directFundingStatus === 'Defunded') {
+      return {isChannelDefunded: true, didSubmitTransaction: false};
+    }
+
+    const hasValidRequest = ['withdraw', 'pushOutcome']
+      .map(requestType =>
+        channel.chainServiceRequests.find(csr => csr.request === requestType)?.isValid()
+      )
+      .some(val => val);
+    if (hasValidRequest) return {isChannelDefunded: false, didSubmitTransaction: false};
+
+    const adjudicatorStatus = await AdjudicatorStatusModel.getAdjudicatorStatus(
+      tx,
+      channel.channelId
+    );
+    let didSubmitTransaction = false;
+    if (adjudicatorStatus.channelMode !== 'Finalized' && channel.hasConclusionProof) {
+      await ChainServiceRequest.insertOrUpdate(channel.channelId, 'withdraw', tx);
+
+      // supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
+      // Note, we are not awaiting transaction submission
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      await this.chainService.concludeAndWithdraw([channel.supported!]);
+      didSubmitTransaction = true;
+    } else if (adjudicatorStatus.channelMode === 'Finalized') {
+      await ChainServiceRequest.insertOrUpdate(channel.channelId, 'pushOutcome', tx);
+      await this.chainService.pushOutcomeAndWithdraw(
+        adjudicatorStatus.states[0],
+        channel.myAddress
+      );
+      didSubmitTransaction = true;
+    }
+
+    return {isChannelDefunded: false, didSubmitTransaction};
+  }
+
+  private async requestLedgerDefunding(channel: Channel, tx: Transaction): Promise<void> {
+    await LedgerRequest.requestLedgerDefunding(
+      channel.channelId,
+      channel.fundingLedgerChannelId,
+      tx
+    );
+  }
+}

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -28,7 +28,7 @@ export class Defunder {
     return new Defunder(store, chainService, logger, timingMetrics);
   }
 
-  public async isChannelDefunded(channel: Channel, tx: Transaction): Promise<DefunderResult> {
+  public async crank(channel: Channel, tx: Transaction): Promise<DefunderResult> {
     const {protocolState: ps} = channel;
 
     switch (ps.fundingStrategy) {

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -55,7 +55,7 @@ export class Defunder {
   }
 
   private async directDefunder(channel: Channel, tx: Transaction): Promise<DefunderResult> {
-    if (channel.protocolState.directFundingStatus === 'Defunded') {
+    if (!channel.isPartlyDirectlyFunded) {
       return {isChannelDefunded: true, didSubmitTransaction: false};
     }
 

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -47,7 +47,7 @@ export class Defunder {
   }
 
   private async directDefunder(channel: Channel, tx: Transaction): Promise<DefunderResult> {
-    if (!channel.isPartlyDirectlyFunded) {
+    if (!channel.isPartlyDirectFunded) {
       return {isChannelDefunded: true, didSubmitTransaction: false};
     }
 


### PR DESCRIPTION
This PR creates a new `Defunder` class. The purpose of the class is to implement the `isChannelDefunded` function. The function is meant to operate as a cranker (and maybe should be renamed to `crank`?). This approach mimics the funding approach in channel opener.

CloseChannel and DefundChannel (and later ChallengeChannel) protocols share the `Defunder` class to make progress toward defunding a channel. The Defunder interprets the complete state of the channel (states signed and chain state) and attempts to take the next step in defunding the channel if such a step can be taken.

This PR is a refactor and has no additional tests. This PR is making progress toward https://github.com/statechannels/statechannels/issues/3124.