### PR TITLE
feat: new ledger channel algorithm

### DIFF
--- a/packages/server-wallet/src/db/migrations/20210218145000_add_addn_ledger_request_columns.ts
+++ b/packages/server-wallet/src/db/migrations/20210218145000_add_addn_ledger_request_columns.ts
@@ -1,0 +1,20 @@
+import * as Knex from 'knex';
+
+const tableName = 'ledger_requests';
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.string('amount_a');
+    table.string('amount_b');
+    table.integer('last_seen_agreed_state');
+    table.integer('missed_opportunity_count');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(tableName, table => {
+    table.dropColumn('amount_a');
+    table.dropColumn('amount_b');
+    table.dropColumn('last_seen_agreed_state');
+    table.dropColumn('missed_opportunity_count');
+  });
+}

--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -1,5 +1,5 @@
 import {constants} from 'ethers';
-import {BN, makeAddress} from '@statechannels/wallet-core';
+import {BN, Destination, makeAddress} from '@statechannels/wallet-core';
 
 import {Channel, ChannelError} from '../channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
@@ -47,7 +47,7 @@ describe('validation', () => {
     expect(
       Channel.query(knex).insert({
         ...channel({vars: [stateWithHashSignedBy()()]}),
-        channelId: 'wrongId',
+        channelId: 'wrongId' as Destination,
       })
     ).rejects.toThrow(ChannelError.reasons.invalidChannelId));
 });

--- a/packages/server-wallet/src/models/channel/outcome.ts
+++ b/packages/server-wallet/src/models/channel/outcome.ts
@@ -1,0 +1,132 @@
+import _ from 'lodash';
+import {
+  AllocationItem,
+  BN,
+  makeDestination,
+  SimpleAllocation,
+  Destination,
+} from '@statechannels/wallet-core';
+
+import {Uint256} from '../../type-aliases';
+
+export class SimpleAllocationOutcome {
+  private outcome: SimpleAllocation;
+
+  constructor(outcome: SimpleAllocation) {
+    this.outcome = outcome;
+  }
+
+  public get destinations(): Destination[] {
+    return this.outcome.allocationItems.map(i => i.destination);
+  }
+
+  public balanceFor(destination: Destination): Uint256 | undefined {
+    return this.itemFor(destination)?.amount;
+  }
+
+  public get toLegacyAllocation(): SimpleAllocation {
+    return this.outcome;
+  }
+
+  public get items(): SimpleAllocation['allocationItems'] {
+    return this.outcome.allocationItems;
+  }
+
+  public dup(): SimpleAllocationOutcome {
+    const newOutcome = _.cloneDeep(this.outcome);
+    return new SimpleAllocationOutcome(newOutcome);
+  }
+
+  public isEqualTo(otherOutcome: SimpleAllocationOutcome | undefined): boolean {
+    return (
+      !!otherOutcome &&
+      this.outcome.type === otherOutcome.toLegacyAllocation.type &&
+      this.outcome.assetHolderAddress === otherOutcome.toLegacyAllocation.assetHolderAddress &&
+      _.every(_.zip(this.items, otherOutcome.items).map(([a, b]) => allocationItemsEqual(a, b)))
+    );
+  }
+
+  public remove(
+    channelId: Destination,
+    refundDestinations: Destination[],
+    refundAmounts: Uint256[]
+  ): SimpleAllocationOutcome | undefined {
+    if (refundDestinations.length !== refundAmounts.length)
+      throw new Error('Destinations and amounts have different lengths');
+    // check that channelId exists
+    const itemToRemove = this.itemFor(channelId);
+    const refundItems = refundDestinations.map(d => this.itemFor(d));
+
+    // check that all destinations exist
+    if (!itemToRemove || _.some(refundItems, _.isUndefined)) return undefined;
+
+    // and the refund amounts tally with the amount in the channel
+    if (!BN.eq(itemToRemove.amount, refundAmounts.reduce(BN.add))) return undefined;
+
+    // remove the item
+    _.remove(this.outcome.allocationItems, itemToRemove);
+
+    // and increase the amounts
+    for (const [item, amt] of _.zip(refundItems, refundAmounts)) {
+      if (item && amt) {
+        // we've already checked that items aren't undefined and the two arrays have the
+        // same length, so we'll always up in here. Typescript doesn't know that though
+        item.amount = BN.add(item.amount, amt);
+      }
+    }
+
+    return this;
+  }
+
+  private itemFor(destination: Destination): AllocationItem | undefined {
+    return this.outcome.allocationItems.find(i => i.destination === destination);
+  }
+
+  public add(
+    channelId: Destination,
+    fundingSources: Destination[],
+    fundingAmounts: Uint256[]
+  ): SimpleAllocationOutcome | undefined {
+    if (fundingSources.length !== fundingAmounts.length)
+      throw new Error('Sources and amounts have different lengths');
+    // check that channelId exists
+    const sourceItems = fundingSources.map(d => this.itemFor(d));
+
+    for (const [item, amt] of _.zip(sourceItems, fundingAmounts)) {
+      // check that all sources exist
+      if (!item) return undefined;
+      // shouldn't ever happen, as we checked the lengths above, but typescript doesn't know this
+      if (!amt) throw new Error('More sources that amounts');
+      // and have enough funds
+      if (!BN.gte(item.amount, amt)) return undefined;
+    }
+
+    // add the new amount
+    this.outcome.allocationItems.push({
+      destination: makeDestination(channelId),
+      amount: BN.from(fundingAmounts.reduce(BN.add)),
+    });
+
+    // and decrease the amounts
+    for (const [item, amt] of _.zip(sourceItems, fundingAmounts)) {
+      if (item && amt) {
+        // we've already checked that items aren't undefined and the two arrays have the
+        // same length, so we'll always up in here. Typescript doesn't know that though
+        item.amount = BN.sub(item.amount, amt);
+      }
+    }
+
+    return this;
+  }
+}
+
+function allocationItemsEqual(
+  a: AllocationItem | undefined,
+  b: AllocationItem | undefined
+): boolean {
+  if (a && b) {
+    return a.destination === b.destination && BN.eq(a.amount, b.amount);
+  } else {
+    return false;
+  }
+}

