### PR TITLE
Objective timestamps are now treated consistently as a Date type.

### DIFF
--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -22,6 +22,13 @@ beforeEach(async () => {
 });
 
 describe('Objective > insert', () => {
+  it('returns an objective with Date types for timestamps', async () => {
+    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    const inserted = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+
+    expect(inserted.createdAt instanceof Date).toBe(true);
+    expect(inserted.progressLastMadeAt instanceof Date).toBe(true);
+  });
   it('fails to insert / associate an objective when it references a channel that does not exist', async () => {
     // For some reason this does not catch the error :/
     await expect(ObjectiveModel.insert({...objective, status: 'pending'}, knex)).rejects.toThrow();
@@ -44,7 +51,6 @@ describe('Objective > insert', () => {
       {objectiveId: `OpenChannel-${c.channelId}`, channelId: c.channelId},
     ]);
   });
-
   it('inserts an objective with a createdAt timestamp', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
@@ -52,8 +58,8 @@ describe('Objective > insert', () => {
     const {createdAt} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
-    expect(Date.parse(createdAt) > before).toBe(true);
-    expect(Date.parse(createdAt) < after).toBe(true);
+    expect(createdAt.getTime() > before).toBe(true);
+    expect(createdAt.getTime() < after).toBe(true);
   });
 
   it('updates the progressLastMadeAt timestamp on an objective when progressMade is called', async () => {
@@ -64,8 +70,19 @@ describe('Objective > insert', () => {
     const {progressLastMadeAt} = await ObjectiveModel.progressMade(objectiveId, knex);
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
-    expect(Date.parse(progressLastMadeAt) > before).toBe(true);
-    expect(Date.parse(progressLastMadeAt) < after).toBe(true);
+    expect(progressLastMadeAt.getTime() > before).toBe(true);
+    expect(progressLastMadeAt.getTime() < after).toBe(true);
+  });
+});
+
+describe('Objective > forId', () => {
+  it('returns an objective with Date types for timestamps', async () => {
+    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+
+    const fetchedObjective = await ObjectiveModel.forId(`OpenChannel-${c.channelId}`, knex);
+    expect(fetchedObjective.createdAt instanceof Date).toBe(true);
+    expect(fetchedObjective.progressLastMadeAt instanceof Date).toBe(true);
   });
 });
 

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -131,14 +131,17 @@ export class ObjectiveModel extends Model {
     const id: string = objectiveId(objectiveToBeStored);
 
     return tx.transaction(async trx => {
-      const model = await ObjectiveModel.query(trx).insert({
-        objectiveId: id,
-        status: objectiveToBeStored.status,
-        type: objectiveToBeStored.type,
-        data: objectiveToBeStored.data,
-        createdAt: new Date(),
-        progressLastMadeAt: new Date(),
-      });
+      const model = await ObjectiveModel.query(trx)
+        .insert({
+          objectiveId: id,
+          status: objectiveToBeStored.status,
+          type: objectiveToBeStored.type,
+          data: objectiveToBeStored.data,
+          createdAt: new Date(),
+          progressLastMadeAt: new Date(),
+        })
+        .returning('*')
+        .first(); // This ensures that the returned object undergoes any type conversion performed during insert
 
       // Associate the objective with any channel that it references
       // By inserting an ObjectiveChannel row for each channel

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -136,8 +136,8 @@ export class ObjectiveModel extends Model {
         status: objectiveToBeStored.status,
         type: objectiveToBeStored.type,
         data: objectiveToBeStored.data,
-        createdAt: new Date(Date.now()),
-        progressLastMadeAt: new Date(Date.now()),
+        createdAt: new Date(),
+        progressLastMadeAt: new Date(),
       });
 
       // Associate the objective with any channel that it references
@@ -180,7 +180,7 @@ export class ObjectiveModel extends Model {
     return (
       await ObjectiveModel.query(tx)
         .findById(objectiveId)
-        .patch({progressLastMadeAt: new Date(Date.now())})
+        .patch({progressLastMadeAt: new Date()})
         .returning('*')
         .first()
     ).toObjective();

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -245,7 +245,7 @@ function createPendingObjective(channelId: string): DBDefundChannelObjective {
     participants: [],
     objectiveId: ['DefundChannel', channelId].join('-'),
     data: {targetChannelId: channelId},
-    createdAt: new Date().toISOString(),
-    progressLastMadeAt: new Date().toISOString(),
+    createdAt: new Date(Date.now()),
+    progressLastMadeAt: new Date(Date.now()),
   };
 }


### PR DESCRIPTION
# Description
Objective timestamps are now treated consistently as a Date type.

Previously we treated timestamps on the objective as `strings` however `knex` would return a `Date` type that we would sometimes get converted to a `string` (depending on the code path)

To fix this  the timestamp fields have been changed to `Date`s on the `Objective`. This reflects the type `knex` gives us and will be easier to manipulate than a string.

 
## How Has This Been Tested?
Two new basic tests have been added that test the correct type is returned.

## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub

