### PR TITLE
increase clarity around ObjectiveModel type

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -89,7 +89,10 @@ export class ObjectiveChannelModel extends Model {
   }
 }
 
-export class ObjectiveModel extends Model {
+type FlattenedDBObjective = {[P in keyof DBObjective]: DBObjective[P]}; // this destroys the correlations in the union type
+type Columns = Omit<FlattenedDBObjective, 'participants'>;
+
+export class ObjectiveModel extends Model implements Columns {
   readonly objectiveId!: DBObjective['objectiveId'];
   readonly status!: DBObjective['status'];
   readonly type!: DBObjective['type'];
@@ -247,11 +250,25 @@ export class ObjectiveModel extends Model {
     return (await ObjectiveModel.query(tx).findByIds(objectiveIds)).map(m => m.toObjective());
   }
 
-  toObjective(): DBObjective {
-    return {
-      ...this,
-      participants: [],
-      data: this.data as any, // Here we will trust that the row respects our types
+  toObjective<O extends DBObjective = DBObjective>(): O {
+    const withParticipants: FlattenedDBObjective = {
+      objectiveId: this.objectiveId,
+      status: this.status,
+      type: this.type,
+      data: this.data,
+      createdAt: this.createdAt,
+      progressLastMadeAt: this.progressLastMadeAt,
+      waitingFor: this.waitingFor,
+      participants: [] as DBObjective['participants'], // reinstate an empty participants array
     };
+    switch (this.type) {
+      case 'CloseChannel':
+      case 'DefundChannel':
+      case 'OpenChannel':
+      case 'SubmitChallenge':
+        return withParticipants as O;
+      default:
+        throw Error('unimplemented');
+    }
   }
 }


### PR DESCRIPTION
Make our current type conversion more explicit and transparent, to aid developer understanding. 

Currently, there are some useful things to know which are not self evident from the code. These changes attempt to remedy that, and I think it will help us judge whether we actually want the current behaviour or not. 

These useful things are:
- we have one DB table that stores all objectives in the *union type* `Objective`. We also have a single ORM class called `ObjectiveModel`. It is not possible to make a union of classes. This implies that the correlations in the union type are washed out when we deal with `ObjectiveModels`. As an example, we could have an `ObjectiveModel` with `type: 'OpenChannel'` but the incompatible `data: submitChallengeData`. The static `insert` method is typed in such a way as to prevent that, but otherwise it is not impossible because no such typing is enforced by the db itself. For example, we can just write a query that inserts such a "bad" objective. 
- The instance method `toObjective()` (which is heavily used) does some typecasting to convert back to a proper union type with the correlations, but this isn't as obvious as it might be. 
- we drop the `participants` property when storing an objective, and add it back again (using `[]`) when reading an objective



Other changes:
I added a generic type to the `toObjective()` function, so that it will be possible to easily narrow the type even further if we want to. I anticipate this will be useful for future refactors. I can split that change onto a different PR if the reviewer prefers. 


---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