--- a/packages/server-wallet/src/models/channel/state.ts
+++ b/packages/server-wallet/src/models/channel/state.ts
@@ -1,0 +1,63 @@
+import {
+  Address,
+  SignedState,
+  isSimpleAllocation,
+  makeDestination,
+} from '@statechannels/wallet-core';
+import _ from 'lodash';
+
+import {Destination} from '../../type-aliases';
+
+import {SimpleAllocationOutcome} from './outcome';
+
+// This is a wrapper around SignedState that adds a few convenience methods that will
+// be useful to protocols
+export class State {
+  private state: SignedState;
+  constructor(state: SignedState) {
+    this.state = state;
+  }
+
+  get turnNum(): number {
+    return this.state.turnNum;
+  }
+
+  public signedBy(address: Address): boolean {
+    return !!this.state.signatures.find(sig => sig.signer == address);
+  }
+
+  public get signerIndices(): number[] {
+    const res = [];
+    if (this.signedBy(this.state.participants[0].signingAddress)) res.push(0);
+    if (this.signedBy(this.state.participants[1].signingAddress)) res.push(1);
+    return res;
+  }
+
+  public get fullySigned(): boolean {
+    return _.every(this.state.participants, p => this.signedBy(p.signingAddress));
+  }
+
+  public get participantDestinations(): Destination[] {
+    return this.state.participants.map(p => makeDestination(p.destination));
+  }
+
+  public get simpleAllocationOutcome(): SimpleAllocationOutcome | undefined {
+    if (isSimpleAllocation(this.state.outcome)) {
+      return new SimpleAllocationOutcome(this.state.outcome);
+    } else {
+      return undefined;
+    }
+  }
+
+  public advanceToOutcome(outcome: SimpleAllocationOutcome): State {
+    return new State({
+      ...this.state,
+      turnNum: this.turnNum + 1,
+      outcome: outcome.toLegacyAllocation,
+    });
+  }
+
+  public get signedState(): SignedState {
+    return this.state;
+  }
+}

