### PR TITLE
Add unit tests for channel model funding getters

### DIFF
--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -149,19 +149,19 @@ describe('Channel funding', () => {
       funds: 0,
     });
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
-    expect(testChannel.isPartlyDirectlyFunded).toEqual(false);
+    expect(testChannel.isPartlyDirectFunded).toEqual(false);
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
     await store.updateFunding(testChannel.channelId, BN.from(1), testChannelObj.assetHolderAddress);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
-    expect(testChannel.isPartlyDirectlyFunded).toEqual(true);
+    expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
     await store.updateFunding(testChannel.channelId, BN.from(8), testChannelObj.assetHolderAddress);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
-    expect(testChannel.isPartlyDirectlyFunded).toEqual(true);
+    expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(true);
   });
 
@@ -172,19 +172,19 @@ describe('Channel funding', () => {
       funds: 5,
     });
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
-    expect(testChannel.isPartlyDirectlyFunded).toEqual(false);
+    expect(testChannel.isPartlyDirectFunded).toEqual(false);
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
     await store.updateFunding(testChannel.channelId, BN.from(6), testChannelObj.assetHolderAddress);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
-    expect(testChannel.isPartlyDirectlyFunded).toEqual(true);
+    expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
     await store.updateFunding(testChannel.channelId, BN.from(8), testChannelObj.assetHolderAddress);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
-    expect(testChannel.isPartlyDirectlyFunded).toEqual(true);
+    expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(true);
   });
 });

--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -142,7 +142,7 @@ describe('Channel funding', () => {
     compareMilestones(testChannel.fundingMilestones, [5, 8, 8]);
   });
 
-  it('Check funding for A', async () => {
+  it('returns the correct funding status for the first participant', async () => {
     await testChannelObj.insertInto(store, {
       participant: 0,
       states: [0, 1],


### PR DESCRIPTION
These functions were added in #3256.

This work follows #3267.