### PR TITLE
Consistently log crank errors

### DIFF
--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -31,51 +31,53 @@ export class ChallengeSubmitter {
   ): Promise<void> {
     const {targetChannelId: channelToLock} = objective.data;
 
-    await this.store.transaction(async tx => {
-      const channel = await this.store.getAndLockChannel(channelToLock, tx);
-      if (!channel) {
-        this.logger.warn(`No channel exists for channel ${channelToLock}`);
-        return;
-      }
+    await this.store
+      .transaction(async tx => {
+        const channel = await this.store.getAndLockChannel(channelToLock, tx);
+        if (!channel) {
+          this.logger.warn(`No channel exists for channel ${channelToLock}`);
+          return;
+        }
 
-      const status = channel.adjudicatorStatus
-        ? channel.adjudicatorStatus.toResult().channelMode
-        : 'Open';
-      if (status !== 'Open') {
-        this.logger.warn('There is an existing challenge or the channel is finalized on chain');
-        return;
-      }
+        const status = channel.adjudicatorStatus
+          ? channel.adjudicatorStatus.toResult().channelMode
+          : 'Open';
+        if (status !== 'Open') {
+          this.logger.warn('There is an existing challenge or the channel is finalized on chain');
+          return;
+        }
 
-      if (!channel.signingWallet) {
-        throw new Error(`No signing wallet fetched for channel ${channelToLock}`);
-      }
+        if (!channel.signingWallet) {
+          throw new Error(`No signing wallet fetched for channel ${channelToLock}`);
+        }
 
-      const existingRequest = await ChainServiceRequest.query(tx)
-        .where({channelId: channelToLock, request: 'challenge'})
-        .first();
+        const existingRequest = await ChainServiceRequest.query(tx)
+          .where({channelId: channelToLock, request: 'challenge'})
+          .first();
 
-      if (existingRequest) {
-        this.logger.warn('There is already an existing request', existingRequest);
-        return;
-      }
+        if (existingRequest) {
+          this.logger.warn('There is already an existing request', existingRequest);
+          return;
+        }
 
-      await ChainServiceRequest.insertOrUpdate(channelToLock, 'challenge', tx);
+        await ChainServiceRequest.insertOrUpdate(channelToLock, 'challenge', tx);
 
-      if (channel.initialSupport.length === 0) {
-        this.logger.error(
-          {channelId: channel.channelId},
-          'There is no initial support stored for the channel'
-        );
-        await this.store.markObjectiveStatus(objective, 'failed', tx);
-        return;
-      }
+        if (channel.initialSupport.length === 0) {
+          this.logger.error(
+            {channelId: channel.channelId},
+            'There is no initial support stored for the channel'
+          );
+          await this.store.markObjectiveStatus(objective, 'failed', tx);
+          return;
+        }
 
-      await this.chainService.challenge(channel.initialSupport, channel.signingWallet.privateKey);
+        await this.chainService.challenge(channel.initialSupport, channel.signingWallet.privateKey);
 
-      objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
-      response.queueChannel(channel);
-      response.queueSucceededObjective(objective);
-    });
+        objective = await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+        response.queueChannel(channel);
+        response.queueSucceededObjective(objective);
+      })
+      .catch(err => this.logger.error({err, objective}, 'Cannot crank ChallengeSubmitter'));
   }
 
   /**

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -31,8 +31,8 @@ export class ChannelCloser {
   public async crank(objective: DBCloseChannelObjective, response: WalletResponse): Promise<void> {
     const channelToLock = objective.data.targetChannelId;
 
-    await this.store.lockApp(channelToLock, async (tx, channel) => {
-      try {
+    await this.store
+      .lockApp(channelToLock, async (tx, channel) => {
         if (!ensureAllAllocationItemsAreExternalDestinations(channel)) {
           response.queueChannel(channel);
           return;
@@ -56,11 +56,8 @@ export class ChannelCloser {
         }
 
         await this.completeObjective(objective, channel, tx, response);
-      } catch (error) {
-        this.logger.error({error}, 'Error taking a protocol step');
-        await tx.rollback(error);
-      }
-    });
+      })
+      .catch(err => this.logger.error({err, objective}, 'Cannot crank ChannelCloser'));
   }
 
   private async areAllFinalStatesSigned(

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -42,17 +42,17 @@ export class ChannelCloser {
           return;
         }
 
+        if (!(await this.areAllFinalStatesSigned(channel, tx, response))) {
+          response.queueChannel(channel);
+          return;
+        }
+
         const defunder = Defunder.create(
           this.store,
           this.chainService,
           this.logger,
           this.timingMetrics
         );
-
-        if (!(await this.areAllFinalStatesSigned(channel, tx, response))) {
-          response.queueChannel(channel);
-          return;
-        }
 
         if (!(await defunder.crank(channel, tx)).isChannelDefunded) {
           response.queueChannel(channel);

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -32,10 +32,6 @@ export class ChannelCloser {
     const channelToLock = objective.data.targetChannelId;
 
     await this.store.lockApp(channelToLock, async (tx, channel) => {
-      if (!channel) {
-        throw new Error('Channel must exist');
-      }
-
       try {
         if (!ensureAllAllocationItemsAreExternalDestinations(channel)) {
           response.queueChannel(channel);


### PR DESCRIPTION
Consistently log crank errors, taking advantage of knex's default behaviour, which rolls back transactions & re-throws the error thrown within the transaction'ss scope.

(Plus some tiny refactor of `channel-closer`)

### Easy mode
[Ignore whitespace when reviewing the diff](https://github.com/statechannels/statechannels/pull/3299/files?diff=unified&w=1)

(You can add `&w=1` to almost any diff-view in GH to achieve the same effect)

## How did I test this?

I ran this script, which is slightly modified from [the docs](http://knexjs.org/#Transactions).
```
// src/tx-test.ts
import Knex from 'knex';

import {createLogger} from './logger';

import {defaultTestConfig, extractDBConfigFromServerWalletConfig} from '.';

const knex = Knex(extractDBConfigFromServerWalletConfig(defaultTestConfig({})));
const logger = createLogger(defaultTestConfig());

// Using trx as a query builder:
knex
  .transaction(function (trx) {
    const books = [{title: 'Canterbury Tales'}, {title: 'Moby Dick'}, {title: 'Hamlet'}];

    return trx
      .insert({name: 'Old Books'}, 'id')
      .into('catalogues')
      .then(function (ids) {
        books.forEach(book => (book.title = 'title' + ids));
        return trx('books').insert(books);
      });
  })
  .then(function (inserts) {
    console.log(inserts.length + ' new books saved.');
  })
  .catch(function (err) {
    // If we get here, that means that neither the 'Old Books' catalogues insert,
    // nor any of the books inserts will have taken place.

    logger.error({err}, 'TX FAILED');
  });

```

It logged this error:
```
packages/server-wallet/src on  ags/log-crank-errors [$?] via ⬢ v12.16.3 on ☁️  (us-west-1) on ☁️ andrew.stewart@mesh.xyz took 9s 
❯ pbpaste | pino-pretty
[1613172482755] ERROR (63848 on MacBook-Pro-10.local): TX FAILED
    dbName: "server_wallet_test"
    walletVersion: ""
    err: {
      "type": "Error",
      "message": "insert into \"catalogues\" (\"name\") values ($1) returning \"id\" - relation \"catalogues\" does not exist",
      "stack":
          error: insert into "catalogues" ("name") values ($1) returning "id" - relation "catalogues" does not exist
              at Connection.parseE (/Users/andrewstewart/Code/magmo/monorepo/node_modules/pg/lib/connection.js:604:13)
              at Connection.parseMessage (/Users/andrewstewart/Code/magmo/monorepo/node_modules/pg/lib/connection.js:403:19)
              at Socket.<anonymous> (/Users/andrewstewart/Code/magmo/monorepo/node_modules/pg/lib/connection.js:123:22)
              at Socket.emit (events.js:310:20)
              at Socket.EventEmitter.emit (domain.js:482:12)
              at addChunk (_stream_readable.js:286:12)
              at readableAddChunk (_stream_readable.js:268:9)
              at Socket.Readable.push (_stream_readable.js:209:10)
              at TCP.onStreamRead (internal/stream_base_commons.js:186:23)
      "name": "error",
      "length": 109,
      "severity": "ERROR",
      "code": "42P01",
      "position": "13",
      "file": "parse_relation.c",
      "line": "1180",
      "routine": "parserOpenTable"
```

---
## Checklist:

- [x] 9/9
