### PR TITLE
feat: add API method for fetching objective

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -293,6 +293,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     destroy(): Promise<void>;
     getChannels(): Promise<MultipleChannelOutput>;
     getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
+    getObjective(objectiveId: string): Promise<DBObjective>;
     getSigningAddress(): Promise<Address>;
     getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -58,6 +58,7 @@ import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
 import {SingleAppUpdater} from '../handlers/single-app-updater';
 import {LedgerManager} from '../protocols/ledger-manager';
+import {DBObjective} from '../models/objective';
 
 import {Store, AppHandler, MissingAppHandler} from './store';
 import {
@@ -69,7 +70,6 @@ import {
   WalletEvent,
 } from './types';
 import {WalletResponse} from './wallet-response';
-import {DBObjective} from '../models/objective';
 
 // TODO: The client-api does not currently allow for outgoing messages to be
 // declared as the result of a wallet API call.

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -69,6 +69,7 @@ import {
   WalletEvent,
 } from './types';
 import {WalletResponse} from './wallet-response';
+import {DBObjective} from '../models/objective';
 
 // TODO: The client-api does not currently allow for outgoing messages to be
 // declared as the result of a wallet API call.
@@ -742,6 +743,15 @@ export class SingleThreadedWallet
     channelStates.forEach(cs => response.queueChannelState(cs));
 
     return response.multipleChannelOutput();
+  }
+
+  /**
+   * Gets the objective for a given id.
+   *
+   * @returns A promise that resolves to a DBObjective, with a progressLastMadeAt timestamp
+   */
+  async getObjective(objectiveId: string): Promise<DBObjective> {
+    return this.store.getObjective(objectiveId);
   }
 
   /**


### PR DESCRIPTION
Expose a `getObjective` method, to mirror the existing `getState` method.

Currently, there is no way to learn about the timestamps or status of an objective. (Except possibly for objectives that go across the wire, but they are bundled up inside messages for opponents). 

This approach is good because it allows information about timestamps to be queried. It is therefore a "pull", and should be robust against wallet/app restarts (in contrast to event emission).

Shortcomings: you can only get one objective at a time, and you need to know its id. 

Towards #3230 and the sprint goal of first class objectives. Builds on #3263 .

## How Has This Been Tested? [Optional] 
An existing case in  `create-channel.test.ts` has had an assertion added.
---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
