### PR TITLE
refactor: rename getters and add comments

### DIFF
--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -406,21 +406,22 @@ export class Channel extends Model implements ChannelColumns {
   }
 
   /**
-   * Have all participants signed a preFund state?
+   * Have all participants signed a consistent preFund state?
    */
   public get preFundComplete(): boolean {
     // The existence of any supported state implies a supported prefund state
-    // which implies a full set of signatures (since no state is earlier than a prefund state)
+    // which implies a full set (nParticipants) of consistent preFund signatures has been seen
+    // (since no state is earlier than a prefund state).
     return !!this.supported;
   }
 
   /**
-   * Have all participants signed a postFund state?
+   * Have all participants signed a consistent postFund state?
    */
   public get postFundComplete(): boolean {
     // The existence of a supported state with sufficiently high turnNum
     // (at least the highest postFund state)
-    // implies a full set of nParticipants postFund signatures have been seen.
+    // implies a full set (nParticipants) of consistent postFund signatures has been seen.
     return !!this.supported && this.supported.turnNum >= 2 * this.nParticipants - 1;
   }
 

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -387,7 +387,7 @@ export class Channel extends Model implements ChannelColumns {
 
     const noFinalStates = _.every(this.sortedStates, s => !s.isFinal);
 
-    return this.postfundSupported && noFinalStates;
+    return this.postFundComplete && noFinalStates;
   }
 
   /**
@@ -406,17 +406,21 @@ export class Channel extends Model implements ChannelColumns {
   }
 
   /**
-   * Is a prefund state (or later) supported
+   * Have all participants signed a preFund state?
    */
-  public get prefundSupported(): boolean {
-    // all states are later than the prefund, so we just check if have any supported state
+  public get preFundComplete(): boolean {
+    // The existence of any supported state implies a supported prefund state
+    // which implies a full set of signatures (since no state is earlier than a prefund state)
     return !!this.supported;
   }
 
   /**
-   * Is a postfund state (or later) supported
+   * Have all participants signed a postFund state?
    */
-  public get postfundSupported(): boolean {
+  public get postFundComplete(): boolean {
+    // The existence of a supported state with sufficiently high turnNum
+    // (at least the highest postFund state)
+    // implies a full set of nParticipants postFund signatures have been seen.
     return !!this.supported && this.supported.turnNum >= 2 * this.nParticipants - 1;
   }
 

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -44,8 +44,8 @@ export class ChannelOpener {
         await this.signPrefundSetup(channel, response, tx);
       }
 
-      // if we don't have a supported preFundSetup, we're done for now
-      if (!channel.prefundSupported) {
+      // if we don't have a complete preFundSetup, we're done for now
+      if (!channel.preFundComplete) {
         response.queueChannel(channel); // always queue the channel if we've potentially touched it
         return;
       }
@@ -59,7 +59,7 @@ export class ChannelOpener {
         await this.signPostfundSetup(channel, response, tx);
       }
 
-      if (channel.postfundSupported) {
+      if (channel.postFundComplete) {
         objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
 
         response.queueSucceededObjective(objective);


### PR DESCRIPTION
This is a genuine refactor and does not change any behaviour. I don't think we have any bugs around this at present, but I want to reduce the chance we get one in future. 

This PR aims to be a little more precise on terminology, and to reduce the chance of confusion between a complete setup round and a supported setup state. 

In the prefund stage, the two concepts are the same. But I have a preference for using the "complete" terminology, still, as it seems simpler to me to match the terminology for the postfund round, which I think should change.

In the postfund stage, participant `0` can make state `n` supported as soon as they sign it: they get the remaining `n-1` signatures from the prefund stage. I think it is important that wallets do not have their `OpenChannel` objective succeed, or to have the `Channel` deemed to be running, if they only have (say) 1 postfund signature. They should wait until all postfund signatures have been received, and not just until a postfund state has been supported.

[Relevant conversation on the forum. ](https://statechannels.discourse.group/t/do-we-really-need-the-post-fund-setup-round/76/5)