### PR TITLE
update progress (conditionally) during objective cranking

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -293,6 +293,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     destroy(): Promise<void>;
     getChannels(): Promise<MultipleChannelOutput>;
     getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
+    getObjective(objectiveId: string): Promise<DBObjective>;
     getSigningAddress(): Promise<Address>;
     getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts

--- a/packages/server-wallet/src/db/migrations/20210126122745_add_objective_timestamp_columns.ts
+++ b/packages/server-wallet/src/db/migrations/20210126122745_add_objective_timestamp_columns.ts
@@ -1,0 +1,16 @@
+import * as Knex from 'knex';
+
+const tableName = 'objectives';
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('progress_last_made_at').defaultTo(knex.fn.now()).notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.dropColumn('created_at');
+    table.dropColumn('progress_last_made_at');
+  });
+}

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -61,11 +61,11 @@ describe('Objective > insert', () => {
     const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
-    const {updatedAt} = await ObjectiveModel.succeed(objectiveId, knex);
+    const {progressLastMadeAt} = await ObjectiveModel.succeed(objectiveId, knex);
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
-    expect(Date.parse(updatedAt) > before).toBe(true);
-    expect(Date.parse(updatedAt) < after).toBe(true);
+    expect(Date.parse(progressLastMadeAt) > before).toBe(true);
+    expect(Date.parse(progressLastMadeAt) < after).toBe(true);
   });
 });
 

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -18,7 +18,7 @@ const objective: OpenChannel = {
   },
 };
 beforeEach(async () => {
-  await seedAlicesSigningWallet(knex);
+  await seedAlicesSigningWallet(knex); // this also truncates
 });
 
 describe('Objective > insert', () => {
@@ -43,6 +43,29 @@ describe('Objective > insert', () => {
     expect(await ObjectiveChannelModel.query(knex).select()).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`, channelId: c.channelId},
     ]);
+  });
+
+  it('inserts an objective with a createdAt timestamp', async () => {
+    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+
+    const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
+    const {createdAt} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
+
+    expect(Date.parse(createdAt) > before).toBe(true);
+    expect(Date.parse(createdAt) < after).toBe(true);
+  });
+
+  it('updates the timestamp on an objective when it succeeds', async () => {
+    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+
+    const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
+    const {updatedAt} = await ObjectiveModel.succeed(objectiveId, knex);
+    const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
+
+    expect(Date.parse(updatedAt) > before).toBe(true);
+    expect(Date.parse(updatedAt) < after).toBe(true);
   });
 });
 

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -56,12 +56,12 @@ describe('Objective > insert', () => {
     expect(Date.parse(createdAt) < after).toBe(true);
   });
 
-  it('updates the timestamp on an objective when it succeeds', async () => {
+  it('updates the progressLastMadeAt timestamp on an objective when progressMade is called', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
     const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
-    const {progressLastMadeAt} = await ObjectiveModel.succeed(objectiveId, knex);
+    const {progressLastMadeAt} = await ObjectiveModel.progressMade(objectiveId, knex);
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
     expect(Date.parse(progressLastMadeAt) > before).toBe(true);

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -63,7 +63,9 @@ export type ComputedColumns = {
   readonly channelId: Bytes32;
 };
 
-export class Channel extends Model implements RequiredColumns {
+type ChannelColumns = RequiredColumns & ComputedColumns;
+
+export class Channel extends Model implements ChannelColumns {
   readonly id!: number;
 
   channelId!: Bytes32;

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -9,6 +9,7 @@ import {
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
+import {time} from 'console';
 
 function extractReferencedChannels(objective: Objective): string[] {
   switch (objective.type) {
@@ -172,6 +173,14 @@ export class ObjectiveModel extends Model {
     return ObjectiveModel.query(tx)
       .findById(objectiveId)
       .patch({status: 'failed'})
+      .returning('*')
+      .first();
+  }
+
+  static async progressMade(objectiveId: string, tx: TransactionOrKnex): Promise<ObjectiveModel> {
+    return ObjectiveModel.query(tx)
+      .findById(objectiveId)
+      .patch({progressLastMadeAt: new Date().toISOString()})
       .returning('*')
       .first();
   }

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -6,7 +6,6 @@ import {
   SharedObjective,
   SubmitChallenge,
   DefundChannel,
-  Participant,
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
@@ -31,31 +30,17 @@ function extractReferencedChannels(objective: Objective): string[] {
 
 type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
 
-/**
- * Objectives that are currently supported by the server wallet (wire format)
- */
-export type SupportedWireObjective = OpenChannel | CloseChannel;
-
-export type DBOpenChannelObjective = OpenChannel & {objectiveId: string; status: ObjectiveStatus};
-export type DBCloseChannelObjective = CloseChannel & {
+type WalletObjective<O extends Objective> = O & {
   objectiveId: string;
   status: ObjectiveStatus;
-};
-export type DBDefundChannelObjective = {
-  type: 'DefundChannel';
-  participants: Participant[];
-  objectiveId: string;
-  status: ObjectiveStatus;
-  data: {targetChannelId: string};
+  createdAt: string;
+  progressLastMadeAt: string;
 };
 
-export type DBSubmitChallengeObjective = {
-  data: {targetChannelId: string};
-  participants: Participant[];
-  objectiveId: string;
-  status: ObjectiveStatus;
-  type: 'SubmitChallenge';
-};
+export type DBOpenChannelObjective = WalletObjective<OpenChannel>;
+export type DBCloseChannelObjective = WalletObjective<CloseChannel>;
+export type DBDefundChannelObjective = WalletObjective<DefundChannel>;
+export type DBSubmitChallengeObjective = WalletObjective<SubmitChallenge>;
 
 export function isSharedObjective(
   objective: DBObjective
@@ -63,11 +48,14 @@ export function isSharedObjective(
   return objective.type === 'OpenChannel' || objective.type === 'CloseChannel';
 }
 
+type SupportedObjective = OpenChannel | CloseChannel | SubmitChallenge | DefundChannel;
 /**
- * A DBObjective is a wire objective with a status and an objectiveId
+ * A DBObjective is a wire objective with a status, timestamps and an objectiveId
  *
  * Limited to 'OpenChannel', 'CloseChannel', 'SubmitChallenge' and 'DefundChannel' which are the only objectives
  * that are currently supported by the server wallet
+ *
+ * TODO: rename to WalletObjective
  */
 export type DBObjective =
   | DBOpenChannelObjective
@@ -103,6 +91,8 @@ export class ObjectiveModel extends Model {
   readonly status!: DBObjective['status'];
   readonly type!: DBObjective['type'];
   readonly data!: DBObjective['data'];
+  createdAt!: string;
+  progressLastMadeAt!: string;
 
   static tableName = 'objectives';
   static get idColumn(): string[] {
@@ -133,7 +123,7 @@ export class ObjectiveModel extends Model {
   }
 
   static async insert(
-    objectiveToBeStored: (SupportedWireObjective | SubmitChallenge | DefundChannel) & {
+    objectiveToBeStored: SupportedObjective & {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
     },
     tx: TransactionOrKnex
@@ -146,6 +136,8 @@ export class ObjectiveModel extends Model {
         status: objectiveToBeStored.status,
         type: objectiveToBeStored.type,
         data: objectiveToBeStored.data,
+        createdAt: new Date().toISOString(),
+        progressLastMadeAt: new Date().toISOString(),
       });
 
       // Associate the objective with any channel that it references

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -9,7 +9,6 @@ import {
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
-import {time} from 'console';
 
 function extractReferencedChannels(objective: Objective): string[] {
   switch (objective.type) {

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -137,11 +137,11 @@ export class ObjectiveModel extends Model {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
     },
     tx: TransactionOrKnex
-  ): Promise<ObjectiveModel> {
+  ): Promise<DBObjective> {
     const id: string = objectiveId(objectiveToBeStored);
 
     return tx.transaction(async trx => {
-      const objective = await ObjectiveModel.query(trx).insert({
+      const model = await ObjectiveModel.query(trx).insert({
         objectiveId: id,
         status: objectiveToBeStored.status,
         type: objectiveToBeStored.type,
@@ -156,7 +156,7 @@ export class ObjectiveModel extends Model {
           ObjectiveChannelModel.query(trx).insert({objectiveId: id, channelId: value})
         )
       );
-      return objective;
+      return model.toObjective();
     });
   }
 

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -245,5 +245,7 @@ function createPendingObjective(channelId: string): DBDefundChannelObjective {
     participants: [],
     objectiveId: ['DefundChannel', channelId].join('-'),
     data: {targetChannelId: channelId},
+    createdAt: new Date().toISOString(),
+    progressLastMadeAt: new Date().toISOString(),
   };
 }

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import {Transaction} from 'knex';
 
 import {Store} from '../wallet/store';
-import {DBOpenChannelObjective} from '../models/objective';
+import {DBOpenChannelObjective, ObjectiveModel} from '../models/objective';
 import {WalletResponse} from '../wallet/wallet-response';
 import {ChainServiceInterface} from '../chain-service';
 import {Channel} from '../models/channel';
@@ -42,6 +42,7 @@ export class ChannelOpener {
       // if we haven't signed the pre-fund, sign it
       if (!channel.prefundSigned) {
         await this.signPrefundSetup(channel, response, tx);
+        await ObjectiveModel.progressMade(objective.objectiveId, tx);
       }
 
       // if we don't have a supported preFundSetup, we're done for now
@@ -57,6 +58,7 @@ export class ChannelOpener {
       // if the channel is funded and I haven't signed the post-fund, sign it
       if (funded && !channel.postfundSigned) {
         await this.signPostfundSetup(channel, response, tx);
+        await ObjectiveModel.progressMade(objective.objectiveId, tx);
       }
 
       if (channel.postfundSupported) {

--- a/packages/server-wallet/src/protocols/direct-funder.ts
+++ b/packages/server-wallet/src/protocols/direct-funder.ts
@@ -6,7 +6,7 @@ import {Logger} from 'pino';
 import {ChainServiceInterface} from '../chain-service';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {Channel} from '../models/channel';
-import {DBOpenChannelObjective} from '../models/objective';
+import {DBOpenChannelObjective, ObjectiveModel} from '../models/objective';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
 
@@ -65,6 +65,7 @@ export class DirectFunder {
       expectedHeld: BN.from(currentAmount),
       amount: BN.from(amountToDeposit),
     });
+    await ObjectiveModel.progressMade(objective.objectiveId, tx);
 
     return false;
   }

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -6,7 +6,7 @@ import {Logger} from 'pino';
 import {ChainServiceInterface} from '../chain-service';
 import {Channel} from '../models/channel';
 import {LedgerRequest} from '../models/ledger-request';
-import {DBOpenChannelObjective} from '../models/objective';
+import {DBOpenChannelObjective, ObjectiveModel} from '../models/objective';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
 
@@ -55,6 +55,7 @@ export class LedgerFunder {
 
     // otherwise request funding
     await this.requestLedgerFunding(channel.channelId, ledgerId, tx);
+    await ObjectiveModel.progressMade(objective.objectiveId, tx);
     return false;
   }
 

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -5,7 +5,7 @@ import {DBAdmin} from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {Channel} from '../../models/channel';
-import {ObjectiveModel} from '../../models/objective';
+import {DBObjective, ObjectiveModel} from '../../models/objective';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {alice, bob} from './fixtures/signing-wallets';
@@ -93,7 +93,7 @@ it('creates a defundChannel objective on channel finalized', async () => {
   const objectiveId = `DefundChannel-${c.channelId}`;
   const objective = await ObjectiveModel.forId(objectiveId, w.knex);
 
-  expect(objective).toEqual({
+  expect(objective).toEqual<DBObjective>({
     objectiveId,
     status: 'approved',
     type: 'DefundChannel',
@@ -101,6 +101,8 @@ it('creates a defundChannel objective on channel finalized', async () => {
       targetChannelId: c.channelId,
     },
     participants: [],
+    createdAt: expect.anything(),
+    progressLastMadeAt: expect.anything(),
   });
 });
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -58,6 +58,7 @@ import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
 import {SingleAppUpdater} from '../handlers/single-app-updater';
 import {LedgerManager} from '../protocols/ledger-manager';
+import {DBObjective} from '../models/objective';
 
 import {Store, AppHandler, MissingAppHandler} from './store';
 import {
@@ -69,7 +70,6 @@ import {
   WalletEvent,
 } from './types';
 import {WalletResponse} from './wallet-response';
-import {DBObjective} from '../models/objective';
 
 // TODO: The client-api does not currently allow for outgoing messages to be
 // declared as the result of a wallet API call.

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -69,6 +69,7 @@ import {
   WalletEvent,
 } from './types';
 import {WalletResponse} from './wallet-response';
+import {DBObjective} from '../models/objective';
 
 // TODO: The client-api does not currently allow for outgoing messages to be
 // declared as the result of a wallet API call.
@@ -742,6 +743,15 @@ export class SingleThreadedWallet
     channelStates.forEach(cs => response.queueChannelState(cs));
 
     return response.multipleChannelOutput();
+  }
+
+  /**
+   * Gets the objective for a given id.
+   *
+   * @returns A promise that resolves to a DBObjective, with a progressLastMadeAt timestamp
+   */
+  async getObjective(objectiveId: string): Promise<DBObjective> {
+    return this.store.getObjective(objectiveId);
   }
 
   /**


### PR DESCRIPTION
Examine each cranking function and manually progress each objective's timestamp where necessary. 

Follows on from #3263 

