### PR TITLE
Fix AdjudicatorState setFinalized

### DIFF
--- a/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
+++ b/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
@@ -43,7 +43,7 @@ describe('AdjudicatorStatus model', () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
     await AdjudicatorStatusModel.insertAdjudicatorStatus(knex, c.channelId, 5, [challengeState]);
-    await AdjudicatorStatusModel.setFinalized(knex, c.channelId, 2, 10);
+    await AdjudicatorStatusModel.setFinalized(knex, c.channelId, 2, 10, 5);
 
     const result = await AdjudicatorStatusModel.getAdjudicatorStatus(knex, c.channelId);
 

--- a/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
+++ b/packages/server-wallet/src/models/__test__/adjudicator-status.test.ts
@@ -16,6 +16,13 @@ describe('AdjudicatorStatus model', () => {
 
   afterAll(async () => await knex.destroy());
 
+  it('inserts an adjudicator status row if the row does not exist', async () => {
+    const c = channel();
+    await Channel.query(knex).insert(c);
+    const result = await AdjudicatorStatusModel.setFinalized(knex, c.channelId, 5, 5, 5);
+    expect(result).toMatchObject({channelMode: 'Finalized'});
+  });
+
   it('returns an active challenge status when the challenge is not finalized (finalizesAt>blockNumber)', async () => {
     const c = channel();
     const challengeState = stateSignedBy([alice()])();

--- a/packages/server-wallet/src/models/adjudicator-status.ts
+++ b/packages/server-wallet/src/models/adjudicator-status.ts
@@ -41,11 +41,17 @@ export class AdjudicatorStatusModel extends Model implements RequiredColumns {
     knex: Knex,
     channelId: string,
     blockNumber: number,
-    blockTimestamp: number
+    blockTimestamp: number,
+    finalizesAt: number
   ): Promise<AdjudicatorStatus> {
-    const existing = await AdjudicatorStatusModel.query(knex).where({channelId});
+    const existing = await AdjudicatorStatusModel.query(knex).where({channelId}).first();
     if (!existing) {
-      await AdjudicatorStatusModel.query(knex).insert({channelId, blockNumber, blockTimestamp});
+      await AdjudicatorStatusModel.query(knex).insert({
+        channelId,
+        blockNumber,
+        blockTimestamp,
+        finalizesAt,
+      });
     }
     const result = await AdjudicatorStatusModel.query(knex)
       .patch({blockNumber, blockTimestamp})

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -191,7 +191,7 @@ async function setAdjudicatorStatus(
     stateSignedBy([alice()])(state),
   ]);
   if (status === 'finalized') {
-    await AdjudicatorStatusModel.setFinalized(knex, channelId, 22, 200);
+    await AdjudicatorStatusModel.setFinalized(knex, channelId, 22, 200, 100);
   }
 }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -749,9 +749,16 @@ export class Store {
   async markAdjudicatorStatusAsFinalized(
     channelId: string,
     blockNumber: number,
-    blockTimestamp: number
+    blockTimestamp: number,
+    finalizedAt: number
   ): Promise<void> {
-    await AdjudicatorStatusModel.setFinalized(this.knex, channelId, blockNumber, blockTimestamp);
+    await AdjudicatorStatusModel.setFinalized(
+      this.knex,
+      channelId,
+      blockNumber,
+      blockTimestamp,
+      finalizedAt
+    );
   }
 
   async updateTransferredOut(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -1006,7 +1006,8 @@ export class SingleThreadedWallet
     await this.store.markAdjudicatorStatusAsFinalized(
       arg.channelId,
       arg.blockNumber,
-      arg.blockTimestamp
+      arg.blockTimestamp,
+      arg.finalizedAt
     );
     await this.knex.transaction(async tx => {
       const objective = await this.store.ensureObjective(


### PR DESCRIPTION
```
// If the query does not contain a result, existing === []
const existing = await AdjudicatorStatusModel.query(knex).where({channelId});
// This condition is false if existing === []
if (!existing)
```
This PR fixes the issue above and wires through `finalizedAt` parameter from the wallet API to the `AdjudicatorState` model as `finalizesAt` is required to be non-null

## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