--- a/packages/server-wallet/src/models/ledger-request.ts
+++ b/packages/server-wallet/src/models/ledger-request.ts
@@ -85,7 +85,7 @@ export class LedgerRequest extends Model implements LedgerRequestType {
       .orWhere({ledgerChannelId, status: 'queued'});
   }
 
-  static async ledgersWithNewReqeustsIds(tx: TransactionOrKnex): Promise<string[]> {
+  static async ledgersWithNewRequestsIds(tx: TransactionOrKnex): Promise<string[]> {
     return (
       await LedgerRequest.query(tx).column('ledgerChannelId').whereNull('lastSeenAgreedState')
     ).map(lr => lr.ledgerChannelId);

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -270,6 +270,16 @@ export class ObjectiveModel extends Model {
     ).toObjective();
   }
 
+  static async approvedObjectiveIds(
+    targetChannelIds: string[],
+    tx: TransactionOrKnex
+  ): Promise<string[]> {
+    // todo: make this more efficient
+    return (await this.forChannelIds(targetChannelIds, tx))
+      .filter(x => x.status === 'approved')
+      .map(x => x.objectiveId);
+  }
+
   static async forChannelIds(
     targetChannelIds: string[],
     tx: TransactionOrKnex

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -74,8 +74,8 @@ describe(`defunding phase (when the channel is closed)`, () => {
   });
   describe(`fake funding`, () => {
     it('marks the objective as complete', async () => {
-      const testChan = TestChannel.create({finalFrom: FINAL, fundingStrategy: 'Fake'});
-      const objective = await setup(testChan, {participant: 0, statesHeld: [FINAL, FINAL + 1]});
+      const testChan2 = TestChannel.create({finalFrom: FINAL, fundingStrategy: 'Fake'});
+      const objective = await setup(testChan2, {participant: 0, statesHeld: [FINAL, FINAL + 1]});
 
       await crankAndAssert(objective, {completesObj: true});
     });

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -14,9 +14,7 @@ import {LedgerManager} from '../ledger-manager';
 import {WalletResponse} from '../../wallet/wallet-response';
 import {Destination} from '../../type-aliases';
 
-// TEST HELPERS
 jest.setTimeout(10_000);
-// END TEST HELPERS
 
 let store: Store;
 
@@ -400,7 +398,6 @@ describe('as follower', () => {
         },
       })
     );
-    // TODO: it will mark a mismatched cancellation as inconsistent
   });
   describe('in the proposal state', () => {
     it(

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -53,9 +53,6 @@ export class LedgerFunder {
     // if we already requested funding return false
     if (await this.alreadyRequestedFunding(channel.channelId, tx)) return false;
 
-    // NOTE FOR TOMORROW:
-    // it seems like the open channel algorithm doens't notice that the channel is funded
-
     // otherwise request funding
     await this.requestLedgerFunding(channel, ledger, tx);
     return false;

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -53,8 +53,11 @@ export class LedgerFunder {
     // if we already requested funding return false
     if (await this.alreadyRequestedFunding(channel.channelId, tx)) return false;
 
+    // NOTE FOR TOMORROW:
+    // it seems like the open channel algorithm doens't notice that the channel is funded
+
     // otherwise request funding
-    await this.requestLedgerFunding(channel.channelId, ledgerId, tx);
+    await this.requestLedgerFunding(channel, ledger, tx);
     return false;
   }
 
@@ -68,11 +71,22 @@ export class LedgerFunder {
   }
 
   private async requestLedgerFunding(
-    channelId: string,
-    ledgerId: string,
+    channel: Channel,
+    ledger: Channel,
     tx: Transaction
   ): Promise<void> {
-    await LedgerRequest.requestLedgerFunding(channelId, ledgerId, tx);
+    const myAmount = channel.myAmount;
+    const theirAmount = channel.opponentAmount;
+    const [amountA, amountB] =
+      ledger.myIndex === 0 ? [myAmount, theirAmount] : [theirAmount, myAmount];
+
+    await LedgerRequest.requestLedgerFunding(
+      channel.channelId,
+      ledger.channelId,
+      amountA,
+      amountB,
+      tx
+    );
   }
 
   private async alreadyRequestedFunding(channelId: string, tx: Transaction): Promise<boolean> {

--- a/packages/server-wallet/src/protocols/ledger-manager.ts
+++ b/packages/server-wallet/src/protocols/ledger-manager.ts
@@ -458,18 +458,18 @@ export class LedgerManager {
     if (!antepenultimateState) return {type: 'protocol-violation'};
 
     if (
-      !antepenultimateState.fullySigned &&
+      antepenultimateState.fullySigned &&
       penultimateState.signedBy(leader) &&
       latestState.signedBy(follower)
     ) {
-      return {type: 'protocol-violation'};
-    } else {
       return {
         type: 'counter-proposal',
         counterProposed: latestState,
         proposed: penultimateState,
         agreed: antepenultimateState,
       };
+    } else {
+      return {type: 'protocol-violation'};
     }
   }
 

--- a/packages/server-wallet/src/protocols/ledger-manager.ts
+++ b/packages/server-wallet/src/protocols/ledger-manager.ts
@@ -32,7 +32,7 @@ import {LedgerRequest} from '../models/ledger-request';
 // The follower acts as follows:
 // * In Agreement, does nothing
 // * In Proposal:
-//    * If all updates are in the queue, double-signs. The state is now Proposal.
+//    * If all updates are in the queue, double-signs. The state is now Agreement.
 //    * Otherwise, removes the states that are not in queue and formulates new state.
 //      The state is now Counter-proposal
 // * In Counter-proposal, does nothing
@@ -257,7 +257,7 @@ export class LedgerManager {
     const agreedOutcome = agreedState.simpleAllocationOutcome;
     if (!agreedOutcome) throw Error("Ledger state doesn't have a simple allocation outcome");
 
-    const [fundings, defundings] = _.partition(requests, r => r.type === 'fund');
+    const [fundings, defundings] = _.partition(requests, r => r.isFund);
 
     // for defundings, one of three things is true:
     // 1. the channel doesn't appear => defunding successful
@@ -491,7 +491,7 @@ export class LedgerManager {
         currentOutcome = updatedOutcome;
       } else {
         // the only way removal fails is if the refund amounts don't match the amount in the channel
-        // in that case the request is not viable and should be marked as insconsistent
+        // in that case the request is not viable and should be marked as inconsistent
         defundReq.status = 'inconsistent';
       }
     }

--- a/packages/server-wallet/src/type-aliases.ts
+++ b/packages/server-wallet/src/type-aliases.ts
@@ -1,8 +1,9 @@
 import {Message as _WireMessage} from '@statechannels/wire-format';
+export {Destination} from '@statechannels/wallet-core';
 
 export declare type ParticipantId = string;
-export declare type Uint256 = string;
 export declare type Uint48 = number;
+export declare type Uint256 = string;
 export declare type Bytes32 = string;
 export declare type Bytes = string;
 

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -3,11 +3,7 @@ import {
   BN,
   serializeState,
   serializeAllocation,
-  makeDestination,
-  SignedStateWithHash,
   serializeOutcome,
-  makeAddress,
-  serializeRequest,
 } from '@statechannels/wallet-core';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
 import Objection from 'objection';
@@ -211,7 +207,6 @@ describe('directly funded app', () => {
 describe('ledger funded app scenarios', () => {
   let ledger: Channel;
   let app: Channel;
-  let expectedUpdatedLedgerState: SignedStateWithHash;
 
   beforeEach(async () => {
     const someNonConflictingChannelNonce = 23364518;
@@ -240,22 +235,6 @@ describe('ledger funded app scenarios', () => {
       fundingStrategy: 'Ledger',
       fundingLedgerChannelId: ledger.channelId,
     });
-
-    // Construct expected ledger update state
-    expectedUpdatedLedgerState = {
-      ...ledger.latest,
-      turnNum: 6,
-      outcome: {
-        type: 'SimpleAllocation' as const,
-        assetHolderAddress: makeAddress('0x0000000000000000000000000000000000000000'),
-        allocationItems: [
-          {
-            destination: makeDestination(app.channelId), // Funds allocated to channel
-            amount: BN.from(5), // As per channel outcome
-          },
-        ],
-      },
-    };
   });
 
   const putTestChannelInsideWallet = async (args: Objection.PartialModelObject<Channel>) => {
@@ -301,15 +280,6 @@ describe('ledger funded app scenarios', () => {
             sender: 'bob',
             data: {
               signedStates: [serializeState(stateWithHashSignedBy([bob()])(signedPreFS1))],
-              requests: [
-                serializeRequest({
-                  type: 'ProposeLedgerUpdate',
-                  channelId: ledger.channelId,
-                  outcome: expectedUpdatedLedgerState.outcome,
-                  nonce: 1,
-                  signingAddress: bob().address,
-                }),
-              ],
             },
           },
         },

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -349,7 +349,7 @@ export class Store {
   }
 
   async getLedgersWithNewRequestsIds(tx?: Transaction): Promise<string[]> {
-    return LedgerRequest.ledgersWithNewReqeustsIds(tx || this.knex);
+    return LedgerRequest.ledgersWithNewRequestsIds(tx || this.knex);
   }
 
   async approveObjective(objectiveId: string, tx?: Transaction): Promise<void> {


### PR DESCRIPTION
Adds a new ledger channel algorithm

## Background

The ledger funding algorithm in current master (roughly) works as follows:

- When an objective wants a channel to added to / removed from a ledger channel it creates a `LedgerRequest`. The request stores the `channelId`, `ledgerId`, and whether it's a fund/defund.
- After all objectives have been cranked, the `LedgerManager` processes the ledger request queue.
- In order to decide what update to propose, the participants exchange *ledger proposals.* Roughly, both participants send each other the list of changes they're willing to make at this point, and the actual change is computed by taking the intersection.
- A ledger update is then proposed containing this intersection, which should be accepted by each party.

As far as I'm aware, there isn't high confidence that the current implementation is robust. ~~There have been some efforts to show that it is, which haven't yet been successful.~~

## Changes made / motivations

This work suggests a new ledger funding algorithm. It makes the following changes:

1. No ledger proposals are required, instead the ledger states themselves are used to communicate proposals. This allows us to remove an object from the store and wire protocol, and should improve robustness, as we can lean on the existing mechanisms for syncing states between participants. We still obtain agreement in a single round-trip. 
2. Adds an efficient and robust mechanism for handling the case where a protocol wants to cancel funding it has requested. In short, a protocol can cancel a funding request with a defund request. The ledger manager will cancel the initial fund request if it can, or defund if it is too late to cancel.
3. Ledger requests now hold the diff they want to apply to the ledger, instead of the just the channelId. This decouples the ledger manager from the state of the channel, which should make it easier to add more exotic ledger operations (e.g. partial withdrawals) in the future. It also slightly more efficient, as it means the ledger manager doesn't need to query the channel.
4. It adds a "missedOpportunityCount" to the ledger request, which tracks how many time the request could have been included in a new agreed state but wasn't. In the future the wallet can use this information to detect ledger updates that have likely stalled (e.g. because the opponent has abandoned/lost the objective), and take appropriate action.

A detailed description of the algorithm is included in the [comments in the code](https://github.com/statechannels/statechannels/blob/tc/new-ledger-algorithm/packages/server-wallet/src/protocols/ledger-manager.ts#L11-L68). 

## Alternative approaches considered

I spent some time considering the "ledger updates as objectives" proposal. My notes are [here](https://www.notion.so/Ledger-Channels-d5af6ed79b7e4d4eb3e3511b7b8f8b18). In short:

- In the current one-objective-per-channel architecture, ledger updates as objectives breaks down pretty quickly, unless you stick to the case where a ledger is used to fund a single set of channels that are funded / defunded at the same time.
- There are no alternative written proposals for architectures that don't use one-objective-per-channel, so I am unable to evaluate the "ledger updates as objectives" in these architectures.

In any case, my understanding is that a key motivation for "ledger updates as objectives" is that it is believed that it would be simple and would just work, and it's worth living with the downsides in the short-term for those reasons (as far as I'm aware there is no proposal outlining the approach and the motivations, so I could be wrong here). If the approach proposed here is simple and works, it dominates this alternative, as it doesn't share the limitations described above.
## How Has This Been Tested?

I have written a fairly comprehensive test suite to test the new ledger-manager.

---

## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue