### PR TITLE
DRY WorkerManager with a sendOperation method

### DIFF
--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
@@ -89,47 +89,11 @@ export class WorkerManager {
   }
 
   public async pushUpdate(args: unknown): Promise<SingleChannelOutput> {
-    this.logger.trace('PushUpdate called');
-    if (!this.pool) throw new Error(`Worker threads are disabled`);
-    const worker = await this.pool.acquire().promise;
-    const data: StateChannelWorkerData = {operation: 'PushUpdate', args};
-    const resultPromise = new Promise<SingleChannelOutput>((resolve, reject) =>
-      worker.once('message', (response: Either<Error, SingleChannelOutput>) => {
-        this.pool?.release(worker);
-
-        if (isLeft(response)) {
-          reject(response.left);
-        } else {
-          resolve(response.right);
-        }
-      })
-    );
-
-    worker.postMessage(data);
-
-    return resultPromise;
+    return this.sendOperation({operation: 'PushUpdate', args});
   }
 
   public async updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput> {
-    this.logger.trace('UpdateChannel called');
-    if (!this.pool) throw new Error(`Worker threads are disabled`);
-    const worker = await this.pool.acquire().promise;
-    const data: StateChannelWorkerData = {operation: 'UpdateChannel', args};
-    const resultPromise = new Promise<SingleChannelOutput>((resolve, reject) =>
-      worker.once('message', (response: Either<Error, SingleChannelOutput>) => {
-        this.pool?.release(worker);
-        if (isLeft(response)) {
-          this.logger.error(response);
-          reject(response.left);
-        } else {
-          resolve(response.right);
-        }
-      })
-    );
-
-    worker.postMessage(data);
-
-    return resultPromise;
+    return this.sendOperation({operation: 'UpdateChannel', args});
   }
 
   public async destroy(): Promise<void> {


### PR DESCRIPTION
# Description
Extracts the common code in the currently implemented multi-threaded wallet API into a generic `sendOperation` function.

The code refactored here is almost entirely overlapping. I am DRYing it out, as I wish to change the implementation of each API function in order to address https://github.com/statechannels/statechannels/issues/3262

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
        * See screenshots below
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
       * This is purely a refactor. There's no good place to write a test that passes, but I promise I will add a test when resolving https://github.com/statechannels/statechannels/issues/3262 
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub

## Easy mode

To make your life easier, feel free to peruse these diffs:
![Screen Shot 2021-02-10 at 2 32 13 PM](https://user-images.githubusercontent.com/8432675/107581972-ad8ac880-6bad-11eb-86b1-2bfd6290b688.png)
![Screen Shot 2021-02-10 at 2 31 57 PM](https://user-images.githubusercontent.com/8432675/107581979-b380a980-6bad-11eb-992c-8eac62ea0510.png)
![Screen Shot 2021-02-10 at 2 31 34 PM](https://user-images.githubusercontent.com/8432675/107581987-b7acc700-6bad-11eb-949f-c3e5bfc3dcff.png)
