### PR TITLE
Introduce deterministic transaction submission

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -6,6 +6,7 @@
 
 import { Address } from '@statechannels/wallet-core';
 import { AllocationItem } from '@statechannels/nitro-protocol';
+import { AllocationItem as AllocationItem_2 } from '@statechannels/wallet-core';
 import { AssetOutcome } from '@statechannels/nitro-protocol';
 import { ChannelConstants } from '@statechannels/wallet-core';
 import { ChannelId } from '@statechannels/client-api-schema';

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -510,6 +510,13 @@ export class Channel extends Model implements ChannelColumns {
     return this.participants.length;
   }
 
+  nthParticipant(n: number): Participant {
+    if (n >= this.nParticipants) {
+      throw new Error(`Cannot get participant ${n} from ${this.participants}`);
+    }
+    return this.participants[n];
+  }
+
   private get _support(): Array<SignedStateWithHash> {
     // TODO: activate these fields for proper application checks (may be resource hungry)
     const logger = undefined;

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -502,7 +502,7 @@ export class Channel extends Model implements ChannelColumns {
   }
 
   /**
-   * The below logic assumes:
+   * WARNING: The below logic assumes
    *  1. Each destination occurs at most once.
    *  2. We only care about a single destination.
    * One reason to drop (2), for instance, is to support ledger top-ups with as few state updates as possible.

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -6,6 +6,7 @@ import {
   SharedObjective,
   SubmitChallenge,
   DefundChannel,
+  unreachable,
 } from '@statechannels/wallet-core';
 import {Model, TransactionOrKnex} from 'objection';
 import _ from 'lodash';
@@ -72,11 +73,31 @@ export const toWireObjective = (dbObj: DBObjective): SharedObjective => {
       'SubmitChallenge and DefundChannel objectives are not supported as wire objectives'
     );
   }
-  return {
-    type: dbObj.type,
-    data: dbObj.data,
-    participants: dbObj.participants,
-  };
+  /**
+   * This switch statement is unfortunate but is necessary to avoid a typescript error.
+   * It seems that the typescript error is the result of:
+   * - The parameter dbObj is a union type.
+   * - The return type is a union type.
+   * - The return value is constructed by creating an object with type, data, and participants fields.
+   * - Typescript considers a return object with "type" OpenChannel and "data" of CloseChannel objective to be a possible return type.
+   * - The above object does not belong to the union return type.
+   */
+  switch (dbObj.type) {
+    case 'OpenChannel':
+      return {
+        type: dbObj.type,
+        data: dbObj.data,
+        participants: dbObj.participants,
+      };
+    case 'CloseChannel':
+      return {
+        type: dbObj.type,
+        data: dbObj.data,
+        participants: dbObj.participants,
+      };
+    default:
+      unreachable(dbObj);
+  }
 };
 
 export class ObjectiveChannelModel extends Model {

--- a/packages/server-wallet/src/objectives/close-channel.ts
+++ b/packages/server-wallet/src/objectives/close-channel.ts
@@ -19,7 +19,7 @@ export class CloseChannelObjective {
             data: {
               targetChannelId: channelId,
               fundingStrategy: channel.fundingStrategy,
-              transactionSubmitter: channel.nthParticipant(1).participantId,
+              txSubmitterOder: [1, 0],
             },
           },
           tx

--- a/packages/server-wallet/src/objectives/close-channel.ts
+++ b/packages/server-wallet/src/objectives/close-channel.ts
@@ -16,7 +16,11 @@ export class CloseChannelObjective {
           {
             type: 'CloseChannel',
             participants: [],
-            data: {targetChannelId: channelId, fundingStrategy: channel.fundingStrategy},
+            data: {
+              targetChannelId: channelId,
+              fundingStrategy: channel.fundingStrategy,
+              transactionSubmitter: channel.nthParticipant(1).participantId,
+            },
           },
           tx
         );

--- a/packages/server-wallet/src/objectives/close-channel.ts
+++ b/packages/server-wallet/src/objectives/close-channel.ts
@@ -19,7 +19,7 @@ export class CloseChannelObjective {
             data: {
               targetChannelId: channelId,
               fundingStrategy: channel.fundingStrategy,
-              txSubmitterOder: [1, 0],
+              txSubmitterOrder: [1, 0],
             },
           },
           tx

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -100,7 +100,10 @@ const setup = async (
 
   // add the closeChannel objective and approve
   const objective = await store.transaction(async tx => {
-    const o = await store.ensureObjective(testChan.closeChannelObjective(participant), tx);
+    const o = await store.ensureObjective(
+      testChan.closeChannelObjective([participant, Math.abs(participant - 1)]),
+      tx
+    );
     await store.approveObjective(o.objectiveId, tx);
     return o as DBCloseChannelObjective;
   });

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -101,7 +101,7 @@ const setup = async (
   // add the closeChannel objective and approve
   const objective = await store.transaction(async tx => {
     const o = await store.ensureObjective(
-      testChan.closeChannelObjective([participant, Math.abs(participant - 1)]),
+      testChan.closeChannelObjective([participant, 1 - participant]),
       tx
     );
     await store.approveObjective(o.objectiveId, tx);

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -100,7 +100,7 @@ const setup = async (
 
   // add the closeChannel objective and approve
   const objective = await store.transaction(async tx => {
-    const o = await store.ensureObjective(testChan.closeChannelObjective, tx);
+    const o = await store.ensureObjective(testChan.closeChannelObjective(participant), tx);
     await store.approveObjective(o.objectiveId, tx);
     return o as DBCloseChannelObjective;
   });

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -29,12 +29,12 @@ let store: Store;
 
 function ensureCloseObjective(
   channel: TestChannel,
-  transactionSubmitterIndex = 0
+  participantIndex = 0
 ): Promise<DBCloseChannelObjective> {
   // add the closeChannel objective and approve
   return store.transaction(async tx => {
     const o = await store.ensureObjective(
-      channel.closeChannelObjective(transactionSubmitterIndex),
+      channel.closeChannelObjective([participantIndex, Math.abs(participantIndex - 1)]),
       tx
     );
     await store.approveObjective(o.objectiveId, tx);

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -10,7 +10,7 @@ import {LedgerRequest} from '../../models/ledger-request';
 import {DBCloseChannelObjective, DBDefundChannelObjective} from '../../models/objective';
 import {Store} from '../../wallet/store';
 import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
-import {Defunder} from '../defunder';
+import {Defunder, shouldSubmitCollaborativeTx} from '../defunder';
 
 const testChannel = TestChannel.create({
   aBal: 5,
@@ -74,24 +74,24 @@ describe('Collaborative transaction submitter', () => {
       type: 'CloseChannel',
       data: {txSubmitterOder: [0, 1]},
     } as DBCloseChannelObjective;
-    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
+    expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
 
     const objective2 = {
       type: 'CloseChannel',
       data: {txSubmitterOder: [1, 0]},
     } as DBCloseChannelObjective;
-    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective2)).toEqual(false);
+    expect(shouldSubmitCollaborativeTx(channel, objective2)).toEqual(false);
 
     const objective3 = ({
       type: 'CloseChannel',
       data: {txSubmitterOder: []},
     } as unknown) as DBCloseChannelObjective;
-    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective3)).toEqual(true);
+    expect(shouldSubmitCollaborativeTx(channel, objective3)).toEqual(true);
 
     const objective4 = {
       type: 'DefundChannel',
     } as DBDefundChannelObjective;
-    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective4)).toEqual(true);
+    expect(shouldSubmitCollaborativeTx(channel, objective4)).toEqual(true);
   });
 
   it('_shouldSubmitCollaborativeTx is correct for participant 1', async () => {
@@ -105,13 +105,13 @@ describe('Collaborative transaction submitter', () => {
       type: 'CloseChannel',
       data: {txSubmitterOder: [0, 1]},
     } as DBCloseChannelObjective;
-    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective)).toEqual(false);
+    expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(false);
 
     const objective2 = {
       type: 'CloseChannel',
       data: {txSubmitterOder: [1, 0]},
     } as DBCloseChannelObjective;
-    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective2)).toEqual(true);
+    expect(shouldSubmitCollaborativeTx(channel, objective2)).toEqual(true);
   });
 });
 

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -104,6 +104,27 @@ describe('Collaborative transaction submitter', () => {
     } as DBDefundChannelObjective;
     expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
   });
