### PR TITLE
update ObjectiveModel.progressLastMadeAt on every crank

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -212,6 +212,11 @@ export class ObjectiveModel extends Model {
       .first();
   }
 
+  /**
+   * Updates the progressLastMadeAt column for this objective (using the current time)
+   * @param objectiveId The objective to patch
+   * @param tx
+   */
   static async progressMade(objectiveId: string, tx: TransactionOrKnex): Promise<DBObjective> {
     return (
       await ObjectiveModel.query(tx)

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -58,7 +58,7 @@ import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
 import {SingleAppUpdater} from '../handlers/single-app-updater';
 import {LedgerManager} from '../protocols/ledger-manager';
-import {DBObjective} from '../models/objective';
+import {DBObjective, ObjectiveModel} from '../models/objective';
 
 import {Store, AppHandler, MissingAppHandler} from './store';
 import {
@@ -1005,6 +1005,9 @@ export class SingleThreadedWallet
       const objective = objectives[0];
 
       await this.objectiveManager.crank(objective.objectiveId, response);
+      await ObjectiveModel.progressMade(objective.objectiveId, this.knex);
+      // TODO we assume here ^^ that progress is made each time we crank the objective
+      // and update the progressLastMadeAt timestamp accordingly
 
       // remove objective from list
       objectives.shift();


### PR DESCRIPTION
There are more ambitious approaches to updating this time stamp (#3286, #3301 ) but this is a faster way to get to closing #3230. 

Closes #3230 