### PR TITLE
MultiThreadedWallet emits events

### DIFF
--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -68,6 +68,7 @@ describe.each([0, 2])('e2e with %i threads', workerThreadAmount => {
     // Create actors
     payerClient = await PayerClient.create(alice().privateKey, `http://127.0.0.1:65535`, {
       workerThreadAmount,
+      loggingConfiguration: {logDestination: '/tmp/server-wallet.e2e-test.log', logLevel: 'trace'},
     });
 
     // Gets participant info for testing convenience

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -58,7 +58,7 @@ afterAll(async () => {
   await knexReceiver.destroy();
 });
 
-describe('e2e', () => {
+describe.each([0, 2])('e2e with %i threads', workerThreadAmount => {
   let payerClient: PayerClient;
 
   let payer: Participant;
@@ -66,7 +66,9 @@ describe('e2e', () => {
 
   beforeAll(async () => {
     // Create actors
-    payerClient = await PayerClient.create(alice().privateKey, `http://127.0.0.1:65535`);
+    payerClient = await PayerClient.create(alice().privateKey, `http://127.0.0.1:65535`, {
+      workerThreadAmount,
+    });
 
     // Gets participant info for testing convenience
     payer = payerClient.me;

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -58,7 +58,7 @@ afterAll(async () => {
   await knexReceiver.destroy();
 });
 
-describe.each([0, 2])('e2e with %i threads', workerThreadAmount => {
+describe.each([0, 2])('e2e with %i worker threads', workerThreadAmount => {
   let payerClient: PayerClient;
 
   let payer: Participant;

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -9,7 +9,7 @@ import {MultiThreadedWallet, Wallet as ServerWallet} from '../../src';
 import {Bytes32} from '../../src/type-aliases';
 import {recordFunctionMetrics, timerFactory} from '../../src/metrics';
 import {payerConfig} from '../e2e-utils';
-import {defaultConfig, ServerWalletConfig} from '../../src/config';
+import {DeepPartial, defaultConfig, ServerWalletConfig} from '../../src/config';
 import {ONE_DAY} from '../../src/__test__/test-helpers';
 import {WalletEvent} from '../../src/wallet/types';
 
@@ -32,9 +32,9 @@ export default class PayerClient {
   public static async create(
     pk: Bytes32,
     receiverHttpServerURL: string,
-    config?: ServerWalletConfig
+    partialConfig?: DeepPartial<ServerWalletConfig>
   ): Promise<PayerClient> {
-    const mergedConfig = _.assign(payerConfig, config);
+    const mergedConfig = _.assign(payerConfig, partialConfig);
     const wallet = recordFunctionMetrics(
       await ServerWallet.create(mergedConfig),
       payerConfig.metricsConfiguration.timingMetrics

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -34,7 +34,7 @@ export default class PayerClient {
     receiverHttpServerURL: string,
     partialConfig?: DeepPartial<ServerWalletConfig>
   ): Promise<PayerClient> {
-    const mergedConfig = _.assign(payerConfig, partialConfig);
+    const mergedConfig = _.merge(payerConfig, partialConfig);
     const wallet = recordFunctionMetrics(
       await ServerWallet.create(mergedConfig),
       payerConfig.metricsConfiguration.timingMetrics

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -319,7 +319,7 @@ describe('when the application protocol returns an action', () => {
   });
 
   it.each([0, 2])(
-    'emits objectiveStarted when a %i-threaded wallet receives a new objective',
+    'emits objectiveStarted when a wallet with %i worker threads receives a new objective',
     async workerThreadAmount => {
       wallet = await Wallet.create(defaultTestConfig({workerThreadAmount}));
       const turnNum = 6;

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -333,7 +333,7 @@ describe('when the application protocol returns an action', () => {
       const callback = jest.fn();
       wallet.once('objectiveStarted', callback);
 
-      const p = wallet.pushMessage({
+      const result = await wallet.pushMessage({
         walletVersion: WALLET_VERSION,
         signedStates: [serializeState(stateSignedBy([bob()])(finalState))],
         objectives: [
@@ -347,7 +347,7 @@ describe('when the application protocol returns an action', () => {
           },
         ],
       });
-      await expect(p.then(r => r.newObjectives)).resolves.toHaveLength(1);
+      expect(result.newObjectives).toHaveLength(1);
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({type: 'CloseChannel'}));
     }
   );

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -320,7 +320,8 @@ describe('when the application protocol returns an action', () => {
 
   it.each([0, 2])(
     'emits objectiveStarted when a %i-threaded wallet receives a new objective',
-    async () => {
+    async workerThreadAmount => {
+      wallet = await Wallet.create(defaultTestConfig({workerThreadAmount}));
       const turnNum = 6;
       const state = stateSignedBy()({outcome: simpleEthAllocation([]), turnNum});
 

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/index.ts
@@ -1,10 +1,22 @@
+import {Worker} from 'worker_threads';
+
 import {UpdateChannelParams} from '@statechannels/client-api-schema';
 
 import {IncomingServerWalletConfig} from '../../config';
-import {MultipleChannelOutput, SingleChannelOutput} from '../types';
+import {MultipleChannelOutput, SingleChannelOutput, WalletEvent} from '../types';
 import {SingleThreadedWallet} from '../wallet';
 
 import {WorkerManager} from './manager';
+
+export type WalletEventEmitted<E extends WalletEvent = WalletEvent> = {
+  type: 'WalletEventEmitted';
+  name: E['type'];
+  value: E['value'];
+};
+
+function isEventEmitted<E extends WalletEvent>(msg: any): msg is WalletEventEmitted<E> {
+  return 'type' in msg && msg.type === 'WalletEventEmitted';
+}
 
 /**
  * A multi-threaded Nitro wallet
@@ -20,7 +32,11 @@ export class MultiThreadedWallet extends SingleThreadedWallet {
 
   protected constructor(walletConfig: IncomingServerWalletConfig) {
     super(walletConfig);
-    this.workerManager = new WorkerManager(this.walletConfig);
+    this.workerManager = new WorkerManager(this.walletConfig, (worker: Worker) =>
+      worker.on('message', (msg: any) => {
+        if (isEventEmitted(msg)) this.emit(msg.name, msg.value);
+      })
+    );
   }
 
   async updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput> {

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
@@ -20,6 +20,12 @@ export class WorkerManager {
   private pool?: Pool<Worker>;
   private threadAmount: number;
   private logger: Logger;
+
+  /**
+   *
+   * @param walletConfig server wallet config to be passed to the worker wallet
+   * @param onNewWorker callback that is executed when a new worker is created
+   */
   constructor(walletConfig: ServerWalletConfig, onNewWorker: (worker: Worker) => void) {
     this.logger = createLogger(walletConfig).child({module: 'Worker-Manager'});
     this.threadAmount = walletConfig.workerThreadAmount;

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
@@ -20,7 +20,7 @@ export class WorkerManager {
   private pool?: Pool<Worker>;
   private threadAmount: number;
   private logger: Logger;
-  constructor(walletConfig: ServerWalletConfig) {
+  constructor(walletConfig: ServerWalletConfig, onNewWorker: (worker: Worker) => void) {
     this.logger = createLogger(walletConfig).child({module: 'Worker-Manager'});
     this.threadAmount = walletConfig.workerThreadAmount;
     if (this.threadAmount === 0) {
@@ -38,6 +38,7 @@ export class WorkerManager {
         worker.on('error', err => {
           throw err;
         });
+        onNewWorker(worker);
         this.logger.trace('Started worker %o', worker.threadId);
         return worker;
       },

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/manager.ts
@@ -69,10 +69,11 @@ export class WorkerManager {
   /**
    *
    * @param {operation, args}: operation & arguments to send to worker
+   * @returns a promise that
+   *   - resolves when the worker thread sends a "right" message, containing a result
+   *   - rejects rejects worker thread sends a "left" message, containing an error
    *
    * Sends {operation, args} to a worker thread.
-   * RESOLVES WHEN: the worker thread sends a "right" message containing a result
-   * REJECTS WHEN: the worker thread sends a "left" message containing an error
    */
   private async sendOperation<
     T extends SingleChannelOutput | MultipleChannelOutput,

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
@@ -61,9 +61,9 @@ async function startWorker() {
             right(await timer('UpdateChannel', () => wallet.updateChannel(message.args)))
           );
         case 'PushMessage':
-          logger.debug({args: message.args}, `Worker-%o handling PushMessage`, threadId);
+          logger.debug(`Worker-%o handling PushMessage`, threadId);
           return parentPort?.postMessage(
-            right(await timer('PushMessage', async () => wallet.pushMessage(message.args)))
+            right(await timer('PushMessage', () => wallet.pushMessage(message.args)))
           );
         case 'PushUpdate':
           logger.debug(`Worker-%o handling PushUpdate`, threadId);

--- a/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
+++ b/packages/server-wallet/src/wallet/multi-threaded-wallet/worker.ts
@@ -3,7 +3,6 @@ import {parentPort, isMainThread, workerData, threadId} from 'worker_threads';
 import {left, right} from 'fp-ts/lib/Either';
 
 import {createLogger} from '../../logger';
-import {Wallet} from '../..';
 import {timerFactory} from '../../metrics';
 import {ServerWalletConfig} from '../../config';
 import {SingleThreadedWallet} from '..';
@@ -33,7 +32,7 @@ async function startWorker() {
   const logger = createLogger(walletConfig);
 
   logger.debug(`Worker %o starting`, threadId);
-  const wallet = (await Wallet.create(walletConfig)) as SingleThreadedWallet;
+  const wallet = await SingleThreadedWallet.create(walletConfig);
 
   const events = ['channelUpdated', 'objectiveStarted', 'objectiveSucceeded'] as const;
   events.forEach(name => wallet.on(name, relayWalletEvents(name)));

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -335,7 +335,9 @@ export class Store {
       return {
         channelIds: stateChannelIds.concat(objectiveChannelIds),
         channelResults,
-        // HACK: This will possibly cause the wallet to re-emit `'objectiveStarted'` multiple times
+        // HACK (1): This may cause the wallet to re-emit `'objectiveStarted'` multiple times
+        // For instance, a peer who sends me an objective `o`, and then triggers `syncObjectives`
+        // including `o`, will cause my wallet to emit `'objectiveStarted'` for `o` twice.
         storedObjectives,
       };
     });

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -305,6 +305,7 @@ export class Store {
   ): Promise<{
     channelIds: Bytes32[];
     channelResults: ChannelResult[];
+    storedObjectives: DBObjective[];
   }> {
     return this.knex.transaction(async tx => {
       const channelResults: ChannelResult[] = [];
@@ -319,7 +320,7 @@ export class Store {
       }
 
       const deserializedObjectives = message.objectives?.map(deserializeObjective) || [];
-      const storedObjectives = [];
+      const storedObjectives: DBObjective[] = [];
       for (const o of deserializedObjectives) {
         storedObjectives.push(await this.ensureObjective(o, tx));
       }
@@ -334,6 +335,8 @@ export class Store {
       return {
         channelIds: stateChannelIds.concat(objectiveChannelIds),
         channelResults,
+        // HACK: This will possibly cause the wallet to re-emit `'objectiveStarted'` multiple times
+        storedObjectives,
       };
     });
   }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -832,7 +832,11 @@ export class SingleThreadedWallet
     const {
       channelIds: channelIdsFromStates,
       channelResults: fromStoring,
+      storedObjectives,
     } = await this.store.pushMessage(wirePayload);
+
+    // HACK: This will possibly re-emit `'objectiveStarted'` multiple times
+    response.createdObjectives = storedObjectives;
 
     const channelIdsFromRequests: Bytes32[] = [];
     const requests = (wirePayload.requests || []).map(deserializeRequest);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -447,6 +447,8 @@ export class SingleThreadedWallet
       'ledger'
     );
 
+    // NB: We intentionally do not call this.takeActions, because there are no actions to take when creating a channel.
+
     return response.singleChannelOutput();
   }
   /**
@@ -466,6 +468,8 @@ export class SingleThreadedWallet
 
     await this._createChannel(response, args, 'app');
 
+    // NB: We intentionally do not call this.takeActions, because there are no actions to take when creating a channel.
+
     return response.multipleChannelOutput();
   }
   /**
@@ -484,6 +488,8 @@ export class SingleThreadedWallet
     await Promise.all(
       _.range(numberOfChannels).map(() => this._createChannel(response, args, 'app'))
     );
+
+    // NB: We intentionally do not call this.takeActions, because there are no actions to take when creating a channel.
 
     return response.multipleChannelOutput();
   }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -531,6 +531,7 @@ export class SingleThreadedWallet
       fundingLedgerChannelId
     );
 
+    this.emit('objectiveStarted', objective);
     response.queueState(signedState, channel.myIndex, channel.channelId);
     response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
     response.queueChannelState(channel);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -841,7 +841,9 @@ export class SingleThreadedWallet
       storedObjectives,
     } = await this.store.pushMessage(wirePayload);
 
-    // HACK: This will possibly re-emit `'objectiveStarted'` multiple times
+    // HACK (1): This may cause the wallet to re-emit `'objectiveStarted'` multiple times
+    // For instance, a peer who sends me an objective `o`, and then triggers `syncObjectives`
+    // including `o`, will cause my wallet to emit `'objectiveStarted'` for `o` twice.
     response.createdObjectives = storedObjectives;
 
     const channelIdsFromRequests: Bytes32[] = [];

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -525,7 +525,6 @@ export class SingleThreadedWallet
       fundingLedgerChannelId
     );
 
-    this.emit('objectiveStarted', objective);
     response.queueState(signedState, channel.myIndex, channel.channelId);
     response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
     response.queueChannelState(channel);
@@ -911,6 +910,7 @@ export class SingleThreadedWallet
       needToCrank = await this.processLedgerQueue(channels, response);
     }
 
+    response.createdObjectives.map(o => this.emit('objectiveStarted', o));
     response.succeededObjectives.map(o => this.emit('objectiveSucceeded', o));
   }
 


### PR DESCRIPTION
# Description
Workers forward events emitted from their wallet, on to the main thread. The main thread re-emits the event from their wallet.

Fixes #3262.
Fixes #3228.

To do this, I needed to make a significant change to the MultiThreadedWallet:
- before, the WorkerManager would send an operation to the worker, listen for one `'message'` event, and _assume that the event contains the result of API call_
- after, the WorkerManager will send an operation to the worker, listen to `'message'` events _until the event contains the result of the API call_

This allows the worker to also forward wallet events to the main thread.

With @lalexgap, I considered changing the type of the value that's sent back by the worker. This was ruled out, as it would have required a large change to the SingleThreadedWallet. It also would have been awkward to deal with the special case `'objectiveStarted'` event emitted by `_createChannel`.

I also considered adding a `messageId` to the operation sent to the worker, so that we can listen for messages with the correct `messageId`. I judged this as overkill, as we are still restricting workers to API call at a time. We may wish to allow workers to handle concurrent API calls, depending on where the bottleneck lies, so this strategy may be employed in the future. This possibility is another reason why I chose this implementation.

To test this effectively, I had to make some changes to the PayerClient, to be able to configure it to use the MultiThreadedWallet.

I snuck in a bug fix where events were not properly emitted during `pushMessage`. This arose naturally while doing this work, which is a bit of scope creep. ⚠️ This will result in multiple `'objectiveStarted'` events being emitted by the wallet, exacerbated by apps using `syncObjectives` from #3275. I'd prefer to tackle this shortcoming separately.

## Changes [Optional] 
In addition to the main change outlined above,

1. Against my own recommendation, I included two additional bugfixes
   1. `pushMessage` trigers wallet events
   2. `MultiThreadedWallet` throws an error when passed an invalid configuration
2. PayerClient can now be configured with a partial wallet config
3. tests are added for the MultiThreadedWallet in two places

## How Has This Been Tested? [Optional] 

1. The `e2e` test now runs against both a single- and multi-threaded wallet
2. A test was added that checks that events are emitted during `pushMessage`. This test runs against both single- and multi-threaded wallets

## :warning: Does this require multiple approvals? [Optional]
Please explain which reason, if any, why this requires more than one approval.
- [ ] Is it security related?
- [ ] Is it a significant process change?
- [x] Is it a significant change to architectural, design?

This is a significant change to the MultiThreadedWallet. Considering there were previously no tests of the MultiThreadedWallet, it is probably worthwhile to get two reviewers.

---
## Checklist: 8/9

### Code quality
- [ ] This change does not have an unduly wide scope
       * explained above
