### PR TITLE
Only return newObjectives if the objective is actually new

### DIFF
--- a/packages/server-wallet/src/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test__/sync-objectives.test.ts
@@ -85,7 +85,7 @@ test('handles the objective being synced even if no message is lost', async () =
   const {outbox: syncOutbox} = await a.syncObjectives([objectiveId]);
 
   // Now we push in the sync payload
-  const {outbox, channelResults} = await b.pushMessage(
+  const {outbox, channelResults, newObjectives} = await b.pushMessage(
     getPayloadFor(bob().participantId, syncOutbox)
   );
 
@@ -102,8 +102,7 @@ test('handles the objective being synced even if no message is lost', async () =
     },
   });
 
-  // TODO: https://github.com/statechannels/statechannels/issues/3289
-  //expect(newObjectives).toHaveLength(0);
+  expect(newObjectives).toHaveLength(0);
 
   expect(channelResults).toHaveLength(1);
 });
@@ -128,7 +127,7 @@ test('Can successfully push the sync objective message multiple times', async ()
   await b.pushMessage(getPayloadFor(bob().participantId, syncResult.outbox));
 
   // We push the message to B again and check the results
-  const {outbox, channelResults} = await b.pushMessage(
+  const {outbox, channelResults, newObjectives} = await b.pushMessage(
     getPayloadFor(bob().participantId, syncResult.outbox)
   );
 
@@ -148,8 +147,7 @@ test('Can successfully push the sync objective message multiple times', async ()
   expect(channelResults).toHaveLength(1);
   expect(channelResults[0]).toMatchObject({channelId});
 
-  // TODO: https://github.com/statechannels/statechannels/issues/3289
-  //expect(newObjectives).toHaveLength(0);
+  expect(newObjectives).toHaveLength(0);
 });
 
 async function getObjective(knex: Knex, objectiveId: string): Promise<DBObjective | undefined> {

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -111,7 +111,19 @@ describe('Objective > forId', () => {
     expect(fetchedObjective.progressLastMadeAt instanceof Date).toBe(true);
   });
 });
+describe('Objective > doesExist', () => {
+  it('returns false when an objective does not exist', async () => {
+    const result = await ObjectiveModel.doesExist('FAKE-ID', knex);
+    expect(result).toBe(false);
+  });
 
+  it('returns true when an objective does exist', async () => {
+    await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
+    const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const result = await ObjectiveModel.doesExist(objectiveId, knex);
+    expect(result).toBe(true);
+  });
+});
 describe('Objective > forChannelIds', () => {
   it('retrieves objectives associated with a given channelId', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -119,7 +119,10 @@ describe('Objective > doesExist', () => {
 
   it('returns true when an objective does exist', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    const {objectiveId} = await ObjectiveModel.insert({...objective, status: 'pending'}, knex);
+    const {objectiveId} = await ObjectiveModel.insert(
+      {...objective, status: 'pending', waitingFor: ChannelOpenerWaitingFor.theirPreFundSetup},
+      knex
+    );
     const result = await ObjectiveModel.doesExist(objectiveId, knex);
     expect(result).toBe(true);
   });

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -190,6 +190,11 @@ export class ObjectiveModel extends Model {
     });
   }
 
+  static async doesExist(objectiveId: string, tx: TransactionOrKnex): Promise<boolean> {
+    const fetched = await ObjectiveModel.query(tx).findById(objectiveId);
+    return fetched !== null && fetched !== undefined;
+  }
+
   static async forId(objectiveId: string, tx: TransactionOrKnex): Promise<DBObjective> {
     const model = await ObjectiveModel.query(tx).findById(objectiveId);
     return model.toObjective();

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -52,6 +52,11 @@ export function isSharedObjective(
 }
 
 type SupportedObjective = OpenChannel | CloseChannel | SubmitChallenge | DefundChannel;
+
+export type ObjectiveToStore = SupportedObjective & {
+  status: ObjectiveStatus;
+  waitingFor: WaitingFor;
+};
 /**
  * A DBObjective is a wire objective with a status, timestamps and an objectiveId
  *
@@ -128,10 +133,7 @@ export class ObjectiveModel extends Model {
   }
 
   static async insert(
-    objectiveToBeStored: SupportedObjective & {
-      status: 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
-      waitingFor: WaitingFor;
-    },
+    objectiveToBeStored: ObjectiveToStore,
     tx: TransactionOrKnex
   ): Promise<DBObjective> {
     const id: string = objectiveId(objectiveToBeStored);

--- a/packages/server-wallet/src/objectives/close-channel.ts
+++ b/packages/server-wallet/src/objectives/close-channel.ts
@@ -12,7 +12,7 @@ export class CloseChannelObjective {
     await store.lockApp(
       channelId,
       async (tx, channel) => {
-        const dbObjective = await store.ensureObjective(
+        const {objective: dbObjective} = await store.ensureObjective(
           {
             type: 'CloseChannel',
             participants: [],

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -100,7 +100,7 @@ const setup = async (
 
   // add the closeChannel objective and approve
   const objective = await store.transaction(async tx => {
-    const o = await store.ensureObjective(testChan.closeChannelObjective, tx);
+    const {objective: o} = await store.ensureObjective(testChan.closeChannelObjective, tx);
     await store.approveObjective(o.objectiveId, tx);
     return o as DBCloseChannelObjective;
   });

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -270,7 +270,7 @@ export class TestChannel {
 
     const objective = await store.transaction(async tx => {
       // need to do this to set the funding type
-      const o = await store.ensureObjective(this.openChannelObjective, tx);
+      const {objective: o} = await store.ensureObjective(this.openChannelObjective, tx);
       await store.approveObjective(o.objectiveId, tx);
 
       return o as DBOpenChannelObjective;


### PR DESCRIPTION
# Description
Only return newObjectives if the objective is actually new.

`ensureObjective` now returns `isNew` to indicate whether the objective existed before attempting to store it.  The `wallet` only adds to `newObjectives` if `isNew===true`


## How Has This Been Tested? [Optional] 

- The commented out checks in sync-objective have been re-enabled
- New tests have been added for the new `doesExist` method on the `ObjectiveModel`

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate pipeline on zenhub
