### PR TITLE
test: detect resource deadlocks caused by starved transaction pool

### DIFF
--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -1,17 +1,36 @@
 import {configureEnvVariables} from '@statechannels/devtools';
 import Knex from 'knex';
 import _ from 'lodash';
-import {DBAdmin} from '../src/db-admin/db-admin'
+import {DBAdmin} from '../src/db-admin/db-admin';
 
 configureEnvVariables();
 
-import {extractDBConfigFromServerWalletConfig, defaultTestConfig} from '../src/config';
+import {
+  extractDBConfigFromServerWalletConfig,
+  defaultTestConfig,
+  DatabaseConfiguration,
+} from '../src/config';
 
+const constructedKnexs: Knex[] = []
+
+/**
+ * 
+ * @param databaseConfiguration 
+ * 
+ * returns a knex instance which is automatically destroyed after all jest tests have run
+ */
+export let constructKnex = (databaseConfiguration: Partial<DatabaseConfiguration>): Knex =>
+  {
+    const knex = Knex(extractDBConfigFromServerWalletConfig(defaultTestConfig({databaseConfiguration})));
+    constructedKnexs.push(knex)
+
+    return knex
+  }
 
 export let testKnex: Knex;
 
 beforeAll(async () => {
-  testKnex = Knex(extractDBConfigFromServerWalletConfig(defaultTestConfig()));
+  testKnex = constructKnex({});
   await DBAdmin.truncateDataBaseFromKnex(testKnex);
 });
 
@@ -19,5 +38,5 @@ afterAll(async () => {
   // We need to close the db connection after the test suite has run.
   // Otherwise, jest will not exit within the required one second after the test
   // suite has finished
-  await testKnex.destroy();
+  await Promise.all(constructedKnexs.map(async knex => knex.destroy()))
 });

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -76,6 +76,7 @@ export const defaultTestConfig = (
         database: DEFAULT_DB_NAME,
         user: DEFAULT_DB_USER,
       },
+      pool: {min: 0, max: 1},
     },
   };
   return _.merge({}, fullDefaultConfig, partialConfig);

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -76,6 +76,9 @@ export const defaultTestConfig = (
         database: DEFAULT_DB_NAME,
         user: DEFAULT_DB_USER,
       },
+      // DO NOT CHANGE DEFAULTS.
+      // `max: 1` is required to detect deadlocks caused by application code that attempts
+      // to acquire a new connection before the connection serving the transaction is released
       pool: {min: 0, max: 1},
     },
   };

--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -51,28 +51,23 @@ describe('validation', () => {
 describe('fundingStatus', () => {
   it("should be undefined if funding wasn't fetched from db", async () => {
     const c1 = channel({vars: [stateWithHashSignedBy()()]});
-    await Channel.transaction(knex, async tx => {
-      const {channelId} = await Channel.query(tx).insert(c1);
-      await Funding.updateFunding(tx, channelId, '0x0a', makeAddress(constants.AddressZero));
-    });
+    const {channelId} = await Channel.query(knex).insert(c1);
+    await Funding.updateFunding(knex, channelId, '0x0a', makeAddress(constants.AddressZero));
 
-    await Channel.transaction(knex, async () => {
+    {
       const channel = await Channel.query(knex).first();
-
       expect(channel.channelResult.fundingStatus).toBeUndefined();
-    });
+    }
   });
+
   it('should not be undefined if funding was fetched from db', async () => {
     const c1 = channel({vars: [stateWithHashSignedBy()()]});
-    await Channel.transaction(knex, async tx => {
-      const {channelId} = await Channel.query(tx).insert(c1);
-      await Funding.updateFunding(tx, channelId, '0x0a', makeAddress(constants.AddressZero));
-    });
+    const {channelId} = await Channel.query(knex).insert(c1);
+    await Funding.updateFunding(knex, channelId, '0x0a', makeAddress(constants.AddressZero));
 
-    await Channel.transaction(knex, async () => {
+    {
       const channel = await Channel.query(knex).withGraphJoined('funding').first();
-
       expect(channel.channelResult.fundingStatus).not.toBeUndefined();
-    });
+    }
   });
 });

--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -38,30 +38,6 @@ it('does not store extraneous fields in the variables property', async () => {
   });
 });
 
-it('can insert multiple channels instances within a transaction', async () => {
-  const c1 = channel({vars: [stateWithHashSignedBy()()]});
-  const c2 = channel({
-    channelNonce: 1234,
-    vars: [stateWithHashSignedBy()({channelNonce: 1234})],
-  });
-
-  await Channel.transaction(knex, async tx => {
-    await Channel.query(tx).insert(c1);
-
-    expect(await Channel.query(tx).select()).toHaveLength(1);
-
-    await Channel.query(tx).insert(c2);
-    expect(await Channel.query(tx).select()).toHaveLength(2);
-
-    // You can query the DB outside of this transaction,
-    // where the channels have not yet been committed
-    expect(await Channel.query(knex).select()).toHaveLength(0);
-  });
-
-  // The transaction has been committed. Two channels were stored.
-  expect(await Channel.query(knex).select()).toHaveLength(2);
-});
-
 describe('validation', () => {
   it('throws when inserting a model where the channelId is inconsistent', () =>
     expect(

--- a/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/add-my-state.test.ts
@@ -1,7 +1,4 @@
-import Objection from 'objection';
-
 import {Store} from '../store';
-import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
 import {channel} from '../../models/__test__/fixtures/channel';
@@ -21,14 +18,6 @@ beforeAll(async () => {
 });
 
 describe('addSignedState', () => {
-  let tx: Objection.Transaction;
-
-  afterEach(async () => tx.rollback());
-
-  beforeEach(async () => {
-    tx = await Channel.startTransaction(knex);
-  });
-
   it('throws when the signer is not me', async () => {
     const stateSignedByBob = stateWithHashSignedBy([bob()])();
     const channelWithAliceAsSigner = channel();

--- a/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sign-state.test.ts
@@ -4,13 +4,14 @@ import {Store} from '../store';
 import {channel} from '../../models/__test__/fixtures/channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../../models/channel';
-import {testKnex as knex} from '../../../jest/knex-setup-teardown';
+import {constructKnex} from '../../../jest/knex-setup-teardown';
 import {defaultTestConfig} from '../../config';
 import {signState} from '../../utilities/signatures';
 
 import {stateWithHashSignedBy} from './fixtures/states';
 import {bob, alice} from './fixtures/signing-wallets';
 
+const knex = constructKnex({pool: {max: 2}});
 let tx: Objection.Transaction;
 
 let store: Store;


### PR DESCRIPTION
One way of introducing deadlocks is to
1. ask for a connection c1 (eg. when starting a transaction)
2. as a blocking step before releasing c1, asking for another connection c2

When your connection pool has size n, this obviously creates deadlocks when n async functions execute 1 before any of them execute 2.

With this change, code with this pattern will time out when running unit tests.'
