### PR TITLE
objectives have an "approved' boolean and a wider type of "status" property

### DIFF
--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -99,7 +99,7 @@ describe('e2e', () => {
     expect(events).toContainObject({
       event: 'objectiveStarted',
       type: 'OpenChannel',
-      status: 'pending',
+      status: expect.any(String),
     });
     expect(events).toContainObject({
       event: 'objectiveSucceeded',

--- a/packages/server-wallet/src/db/migrations/20210126122746_add_objective_approved_column.ts
+++ b/packages/server-wallet/src/db/migrations/20210126122746_add_objective_approved_column.ts
@@ -1,0 +1,14 @@
+import * as Knex from 'knex';
+
+const tableName = 'objectives';
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.boolean('approved').defaultTo(false).notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.dropColumn('approved');
+  });
+}

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -24,14 +24,14 @@ beforeEach(async () => {
 describe('Objective > insert', () => {
   it('returns an objective with Date types for timestamps', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    const inserted = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const inserted = await ObjectiveModel.insert(objective, knex);
 
     expect(inserted.createdAt instanceof Date).toBe(true);
     expect(inserted.progressLastMadeAt instanceof Date).toBe(true);
   });
   it('fails to insert / associate an objective when it references a channel that does not exist', async () => {
     // For some reason this does not catch the error :/
-    await expect(ObjectiveModel.insert({...objective, status: 'pending'}, knex)).rejects.toThrow();
+    await expect(ObjectiveModel.insert(objective, knex)).rejects.toThrow();
 
     expect(await ObjectiveModel.query(knex).select()).toMatchObject([]);
 
@@ -41,7 +41,7 @@ describe('Objective > insert', () => {
   it('inserts and associates an objective with all channels that it references (channels exist)', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
-    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert(objective, knex);
 
     expect(await ObjectiveModel.query(knex).select()).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},
@@ -55,7 +55,7 @@ describe('Objective > insert', () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
-    const {createdAt} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const {createdAt} = await ObjectiveModel.insert(objective, knex);
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
     expect(createdAt.getTime() > before).toBe(true);
@@ -64,7 +64,7 @@ describe('Objective > insert', () => {
 
   it('updates the progressLastMadeAt timestamp on an objective when progressMade is called', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const {objectiveId} = await ObjectiveModel.insert(objective, knex);
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
     const {progressLastMadeAt} = await ObjectiveModel.progressMade(objectiveId, knex);
@@ -78,7 +78,7 @@ describe('Objective > insert', () => {
 describe('Objective > forId', () => {
   it('returns an objective with Date types for timestamps', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert(objective, knex);
 
     const fetchedObjective = await ObjectiveModel.forId(`OpenChannel-${c.channelId}`, knex);
     expect(fetchedObjective.createdAt instanceof Date).toBe(true);
@@ -90,7 +90,7 @@ describe('Objective > forChannelIds', () => {
   it('retrieves objectives associated with a given channelId', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
-    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert(objective, knex);
 
     expect(await ObjectiveModel.forChannelIds([c.channelId], knex)).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -122,6 +122,6 @@ const crankAndAssert = async (
   if (completesObj) {
     expect(reloadedObjective.status).toEqual('succeeded');
   } else {
-    expect(reloadedObjective.status).toEqual('pending');
+    expect(reloadedObjective.status).not.toEqual('succeeded');
   }
 };

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -146,6 +146,6 @@ const crankAndAssert = async (
   if (completesObj) {
     expect(reloadedObjective.status).toEqual('succeeded');
   } else {
-    expect(reloadedObjective.status).toEqual('approved');
+    expect(reloadedObjective.status).not.toEqual('succeeded');
   }
 };

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -198,7 +198,8 @@ async function setAdjudicatorStatus(
 function createPendingObjective(channelId: string): DBDefundChannelObjective {
   return {
     type: 'DefundChannel',
-    status: 'pending',
+    approved: false,
+    status: '',
     participants: [],
     objectiveId: ['DefundChannel', channelId].join('-'),
     data: {targetChannelId: channelId},

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -102,7 +102,7 @@ describe('when there is an active challenge', () => {
 
     // Check the results
     const reloadedObjective = await store.getObjective(objective.objectiveId);
-    expect(reloadedObjective.status).toEqual('pending');
+    expect(reloadedObjective.status).toEqual(expect.any(String));
   });
 });
 
@@ -165,7 +165,7 @@ describe('when the channel is finalized on chain', () => {
 
     // Check the results
     const reloadedObjective = await store.getObjective(objective.objectiveId);
-    expect(reloadedObjective.status).toEqual('pending');
+    expect(reloadedObjective.status).toEqual(expect.any(String));
   });
 });
 

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -192,6 +192,6 @@ const crankAndAssert = async (
   if (completesObj) {
     expect(reloadedObjective.status).toEqual('succeeded');
   } else {
-    expect(reloadedObjective.status).toEqual('approved');
+    expect(reloadedObjective.status).not.toEqual('succeeded');
   }
 };

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -95,7 +95,8 @@ it('creates a defundChannel objective on channel finalized', async () => {
 
   expect(objective).toEqual<DBObjective>({
     objectiveId,
-    status: 'approved',
+    approved: true,
+    status: expect.any(String),
     type: 'DefundChannel',
     data: {
       targetChannelId: c.channelId,

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -67,7 +67,6 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
-        status: 'pending',
       },
       w.knex
     );
@@ -81,7 +80,6 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
-        status: 'pending',
       },
       w.knex
     );
@@ -135,7 +133,6 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
-        status: 'pending',
       },
       w.knex
     );
@@ -174,7 +171,6 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
-        status: 'pending',
       },
       w.knex
     );
@@ -271,7 +267,6 @@ describe('ledger funded app scenarios', () => {
           fundingLedgerChannelId: ledger.channelId,
           role: 'app',
         },
-        status: 'approved',
       },
       w.knex
     );

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -287,7 +287,6 @@ describe('when the application protocol returns an action', () => {
     await ObjectiveModel.insert(
       {
         type: 'OpenChannel',
-        status: 'approved',
         participants: c.participants,
         data: {
           targetChannelId: c.channelId,
@@ -295,7 +294,8 @@ describe('when the application protocol returns an action', () => {
           role: 'app',
         },
       },
-      wallet.knex
+      wallet.knex,
+      true // preApprove
     );
 
     expect(c.latestSignedByMe?.turnNum).toEqual(0);
@@ -540,7 +540,6 @@ describe('ledger funded app scenarios', () => {
     await ObjectiveModel.insert(
       {
         type: 'OpenChannel',
-        status: 'approved',
         participants: channel.participants,
         data: {
           targetChannelId: channel.channelId,
@@ -549,7 +548,8 @@ describe('ledger funded app scenarios', () => {
           role: 'app',
         },
       },
-      wallet.knex
+      wallet.knex,
+      true // preApprove
     );
 
     return channel;

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -48,9 +48,9 @@ it('sends the post fund setup when the funding event is provided for multiple ch
         fundingStrategy: 'Direct',
         role: 'app',
       },
-      status: 'approved',
     },
-    w.knex
+    w.knex,
+    true // preApprove
   );
 
   await ObjectiveModel.insert(
@@ -62,9 +62,9 @@ it('sends the post fund setup when the funding event is provided for multiple ch
         fundingStrategy: 'Direct',
         role: 'app',
       },
-      status: 'approved',
     },
-    w.knex
+    w.knex,
+    true // preApprove
   );
 
   const {outbox, channelResults} = await w.updateFundingForChannels(
@@ -118,9 +118,9 @@ it('sends the post fund setup when the funding event is provided', async () => {
         fundingStrategy: 'Direct',
         role: 'app',
       },
-      status: 'approved',
     },
-    w.knex
+    w.knex,
+    true // preApprove
   );
 
   const result = await w.updateFundingForChannels([
@@ -163,9 +163,9 @@ it('emits new channel result when the funding event is provided via holdingUpdat
         fundingStrategy: 'Direct',
         role: 'app',
       },
-      status: 'approved',
     },
-    w.knex
+    w.knex,
+    true // preApprove
   );
 
   const channelUpdatedPromise = new Promise(resolve =>

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -413,7 +413,7 @@ export class Store {
   async ensureDefundChannelObjective(
     objective: DefundChannel,
     tx: Transaction,
-    preApprove: boolean
+    preApprove = false
   ): Promise<DBDefundChannelObjective> {
     const {data} = objective;
     const {targetChannelId} = data;
@@ -429,7 +429,7 @@ export class Store {
   async ensureSubmitChallengeObjective(
     objective: SubmitChallenge,
     tx: Transaction,
-    preApprove: boolean
+    preApprove = false
   ): Promise<DBSubmitChallengeObjective> {
     const {data} = objective;
     const {targetChannelId} = data;
@@ -445,7 +445,7 @@ export class Store {
   async ensureOpenChannelObjective(
     objective: OpenChannel,
     tx: Transaction,
-    preApprove: boolean
+    preApprove = false
   ): Promise<DBOpenChannelObjective> {
     const {
       data: {targetChannelId: channelId, fundingStrategy, fundingLedgerChannelId, role},
@@ -479,7 +479,7 @@ export class Store {
   async ensureCloseChannelObjective(
     objective: CloseChannel,
     tx: Transaction,
-    _preApprove: boolean
+    preApprove = true // TODO: should this always be true?
   ): Promise<DBCloseChannelObjective> {
     const {
       data: {targetChannelId, fundingStrategy},
@@ -504,7 +504,7 @@ export class Store {
     return ObjectiveModel.insert(
       objectiveToBeStored,
       tx,
-      true // preApprove TODO: should this always be true?
+      preApprove
     ) as Promise<DBCloseChannelObjective>;
   }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -400,7 +400,7 @@ export class Store {
       case 'OpenChannel':
         return this.ensureOpenChannelObjective(objective, tx, preApprove);
       case 'CloseChannel':
-        return this.ensureCloseChannelObjective(objective, tx, preApprove);
+        return this.ensureCloseChannelObjective(objective, tx);
       case 'SubmitChallenge':
         return this.ensureSubmitChallengeObjective(objective, tx, preApprove);
       case 'DefundChannel':
@@ -478,8 +478,7 @@ export class Store {
 
   async ensureCloseChannelObjective(
     objective: CloseChannel,
-    tx: Transaction,
-    preApprove = true // TODO: should this always be true?
+    tx: Transaction
   ): Promise<DBCloseChannelObjective> {
     const {
       data: {targetChannelId, fundingStrategy},
@@ -504,7 +503,7 @@ export class Store {
     return ObjectiveModel.insert(
       objectiveToBeStored,
       tx,
-      preApprove
+      true // TODO: should this always be true?
     ) as Promise<DBCloseChannelObjective>;
   }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -423,13 +423,7 @@ export class Store {
       throw new StoreError(StoreError.reasons.channelMissing, {channelId: targetChannelId});
     }
 
-    const objectiveToBeStored = {...objective, status: 'pending' as const};
-
-    return ObjectiveModel.insert(
-      objectiveToBeStored,
-      tx,
-      preApprove
-    ) as Promise<DBDefundChannelObjective>;
+    return ObjectiveModel.insert(objective, tx, preApprove) as Promise<DBDefundChannelObjective>;
   }
 
   async ensureSubmitChallengeObjective(
@@ -445,16 +439,7 @@ export class Store {
       throw new StoreError(StoreError.reasons.channelMissing, {channelId: targetChannelId});
     }
 
-    const objectiveToBeStored = {
-      ...objective,
-      status: 'pending' as const,
-    };
-
-    return ObjectiveModel.insert(
-      objectiveToBeStored,
-      tx,
-      preApprove
-    ) as Promise<DBSubmitChallengeObjective>;
+    return ObjectiveModel.insert(objective, tx, preApprove) as Promise<DBSubmitChallengeObjective>;
   }
 
   async ensureOpenChannelObjective(
@@ -475,18 +460,6 @@ export class Store {
     if (!_.includes(['Ledger', 'Direct', 'Fake'], objective.data.fundingStrategy))
       throw new StoreError(StoreError.reasons.unimplementedFundingStrategy, {fundingStrategy});
 
-    const objectiveToBeStored = {
-      participants: [],
-      status: 'pending' as const,
-      type: objective.type,
-      data: {
-        fundingStrategy,
-        fundingLedgerChannelId,
-        targetChannelId: channelId,
-        role,
-      },
-    };
-
     if (role === 'ledger')
       await Channel.setLedger(
         channelId,
@@ -500,11 +473,7 @@ export class Store {
       .returning('*')
       .first();
 
-    return ObjectiveModel.insert(
-      objectiveToBeStored,
-      tx,
-      preApprove
-    ) as Promise<DBOpenChannelObjective>;
+    return ObjectiveModel.insert(objective, tx, preApprove) as Promise<DBOpenChannelObjective>;
   }
 
   async ensureCloseChannelObjective(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -940,7 +940,7 @@ export class SingleThreadedWallet
 
     const objectives = (
       await this.store.getObjectives(channels.concat(channelsWithRelevantPendingReqs))
-    ).filter(objective => objective.status === 'approved');
+    ).filter(objective => objective.approved);
 
     // todo(tom): why isn't this just a for loop?
     while (objectives.length) {


### PR DESCRIPTION
See https://github.com/statechannels/statechannels/pull/3264#issuecomment-776796176

Change the type of an objective to better reflect its lifecycle. 

The *only* magic string that is used in critical code for `status` currently is the `approved` string. On this branch, this has been pinched off into a boolean property of the objective. 

`status` is preserved and now has a new use. The type of `status` is changed to `string`. This is intentionally very permissive, and no critical code will depend on it. It is only there to help track progress and aid debugging. The strings that will end up being stored will be defined by the implementation of an objective cranker. If this implementation changes, and the strings that get stored changed, this won't present a data migration issue, because the only way these strings are used is to track progress. As an example: we make a change from `status: 'waitingForFunding` to `status: waiting-for-funding'. If the wallet reads the status from some stored data before the change, it will recompute the new string and store that. The only bad thing that happens is that the status will have been deemed to have _changed_ (i.e some progress has been made on that objective) when in fact it probably hasn't. And the data has now effectively been migrated.

I considered renaming `status` to `state` but neglected to do so in order to keep the changeset small. It also means we don't need to add a migration.





 

> Approval is more critical,
>   and so has been separated into its own property.
>   'approved' is currently the only value of
>   'status' that is ever checked.
> 
> # Description
> **Title** Clear, single line description of the pull request, written as though it was an order.
> 
> Then, following a single blank line, a summary of the change and which issue is fixed, including 
> - [ ] what is the problem being solved
> - [ ] why this is a good approach
> - [ ] what are the shortcomings of this approach, if any
> 
> It may include
> - [ ] background information, such as "Fixes #"
> - [ ] benchmark results
> - [ ] links to design documents
> - [ ] dependencies required for this change
> 
> The summary may omit some of these details if this PR fixes a single ticket that includes these details. It is the reviewer's discretion. 
> 
> ## Changes [Optional] 
> Multiple changes are not recommended, so this section should normally be omitted. Unfortunately, they are sometimes unavoidable. If there are multiple logical changes, list them separately.
> 
> 1. `'foo'` is replaced by `'bar'`
> 2. `'fizzbuzz'` is optimized for gas
> 
> ## How Has This Been Tested? [Optional] 
> 
> Did you need to run manual tests to verify this change? If so, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
> 
> ## :warning: Does this require multiple approvals? [Optional]
> Please explain which reason, if any, why this requires more than one approval.
> - [ ] Is it security related?
> - [ ] Is it a significant process change?
> - [ ] Is it a significant change to architectural, design?
> 
> ---
> ## Checklist:
> 
> ### Code quality
> - [ ] I have written clear commit messages
> - [ ] I have performed a self-review of my own code
> - [ ] This change does not have an unduly wide scope
> - [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
> - [ ] I have commented my code wherever necessary (can be 0)
> - [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
> ### Project management
> - [ ] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
> - [ ] I have linked to all relevant issues (can be 0)
> - [ ] I have added all dependent tickets (can be 0)
> - [ ] I have assigned myself to this PR
> - [ ] I have chosen the appropriate pipeline on zenhub
> 