### PR TITLE
refactor: ObjectiveModel.insert returns a DBObjective

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -137,11 +137,11 @@ export class ObjectiveModel extends Model {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
     },
     tx: TransactionOrKnex
-  ): Promise<ObjectiveModel> {
+  ): Promise<DBObjective> {
     const id: string = objectiveId(objectiveToBeStored);
 
     return tx.transaction(async trx => {
-      const objective = await ObjectiveModel.query(trx).insert({
+      const model = await ObjectiveModel.query(trx).insert({
         objectiveId: id,
         status: objectiveToBeStored.status,
         type: objectiveToBeStored.type,
@@ -156,7 +156,7 @@ export class ObjectiveModel extends Model {
           ObjectiveChannelModel.query(trx).insert({objectiveId: id, channelId: value})
         )
       );
-      return objective;
+      return model.toObjective();
     });
   }
 


### PR DESCRIPTION
Currently, the various methods on `ObjectiveModel` have different return types: either a promise resolving to a`DBObjective` or to an `ObjectiveModel` instance. Most code in `store.ts` uses the former type, so it is far more convenient to return that. 

The current workarounds in the various `ensureObjective` functions involve preparing a `DBObjective`, `insert`ing it, and if success, returning the thing that was prepared beforehand. This PR moves to a model where the `insert` method accepts a type that may *not* be a `DBObjective`. Now in the `ensureObjective` functions, we simply return the result of `insert` if it succeeds. 

The reason for this alternative pattern is that we shortly intend to introduce timestamps to `DBObjectives`. If these timestamps are added at the data model layer, it isn't going to be possible to prepare a `DBObjective` before inserting. 

### Shortcomings
The current behaviour of returning the existing objective on a `UniqueViolationError` is preserved, at the cost of having another query in the error handler. This behaviour can be tidied up further in a future PR. 

This is preparatory work for #3230. 

## Changes 

1. ObjectiveModel.insert returns a DBObjective
2. `ensureFooObjective` functions have narrower return types
3.  `ensureFooObjective` functions are exported

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
