### PR TITLE
move "ledger channel patching" outside of ensureOpenChannelObjective

### DIFF
--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -200,8 +200,14 @@ export class ObjectiveModel extends Model {
     return model.map(m => m.toObjective());
   }
 
-  static async approve(objectiveId: string, tx: TransactionOrKnex): Promise<void> {
-    await ObjectiveModel.query(tx).findById(objectiveId).patch({status: 'approved'});
+  static async approve(objectiveId: string, tx: TransactionOrKnex): Promise<DBObjective> {
+    return (
+      await ObjectiveModel.query(tx)
+        .findById(objectiveId)
+        .patch({status: 'approved'})
+        .returning('*')
+        .first()
+    ).toObjective();
   }
 
   static async succeed(objectiveId: string, tx: TransactionOrKnex): Promise<ObjectiveModel> {

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -498,11 +498,7 @@ export class Store {
         tx
       );
 
-    await Channel.query(tx)
-      .where({channelId: channel.channelId})
-      .patch({fundingStrategy, fundingLedgerChannelId})
-      .returning('*')
-      .first();
+    await Channel.query(tx).where({channelId}).patch({fundingStrategy, fundingLedgerChannelId});
 
     return ObjectiveModel.insert(objectiveToBeStored, tx) as Promise<DBOpenChannelObjective>;
   }

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -491,15 +491,6 @@ export class Store {
       },
     };
 
-    if (role === 'ledger')
-      await Channel.setLedger(
-        channelId,
-        checkThat(channel.latest.outcome, isSimpleAllocation).assetHolderAddress,
-        tx
-      );
-
-    await Channel.query(tx).where({channelId}).patch({fundingStrategy, fundingLedgerChannelId});
-
     return ObjectiveModel.insert(objectiveToBeStored, tx) as Promise<DBOpenChannelObjective>;
   }
 
@@ -708,6 +699,7 @@ export class Store {
     return await this.knex.transaction(async tx => {
       const channel = await createChannel(constants, fundingStrategy, fundingLedgerChannelId, tx);
       const {channelId, participants} = channel;
+
       const firstSignedState = await this.signState(
         channel,
         {
@@ -719,6 +711,13 @@ export class Store {
         },
         tx
       );
+
+      if (role === 'ledger')
+        await Channel.setLedger(
+          channelId,
+          checkThat(outcome, isSimpleAllocation).assetHolderAddress,
+          tx
+        );
 
       const objectiveParams = {
         type: 'OpenChannel' as const,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -595,22 +595,7 @@ export class SingleThreadedWallet
 
     await Promise.all(
       objectives.map(async objective => {
-        const channelId = objective.data.targetChannelId;
-        if (objective.type === 'OpenChannel') {
-          if (objective.data.role === 'ledger') {
-            const channel = await this.store.getChannelState(channelId);
-            await Channel.setLedger(
-              channelId,
-              checkThat(channel.latest.outcome, isSimpleAllocation).assetHolderAddress,
-              this.store.knex
-            );
-          }
-          const {fundingStrategy, fundingLedgerChannelId} = objective.data;
-          await Channel.query(this.store.knex)
-            .where({channelId})
-            .patch({fundingStrategy, fundingLedgerChannelId});
-          await this.store.approveObjective(objective.objectiveId);
-        }
+        await this.store.approveObjective(objective.objectiveId);
       })
     );
 
@@ -650,18 +635,6 @@ export class SingleThreadedWallet
 
     const objective = objectives[0];
     if (objective.type === 'OpenChannel') {
-      // TODO move this code to the objective manager?
-      await this.store.transaction(async tx => {
-        if (objective.data.role === 'ledger') {
-          await Channel.setLedger(
-            channelId,
-            checkThat(channel.latest.outcome, isSimpleAllocation).assetHolderAddress,
-            tx
-          );
-        }
-        const {fundingStrategy, fundingLedgerChannelId} = objective.data;
-        await Channel.query(tx).where({channelId}).patch({fundingStrategy, fundingLedgerChannelId});
-      });
       await this.store.approveObjective(objectives[0].objectiveId);
     }
 


### PR DESCRIPTION
...and into `createChannel` and `approveObjective`.

The various `ensure*Objective()` functions all do very similar but slightly different things, and are called into both when
- instigating an objective myself (should be OK to pre approve)
- receiving an objective from a counter-party (should ask app for approval).

The wider context is that I want to remove `ensureObjectives` entirely because it is not clear what the function is responsible for, and it makes several non-obvious decisions when it executes. A blocker to that work is that the existing functionality of this function is heavily leaned on. The functionality about approval and about insertion / checking existence in the DB should be fairly straightforward, but any other functionality needs to be preserved too. This PR takes that remaining functionality and puts it elsewhere in the wallet, enabling `ensureObjectives` to have a narrower scope and be cleared up in a future PR. 

The `ensureOpenChannelObjective` branch is also special in that it *patches* an existing channel so that we know it is a ledger channel. Whether this should be necessary, or where exactly this code should live, is a conversation I want to have but which is beyond the scope of the PR.

Here I move this patching out of `ensureOpenChannelObjective`, and replicate it *both* in `createChannel` and in `approveObjective`. 

It's a good approach because it is more verbose. A downside is that it is more verbose. I think the verbosity is important, given the two distinct "routes to objective approval".

In fact, I just realised that the current behaviour will patch the DB before the app is even given the chance to approve the objective. This seems wrong: if I'm going to let an objective drive changes to my store, it had better wait for approval. So this PR fixes that issue, too.

## Changes [Optional] 
1. moving the patching code out of `ensureObjective`
2. makes `ObjectiveModel.approve()` return a `DBObjective`.

## How Has This Been Tested? 
Relying on existing tests.

---
## Checklist:

### Code quality
- [ ] I have written clear commit messages // they are clear, but I would probably want to squash them because I went down some blind alleys
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
