### PR TITLE
Add SyncObjective method to Wallet

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -326,6 +326,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     syncChannel({ channelId }: SyncChannelParams): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "Bytes32" needs to be exported by the entry point index.d.ts
     syncChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
+    syncObjectives(objectiveIds: string[]): Promise<MultipleChannelOutput>;
     updateChannel({ channelId, allocations, appData, }: UpdateChannelParams): Promise<SingleChannelOutput>;
     updateChannelFunding(args: UpdateChannelFundingParams): Promise<SingleChannelOutput>;
     updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;

--- a/packages/server-wallet/src/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test__/sync-objectives.test.ts
@@ -1,0 +1,79 @@
+import {CreateChannelParams} from '@statechannels/client-api-schema';
+import Knex from 'knex';
+
+import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../config';
+import {DBAdmin} from '../db-admin/db-admin';
+import {seedAlicesSigningWallet, seedBobsSigningWallet} from '../db/seeds/1_signing_wallet_seeds';
+import {DBObjective, ObjectiveModel} from '../models/objective';
+import {Wallet} from '../wallet';
+import {createChannelArgs} from '../wallet/__test__/fixtures/create-channel';
+import {bob} from '../wallet/__test__/fixtures/participants';
+
+import {getChannelResultFor, getPayloadFor} from './test-helpers';
+
+jest.setTimeout(10_000);
+const aWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+  database: 'TEST_A',
+});
+const bWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
+  database: 'TEST_B',
+});
+
+let a: Wallet;
+let b: Wallet;
+
+beforeAll(async () => {
+  await Promise.all([DBAdmin.dropDatabase(aWalletConfig), DBAdmin.dropDatabase(bWalletConfig)]);
+  await DBAdmin.createDatabase(aWalletConfig);
+  await DBAdmin.createDatabase(bWalletConfig);
+  await Promise.all([
+    DBAdmin.migrateDatabase(aWalletConfig),
+    DBAdmin.migrateDatabase(bWalletConfig),
+  ]);
+  a = await Wallet.create(aWalletConfig);
+  b = await Wallet.create(bWalletConfig);
+
+  await seedAlicesSigningWallet(a.knex);
+  await seedBobsSigningWallet(b.knex);
+});
+afterAll(async () => {
+  await Promise.all([a.destroy(), b.destroy()]);
+  await Promise.all([DBAdmin.dropDatabase(aWalletConfig), DBAdmin.dropDatabase(bWalletConfig)]);
+});
+
+test('Objectives can be synced if a message is lost', async () => {
+  const createChannelParams: CreateChannelParams = createChannelArgs();
+
+  // We mimic not receiving a message containing objectives
+  const messageToLose = await a.createChannel(createChannelParams);
+
+  const channelId = messageToLose.channelResults[0].channelId;
+  const objectiveId = `OpenChannel-${channelId}`;
+
+  // Only A should have the objective since we "lost" the message
+  expect(await getObjective(a.knex, objectiveId)).toBeDefined();
+  expect(await getObjective(b.knex, objectiveId)).toBeUndefined();
+
+  // We would then call sync after some time of waiting and not making progress
+  const syncResult = await a.syncObjectives([objectiveId]);
+
+  // We should now see the objective
+  expect(await getObjective(b.knex, objectiveId)).toBeUndefined();
+
+  // After sync funding should continue as normal
+  const resultB0 = await b.pushMessage(getPayloadFor(bob().participantId, syncResult.outbox));
+  expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
+    status: 'proposed',
+    turnNum: 0,
+  });
+});
+
+async function getObjective(knex: Knex, objectiveId: string): Promise<DBObjective | undefined> {
+  const model = await ObjectiveModel.query(knex).findById(objectiveId);
+
+  if (model) {
+    return model.toObjective();
+  } else {
+    return undefined;
+  }
+}

--- a/packages/server-wallet/src/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test__/sync-objectives.test.ts
@@ -90,21 +90,20 @@ test('handles the objective being synced even if no message is lost', async () =
     getPayloadFor(bob().participantId, syncResult.outbox)
   );
 
-  // The only result will be a message containing the latest states
+  // The only expected result is a sync channel response
   expect(outbox).toHaveLength(1);
   expect(outbox[0]).toMatchObject({
     method: 'MessageQueued',
     params: {
-      recipient: 'bob',
-      sender: 'alice',
+      recipient: 'alice',
+      sender: 'bob',
       data: {
         signedStates: [expect.objectContaining({turnNum: 0})],
-        requests: [],
       },
     },
   });
   expect(newObjectives).toHaveLength(0);
