### PR TITLE
perf: save an unecessary query during joinChannel

### DIFF
--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -33,7 +33,6 @@ import {ValidationErrorItem} from 'joi';
 import {Bytes32} from '../type-aliases';
 import {createLogger} from '../logger';
 import * as UpdateChannel from '../handlers/update-channel';
-import * as JoinChannel from '../handlers/join-channel';
 import * as ChannelState from '../protocols/state';
 import {PushMessageError} from '../errors/wallet-error';
 import {timerFactory, recordFunctionMetrics, setupMetrics} from '../metrics';

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -618,13 +618,6 @@ export class SingleThreadedWallet
    */
   async joinChannel({channelId}: JoinChannelParams): Promise<SingleChannelOutput> {
     const response = WalletResponse.initialize();
-    const channel = await this.store.getChannelState(channelId);
-
-    if (!channel)
-      throw new JoinChannel.JoinChannelError(
-        JoinChannel.JoinChannelError.reasons.channelNotFound,
-        channelId
-      );
 
     const objectives = await this.store.getObjectives([channelId]);
 


### PR DESCRIPTION
Brings into line with `joinChannels` (plural). 

API calls should probably be "Objective-centric": what matters is whether you have the objective or not (you couldn't have the objective without already having the channel, anyway, due to DB constraints added during insert). 

The channel will be re-fetched, later, (in any case) when the objective is cranked. 