### PR TITLE
enhance:createdb - don't error out if db already exists

### DIFF
--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -32,7 +32,13 @@ export class DBAdmin {
    * @param config The wallet configuration object with a database specified
    */
   static async createDatabase(config: IncomingServerWalletConfig): Promise<void> {
-    await exec(`createdb ${getDbNameFromConfig(config)} $PSQL_ARGS`);
+    try {
+      await exec(`createdb ${getDbNameFromConfig(config)} $PSQL_ARGS`);
+    } catch (e) {
+      if (!(e.stderr && e.stderr.includes(' already exists'))) {
+        throw e;
+      } // ignore error if db already exists
+    }
   }
 
   /**


### PR DESCRIPTION
# Description
Make "createdb" more robust by avoiding throwing fatal error if db already exists

Then, following a single blank line, a summary of the change and which issue is fixed, including 
- [ ] what is the problem being solved
UT repeatedly create "TEST_A" and "TEST_B", if one fails to clean up somehow, it will fail all future test case
- [ ] why this is a good approach
If db already exists then no good to recreate it regardless
- [ ] what are the shortcomings of this approach, if any
We yet don't know how DB destroy failed but it can be due to process killed while running.

