### PR TITLE
fix: do not assume that a ledger channel is directly funded

### DIFF
--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -63,13 +63,7 @@ export class LedgerFunder {
     ledger: Channel,
     _tx: Transaction
   ): Promise<boolean> {
-    // for time being ledger must be a direct channel
-    // TODO: in the future check "funding table"
-    if (!ledger.isFullyDirectFunded) return false;
-
-    // ledger is running
     if (!ledger.isRunning) return false;
-
     return doesLedgerFundApp(ledger, channel);
   }
 


### PR DESCRIPTION
At the moment, a ledger channel might be directly funded or fake funded. In the future, a ledger channel might be virtually funded or funded by another ledger channel.

In any of the above cases, when funding a channel with a ledger channel, we should only proceed with the ledger funding protocol if the ledger channel is in the running stage regardless of how it was funded.

This hopefully addresses https://github.com/statechannels/statechannels/issues/3295.