+
+  it('shouldSubmitCollaborativeTx is correct for participant with no funds', async () => {
+    const testChannel2 = TestChannel.create({
+      aBal: 0,
+      bBal: 3,
+      finalFrom: 4,
+    });
+
+    await testChannel2.insertInto(store, {
+      participant: 0,
+      states: [3, 4],
+    });
+    const channel = await Channel.forId(testChannel2.channelId, testKnex);
+
+    testShouldSubmitCollaborativeTx(channel, [0, 1], false);
+
+    const objective = {
+      type: 'DefundChannel',
+    } as DBDefundChannelObjective;
+    expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
+  });
 });
 
 describe('Direct channel defunding', () => {

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -62,6 +62,59 @@ beforeEach(async () => {
   );
 });
 
+describe('Collaborative transaction submitter', () => {
+  it('_shouldSubmitCollaborativeTx is correct for participant 0', async () => {
+    await testChannel.insertInto(store, {
+      participant: 0,
+      states: [3, 4],
+    });
+    const channel = await Channel.forId(testChannel.channelId, testKnex);
+
+    const objective = {
+      type: 'CloseChannel',
+      data: {txSubmitterOder: [0, 1]},
+    } as DBCloseChannelObjective;
+    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
+
+    const objective2 = {
+      type: 'CloseChannel',
+      data: {txSubmitterOder: [1, 0]},
+    } as DBCloseChannelObjective;
+    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective2)).toEqual(false);
+
+    const objective3 = ({
+      type: 'CloseChannel',
+      data: {txSubmitterOder: []},
+    } as unknown) as DBCloseChannelObjective;
+    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective3)).toEqual(true);
+
+    const objective4 = {
+      type: 'DefundChannel',
+    } as DBDefundChannelObjective;
+    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective4)).toEqual(true);
+  });
+
+  it('_shouldSubmitCollaborativeTx is correct for participant 1', async () => {
+    await testChannel.insertInto(store, {
+      participant: 1,
+      states: [3, 4],
+    });
+    const channel = await Channel.forId(testChannel.channelId, testKnex);
+
+    const objective = {
+      type: 'CloseChannel',
+      data: {txSubmitterOder: [0, 1]},
+    } as DBCloseChannelObjective;
+    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective)).toEqual(false);
+
+    const objective2 = {
+      type: 'CloseChannel',
+      data: {txSubmitterOder: [1, 0]},
+    } as DBCloseChannelObjective;
+    expect(Defunder._shouldSubmitCollaborativeTx(channel, objective2)).toEqual(true);
+  });
+});
+
 describe('Direct channel defunding', () => {
   it('Channel is defunded via submission of withdrawAndConlcude transaction', async () => {
     // Channel has yet to be concluded

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -34,7 +34,7 @@ function ensureCloseObjective(
   // add the closeChannel objective and approve
   return store.transaction(async tx => {
     const o = await store.ensureObjective(
-      channel.closeChannelObjective([participantIndex, Math.abs(participantIndex - 1)]),
+      channel.closeChannelObjective([participantIndex, 1 - participantIndex]),
       tx
     );
     await store.approveObjective(o.objectiveId, tx);

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -43,7 +43,7 @@ function ensureCloseObjective(
 }
 
 function ensureDefundObjective(channel: TestChannel): Promise<DBDefundChannelObjective> {
-  // add the closeChannel objective and approve
+  // add the defundChannel objective and approve
   return store.transaction(async tx => {
     const o = await store.ensureObjective(channel.defundChannelObjective(), tx);
     await store.approveObjective(o.objectiveId, tx);

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -72,19 +72,19 @@ describe('Collaborative transaction submitter', () => {
 
     const objective = {
       type: 'CloseChannel',
-      data: {txSubmitterOder: [0, 1]},
+      data: {txSubmitterOrder: [0, 1]},
     } as DBCloseChannelObjective;
     expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
 
     const objective2 = {
       type: 'CloseChannel',
-      data: {txSubmitterOder: [1, 0]},
+      data: {txSubmitterOrder: [1, 0]},
     } as DBCloseChannelObjective;
     expect(shouldSubmitCollaborativeTx(channel, objective2)).toEqual(false);
 
     const objective3 = ({
       type: 'CloseChannel',
-      data: {txSubmitterOder: []},
+      data: {txSubmitterOrder: []},
     } as unknown) as DBCloseChannelObjective;
     expect(shouldSubmitCollaborativeTx(channel, objective3)).toEqual(true);
 
@@ -103,13 +103,13 @@ describe('Collaborative transaction submitter', () => {
 
     const objective = {
       type: 'CloseChannel',
-      data: {txSubmitterOder: [0, 1]},
+      data: {txSubmitterOrder: [0, 1]},
     } as DBCloseChannelObjective;
     expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(false);
 
     const objective2 = {
       type: 'CloseChannel',
-      data: {txSubmitterOder: [1, 0]},
+      data: {txSubmitterOrder: [1, 0]},
     } as DBCloseChannelObjective;
     expect(shouldSubmitCollaborativeTx(channel, objective2)).toEqual(true);
   });

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -70,7 +70,7 @@ export class ChannelCloser implements Cranker<DBCloseChannelObjective> {
         return WaitingFor.theirFinalState;
       }
 
-      if (!(await defunder.crank(channel, tx)).isChannelDefunded) {
+      if (!(await defunder.crank(channel, objective, tx)).isChannelDefunded) {
         response.queueChannel(channel);
         return WaitingFor.defunding;
       }

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -57,7 +57,7 @@ export class ChannelDefunder implements Cranker<DBDefundChannelObjective> {
       this.chainService,
       this.logger,
       this.timingMetrics
-    ).crank(channel, tx);
+    ).crank(channel, objective, tx);
 
     // A better methodology is likely to create a Challenge objective that succeeds after a
     // channel has been defunded (instead of succeeding an objective on transaction submission)

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -91,17 +91,7 @@ export class Defunder {
     );
 
     let didSubmitTransaction = false;
-
-    let shouldSubmitCollaborativeTx = true;
-    if (isCloseChannel(objective)) {
-      for (const txSubmitter of objective.data.txSubmitterOder) {
-        const allocation = channel.allocationItemForParticipantIndex(txSubmitter);
-        if (allocation && BN.gt(allocation.amount, 0)) {
-          shouldSubmitCollaborativeTx = txSubmitter === channel.myIndex;
-          break;
-        }
-      }
-    }
+    const shouldSubmitCollaborativeTx = this._shouldSubmitCollaborativeTx(channel, objective);
 
     /**
      * The below if/else does not account for the following scenario:
@@ -162,5 +152,26 @@ export class Defunder {
       channel.fundingLedgerChannelId,
       tx
     );
+  }
+
+  /**
+   * Assume that we are going to submit collaborative transaction(s) unless:
+   * 1. There is an agreed upon order of transaction submitters.
+   * 2. There is a transaction submitter before us who has funds in the channel.
+   *
+   * This method is public for unit testing only
+   */
+  public _shouldSubmitCollaborativeTx(channel: Channel, objective: Objective): boolean {
+    let shouldSubmitCollaborativeTx = true;
+    if (isCloseChannel(objective)) {
+      for (const txSubmitter of objective.data.txSubmitterOder) {
+        const allocation = channel.allocationItemForParticipantIndex(txSubmitter);
+        if (allocation && BN.gt(allocation.amount, 0)) {
+          shouldSubmitCollaborativeTx = txSubmitter === channel.myIndex;
+          break;
+        }
+      }
+    }
+    return shouldSubmitCollaborativeTx;
   }
 }

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -168,7 +168,7 @@ export function shouldSubmitCollaborativeTx(channel: Channel, objective: Objecti
    * Challenge channel objective does not result in any collaborative transactions.
    */
   if (isCloseChannel(objective)) {
-    for (const txSubmitter of objective.data.txSubmitterOder) {
+    for (const txSubmitter of objective.data.txSubmitterOrder) {
       const allocation = channel.allocationItemForParticipantIndex(txSubmitter);
       if (allocation && BN.gt(allocation.amount, 0)) {
         shouldSubmitCollaborativeTx = txSubmitter === channel.myIndex;

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -94,7 +94,7 @@ export class Defunder {
     const shouldSubmitTx = shouldSubmitCollaborativeTx(channel, objective);
 
     /**
-     * The below if/else does not account for the following scenario:
+     * TODO: The below if/else does not account for the following scenario:
      * - Channel is finalized.
      * - Outcomes have been pushed to AssetHolders.
      * - Transfer needs to be called on each AssetHolder

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -1,4 +1,4 @@
-import {unreachable} from '@statechannels/wallet-core';
+import {isCloseChannel, unreachable} from '@statechannels/wallet-core';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
 
@@ -7,6 +7,7 @@ import {AdjudicatorStatusModel} from '../models/adjudicator-status';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {Channel} from '../models/channel';
 import {LedgerRequest} from '../models/ledger-request';
+import {DBCloseChannelObjective, DBDefundChannelObjective} from '../models/objective';
 import {Store} from '../wallet/store';
 
 /**
@@ -25,6 +26,7 @@ import {Store} from '../wallet/store';
  * make the ChannelDefunder protocol aboslete.
  */
 export type DefunderResult = {isChannelDefunded: boolean; didSubmitTransaction: boolean};
+type Objective = DBCloseChannelObjective | DBDefundChannelObjective;
 
 export class Defunder {
   constructor(
@@ -43,16 +45,20 @@ export class Defunder {
     return new Defunder(store, chainService, logger, timingMetrics);
   }
 
-  public async crank(channel: Channel, tx: Transaction): Promise<DefunderResult> {
+  public async crank(
+    channel: Channel,
+    objective: Objective,
+    tx: Transaction
+  ): Promise<DefunderResult> {
     const {protocolState: ps} = channel;
     await channel.$fetchGraph('funding', {transaction: tx});
     await channel.$fetchGraph('chainServiceRequests', {transaction: tx});
 
     switch (ps.fundingStrategy) {
       case 'Direct':
-        return this.directDefunder(channel, tx);
+        return this.directDefunder(channel, objective, tx);
       case 'Ledger':
-        return this.ledgerDefunder(channel, tx);
+        return this.ledgerDefunder(channel, objective, tx);
       case 'Unknown':
       case 'Fake':
         return {isChannelDefunded: true, didSubmitTransaction: false};
@@ -63,7 +69,11 @@ export class Defunder {
     }
   }
 
-  private async directDefunder(channel: Channel, tx: Transaction): Promise<DefunderResult> {
+  private async directDefunder(
+    channel: Channel,
+    objective: Objective,
+    tx: Transaction
+  ): Promise<DefunderResult> {
     if (!channel.isPartlyDirectFunded) {
       return {isChannelDefunded: true, didSubmitTransaction: false};
     }
@@ -79,8 +89,38 @@ export class Defunder {
       tx,
       channel.channelId
     );
+
     let didSubmitTransaction = false;
-    if (adjudicatorStatus.channelMode !== 'Finalized' && channel.hasConclusionProof) {
+
+    /**
+     * Collaboratively concluding a channel on-chain involves:
+     * 1. Submit a conclusion proof to the NitroAdjudicator.
+     * 2. Push the outcome to all AssetHolders.
+     * 3. Transfer out of the channel for all asset holders.
+     *
+     * Steps 1 and 2 require one or two transactions that are submitted by one participant
+     * but affect (and block) both participants. The participant who submits the transaction(s) is
+     * called the primaryTransactionSubmitter.
+     */
+    let isPrimaryTransactionSubmitter = true;
+    if (
+      isCloseChannel(objective) &&
+      objective.data.transactionSubmitter !== channel.myParticipantId
+    ) {
+      isPrimaryTransactionSubmitter = false;
+    }
+
+    /**
+     * The below if/else does not account for the following scenario:
+     * - Channel is finalized.
+     * - Outcomes have been pushed to AssetHolders.
+     * - Transfer needs to be called on each AssetHolder
+     */
+    if (
+      adjudicatorStatus.channelMode !== 'Finalized' &&
+      channel.hasConclusionProof &&
+      isPrimaryTransactionSubmitter
+    ) {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'withdraw', tx);
 
       // supported is defined (if the wallet is functioning correctly), but the compiler is not aware of that
@@ -90,7 +130,7 @@ export class Defunder {
       // Note, we are not awaiting transaction submission
       await this.chainService.concludeAndWithdraw([channel.supported]);
       didSubmitTransaction = true;
-    } else if (adjudicatorStatus.channelMode === 'Finalized') {
+    } else if (adjudicatorStatus.channelMode === 'Finalized' && isPrimaryTransactionSubmitter) {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'pushOutcome', tx);
       await this.chainService.pushOutcomeAndWithdraw(
         adjudicatorStatus.states[0],
@@ -104,7 +144,11 @@ export class Defunder {
     return {isChannelDefunded: false, didSubmitTransaction};
   }
 
-  private async ledgerDefunder(channel: Channel, tx: Transaction): Promise<DefunderResult> {
+  private async ledgerDefunder(
+    channel: Channel,
+    objective: Objective,
+    tx: Transaction
+  ): Promise<DefunderResult> {
     const didSubmitTransaction = false;
     if (!channel.hasConclusionProof) {
       return {isChannelDefunded: false, didSubmitTransaction};

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -91,7 +91,7 @@ export class Defunder {
     );
 
     let didSubmitTransaction = false;
-    const shouldSubmitCollaborativeTx = Defunder._shouldSubmitCollaborativeTx(channel, objective);
+    const shouldSubmitTx = shouldSubmitCollaborativeTx(channel, objective);
 
     /**
      * The below if/else does not account for the following scenario:
@@ -102,7 +102,7 @@ export class Defunder {
     if (
       adjudicatorStatus.channelMode !== 'Finalized' &&
       channel.hasConclusionProof &&
-      shouldSubmitCollaborativeTx
+      shouldSubmitTx
     ) {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'withdraw', tx);
 
@@ -113,7 +113,7 @@ export class Defunder {
       // Note, we are not awaiting transaction submission
       await this.chainService.concludeAndWithdraw([channel.supported]);
       didSubmitTransaction = true;
-    } else if (adjudicatorStatus.channelMode === 'Finalized' && shouldSubmitCollaborativeTx) {
+    } else if (adjudicatorStatus.channelMode === 'Finalized' && shouldSubmitTx) {
       await ChainServiceRequest.insertOrUpdate(channel.channelId, 'pushOutcome', tx);
       await this.chainService.pushOutcomeAndWithdraw(
         adjudicatorStatus.states[0],

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -91,7 +91,7 @@ export class Defunder {
     );
 
     let didSubmitTransaction = false;
-    const shouldSubmitCollaborativeTx = this._shouldSubmitCollaborativeTx(channel, objective);
+    const shouldSubmitCollaborativeTx = Defunder._shouldSubmitCollaborativeTx(channel, objective);
 
     /**
      * The below if/else does not account for the following scenario:
@@ -161,8 +161,13 @@ export class Defunder {
    *
    * This method is public for unit testing only
    */
-  public _shouldSubmitCollaborativeTx(channel: Channel, objective: Objective): boolean {
+  public static _shouldSubmitCollaborativeTx(channel: Channel, objective: Objective): boolean {
     let shouldSubmitCollaborativeTx = true;
+    /**
+     * Only CloseChannel objective specifies the transaction submitter order.
+     * The DefundChannel objective will be soon replaced with the ChallengeChannel objective.
+     * Challenge channel objective does not result in any collaborative transactions.
+     */
     if (isCloseChannel(objective)) {
       for (const txSubmitter of objective.data.txSubmitterOder) {
         const allocation = channel.allocationItemForParticipantIndex(txSubmitter);

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -159,8 +159,6 @@ export class Defunder {
  * Assume that we are going to submit collaborative transaction(s) unless:
  * 1. There is an agreed upon order of transaction submitters.
  * 2. There is a transaction submitter before us who has funds in the channel.
- *
- * This method is public for unit testing only
  */
 export function shouldSubmitCollaborativeTx(channel: Channel, objective: Objective): boolean {
   let shouldSubmitCollaborativeTx = true;

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -153,30 +153,30 @@ export class Defunder {
       tx
     );
   }
+}
 
+/**
+ * Assume that we are going to submit collaborative transaction(s) unless:
+ * 1. There is an agreed upon order of transaction submitters.
+ * 2. There is a transaction submitter before us who has funds in the channel.
+ *
+ * This method is public for unit testing only
+ */
+export function shouldSubmitCollaborativeTx(channel: Channel, objective: Objective): boolean {
+  let shouldSubmitCollaborativeTx = true;
   /**
-   * Assume that we are going to submit collaborative transaction(s) unless:
-   * 1. There is an agreed upon order of transaction submitters.
-   * 2. There is a transaction submitter before us who has funds in the channel.
-   *
-   * This method is public for unit testing only
+   * Only CloseChannel objective specifies the transaction submitter order.
+   * The DefundChannel objective will be soon replaced with the ChallengeChannel objective.
+   * Challenge channel objective does not result in any collaborative transactions.
    */
-  public static _shouldSubmitCollaborativeTx(channel: Channel, objective: Objective): boolean {
-    let shouldSubmitCollaborativeTx = true;
-    /**
-     * Only CloseChannel objective specifies the transaction submitter order.
-     * The DefundChannel objective will be soon replaced with the ChallengeChannel objective.
-     * Challenge channel objective does not result in any collaborative transactions.
-     */
-    if (isCloseChannel(objective)) {
-      for (const txSubmitter of objective.data.txSubmitterOder) {
-        const allocation = channel.allocationItemForParticipantIndex(txSubmitter);
-        if (allocation && BN.gt(allocation.amount, 0)) {
-          shouldSubmitCollaborativeTx = txSubmitter === channel.myIndex;
-          break;
-        }
+  if (isCloseChannel(objective)) {
+    for (const txSubmitter of objective.data.txSubmitterOder) {
+      const allocation = channel.allocationItemForParticipantIndex(txSubmitter);
+      if (allocation && BN.gt(allocation.amount, 0)) {
+        shouldSubmitCollaborativeTx = txSubmitter === channel.myIndex;
+        break;
       }
     }
-    return shouldSubmitCollaborativeTx;
   }
+  return shouldSubmitCollaborativeTx;
 }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -193,14 +193,14 @@ export class TestChannel {
     };
   }
 
-  public closeChannelObjective(transactionSubmitterIndex = 0): CloseChannel {
+  public closeChannelObjective(txSubmitterOder = [0, 1]): CloseChannel {
     return {
       participants: this.participants,
       type: 'CloseChannel',
       data: {
         targetChannelId: this.channelId,
         fundingStrategy: this.fundingStrategy,
-        transactionSubmitter: this.participants[transactionSubmitterIndex].participantId,
+        txSubmitterOder,
       },
     };
   }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -198,6 +198,7 @@ export class TestChannel {
       data: {
         targetChannelId: this.channelId,
         fundingStrategy: this.fundingStrategy,
+        transactionSubmitter: this.participantB.participantId,
       },
     };
   }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -17,6 +17,7 @@ import {
   State,
   NULL_APP_DATA,
   CloseChannel,
+  DefundChannel,
 } from '@statechannels/wallet-core';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
 import {SignedState as WireState, Payload} from '@statechannels/wire-format';
@@ -200,6 +201,16 @@ export class TestChannel {
         targetChannelId: this.channelId,
         fundingStrategy: this.fundingStrategy,
         transactionSubmitter: this.participants[transactionSubmitterIndex].participantId,
+      },
+    };
+  }
+
+  public defundChannelObjective(): DefundChannel {
+    return {
+      participants: this.participants,
+      type: 'DefundChannel',
+      data: {
+        targetChannelId: this.channelId,
       },
     };
   }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -16,6 +16,7 @@ import {
   simpleEthAllocation,
   State,
   NULL_APP_DATA,
+  CloseChannel,
 } from '@statechannels/wallet-core';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
 import {SignedState as WireState, Payload} from '@statechannels/wire-format';
@@ -191,14 +192,14 @@ export class TestChannel {
     };
   }
 
-  public get closeChannelObjective(): SharedObjective {
+  public closeChannelObjective(transactionSubmitterIndex = 0): CloseChannel {
     return {
       participants: this.participants,
       type: 'CloseChannel',
       data: {
         targetChannelId: this.channelId,
         fundingStrategy: this.fundingStrategy,
-        transactionSubmitter: this.participantB.participantId,
+        transactionSubmitter: this.participants[transactionSubmitterIndex].participantId,
       },
     };
   }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -193,14 +193,14 @@ export class TestChannel {
     };
   }
 
-  public closeChannelObjective(txSubmitterOder = [0, 1]): CloseChannel {
+  public closeChannelObjective(txSubmitterOrder = [0, 1]): CloseChannel {
     return {
       participants: this.participants,
       type: 'CloseChannel',
       data: {
         targetChannelId: this.channelId,
         fundingStrategy: this.fundingStrategy,
-        txSubmitterOder,
+        txSubmitterOrder,
       },
     };
   }

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -352,6 +352,7 @@ describe('when the application protocol returns an action', () => {
             data: {
               targetChannelId: channelId,
               fundingStrategy: 'Direct',
+              transactionSubmitter: c.nthParticipant(1).participantId,
             },
           },
         ],
@@ -381,6 +382,7 @@ describe('when the application protocol returns an action', () => {
           data: {
             targetChannelId: channelId,
             fundingStrategy: 'Direct',
+            transactionSubmitter: c.nthParticipant(1).participantId,
           },
         },
       ],

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -352,7 +352,7 @@ describe('when the application protocol returns an action', () => {
             data: {
               targetChannelId: channelId,
               fundingStrategy: 'Direct',
-              transactionSubmitter: c.nthParticipant(1).participantId,
+              txSubmitterOder: [1, 0],
             },
           },
         ],
@@ -382,7 +382,7 @@ describe('when the application protocol returns an action', () => {
           data: {
             targetChannelId: channelId,
             fundingStrategy: 'Direct',
-            transactionSubmitter: c.nthParticipant(1).participantId,
+            txSubmitterOder: [1, 0],
           },
         },
       ],

--- a/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/push-message.test.ts
@@ -352,7 +352,7 @@ describe('when the application protocol returns an action', () => {
             data: {
               targetChannelId: channelId,
               fundingStrategy: 'Direct',
-              txSubmitterOder: [1, 0],
+              txSubmitterOrder: [1, 0],
             },
           },
         ],
@@ -382,7 +382,7 @@ describe('when the application protocol returns an action', () => {
           data: {
             targetChannelId: channelId,
             fundingStrategy: 'Direct',
-            txSubmitterOder: [1, 0],
+            txSubmitterOrder: [1, 0],
           },
         },
       ],

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -512,7 +512,7 @@ export class Store {
     tx: Transaction
   ): Promise<DBCloseChannelObjective> {
     const {
-      data: {targetChannelId, fundingStrategy},
+      data: {targetChannelId},
     } = objective;
 
     // fetch the channel to make sure the channel exists
@@ -526,12 +526,8 @@ export class Store {
       status: 'approved' as const,
       waitingFor: CloseChannelWaitingFor.allAllocationItemsToBeExternalDestination,
       type: objective.type,
-      participants: [],
-      data: {
-        targetChannelId,
-        fundingStrategy,
-        transactionSubmitter: channel.nthParticipant(1).participantId,
-      },
+      participants: objective.participants,
+      data: objective.data,
     };
 
     return ObjectiveModel.insert(objectiveToBeStored, tx) as Promise<DBCloseChannelObjective>;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -516,7 +516,7 @@ export class Store {
     } = objective;
 
     // fetch the channel to make sure the channel exists
-    const channel = await this.getChannelState(targetChannelId, tx);
+    const channel = await this.getChannel(targetChannelId, tx);
     if (!channel)
       throw new StoreError(StoreError.reasons.channelMissing, {
         channelId: targetChannelId,
@@ -530,6 +530,7 @@ export class Store {
       data: {
         targetChannelId,
         fundingStrategy,
+        transactionSubmitter: channel.nthParticipant(1).participantId,
       },
     };
 

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -107,7 +107,23 @@ export type CloseChannel = _Objective<
   {
     targetChannelId: string;
     fundingStrategy: FundingStrategy;
-    transactionSubmitter: string;
+    /**
+     * Collaboratively concluding a channel on-chain involves the following:
+     * 1. Submit a conclusion proof to the NitroAdjudicator.
+     * 2. Push the outcome to all AssetHolders.
+     * 3. Transfer out of the channel for all asset holders.
+     *
+     * Steps 1 and 2 require one or two transactions that are submitted by one participant
+     * but affect (and block) both participants. txSubmitterOrder defines the order in which
+     * participants will try to submit the collaborative transactions.
+     *
+     * CAVEAT:
+     * Let's say 2 participants are concluding a channel with:
+     * - txSubmitterOrder of [0, 1]
+     * - participant 0 has no funds in the channel.
+     * In the above, participant 0 is expected to NOT submit any collaborative transactions.
+     */
+    txSubmitterOder: number[];
   }
 >;
 export type VirtuallyFund = _Objective<

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -123,7 +123,7 @@ export type CloseChannel = _Objective<
      * - participant 0 has no funds in the channel.
      * In the above, participant 0 is expected to NOT submit any collaborative transactions.
      */
-    txSubmitterOder: number[];
+    txSubmitterOrder: number[];
   }
 >;
 export type VirtuallyFund = _Objective<

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -107,6 +107,7 @@ export type CloseChannel = _Objective<
   {
     targetChannelId: string;
     fundingStrategy: FundingStrategy;
+    transactionSubmitter: string;
   }
 >;
 export type VirtuallyFund = _Objective<
@@ -164,7 +165,7 @@ export type Objective = SharedObjective | SubmitChallenge | DefundChannel;
 const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
   o.type === name;
 export const isOpenChannel = guard<OpenChannel>('OpenChannel');
-export const isCloseChannel = guard<OpenChannel>('CloseChannel');
+export const isCloseChannel = guard<CloseChannel>('CloseChannel');
 export const isVirtuallyFund = guard<VirtuallyFund>('VirtuallyFund');
 export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');
 export const isFundLedger = guard<FundLedger>('FundLedger');

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -19,10 +19,7 @@
           "$ref": "#/definitions/Address"
         }
       },
-      "required": [
-        "assetHolderAddress",
-        "allocationItems"
-      ],
+      "required": ["assetHolderAddress", "allocationItems"],
       "type": "object"
     },
     "AllocationItem": {
@@ -35,10 +32,7 @@
           "$ref": "#/definitions/Bytes32"
         }
       },
-      "required": [
-        "destination",
-        "amount"
-      ],
+      "required": ["destination", "amount"],
       "type": "object"
     },
     "Allocations": {
@@ -70,10 +64,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "type",
-            "channelId"
-          ],
+          "required": ["type", "channelId"],
           "type": "object"
         },
         {
@@ -96,13 +87,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "type",
-            "nonce",
-            "channelId",
-            "outcome",
-            "signingAddress"
-          ],
+          "required": ["type", "nonce", "channelId", "outcome", "signingAddress"],
           "type": "object"
         }
       ]
@@ -114,30 +99,20 @@
           "additionalProperties": false,
           "properties": {
             "fundingStrategy": {
-              "enum": [
-                "Direct",
-                "Ledger",
-                "Virtual",
-                "Fake",
-                "Unknown"
-              ],
+              "enum": ["Direct", "Ledger", "Virtual", "Fake", "Unknown"],
               "type": "string"
             },
             "targetChannelId": {
               "$ref": "#/definitions/Bytes32"
             },
-            "txSubmitterOder": {
+            "txSubmitterOrder": {
               "items": {
                 "type": "number"
               },
               "type": "array"
             }
           },
-          "required": [
-            "targetChannelId",
-            "fundingStrategy",
-            "txSubmitterOder"
-          ],
+          "required": ["targetChannelId", "fundingStrategy", "txSubmitterOrder"],
           "type": "object"
         },
         "participants": {
@@ -151,11 +126,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "participants",
-        "type",
-        "data"
-      ],
+      "required": ["participants", "type", "data"],
       "type": "object"
     },
     "CloseLedger": {
@@ -168,9 +139,7 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": [
-            "ledgerId"
-          ],
+          "required": ["ledgerId"],
           "type": "object"
         },
         "participants": {
@@ -184,11 +153,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "participants",
-        "type",
-        "data"
-      ],
+      "required": ["participants", "type", "data"],
       "type": "object"
     },
     "FundGuarantor": {
@@ -207,11 +172,7 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": [
-            "jointChannelId",
-            "ledgerId",
-            "guarantorId"
-          ],
+          "required": ["jointChannelId", "ledgerId", "guarantorId"],
           "type": "object"
         },
         "participants": {
@@ -225,11 +186,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "participants",
-        "type",
-        "data"
-      ],
+      "required": ["participants", "type", "data"],
       "type": "object"
     },
     "FundLedger": {
@@ -242,9 +199,7 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": [
-            "ledgerId"
-          ],
+          "required": ["ledgerId"],
           "type": "object"
         },
         "participants": {
@@ -258,11 +213,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "participants",
-        "type",
-        "data"
-      ],
+      "required": ["participants", "type", "data"],
       "type": "object"
     },
     "Guarantee": {
@@ -281,11 +232,7 @@
           "$ref": "#/definitions/Bytes32"
         }
       },
-      "required": [
-        "assetHolderAddress",
-        "targetChannelId",
-        "destinations"
-      ],
+      "required": ["assetHolderAddress", "targetChannelId", "destinations"],
       "type": "object"
     },
     "Guarantees": {
@@ -307,10 +254,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "recipient",
-        "data"
-      ],
+      "required": ["recipient", "data"],
       "type": "object"
     },
     "Objective": {
@@ -345,30 +289,18 @@
               "$ref": "#/definitions/Address"
             },
             "fundingStrategy": {
-              "enum": [
-                "Direct",
-                "Ledger",
-                "Virtual",
-                "Fake",
-                "Unknown"
-              ],
+              "enum": ["Direct", "Ledger", "Virtual", "Fake", "Unknown"],
               "type": "string"
             },
             "role": {
-              "enum": [
-                "app",
-                "ledger"
-              ],
+              "enum": ["app", "ledger"],
               "type": "string"
             },
             "targetChannelId": {
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": [
-            "targetChannelId",
-            "fundingStrategy"
-          ],
+          "required": ["targetChannelId", "fundingStrategy"],
           "type": "object"
         },
         "participants": {
@@ -382,11 +314,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "participants",
-        "type",
-        "data"
-      ],
+      "required": ["participants", "type", "data"],
       "type": "object"
     },
     "Outcome": {
@@ -412,11 +340,7 @@
           "$ref": "#/definitions/Address"
         }
       },
-      "required": [
-        "participantId",
-        "signingAddress",
-        "destination"
-      ],
+      "required": ["participantId", "signingAddress", "destination"],
       "type": "object"
     },
     "Payload": {
@@ -444,9 +368,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "walletVersion"
-      ],
+      "required": ["walletVersion"],
       "type": "object"
     },
     "SignedState": {
@@ -528,10 +450,7 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": [
-            "targetChannelId",
-            "jointChannelId"
-          ],
+          "required": ["targetChannelId", "jointChannelId"],
           "type": "object"
         },
         "participants": {
@@ -545,11 +464,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "participants",
-        "type",
-        "data"
-      ],
+      "required": ["participants", "type", "data"],
       "type": "object"
     }
   }

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -19,7 +19,10 @@
           "$ref": "#/definitions/Address"
         }
       },
-      "required": ["assetHolderAddress", "allocationItems"],
+      "required": [
+        "assetHolderAddress",
+        "allocationItems"
+      ],
       "type": "object"
     },
     "AllocationItem": {
@@ -32,7 +35,10 @@
           "$ref": "#/definitions/Bytes32"
         }
       },
-      "required": ["destination", "amount"],
+      "required": [
+        "destination",
+        "amount"
+      ],
       "type": "object"
     },
     "Allocations": {
@@ -64,7 +70,10 @@
               "type": "string"
             }
           },
-          "required": ["type", "channelId"],
+          "required": [
+            "type",
+            "channelId"
+          ],
           "type": "object"
         },
         {
@@ -87,7 +96,13 @@
               "type": "string"
             }
           },
