### PR TITLE
Roll out waitingFor to all objective crankers

### DIFF
--- a/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test__/create-and-close-channel/direct-funding.test.ts
@@ -9,6 +9,7 @@ import {BigNumber, ethers} from 'ethers';
 
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection} from '../../config';
 import {DBAdmin} from '../../db-admin/db-admin';
+import {WaitingFor} from '../../protocols/channel-opener';
 import {Wallet} from '../../wallet';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../test-helpers';
 
@@ -96,6 +97,7 @@ it('Create a directly funded channel between two wallets ', async () => {
   // Let's check what wallet a is waiting for. Expect it to be 'theirPreFundSetup' or ''
   // (if the objective has never been cranked)
   const waitingForBefore = (await a.getObjective(`OpenChannel-${channelId}`)).waitingFor;
+  expect([WaitingFor.theirPreFundSetup, '']).toContain(waitingForBefore);
 
   //    > PreFund0A
   const resultB0 = await b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
@@ -119,6 +121,7 @@ it('Create a directly funded channel between two wallets ', async () => {
   //  a's OpenChannel objective should have made some progress (it is now waiting on something else)
   const waitingForAfter = (await a.getObjective(`OpenChannel-${channelId}`)).waitingFor;
   expect(waitingForAfter).not.toEqual(waitingForBefore);
+  expect(waitingForAfter).toEqual(WaitingFor.funding);
 
   /**
    * In this case, there is no auto-advancing to the running stage. Instead we have

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -25,14 +25,22 @@ beforeEach(async () => {
 describe('Objective > insert', () => {
   it('returns an objective with Date types for timestamps', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    const inserted = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const inserted = await ObjectiveModel.insert(
+      {...objective, status: 'pending', waitingFor: WaitingFor.theirPreFundSetup},
+      knex
+    );
 
     expect(inserted.createdAt instanceof Date).toBe(true);
     expect(inserted.progressLastMadeAt instanceof Date).toBe(true);
   });
   it('fails to insert / associate an objective when it references a channel that does not exist', async () => {
     // For some reason this does not catch the error :/
-    await expect(ObjectiveModel.insert({...objective, status: 'pending'}, knex)).rejects.toThrow();
+    await expect(
+      ObjectiveModel.insert(
+        {...objective, status: 'pending', waitingFor: WaitingFor.theirPreFundSetup},
+        knex
+      )
+    ).rejects.toThrow();
 
     expect(await ObjectiveModel.query(knex).select()).toMatchObject([]);
 
@@ -42,7 +50,10 @@ describe('Objective > insert', () => {
   it('inserts and associates an objective with all channels that it references (channels exist)', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
-    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert(
+      {...objective, status: 'pending', waitingFor: WaitingFor.theirPreFundSetup},
+      knex
+    );
 
     expect(await ObjectiveModel.query(knex).select()).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},
@@ -56,7 +67,10 @@ describe('Objective > insert', () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
-    const {createdAt} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const {createdAt} = await ObjectiveModel.insert(
+      {...objective, status: 'pending', waitingFor: WaitingFor.theirPreFundSetup},
+      knex
+    );
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
 
     expect(createdAt.getTime() > before).toBe(true);
@@ -65,7 +79,10 @@ describe('Objective > insert', () => {
 
   it('updates the progressLastMadeAt timestamp on an objective when updateWaitingFor is called', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const {objectiveId} = await ObjectiveModel.insert(
+      {...objective, status: 'pending', waitingFor: WaitingFor.theirPreFundSetup},
+      knex
+    );
 
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
     const {progressLastMadeAt} = await ObjectiveModel.updateWaitingFor(
@@ -83,7 +100,10 @@ describe('Objective > insert', () => {
 describe('Objective > forId', () => {
   it('returns an objective with Date types for timestamps', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert(
+      {...objective, status: 'pending', waitingFor: WaitingFor.theirPreFundSetup},
+      knex
+    );
 
     const fetchedObjective = await ObjectiveModel.forId(`OpenChannel-${c.channelId}`, knex);
     expect(fetchedObjective.createdAt instanceof Date).toBe(true);
@@ -95,7 +115,10 @@ describe('Objective > forChannelIds', () => {
   it('retrieves objectives associated with a given channelId', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
-    await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    await ObjectiveModel.insert(
+      {...objective, status: 'pending', waitingFor: WaitingFor.theirPreFundSetup},
+      knex
+    );
 
     expect(await ObjectiveModel.forChannelIds([c.channelId], knex)).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -2,6 +2,7 @@ import {OpenChannel} from '@statechannels/wallet-core';
 
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {WaitingFor} from '../../protocols/channel-opener';
 import {Channel} from '../channel';
 import {ObjectiveModel, ObjectiveChannelModel} from '../objective';
 
@@ -69,7 +70,7 @@ describe('Objective > insert', () => {
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
     const {progressLastMadeAt} = await ObjectiveModel.updateWaitingFor(
       objectiveId,
-      'somethingElse',
+      WaitingFor.theirPostFundState,
       knex
     );
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -35,7 +35,7 @@ type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeed
 type WalletObjective<O extends Objective> = O & {
   objectiveId: string;
   status: ObjectiveStatus;
-  waitingFor: string;
+  waitingFor: WaitingFor;
   createdAt: Date;
   progressLastMadeAt: Date;
 };
@@ -129,6 +129,7 @@ export class ObjectiveModel extends Model {
   static async insert(
     objectiveToBeStored: SupportedObjective & {
       status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+      waitingFor: WaitingFor;
     },
     tx: TransactionOrKnex
   ): Promise<DBObjective> {
@@ -143,7 +144,7 @@ export class ObjectiveModel extends Model {
           data: objectiveToBeStored.data,
           createdAt: new Date(),
           progressLastMadeAt: new Date(),
-          waitingFor: '',
+          waitingFor: objectiveToBeStored.waitingFor,
         })
         .returning('*')
         .first() // This ensures that the returned object undergoes any type conversion performed during insert

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -10,6 +10,8 @@ import {
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
 
+import {WaitingFor} from '../objectives/objective-manager';
+
 function extractReferencedChannels(objective: Objective): string[] {
   switch (objective.type) {
     case 'OpenChannel':
@@ -190,7 +192,7 @@ export class ObjectiveModel extends Model {
 
   static async updateWaitingFor(
     objectiveId: string,
-    waitingFor: string,
+    waitingFor: WaitingFor,
     tx: TransactionOrKnex
   ): Promise<DBObjective> {
     return (

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -39,20 +39,22 @@ export class ObjectiveManager {
    * @param response - response builder; will be modified by the method
    */
   async crank(objectiveId: string, response: WalletResponse): Promise<void> {
-    const objective = await this.store.getObjective(objectiveId);
+    return this.store.transaction(async tx => {
+      const objective = await this.store.getObjective(objectiveId, tx);
 
-    switch (objective.type) {
-      case 'OpenChannel':
-        return this.channelOpener.crank(objective, response);
-      case 'CloseChannel':
-        return this.channelCloser.crank(objective, response);
-      case 'SubmitChallenge':
-        return this.challengeSubmitter.crank(objective, response);
-      case 'DefundChannel':
-        return this.channelDefunder.crank(objective, response);
-      default:
-        unreachable(objective);
-    }
+      switch (objective.type) {
+        case 'OpenChannel':
+          return this.channelOpener.crank(objective, response, tx);
+        case 'CloseChannel':
+          return this.channelCloser.crank(objective, response, tx);
+        case 'SubmitChallenge':
+          return this.challengeSubmitter.crank(objective, response, tx);
+        case 'DefundChannel':
+          return this.channelDefunder.crank(objective, response, tx);
+        default:
+          unreachable(objective);
+      }
+    });
   }
 
   private get channelDefunder(): ChannelDefunder {

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -67,7 +67,10 @@ export class ObjectiveManager {
         default:
           unreachable(objective);
       }
-      await ObjectiveModel.updateWaitingFor(objectiveId, waitingFor, tx);
+      if (objective.waitingFor != waitingFor) {
+        // important to only update in the case of a change
+        await ObjectiveModel.updateWaitingFor(objectiveId, waitingFor, tx);
+      }
     });
   }
 

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -109,7 +109,9 @@ const crankAndAssert = async (
   const challengeSubmitter = ChallengeSubmitter.create(store, chainService, logger, timingMetrics);
   const response = WalletResponse.initialize();
   const spy = jest.spyOn(chainService, 'challenge');
-  await challengeSubmitter.crank(objective, response);
+  await store.transaction(async tx => {
+    await challengeSubmitter.crank(objective, response, tx);
+  });
 
   if (callsChallenge) {
     expect(spy).toHaveBeenCalled();

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -129,7 +129,9 @@ const crankAndAssert = async (
   const channelCloser = ChannelCloser.create(store, chainService, logger, timingMetrics);
   const response = WalletResponse.initialize();
   const spy = jest.spyOn(chainService, 'concludeAndWithdraw');
-  await channelCloser.crank(objective, response);
+  await store.transaction(async tx => {
+    await channelCloser.crank(objective, response, tx);
+  });
 
   // expect there to be an outgoing message in the response
   expect(response._signedStates).toMatchObject(

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -13,7 +13,7 @@ import {
   MockChainService,
 } from '../../chain-service';
 import {WalletResponse} from '../../wallet/wallet-response';
-import {ChannelDefunder} from '../defund-channel';
+import {ChannelDefunder, WaitingFor} from '../defund-channel';
 import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {stateSignedBy} from '../../wallet/__test__/fixtures/states';
 import {alice} from '../../wallet/__test__/fixtures/signing-wallets';
@@ -198,7 +198,7 @@ function createPendingObjective(channelId: string): DBDefundChannelObjective {
     type: 'DefundChannel',
     status: 'pending',
     participants: [],
-    waitingFor: '',
+    waitingFor: WaitingFor.transactionSubmission,
     objectiveId: ['DefundChannel', channelId].join('-'),
     data: {targetChannelId: channelId},
     createdAt: new Date(Date.now()),

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,8 +1,8 @@
-import {makeAddress, Objective, State} from '@statechannels/wallet-core';
+import {makeAddress, State} from '@statechannels/wallet-core';
 
 import {defaultTestConfig} from '../..';
 import {createLogger} from '../../logger';
-import {DBDefundChannelObjective, DBObjective} from '../../models/objective';
+import {DBDefundChannelObjective} from '../../models/objective';
 import {Store} from '../../wallet/store';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,8 +1,8 @@
-import {makeAddress, State} from '@statechannels/wallet-core';
+import {makeAddress, Objective, State} from '@statechannels/wallet-core';
 
 import {defaultTestConfig} from '../..';
 import {createLogger} from '../../logger';
-import {DBDefundChannelObjective} from '../../models/objective';
+import {DBDefundChannelObjective, DBObjective} from '../../models/objective';
 import {Store} from '../../wallet/store';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
@@ -73,7 +73,7 @@ beforeEach(async () => {
 describe('when there is no challenge or finalized channel', () => {
   it('should do nothing', async () => {
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await crankChannelDefunder(objective);
 
     // Check the results
     expect(pushSpy).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe('when there is an active challenge', () => {
   it('should submit a conclude transaction if there is a conclusion proof', async () => {
     await setAdjudicatorStatus('active', testChan2.channelId);
     // Crank the protocol
-    await channelDefunder.crank(objective2, WalletResponse.initialize());
+    await crankChannelDefunder(objective2);
 
     // Check the results
     const reloadedObjective = await store.getObjective(objective2.objectiveId);
@@ -98,7 +98,7 @@ describe('when there is an active challenge', () => {
     await setAdjudicatorStatus('active', testChan.channelId);
 
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await crankChannelDefunder(objective);
 
     // Check the results
     const reloadedObjective = await store.getObjective(objective.objectiveId);
@@ -120,7 +120,7 @@ describe('when the channel is finalized on chain', () => {
     await setAdjudicatorStatus('finalized', testChan.channelId, challengeState);
 
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await crankChannelDefunder(objective);
 
     // Check the results
     expect(pushSpy).toHaveBeenCalledWith(
@@ -136,7 +136,7 @@ describe('when the channel is finalized on chain', () => {
     await setAdjudicatorStatus('finalized', testChan.channelId);
 
     // Crank the protocol
-    await channelDefunder.crank(objective, WalletResponse.initialize());
+    await crankChannelDefunder(objective);
 
     // Check the results
     expect(withdrawSpy).not.toHaveBeenCalled();
@@ -159,9 +159,7 @@ describe('when the channel is finalized on chain', () => {
     await setAdjudicatorStatus('finalized', testChan.channelId, challengeState);
 
     // Crank the protocol
-    await expect(channelDefunder.crank(objective, WalletResponse.initialize())).rejects.toThrow(
-      'Failed to submit transaction'
-    );
+    await expect(crankChannelDefunder(objective)).rejects.toThrow('Failed to submit transaction');
 
     // Check the results
     const reloadedObjective = await store.getObjective(objective.objectiveId);
@@ -174,7 +172,7 @@ it('should fail when using non-direct funding', async () => {
   await Channel.query(knex).where({channelId: testChan.channelId}).patch({fundingStrategy: 'Fake'});
 
   // Crank the protocol
-  await channelDefunder.crank(objective, WalletResponse.initialize());
+  await crankChannelDefunder(objective);
 
   // Check the results
   const reloadedObjective = await store.getObjective(objective.objectiveId);
@@ -206,4 +204,10 @@ function createPendingObjective(channelId: string): DBDefundChannelObjective {
     createdAt: new Date(Date.now()),
     progressLastMadeAt: new Date(Date.now()),
   };
+}
+
+async function crankChannelDefunder(objective: DBDefundChannelObjective) {
+  return store.transaction(async tx => {
+    return channelDefunder.crank(objective, WalletResponse.initialize(), tx);
+  });
 }

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -175,7 +175,9 @@ const crankAndAssert = async (
   const channelOpener = ChannelOpener.create(store, chainService, logger, timingMetrics);
   const response = WalletResponse.initialize();
   const spy = jest.spyOn(chainService, 'fundChannel');
-  await channelOpener.crank(objective, response);
+  await store.transaction(async tx => {
+    await channelOpener.crank(objective, response, tx);
+  });
 
   // expect there to be an outgoing message in the response
   expect(response._signedStates).toMatchObject(

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -10,7 +10,7 @@ import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
 
 export const enum WaitingFor {
-  nothing = 'nothing',
+  nothing = '',
   // This objective is not shared, therefore there are no other channel participants to wait on
   // The aim of the objective is only to *submit* a challenge, so there are also no blockchain events to wait on
 }

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -12,9 +12,9 @@ import {Channel} from '../models/channel';
 import {Defunder} from './defunder';
 
 export const enum WaitingFor {
-  allAllocationItemsToBeExternalDestination = 'allAllocationItemsToBeExternalDestination',
-  theirFinalState = 'theirFinalState', // i.e. other participants' final states
-  defunding = 'defunding',
+  allAllocationItemsToBeExternalDestination = 'ChannelCloser.allAllocationItemsToBeExternalDestination',
+  theirFinalState = 'ChannelCloser.theirFinalState', // i.e. other participants' final states
+  defunding = 'ChannelCloser.defunding',
   nothing = '',
 }
 

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -13,9 +13,9 @@ import {DirectFunder} from './direct-funder';
 import {LedgerFunder} from './ledger-funder';
 
 export const enum WaitingFor {
-  theirPreFundSetup = 'theirPreFundSetup',
-  theirPostFundState = 'theirPostFundSetup',
-  funding = 'funding', // TODO reuse ChannelFunder.waitingFor,
+  theirPreFundSetup = 'ChannelOpener.theirPreFundSetup',
+  theirPostFundState = 'ChannelOpener.theirPostFundSetup',
+  funding = 'ChannelOpener.funding', // TODO reuse ChannelFunder.waitingFor,
   nothing = '',
 }
 export class ChannelOpener {

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -1,6 +1,8 @@
+import {Transaction} from 'objection';
 import {Logger} from 'pino';
 
 import {ChainServiceInterface} from '../chain-service';
+import {Channel} from '../models/channel';
 import {DBDefundChannelObjective} from '../models/objective';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
@@ -23,40 +25,41 @@ export class ChannelDefunder {
     return new ChannelDefunder(store, chainService, logger, timingMetrics);
   }
 
-  public async crank(objective: DBDefundChannelObjective, response: WalletResponse): Promise<void> {
+  public async crank(
+    objective: DBDefundChannelObjective,
+    response: WalletResponse,
+    tx: Transaction
+  ): Promise<void> {
     const {targetChannelId: channelId} = objective.data;
-    await this.store.lockApp(channelId, async (tx, channel) => {
-      if (!channel) {
-        this.logger.error(`No channel found for channel id ${channelId}`);
-        await this.store.markObjectiveStatus(objective, 'failed', tx);
-        return;
-      }
+    const channel = await this.store.getAndLockChannel(channelId, tx);
+    if (!channel) {
+      throw new Error('Channel must exist');
+    }
 
-      await channel.$fetchGraph('funding', {transaction: tx});
-      await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
+    await channel.$fetchGraph('funding', {transaction: tx});
+    await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
 
-      // This if-statement should be removed and test cases should be added.
-      // Defund channel now (in theory) supports Ledger funded channels.
-      if (channel.fundingStrategy !== 'Direct') {
-        // TODO: https://github.com/statechannels/statechannels/issues/3124
-        this.logger.error(`Only direct funding is currently supported.`);
-        await this.store.markObjectiveStatus(objective, 'failed', tx);
-        return;
-      }
+    // This if-statement should be removed and test cases should be added.
+    // Defund channel now (in theory) supports Ledger funded channels.
+    if (channel.fundingStrategy !== 'Direct') {
+      // TODO: https://github.com/statechannels/statechannels/issues/3124
+      this.logger.error(`Only direct funding is currently supported.`);
+      await this.store.markObjectiveStatus(objective, 'failed', tx);
+      return;
+    }
 
-      const {didSubmitTransaction} = await Defunder.create(
-        this.store,
-        this.chainService,
-        this.logger,
-        this.timingMetrics
-      ).crank(channel, tx);
+    const {didSubmitTransaction} = await Defunder.create(
+      this.store,
+      this.chainService,
+      this.logger,
+      this.timingMetrics
+    ).crank(channel, tx);
 
-      // A better methodology is likely to create a Challenge objective that succeeds after a
-      // channel has been defunded (instead of succeeding an objective on transaction submission)
-      if (didSubmitTransaction) {
-        await this.store.markObjectiveStatus(objective, 'succeeded', tx);
-        response.queueSucceededObjective(objective);
-      }
-    });
+    // A better methodology is likely to create a Challenge objective that succeeds after a
+    // channel has been defunded (instead of succeeding an objective on transaction submission)
+    if (didSubmitTransaction) {
+      await this.store.markObjectiveStatus(objective, 'succeeded', tx);
+      response.queueSucceededObjective(objective);
+    }
   }
 }

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -2,7 +2,6 @@ import {Transaction} from 'objection';
 import {Logger} from 'pino';
 
 import {ChainServiceInterface} from '../chain-service';
-
 import {DBDefundChannelObjective} from '../models/objective';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
@@ -10,7 +9,8 @@ import {WalletResponse} from '../wallet/wallet-response';
 import {Defunder} from './defunder';
 
 export const enum WaitingFor {
-  TODO = 'TODO',
+  transactionSubmission = 'ChannelDefunder.transactionSubmission',
+  nothing = '',
 }
 
 export class ChannelDefunder {
@@ -49,7 +49,7 @@ export class ChannelDefunder {
       // TODO: https://github.com/statechannels/statechannels/issues/3124
       this.logger.error(`Only direct funding is currently supported.`);
       await this.store.markObjectiveStatus(objective, 'failed', tx);
-      return WaitingFor.TODO;
+      return WaitingFor.nothing;
     }
 
     const {didSubmitTransaction} = await Defunder.create(
@@ -64,7 +64,7 @@ export class ChannelDefunder {
     if (didSubmitTransaction) {
       await this.store.markObjectiveStatus(objective, 'succeeded', tx);
       response.queueSucceededObjective(objective);
-    }
-    return WaitingFor.TODO;
+      return WaitingFor.nothing;
+    } else return WaitingFor.transactionSubmission;
   }
 }

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -97,7 +97,7 @@ it('creates a defundChannel objective on channel finalized', async () => {
     objectiveId,
     status: 'approved',
     type: 'DefundChannel',
-    waitingFor: '',
+    waitingFor: expect.any(String),
     data: {
       targetChannelId: c.channelId,
     },

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -5,6 +5,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {DBOpenChannelObjective} from '../../../models/objective';
+import {WaitingFor} from '../../../protocols/channel-opener';
 
 let w: Wallet;
 beforeEach(async () => {
@@ -78,7 +79,7 @@ describe('happy path', () => {
       progressLastMadeAt: expect.any(Date),
       status: 'approved',
       participants: [],
-      waitingFor: '',
+      waitingFor: WaitingFor.theirPreFundSetup,
       type: 'OpenChannel',
       data: expect.anything(),
     });

--- a/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/join-channel.test.ts
@@ -23,6 +23,7 @@ import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';
+import {WaitingFor} from '../../../protocols/channel-opener';
 
 let w: Wallet;
 beforeEach(async () => {
@@ -67,6 +68,7 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
+        waitingFor: WaitingFor.theirPreFundSetup,
         status: 'pending',
       },
       w.knex
@@ -81,6 +83,7 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
+        waitingFor: WaitingFor.theirPreFundSetup,
         status: 'pending',
       },
       w.knex
@@ -135,6 +138,7 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
+        waitingFor: WaitingFor.theirPreFundSetup,
         status: 'pending',
       },
       w.knex
@@ -174,6 +178,7 @@ describe('directly funded app', () => {
           fundingStrategy: 'Direct',
           role: 'app',
         },
+        waitingFor: WaitingFor.theirPreFundSetup,
         status: 'pending',
       },
       w.knex
@@ -271,6 +276,7 @@ describe('ledger funded app scenarios', () => {
           fundingLedgerChannelId: ledger.channelId,
           role: 'app',
         },
+        waitingFor: WaitingFor.theirPreFundSetup,
         status: 'approved',
       },
       w.knex

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -37,6 +37,7 @@ import {
   getSignedStateFor,
   getRequestFor,
 } from '../../../__test__/test-helpers';
+import {WaitingFor} from '../../../protocols/channel-opener';
 
 const dropNonVariables = (s: SignedState): any =>
   _.pick(s, 'appData', 'outcome', 'isFinal', 'turnNum', 'stateHash', 'signatures');
@@ -294,6 +295,7 @@ describe('when the application protocol returns an action', () => {
           fundingStrategy: 'Fake', // Could also be Direct, funding is empty
           role: 'app',
         },
+        waitingFor: WaitingFor.theirPreFundSetup,
       },
       wallet.knex
     );
@@ -548,6 +550,7 @@ describe('ledger funded app scenarios', () => {
           fundingLedgerChannelId: ledger.channelId,
           role: 'app',
         },
+        waitingFor: WaitingFor.theirPreFundSetup,
       },
       wallet.knex
     );

--- a/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/update-funding.test.ts
@@ -12,6 +12,7 @@ import {ObjectiveModel} from '../../../models/objective';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {defaultTestConfig} from '../../../config';
+import {WaitingFor} from '../../../protocols/channel-opener';
 
 const AddressZero = makeAddress(ethers.constants.AddressZero);
 
@@ -48,6 +49,7 @@ it('sends the post fund setup when the funding event is provided for multiple ch
         fundingStrategy: 'Direct',
         role: 'app',
       },
+      waitingFor: WaitingFor.theirPreFundSetup,
       status: 'approved',
     },
     w.knex
@@ -62,6 +64,7 @@ it('sends the post fund setup when the funding event is provided for multiple ch
         fundingStrategy: 'Direct',
         role: 'app',
       },
+      waitingFor: WaitingFor.theirPreFundSetup,
       status: 'approved',
     },
     w.knex
@@ -118,6 +121,7 @@ it('sends the post fund setup when the funding event is provided', async () => {
         fundingStrategy: 'Direct',
         role: 'app',
       },
+      waitingFor: WaitingFor.theirPreFundSetup,
       status: 'approved',
     },
     w.knex
@@ -163,6 +167,7 @@ it('emits new channel result when the funding event is provided via holdingUpdat
         fundingStrategy: 'Direct',
         role: 'app',
       },
+      waitingFor: WaitingFor.theirPreFundSetup,
       status: 'approved',
     },
     w.knex

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -58,6 +58,10 @@ import {createLogger} from '../logger';
 import {LedgerProposal} from '../models/ledger-proposal';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {AdjudicatorStatusModel} from '../models/adjudicator-status';
+import {WaitingFor as DefundChannelWaitingFor} from '../protocols/defund-channel';
+import {WaitingFor as ChallengeSubmitterWaitingFor} from '../protocols/challenge-submitter';
+import {WaitingFor as OpenChannelWaitingFor} from '../protocols/channel-opener';
+import {WaitingFor as CloseChannelWaitingFor} from '../protocols/channel-closer';
 
 const defaultLogger = createLogger(defaultTestConfig());
 
@@ -418,7 +422,11 @@ export class Store {
       throw new StoreError(StoreError.reasons.channelMissing, {channelId: targetChannelId});
     }
 
-    const objectiveToBeStored = {...objective, status: 'pending' as const};
+    const objectiveToBeStored = {
+      ...objective,
+      status: 'pending' as const,
+      waitingFor: DefundChannelWaitingFor.transactionSubmission,
+    };
 
     return ObjectiveModel.insert(objectiveToBeStored, tx) as Promise<DBDefundChannelObjective>;
   }
@@ -438,6 +446,7 @@ export class Store {
     const objectiveToBeStored = {
       ...objective,
       status: 'pending' as const,
+      waitingFor: ChallengeSubmitterWaitingFor.nothing,
     };
 
     return ObjectiveModel.insert(objectiveToBeStored, tx) as Promise<DBSubmitChallengeObjective>;
@@ -462,6 +471,7 @@ export class Store {
 
     const objectiveToBeStored = {
       participants: [],
+      waitingFor: OpenChannelWaitingFor.theirPreFundSetup,
       status: 'pending' as const,
       type: objective.type,
       data: {
@@ -505,6 +515,7 @@ export class Store {
 
     const objectiveToBeStored = {
       status: 'approved' as const,
+      waitingFor: CloseChannelWaitingFor.allAllocationItemsToBeExternalDestination,
       type: objective.type,
       participants: [],
       data: {


### PR DESCRIPTION
⚠️ For the reviewer: stacked PR (base not master).  This PR will be marked ready for review after #3286 is merged, but reviewers may wish to refer to it or even review it before then. 

- moves the transaction instigation up one level into the objective manager. This is pretty much the same as #3131 , but without introducing any objective locking. It could be considered preparatory work for that.
- individual crankers *return* a typed `waitingFor` string *each and every time they return*. Otherwise, they continue to make progress or throw an error
- the manager updates the objective's `waitingFor` property (and associated timestamp) as the final step in the transaction only if that property has changed
- ⚠️  the changeset is relatively large, mostly because many test files were changed and there were several whitespace changes. I recommend i) hiding whitespace changes when reviewing, and ii) to ignore any changes to `.test.ts` on your first pass.


