### PR TITLE
add objective timestamps

### DIFF
--- a/packages/server-wallet/src/db/migrations/20210126122745_add_objective_timestamp_columns.ts
+++ b/packages/server-wallet/src/db/migrations/20210126122745_add_objective_timestamp_columns.ts
@@ -1,0 +1,16 @@
+import * as Knex from 'knex';
+
+const tableName = 'objectives';
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('progress_last_made_at').defaultTo(knex.fn.now()).notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.dropColumn('created_at');
+    table.dropColumn('progress_last_made_at');
+  });
+}

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -61,11 +61,11 @@ describe('Objective > insert', () => {
     const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
-    const {updatedAt} = await ObjectiveModel.succeed(objectiveId, knex);
+    const {progressLastMadeAt} = await ObjectiveModel.succeed(objectiveId, knex);
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
-    expect(Date.parse(updatedAt) > before).toBe(true);
-    expect(Date.parse(updatedAt) < after).toBe(true);
+    expect(Date.parse(progressLastMadeAt) > before).toBe(true);
+    expect(Date.parse(progressLastMadeAt) < after).toBe(true);
   });
 });
 

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -18,7 +18,7 @@ const objective: OpenChannel = {
   },
 };
 beforeEach(async () => {
-  await seedAlicesSigningWallet(knex);
+  await seedAlicesSigningWallet(knex); // this also truncates
 });
 
 describe('Objective > insert', () => {
@@ -43,6 +43,29 @@ describe('Objective > insert', () => {
     expect(await ObjectiveChannelModel.query(knex).select()).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`, channelId: c.channelId},
     ]);
+  });
+
+  it('inserts an objective with a createdAt timestamp', async () => {
+    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+
+    const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
+    const {createdAt} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
+
+    expect(Date.parse(createdAt) > before).toBe(true);
+    expect(Date.parse(createdAt) < after).toBe(true);
+  });
+
+  it('updates the timestamp on an objective when it succeeds', async () => {
+    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+
+    const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
+    const {updatedAt} = await ObjectiveModel.succeed(objectiveId, knex);
+    const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
+
+    expect(Date.parse(updatedAt) > before).toBe(true);
+    expect(Date.parse(updatedAt) < after).toBe(true);
   });
 });
 

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -56,12 +56,12 @@ describe('Objective > insert', () => {
     expect(Date.parse(createdAt) < after).toBe(true);
   });
 
-  it('updates the timestamp on an objective when it succeeds', async () => {
+  it('updates the progressLastMadeAt timestamp on an objective when progressMade is called', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
     const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
-    const {progressLastMadeAt} = await ObjectiveModel.succeed(objectiveId, knex);
+    const {progressLastMadeAt} = await ObjectiveModel.progressMade(objectiveId, knex);
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
     expect(Date.parse(progressLastMadeAt) > before).toBe(true);

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -63,7 +63,9 @@ export type ComputedColumns = {
   readonly channelId: Bytes32;
 };
 
-export class Channel extends Model implements RequiredColumns {
+type ChannelColumns = RequiredColumns & ComputedColumns;
+
+export class Channel extends Model implements ChannelColumns {
   readonly id!: number;
 
   channelId!: Bytes32;

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -9,6 +9,7 @@ import {
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
+import {time} from 'console';
 
 function extractReferencedChannels(objective: Objective): string[] {
   switch (objective.type) {
@@ -172,6 +173,14 @@ export class ObjectiveModel extends Model {
     return ObjectiveModel.query(tx)
       .findById(objectiveId)
       .patch({status: 'failed'})
+      .returning('*')
+      .first();
+  }
+
+  static async progressMade(objectiveId: string, tx: TransactionOrKnex): Promise<ObjectiveModel> {
+    return ObjectiveModel.query(tx)
+      .findById(objectiveId)
+      .patch({progressLastMadeAt: new Date().toISOString()})
       .returning('*')
       .first();
   }

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -6,7 +6,6 @@ import {
   SharedObjective,
   SubmitChallenge,
   DefundChannel,
-  Participant,
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
@@ -31,31 +30,17 @@ function extractReferencedChannels(objective: Objective): string[] {
 
 type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
 
-/**
- * Objectives that are currently supported by the server wallet (wire format)
- */
-export type SupportedWireObjective = OpenChannel | CloseChannel;
-
-export type DBOpenChannelObjective = OpenChannel & {objectiveId: string; status: ObjectiveStatus};
-export type DBCloseChannelObjective = CloseChannel & {
+type WalletObjective<O extends Objective> = O & {
   objectiveId: string;
   status: ObjectiveStatus;
-};
-export type DBDefundChannelObjective = {
-  type: 'DefundChannel';
-  participants: Participant[];
-  objectiveId: string;
-  status: ObjectiveStatus;
-  data: {targetChannelId: string};
+  createdAt: string;
+  progressLastMadeAt: string;
 };
 
-export type DBSubmitChallengeObjective = {
-  data: {targetChannelId: string};
-  participants: Participant[];
-  objectiveId: string;
-  status: ObjectiveStatus;
-  type: 'SubmitChallenge';
-};
+export type DBOpenChannelObjective = WalletObjective<OpenChannel>;
+export type DBCloseChannelObjective = WalletObjective<CloseChannel>;
+export type DBDefundChannelObjective = WalletObjective<DefundChannel>;
+export type DBSubmitChallengeObjective = WalletObjective<SubmitChallenge>;
 
 export function isSharedObjective(
   objective: DBObjective
@@ -63,11 +48,14 @@ export function isSharedObjective(
   return objective.type === 'OpenChannel' || objective.type === 'CloseChannel';
 }
 
+type SupportedObjective = OpenChannel | CloseChannel | SubmitChallenge | DefundChannel;
 /**
- * A DBObjective is a wire objective with a status and an objectiveId
+ * A DBObjective is a wire objective with a status, timestamps and an objectiveId
  *
  * Limited to 'OpenChannel', 'CloseChannel', 'SubmitChallenge' and 'DefundChannel' which are the only objectives
  * that are currently supported by the server wallet
+ *
+ * TODO: rename to WalletObjective
  */
 export type DBObjective =
   | DBOpenChannelObjective
@@ -103,6 +91,8 @@ export class ObjectiveModel extends Model {
   readonly status!: DBObjective['status'];
   readonly type!: DBObjective['type'];
   readonly data!: DBObjective['data'];
+  createdAt!: string;
+  progressLastMadeAt!: string;
 
   static tableName = 'objectives';
   static get idColumn(): string[] {
@@ -133,7 +123,7 @@ export class ObjectiveModel extends Model {
   }
 
   static async insert(
-    objectiveToBeStored: (SupportedWireObjective | SubmitChallenge | DefundChannel) & {
+    objectiveToBeStored: SupportedObjective & {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
     },
     tx: TransactionOrKnex
@@ -146,6 +136,8 @@ export class ObjectiveModel extends Model {
         status: objectiveToBeStored.status,
         type: objectiveToBeStored.type,
         data: objectiveToBeStored.data,
+        createdAt: new Date().toISOString(),
+        progressLastMadeAt: new Date().toISOString(),
       });
 
       // Associate the objective with any channel that it references

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -9,7 +9,6 @@ import {
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
-import {time} from 'console';
 
 function extractReferencedChannels(objective: Objective): string[] {
   switch (objective.type) {

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -137,11 +137,11 @@ export class ObjectiveModel extends Model {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
     },
     tx: TransactionOrKnex
-  ): Promise<ObjectiveModel> {
+  ): Promise<DBObjective> {
     const id: string = objectiveId(objectiveToBeStored);
 
     return tx.transaction(async trx => {
-      const objective = await ObjectiveModel.query(trx).insert({
+      const model = await ObjectiveModel.query(trx).insert({
         objectiveId: id,
         status: objectiveToBeStored.status,
         type: objectiveToBeStored.type,
@@ -156,7 +156,7 @@ export class ObjectiveModel extends Model {
           ObjectiveChannelModel.query(trx).insert({objectiveId: id, channelId: value})
         )
       );
-      return objective;
+      return model.toObjective();
     });
   }
 

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -245,5 +245,7 @@ function createPendingObjective(channelId: string): DBDefundChannelObjective {
     participants: [],
     objectiveId: ['DefundChannel', channelId].join('-'),
     data: {targetChannelId: channelId},
+    createdAt: new Date().toISOString(),
+    progressLastMadeAt: new Date().toISOString(),
   };
 }

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -5,7 +5,7 @@ import {DBAdmin} from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {Channel} from '../../models/channel';
-import {ObjectiveModel} from '../../models/objective';
+import {DBObjective, ObjectiveModel} from '../../models/objective';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {alice, bob} from './fixtures/signing-wallets';
@@ -93,7 +93,7 @@ it('creates a defundChannel objective on channel finalized', async () => {
   const objectiveId = `DefundChannel-${c.channelId}`;
   const objective = await ObjectiveModel.forId(objectiveId, w.knex);
 
-  expect(objective).toEqual({
+  expect(objective).toEqual<DBObjective>({
     objectiveId,
     status: 'approved',
     type: 'DefundChannel',
@@ -101,6 +101,8 @@ it('creates a defundChannel objective on channel finalized', async () => {
       targetChannelId: c.channelId,
     },
     participants: [],
+    createdAt: expect.anything(),
+    progressLastMadeAt: expect.anything(),
   });
 });
 


### PR DESCRIPTION
Add a `createdAt` and `progressLastMadeAt` columns to the `objectives` table. Does not add any methods to query these fields, yet (the next PR in this stack does that #3264). Towards #3230.

 **what is the problem being solved**
The app requires a means to detect inactivity on an ongoing objective, so that it can i) try and synchronize data with peers to get the objective going again or ii) launch a challenge to recover funds. This first step installs a location for the wallet to store the data required to track objective progress. 
**why this is a good approach**
The most important timestamp here is the `progressLastMadeAt`. If this timestamp is long enough ago (let's say, 10x the expected network latency), then this is a very strong indication that the objective will no longer progress and a different course of action is needed. 
**what are the shortcomings of this approach, if any**
- This mechanism will not cover inactivity in running app channels, as they are not to be governed by objectives. We may or may not want a similar solution for detecting that. 
- This `progressLastMadeAt` soluition requires us to think harder and write more code around when "progress has been made", compared to alternative approaches.  See #3264. Alternatives I considered were:

### `updatedAt` 
This could be managed directly by the database, and would update automatically when a row was patched. The downside is that the objective does not really contain any information (aside from a `status`) that tells us about it's lifecycle. The information is actually stored in other DB tables such as `channels`. (i.e. the channels in the scope of the objective).

### `lastCrankedAt`
This seems much better as a column on the  `objectives` table, and would also be quite easy to decide when to update it (we already have code that finds relevant objectives when the runloop is triggered, and cranks them). The downside here, in my opinion, is that we can crank and make no progress. For example: my counterparty is relentlessly sending me old states, and my objective keeps getting cranked, but no progress is made. While this is not indicative of inactivity, it likely still requires some action to be taken.


## How Has This Been Tested?
Test coverage was increased to cover timestamps. I have done this in a fuzzy way, expecting timestamps to lie in a 2 second window either side of the database query. This window is very large and the test is probably over permissive as a result. I could add a few-second delay to the test to ensure the `createdAt` and `progressLastMadeAt` stamps are further apart.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