-          "required": ["type", "nonce", "channelId", "outcome", "signingAddress"],
+          "required": [
+            "type",
+            "nonce",
+            "channelId",
+            "outcome",
+            "signingAddress"
+          ],
           "type": "object"
         }
       ]
@@ -99,7 +114,13 @@
           "additionalProperties": false,
           "properties": {
             "fundingStrategy": {
-              "enum": ["Direct", "Ledger", "Virtual", "Fake", "Unknown"],
+              "enum": [
+                "Direct",
+                "Ledger",
+                "Virtual",
+                "Fake",
+                "Unknown"
+              ],
               "type": "string"
             },
             "targetChannelId": {
@@ -112,7 +133,11 @@
               "type": "array"
             }
           },
-          "required": ["targetChannelId", "fundingStrategy", "txSubmitterOrder"],
+          "required": [
+            "targetChannelId",
+            "fundingStrategy",
+            "txSubmitterOrder"
+          ],
           "type": "object"
         },
         "participants": {
@@ -126,7 +151,11 @@
           "type": "string"
         }
       },
-      "required": ["participants", "type", "data"],
+      "required": [
+        "participants",
+        "type",
+        "data"
+      ],
       "type": "object"
     },
     "CloseLedger": {
@@ -139,7 +168,9 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": ["ledgerId"],
+          "required": [
+            "ledgerId"
+          ],
           "type": "object"
         },
         "participants": {
@@ -153,7 +184,11 @@
           "type": "string"
         }
       },