-  expect(channelResults).toHaveLength(0);
+  expect(channelResults).toHaveLength(1);
 });
 
 test('Can successfully push the sync objective message multiple times', async () => {
@@ -133,21 +132,21 @@ test('Can successfully push the sync objective message multiple times', async ()
     getPayloadFor(bob().participantId, syncResult.outbox)
   );
 
-  // The only result will be a message containing the latest states
+  // The only expected result is a sync channel response
   expect(outbox).toHaveLength(1);
   expect(outbox[0]).toMatchObject({
     method: 'MessageQueued',
     params: {
-      recipient: 'bob',
-      sender: 'alice',
+      recipient: 'alice',
+      sender: 'bob',
       data: {
         signedStates: [expect.objectContaining({turnNum: 0})],
-        requests: [],
       },
     },
   });
   expect(newObjectives).toHaveLength(0);
-  expect(channelResults).toHaveLength(0);
+  expect(channelResults).toHaveLength(1);
+  expect(channelResults[0]).toMatchObject({channelId});
 });
 
 async function getObjective(knex: Knex, objectiveId: string): Promise<DBObjective | undefined> {

--- a/packages/server-wallet/src/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test__/sync-objectives.test.ts
@@ -71,7 +71,6 @@ test('Objectives can be synced if a message is lost', async () => {
 test('handles the objective being synced even if no message is lost', async () => {
   const createChannelParams: CreateChannelParams = createChannelArgs();
 
-  // We mimic not receiving a message containing objectives
   const messageResponse = await a.createChannel(createChannelParams);
 
   const channelId = messageResponse.channelResults[0].channelId;
@@ -125,9 +124,10 @@ test('Can successfully push the sync objective message multiple times', async ()
   // We should not see the objective yet
   expect(await getObjective(b.knex, objectiveId)).toBeUndefined();
 
-  // We should be able to push
+  // We push once
   await b.pushMessage(getPayloadFor(bob().participantId, syncResult.outbox));
 
+  // We push again and check the results of the second push
   const {outbox, newObjectives, channelResults} = await b.pushMessage(
     getPayloadFor(bob().participantId, syncResult.outbox)
   );

--- a/packages/server-wallet/src/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test__/sync-objectives.test.ts
@@ -70,10 +70,5 @@ test('Objectives can be synced if a message is lost', async () => {
 
 async function getObjective(knex: Knex, objectiveId: string): Promise<DBObjective | undefined> {
   const model = await ObjectiveModel.query(knex).findById(objectiveId);
-
-  if (model) {
-    return model.toObjective();
-  } else {
-    return undefined;
-  }
+  return model?.toObjective();
 }

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -152,14 +152,7 @@ export class Channel extends Model implements ChannelColumns {
   };
 
   static jsonAttributes = ['vars', 'participants', 'initialSupport'];
-  static async forIds(channelIds: Bytes32[], txOrKnex: TransactionOrKnex): Promise<Channel[]> {
-    return Channel.query(txOrKnex)
-      .whereIn('channelId', channelIds)
-      .withGraphFetched('signingWallet')
-      .withGraphFetched('funding')
-      .withGraphFetched('chainServiceRequests')
-      .withGraphFetched('adjudicatorStatus');
-  }
+
   static async forId(channelId: Bytes32, txOrKnex: TransactionOrKnex): Promise<Channel> {
     return Channel.query(txOrKnex)
       .where({channelId})

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -152,7 +152,14 @@ export class Channel extends Model implements ChannelColumns {
   };
 
   static jsonAttributes = ['vars', 'participants', 'initialSupport'];
-
+  static async forIds(channelIds: Bytes32[], txOrKnex: TransactionOrKnex): Promise<Channel[]> {
+    return Channel.query(txOrKnex)
+      .whereIn('channelId', channelIds)
+      .withGraphFetched('signingWallet')
+      .withGraphFetched('funding')
+      .withGraphFetched('chainServiceRequests')
+      .withGraphFetched('adjudicatorStatus');
+  }
   static async forId(channelId: Bytes32, txOrKnex: TransactionOrKnex): Promise<Channel> {
     return Channel.query(txOrKnex)
       .where({channelId})

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -166,6 +166,11 @@ export class ObjectiveModel extends Model {
     return model.toObjective();
   }
 
+  static async forIds(objectiveIds: string[], tx: TransactionOrKnex): Promise<DBObjective[]> {
+    const model = await ObjectiveModel.query(tx).findByIds(objectiveIds);
+    return model.map(m => m.toObjective());
+  }
+
   static async approve(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
     await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'approved'});
   }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/open-channel-objective.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/open-channel-objective.ts
@@ -1,0 +1,17 @@
+import {DBOpenChannelObjective} from '../../../models/objective';
+import {channel} from '../../../models/__test__/fixtures/channel';
+
+import {alice, bob} from './participants';
+import {fixture} from './utils';
+
+const defaultObjective: DBOpenChannelObjective = {
+  data: {targetChannelId: channel().channelId, role: 'app', fundingStrategy: 'Direct'},
+  participants: [alice(), bob()],
+  type: 'OpenChannel',
+  objectiveId: ['OpenChannel', channel().channelId].join('-'),
+  status: 'pending',
+  createdAt: new Date(),
+  progressLastMadeAt: new Date(),
+};
+
+export const openChannelObjective = fixture(defaultObjective);

--- a/packages/server-wallet/src/wallet/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sync-objectives.test.ts
@@ -9,7 +9,6 @@ import {ObjectiveModel} from '../../models/objective';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {openChannelObjective} from './fixtures/open-channel-objective';
-import {bob, alice as aliceP} from './fixtures/participants';
 import {alice} from './fixtures/signing-wallets';
 import {stateWithHashSignedBy} from './fixtures/states';
 
@@ -44,12 +43,7 @@ describe('SyncObjective', () => {
     const objective = await ObjectiveModel.insert(openChannelObjective(), testKnex);
 
     const syncResult = await wallet.syncObjectives([objective.objectiveId]);
-    // TODO: Currently the objective model differs slightly from what we see on the message
-    const massagedObjective = {
-      ...objective,
-      participants: [aliceP(), bob()],
-    };
-    expect(syncResult.newObjectives).toEqual([massagedObjective]);
+    expect(syncResult.newObjectives).toHaveLength(0);
     expect(syncResult.channelResults).toEqual([targetChannel.channelResult]);
 
     expect((syncResult.outbox[0].params.data as any).objectives).toEqual([

--- a/packages/server-wallet/src/wallet/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/sync-objectives.test.ts
@@ -1,0 +1,59 @@
+import _ from 'lodash';
+
+import {Wallet} from '..';
+import {testKnex} from '../../../jest/knex-setup-teardown';
+import {defaultTestConfig} from '../../config';
+import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {Channel} from '../../models/channel';
+import {ObjectiveModel} from '../../models/objective';
+import {channel} from '../../models/__test__/fixtures/channel';
+
+import {openChannelObjective} from './fixtures/open-channel-objective';
+import {bob, alice as aliceP} from './fixtures/participants';
+import {alice} from './fixtures/signing-wallets';
+import {stateWithHashSignedBy} from './fixtures/states';
+
+let wallet: Wallet;
+
+beforeAll(async () => {
+  await seedAlicesSigningWallet(testKnex);
+  wallet = await Wallet.create(defaultTestConfig());
+});
+
+afterAll(async () => {
+  await wallet.destroy();
+});
+describe('SyncObjective', () => {
+  it('throws an error if an objectiveId does not exist', async () => {
+    await expect(wallet.syncObjectives(['FAKE'])).rejects.toThrow('Could not find all objectives');
+  });
+
+  it('handles being called with no objective ids', async () => {
+    const syncResults = await wallet.syncObjectives([]);
+    expect(syncResults.channelResults).toHaveLength(0);
+    expect(syncResults.newObjectives).toHaveLength(0);
+    expect(syncResults.outbox).toHaveLength(0);
+  });
+
+  it('generates a message containing specified objectives and channels', async () => {
+    // Create the existing data
+    const targetChannel = await Channel.query(testKnex)
+      .insert(channel({vars: [stateWithHashSignedBy([alice()])()]}))
+      .withGraphFetched('signingWallet')
+      .withGraphFetched('funding');
+    const objective = await ObjectiveModel.insert(openChannelObjective(), testKnex);
+
+    const syncResult = await wallet.syncObjectives([objective.objectiveId]);
+    // TODO: Currently the objective model differs slightly from what we see on the message
+    const massagedObjective = {
+      ...objective,
+      participants: [aliceP(), bob()],
+    };
+    expect(syncResult.newObjectives).toEqual([massagedObjective]);
+    expect(syncResult.channelResults).toEqual([targetChannel.channelResult]);
+
+    expect((syncResult.outbox[0].params.data as any).objectives).toEqual([
+      expect.objectContaining(_.pick(objective, 'data')),
+    ]);
+  });
+});

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -283,10 +283,6 @@ export class Store {
     return ObjectiveModel.forIds(objectiveIds, this.knex);
   }
 
-  async getChannelsByIds(channelIds: string[]): Promise<ChannelState[]> {
-    return (await Channel.forIds(channelIds, this.knex)).map(c => c.protocolState);
-  }
-
   async getChannels(): Promise<ChannelState[]> {
     return (await Channel.query(this.knex)).map(channel => channel.protocolState);
   }

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -279,6 +279,14 @@ export class Store {
     return {states: vars.map(ss => _.merge(ss, channelConstants)), channelState};
   }
 
+  async getObjectivesByIds(objectiveIds: string[]): Promise<DBObjective[]> {
+    return ObjectiveModel.forIds(objectiveIds, this.knex);
+  }
+
+  async getChannelsByIds(channelIds: string[]): Promise<ChannelState[]> {
+    return (await Channel.forIds(channelIds, this.knex)).map(c => c.protocolState);
+  }
+
   async getChannels(): Promise<ChannelState[]> {
     return (await Channel.query(this.knex)).map(channel => channel.protocolState);
   }

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -86,7 +86,9 @@ export class WalletResponse {
     myIndex: number,
     participants: Participant[]
   ): void {
-    this.createdObjectives.push(objective);
+    // TODO: The objective model currently always sets the participants to an empty array when creating the DBObjective
+    // So we override that here
+    this.createdObjectives.push({...objective, participants});
 
     const myParticipantId = participants[myIndex].participantId;
     if (isSharedObjective(objective)) {

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -18,7 +18,6 @@ import {WalletEvent, MultipleChannelOutput, SingleChannelOutput, Output} from '.
 export class WalletResponse {
   _channelResults: Record<string, ChannelResult> = {};
   private queuedMessages: WireMessage[] = [];
-  objectivesToSend: DBObjective[] = [];
   objectivesToApprove: DBObjective[] = [];
   createdObjectives: DBObjective[] = [];
   succeededObjectives: DBObjective[] = [];
@@ -77,19 +76,9 @@ export class WalletResponse {
   }
 
   /**
-   * Queues objectives for
-   * - sending to opponent
-   * - notifying the app
+   * Queues an objective to be sent to the opponent
    */
-  queueCreatedObjective(
-    objective: DBObjective,
-    myIndex: number,
-    participants: Participant[]
-  ): void {
-    // TODO: The objective model currently always sets the participants to an empty array when creating the DBObjective
-    // So we override that here
-    this.createdObjectives.push({...objective, participants});
-
+  queueSendObjective(objective: DBObjective, myIndex: number, participants: Participant[]): void {
     const myParticipantId = participants[myIndex].participantId;
     if (isSharedObjective(objective)) {
       participants.forEach((p, i) => {
@@ -108,6 +97,21 @@ export class WalletResponse {
         }
       });
     }
+  }
+
+  /**
+   * Queues objectives for
+   * - sending to opponent
+   * - notifying the app
+   */
+  queueCreatedObjective(
+    objective: DBObjective,
+    myIndex: number,
+    participants: Participant[]
+  ): void {
+    this.createdObjectives.push(objective);
+
+    this.queueSendObjective(objective, myIndex, participants);
   }
 
   /**

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -319,6 +319,7 @@ export class SingleThreadedWallet
 
     return response.multipleChannelOutput();
   }
+
   /**
    * Trigger a response containing a message for all counterparties, with all stored states for a given channel.
    *

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -309,6 +309,9 @@ export class SingleThreadedWallet
     }
 
     for (const o of objectives) {
+      // NOTE: Currently we're fetching the channel twice
+      // Once here and one in syncChannel
+      // This could be refactored if performance is an issue
       const channel = await this.store.getChannelState(o.data.targetChannelId);
       // This will make sure any relevant channel information is synced
       await this._syncChannel(channel.channelId, response);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -314,7 +314,7 @@ export class SingleThreadedWallet
       await this._syncChannel(channel.channelId, response);
 
       const {participants} = channel;
-      response.queueCreatedObjective(o, channel.myIndex, participants);
+      response.queueSendObjective(o, channel.myIndex, participants);
     }
 
     return response.multipleChannelOutput();

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -289,7 +289,7 @@ export class SingleThreadedWallet
   }
 
   /**
-   * Trigger a response containing a message for counterparties, with all objectives and channels for a set of
+   * Trigger a response containing a message for counterparties, with all objectives and channels for a set of objectives.
    * @param objectiveIds The ids of the objectives that should be sent to the counterparties
    * @returns A promise that resolves to an object containing the messages.
    */


### PR DESCRIPTION
# Description
Add a new SyncObjective method to the wallet API.

This PR introduces a new method on the wallet `syncObjectives`. It accepts a list of `objectiveId`s and returns a message that can be sent to other counterparties. 

The syncObjectives method will also call `syncChannel` for any relevant channels so the message payload will contain all relevant channels for the objective.

The main use case this is designed around is for resending objectives if a message gets dropped.

## How Has This Been Tested? 

Two new test files have been added to test the functionality. One is a unit test, while the other is more of an integration style test with two wallets.

It would be nice to test this is out on an e2e style test however I think the amount of effort to do that is outside the scope of this PR.

## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
