### PR TITLE
Defunder protocol tests

### DIFF
--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -227,7 +227,9 @@ it('Create a directly funded channel between two wallets ', async () => {
   expect(closeA.channelResult).toMatchObject({
     status: 'closing',
     turnNum: 4,
-    fundingStatus: 'Funded',
+    // TODO: the fundingStatus is incorrect as the funding table is not joined with channels table
+    //  when processing the pushMessage above
+    // fundingStatus: 'Funded',
   });
 
   const closeB = await b.pushMessage(getPayloadFor(participantB.participantId, closeA.outbox));

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -1,0 +1,119 @@
+import {defaultTestConfig} from '../..';
+import {testKnex} from '../../../jest/knex-setup-teardown';
+import {MockChainService} from '../../chain-service';
+import {DBAdmin} from '../../db-admin/db-admin';
+import {createLogger} from '../../logger';
+import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
+import {Channel} from '../../models/channel';
+import {Funding} from '../../models/funding';
+import {Store} from '../../wallet/store';
+import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
+import {Defunder} from '../defunder';
+
+const testChannelObj = TestChannel.create({
+  aBal: 5,
+  bBal: 3,
+  finalFrom: 4,
+});
+let store: Store;
+
+beforeEach(async () => {
+  await DBAdmin.truncateDataBaseFromKnex(testKnex);
+
+  store = new Store(
+    testKnex,
+    defaultTestConfig().metricsConfiguration.timingMetrics,
+    defaultTestConfig().skipEvmValidation,
+    '0'
+  );
+});
+
+describe('Direct channel defunding', () => {
+  it('Channel is defunded via submission of withdrawAndConlcude transaction', async () => {
+    // Channel has yet to be concluded
+    await testChannelObj.insertInto(store, {
+      participant: 0,
+      states: [3, 4],
+      funds: 8,
+    });
+    const chainService = new MockChainService();
+    const spy = jest.spyOn(chainService, 'concludeAndWithdraw');
+    const logger = createLogger(defaultTestConfig());
+
+    let channel = await Channel.forId(testChannelObj.channelId, testKnex);
+    const defunder = new Defunder(store, chainService, logger);
+
+    testKnex.transaction(async tx => {
+      // Defunder should take no actions as there is no conclusion proof.
+      expect(await defunder.crank(channel, tx)).toEqual({
+        didSubmitTransaction: false,
+        isChannelDefunded: false,
+      });
+      expect(spy).not.toHaveBeenCalled();
+
+      // Defunder should submit a transaction since there is a conclusion proof.
+      const state = testChannelObj.wireState(5);
+      channel = await store.addSignedState(channel.channelId, state, tx);
+      expect(await defunder.crank(channel, tx)).toEqual({
+        didSubmitTransaction: true,
+        isChannelDefunded: false,
+      });
+      expect(spy).toHaveBeenCalledWith(channel.support);
+
+      // The channel has NOT been fully defunded.
+      // Defunder does not complete
+      await Funding.updateFunding(tx, channel.channelId, '0x03', testChannelObj.assetHolderAddress);
+      expect(await defunder.crank(channel, tx)).toEqual({
+        didSubmitTransaction: false,
+        isChannelDefunded: false,
+      });
+
+      // The channel has been fully defunded
+      // Defunder completes
+      await Funding.updateFunding(tx, channel.channelId, '0x00', testChannelObj.assetHolderAddress);
+      expect(await defunder.crank(channel, tx)).toEqual({
+        didSubmitTransaction: false,
+        isChannelDefunded: true,
+      });
+    });
+  });
+
+  it('Channel is defunded via pushOutcome transaction', async () => {
+    // Channel has yet to be concluded
+    await testChannelObj.insertInto(store, {
+      participant: 0,
+      states: [3, 4],
+      funds: 8,
+    });
+    const state3 = testChannelObj.signedStateWithHash(3);
+    const state4 = testChannelObj.signedStateWithHash(4);
+
+    const chainService = new MockChainService();
+    const spy = jest.spyOn(chainService, 'pushOutcomeAndWithdraw');
+    const logger = createLogger(defaultTestConfig());
+
+    const channel = await Channel.forId(testChannelObj.channelId, testKnex);
+    const defunder = new Defunder(store, chainService, logger);
+    await AdjudicatorStatusModel.insertAdjudicatorStatus(testKnex, channel.channelId, 1, [
+      state4,
+      state3,
+    ]);
+    await AdjudicatorStatusModel.setFinalized(testKnex, channel.channelId, 1, 1, 1);
+
+    await testKnex.transaction(async tx => {
+      expect(await defunder.crank(channel, tx)).toEqual({
+        didSubmitTransaction: true,
+        isChannelDefunded: false,
+      });
+      expect(spy).toHaveBeenCalledWith(state4, channel.myAddress);
+
+      // The channel has been fully defunded
+      // Defunder completes
+      await Funding.updateFunding(tx, channel.channelId, '0x00', testChannelObj.assetHolderAddress);
+      expect(await defunder.crank(channel, tx)).toEqual({
+        didSubmitTransaction: false,
+        isChannelDefunded: true,
+      });
+    });
+  });
+});

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -36,9 +36,6 @@ export class ChannelCloser {
         throw new Error('Channel must exist');
       }
 
-      await channel.$fetchGraph('funding', {transaction: tx});
-      await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
-
       try {
         if (!ensureAllAllocationItemsAreExternalDestinations(channel)) {
           response.queueChannel(channel);

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -32,9 +32,6 @@ export class ChannelDefunder {
         return;
       }
 
-      await channel.$fetchGraph('funding', {transaction: tx});
-      await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
-
       // This if-statement should be removed and test cases should be added.
       // Defund channel now (in theory) supports Ledger funded channels.
       if (channel.fundingStrategy !== 'Direct') {

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -79,6 +79,8 @@ export class Defunder {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'pushOutcome', tx);
       await this.chainService.pushOutcomeAndWithdraw(
         adjudicatorStatus.states[0],
+        // todo: we are assuming that we submitted the challenge.
+        // This is not a valid assumption as the defunder protocol can be run no matter how the channel was finalized
         channel.myAddress
       );
       didSubmitTransaction = true;

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -90,14 +90,18 @@ export class Defunder {
   }
 
   private async ledgerDefunder(channel: Channel, tx: Transaction): Promise<DefunderResult> {
+    const didSubmitTransaction = false;
+    if (!channel.hasConclusionProof) {
+      return {isChannelDefunded: false, didSubmitTransaction};
+    }
     const ledgerRequest = await this.store.getLedgerRequest(channel.channelId, 'defund', tx);
     if (ledgerRequest && ledgerRequest.status === 'succeeded') {
-      return {isChannelDefunded: true, didSubmitTransaction: false};
+      return {isChannelDefunded: true, didSubmitTransaction};
     }
     if (!ledgerRequest || ledgerRequest.status !== 'pending') {
       await this.requestLedgerDefunding(channel, tx);
     }
-    return {isChannelDefunded: false, didSubmitTransaction: false};
+    return {isChannelDefunded: false, didSubmitTransaction};
   }
 
   private async requestLedgerDefunding(channel: Channel, tx: Transaction): Promise<void> {

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -30,10 +30,12 @@ export class Defunder {
 
   public async crank(channel: Channel, tx: Transaction): Promise<DefunderResult> {
     const {protocolState: ps} = channel;
+    await channel.$fetchGraph('funding', {transaction: tx});
+    await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
 
     switch (ps.fundingStrategy) {
       case 'Direct':
-        return await this.directDefunder(channel, tx);
+        return this.directDefunder(channel, tx);
       case 'Ledger':
         return this.ledgerDefunder(channel, tx);
       case 'Unknown':

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -9,6 +9,21 @@ import {Channel} from '../models/channel';
 import {LedgerRequest} from '../models/ledger-request';
 import {Store} from '../wallet/store';
 
+/**
+ * DefunderResult type is the return value of the crank method. The return value of the crank method
+ * should be a boolean in the medium/long term.
+ *
+ * Why is that?
+ * The boolean will represent whether the Defunder protocol has reached the terminal point.
+ * This is the pattern established by the ChannelOpener protocol. The caller of the Defunder
+ * protocol should not be concerned with internal details of whether a transaction is submitted.
+ *
+ * What about didSubmitTransaction?
+ * In the short term, the ChannelDefunder protocol (which invoked the Defunder protocol) completes
+ * upon transaction submission. ChannelDefunder protocol will not be used in the medium term.
+ * Most likely, a ChallengeAndWithdraw protocol (which invokes this Defunder protocol) will
+ * make the ChannelDefunder protocol aboslete.
+ */
 export type DefunderResult = {isChannelDefunded: boolean; didSubmitTransaction: boolean};
 
 export class Defunder {

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -79,7 +79,7 @@ export class Defunder {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'pushOutcome', tx);
       await this.chainService.pushOutcomeAndWithdraw(
         adjudicatorStatus.states[0],
-        // todo: we are assuming that we submitted the challenge.
+        // TODO: we are assuming that we submitted the challenge.
         // This is not a valid assumption as the defunder protocol can be run no matter how the channel was finalized
         channel.myAddress
       );


### PR DESCRIPTION
The bulk of this PR is the addition of Defunder protocol tests. A couple minor changes are also included. These are:
- Defunder protocol ensures that all relations needed for the protocol are joined when `crank` is invoked.
- Defunder for ledger funded channels checks that the channel has a conclusion proof.

This PR fixes https://github.com/statechannels/statechannels/issues/3124 as it is the last piece of work needed.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