-      "required": ["participants", "type", "data"],
+      "required": [
+        "participants",
+        "type",
+        "data"
+      ],
       "type": "object"
     },
     "FundGuarantor": {
@@ -172,7 +207,11 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": ["jointChannelId", "ledgerId", "guarantorId"],
+          "required": [
+            "jointChannelId",
+            "ledgerId",
+            "guarantorId"
+          ],
           "type": "object"
         },
         "participants": {
@@ -186,7 +225,11 @@
           "type": "string"
         }
       },
-      "required": ["participants", "type", "data"],
+      "required": [
+        "participants",
+        "type",
+        "data"
+      ],
       "type": "object"
     },
     "FundLedger": {
@@ -199,7 +242,9 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": ["ledgerId"],
+          "required": [
+            "ledgerId"
+          ],
           "type": "object"
         },
         "participants": {
@@ -213,7 +258,11 @@
           "type": "string"
         }
       },
-      "required": ["participants", "type", "data"],
+      "required": [
+        "participants",
+        "type",
+        "data"
+      ],
       "type": "object"
     },
     "Guarantee": {
@@ -232,7 +281,11 @@
           "$ref": "#/definitions/Bytes32"
         }
       },
-      "required": ["assetHolderAddress", "targetChannelId", "destinations"],
+      "required": [
+        "assetHolderAddress",
+        "targetChannelId",
+        "destinations"
+      ],
       "type": "object"
     },
     "Guarantees": {
@@ -254,7 +307,10 @@
           "type": "string"
         }
       },
-      "required": ["recipient", "data"],
+      "required": [
+        "recipient",
+        "data"
+      ],
       "type": "object"
     },
     "Objective": {
@@ -289,18 +345,30 @@
               "$ref": "#/definitions/Address"
             },
             "fundingStrategy": {
-              "enum": ["Direct", "Ledger", "Virtual", "Fake", "Unknown"],
+              "enum": [
+                "Direct",
+                "Ledger",
+                "Virtual",
+                "Fake",
+                "Unknown"
+              ],
               "type": "string"
             },
             "role": {
-              "enum": ["app", "ledger"],
+              "enum": [
+                "app",
+                "ledger"
+              ],
               "type": "string"
             },
             "targetChannelId": {
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": ["targetChannelId", "fundingStrategy"],
+          "required": [
+            "targetChannelId",
+            "fundingStrategy"
+          ],
           "type": "object"
         },
         "participants": {
@@ -314,7 +382,11 @@
           "type": "string"
         }
       },
-      "required": ["participants", "type", "data"],
+      "required": [
+        "participants",
+        "type",
+        "data"
+      ],
       "type": "object"
     },
     "Outcome": {
@@ -340,7 +412,11 @@
           "$ref": "#/definitions/Address"
         }
       },
-      "required": ["participantId", "signingAddress", "destination"],
+      "required": [
+        "participantId",
+        "signingAddress",
+        "destination"
+      ],
       "type": "object"
     },
     "Payload": {
@@ -368,7 +444,9 @@
           "type": "string"
         }
       },
-      "required": ["walletVersion"],
+      "required": [
+        "walletVersion"
+      ],
       "type": "object"
     },
     "SignedState": {
@@ -450,7 +528,10 @@
               "$ref": "#/definitions/Bytes32"
             }
           },
-          "required": ["targetChannelId", "jointChannelId"],
+          "required": [
+            "targetChannelId",
+            "jointChannelId"
+          ],
           "type": "object"
         },
         "participants": {
@@ -464,7 +545,11 @@
           "type": "string"
         }
       },
-      "required": ["participants", "type", "data"],
+      "required": [
+        "participants",
+        "type",
+        "data"
+      ],
       "type": "object"
     }
   }

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -126,14 +126,17 @@
             "targetChannelId": {
               "$ref": "#/definitions/Bytes32"
             },
-            "transactionSubmitter": {
-              "type": "string"
+            "txSubmitterOder": {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
             }
           },
           "required": [
             "targetChannelId",
             "fundingStrategy",
-            "transactionSubmitter"
+            "txSubmitterOder"
           ],
           "type": "object"
         },

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -125,11 +125,15 @@
             },
             "targetChannelId": {
               "$ref": "#/definitions/Bytes32"
+            },
+            "transactionSubmitter": {
+              "type": "string"
             }
           },
           "required": [
             "targetChannelId",
-            "fundingStrategy"
+            "fundingStrategy",
+            "transactionSubmitter"
           ],
           "type": "object"
         },

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -95,7 +95,7 @@ export type CloseChannel = _Objective<
   {
     targetChannelId: Bytes32;
     fundingStrategy: FundingStrategy;
-    txSubmitterOder: number[];
+    txSubmitterOrder: number[];
   }
 >;
 export type VirtuallyFund = _Objective<

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -95,7 +95,7 @@ export type CloseChannel = _Objective<
   {
     targetChannelId: Bytes32;
     fundingStrategy: FundingStrategy;
-    transactionSubmitter: string;
+    txSubmitterOder: number[];
   }
 >;
 export type VirtuallyFund = _Objective<

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -95,6 +95,7 @@ export type CloseChannel = _Objective<
   {
     targetChannelId: Bytes32;
     fundingStrategy: FundingStrategy;
+    transactionSubmitter: string;
   }
 >;
 export type VirtuallyFund = _Objective<


### PR DESCRIPTION
Assume a 2-party, directly funded channel, though the following easily generalizes to `n` parties.

Once participants A and B hold a conclusion proof, the following sequence should occur:
1. The channel should be concluded on-chain.
1. The channel outcome should be pushed to all AssetHolders.
1. In each AssetHolder, funds should be transferred to each participant.

The above can be done in 1 or many transactions. Regardless of how many transactions are mined, at least 1 transaction is a "collaborative" transaction: a transaction that benefits both parties, but only one party pays gas fees.

This PR introduces a transaction submitter order for collaborative conclusions. The order is agreed upon when the collaborative conclusion objective is created. At the moment, the order is hardcoded as `[1, 0]`, which means that the second participant is the primary transaction submitter and the second participant is the secondary transaction submitter.

If a participant has no funds in a channel, the participant is not incentivized to submit collaborative transactions. If a participant is the primary transaction submitter but has no funds in the channel, the secondary transaction submitter is expected to submit a transaction. Same logic applies to the tertiary transaction submitter, etc.

Fixes https://github.com/statechannels/statechannels/issues/3205, https://github.com/statechannels/statechannels/issues/3206. 
