### PR TITLE
deprecate DBObjective in favour of WalletObjective<> 

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -31,7 +31,6 @@ import { Payload as Message } from '@statechannels/wallet-core';
 import { MessageQueuedNotification } from '@statechannels/client-api-schema';
 import { Model } from 'objection';
 import { ModelOptions } from 'objection';
-import { Objective } from '@statechannels/wallet-core';
 import { OpenChannel } from '@statechannels/wallet-core';
 import { Outcome } from '@statechannels/wallet-core';
 import { Participant } from '@statechannels/wallet-core';
@@ -163,7 +162,7 @@ export type MetricsConfiguration = {
 export type MultipleChannelOutput = {
     outbox: Outgoing[];
     channelResults: ChannelResult[];
-    newObjectives: DBObjective[];
+    newObjectives: WalletObjective[];
 };
 
 // @public
@@ -255,7 +254,7 @@ export type ServerWalletConfig = RequiredServerWalletConfig & OptionalServerWall
 export type SingleChannelOutput = {
     outbox: Outgoing[];
     channelResult: ChannelResult;
-    newObjective: DBObjective | undefined;
+    newObjective: WalletObjective | undefined;
 };
 
 // Warning: (ae-forgotten-export) The symbol "EventEmitterType" needs to be exported by the entry point index.d.ts
@@ -292,7 +291,7 @@ export class SingleThreadedWallet extends EventEmitter<EventEmitterType> impleme
     destroy(): Promise<void>;
     getChannels(): Promise<MultipleChannelOutput>;
     getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
-    getObjective(objectiveId: string): Promise<DBObjective>;
+    getObjective(objectiveId: string): Promise<WalletObjective>;
     getSigningAddress(): Promise<Address>;
     getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;
     // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts
@@ -400,6 +399,6 @@ export interface WalletInterface {
 
 // Warnings were encountered during analysis:
 //
-// src/wallet/types.ts:30:3 - (ae-forgotten-export) The symbol "DBObjective" needs to be exported by the entry point index.d.ts
+// src/wallet/types.ts:30:3 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
 
 ```

--- a/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
@@ -2,7 +2,7 @@ import {CreateChannelParams} from '@statechannels/client-api-schema';
 import Knex from 'knex';
 
 import {peerWallets, getPeersSetup, peersTeardown} from '../../jest/with-peers-setup-teardown';
-import {DBObjective, ObjectiveModel} from '../models/objective';
+import {WalletObjective, ObjectiveModel} from '../models/objective';
 import {createChannelArgs} from '../wallet/__test__/fixtures/create-channel';
 import {bob} from '../wallet/__test__/fixtures/participants';
 import {getChannelResultFor, getPayloadFor} from '../__test__/test-helpers';
@@ -123,7 +123,7 @@ test('Can successfully push the sync objective message multiple times', async ()
   //expect(newObjectives).toHaveLength(0);
 });
 
-async function getObjective(knex: Knex, objectiveId: string): Promise<DBObjective | undefined> {
+async function getObjective(knex: Knex, objectiveId: string): Promise<WalletObjective | undefined> {
   const model = await ObjectiveModel.query(knex).findById(objectiveId);
   return model?.toObjective();
 }

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -299,7 +299,7 @@ export class ObjectiveModel extends Model {
       participants: [] as SupportedObjective['participants'], // reinstate an empty participants array
     } as O;
 
-    const wO: WalletObjective<O> = {
+    const walletObjective: WalletObjective<O> = {
       ...o,
       objectiveId: this.objectiveId,
       status: this.status,
@@ -309,7 +309,7 @@ export class ObjectiveModel extends Model {
     };
 
     if (isSupportedObjective(o)) {
-      return wO as WalletObjective<O>;
+      return walletObjective as WalletObjective<O>;
     }
 
     throw Error('unsupported');

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -34,7 +34,7 @@ function extractReferencedChannels(objective: Objective): string[] {
 type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
 
 /**
- * A WalletObjective is a wire objective with a status, timestamps and an objectiveId
+ * A WalletObjective is a wire objective with a status, waitingFor state-string, timestamps and an objectiveId
  *
  * Limited to 'OpenChannel', 'CloseChannel', 'SubmitChallenge' and 'DefundChannel' which are the only objectives
  * that are currently supported by the server wallet
@@ -65,13 +65,6 @@ export function isSupportedObjective(o: Objective): o is SupportedObjective {
     o.type === 'DefundChannel'
   );
 }
-/**
- * A WalletObjective is a wire objective with a status, timestamps and an objectiveId
- *
- * Limited to 'OpenChannel', 'CloseChannel', 'SubmitChallenge' and 'DefundChannel' which are the only objectives
- * that are currently supported by the server wallet
- *
- */
 
 export const toWireObjective = (dbObj: WalletObjective<SupportedObjective>): SharedObjective => {
   if (dbObj.type === 'SubmitChallenge' || dbObj.type === 'DefundChannel') {

--- a/packages/server-wallet/src/objectives/close-channel.ts
+++ b/packages/server-wallet/src/objectives/close-channel.ts
@@ -13,7 +13,7 @@ export class CloseChannelObjective {
     await store.lockApp(
       channelId,
       async (tx, channel) => {
-        const wO = await ObjectiveModel.insert(
+        const walletObjective = await ObjectiveModel.insert(
           {
             type: 'CloseChannel',
             participants: [],
@@ -27,7 +27,7 @@ export class CloseChannelObjective {
           tx
         );
         // add new objective to the response
-        response.queueCreatedObjective(wO, channel.myIndex, channel.participants);
+        response.queueCreatedObjective(walletObjective, channel.myIndex, channel.participants);
       },
       () => {
         throw new CloseChannelError(CloseChannelError.reasons.channelMissing, {channelId});

--- a/packages/server-wallet/src/objectives/close-channel.ts
+++ b/packages/server-wallet/src/objectives/close-channel.ts
@@ -13,7 +13,7 @@ export class CloseChannelObjective {
     await store.lockApp(
       channelId,
       async (tx, channel) => {
-        const dbObjective = await ObjectiveModel.insert(
+        const wO = await ObjectiveModel.insert(
           {
             type: 'CloseChannel',
             participants: [],
@@ -27,7 +27,7 @@ export class CloseChannelObjective {
           tx
         );
         // add new objective to the response
-        response.queueCreatedObjective(dbObjective, channel.myIndex, channel.participants);
+        response.queueCreatedObjective(wO, channel.myIndex, channel.participants);
       },
       () => {
         throw new CloseChannelError(CloseChannelError.reasons.channelMissing, {channelId});

--- a/packages/server-wallet/src/objectives/objective-manager.ts
+++ b/packages/server-wallet/src/objectives/objective-manager.ts
@@ -13,7 +13,7 @@ import {
   WaitingFor as ChallengeSubmitterWaitingFor,
 } from '../protocols/challenge-submitter';
 import {ChannelDefunder, WaitingFor as DefundChannelWaitingFor} from '../protocols/defund-channel';
-import {DBObjective, ObjectiveModel} from '../models/objective';
+import {WalletObjective, ObjectiveModel} from '../models/objective';
 
 import {ObjectiveManagerParams} from './types';
 import {CloseChannelObjective} from './close-channel';
@@ -34,7 +34,7 @@ export type WaitingFor =
   | DefundChannelWaitingFor
   | Nothing;
 
-export interface Cranker<O extends DBObjective> {
+export interface Cranker<O extends WalletObjective> {
   crank: (objective: O, response: WalletResponse, tx: Transaction) => Promise<WaitingFor | Nothing>;
 }
 export class ObjectiveManager {
@@ -84,7 +84,7 @@ export class ObjectiveManager {
           // 1. Define a WaitingFor enum which contains the "early return" or "pause" points of the objective.
           //    These pause points will be used to track progress over time, and for debugging.
           // 2. Import and add it to the WaitingFor union type in this file.
-          // 2. Implement the Cranker<YourDBObjectiveHere> interface
+          // 2. Implement the Cranker<YourWalletObjectiveHere> interface
           // 3. Make as much progress as you can towards the objective (sign states, submit transactions)
           //    until progress is blocked on an external event (e.g. counterparty State
           //    or blockchain event). Then return early with the waitingFor string

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -7,7 +7,7 @@ import {defaultTestConfig} from '../../config';
 import {WalletResponse} from '../../wallet/wallet-response';
 import {MockChainService} from '../../chain-service';
 import {createLogger} from '../../logger';
-import {DBSubmitChallengeObjective, ObjectiveModel} from '../../models/objective';
+import {WalletObjective, ObjectiveModel} from '../../models/objective';
 import {ChallengeSubmitter} from '../challenge-submitter';
 import {Channel} from '../../models/channel';
 import {channel} from '../../models/__test__/fixtures/channel';
@@ -51,11 +51,9 @@ describe(`challenge-submitter`, () => {
       data: {targetChannelId: c.channelId},
     };
 
-    const dbObjective = await knex.transaction(async tx =>
-      ObjectiveModel.insert<DBSubmitChallengeObjective>(obj, false, tx)
-    );
+    const wO = await knex.transaction(async tx => ObjectiveModel.insert(obj, false, tx));
 
-    await await crankAndAssert(dbObjective, {callsChallenge: false, completesObj: false});
+    await await crankAndAssert(wO, {callsChallenge: false, completesObj: false});
   });
   it(`takes no action if there is an existing challenge`, async () => {
     const c = channel();
@@ -71,9 +69,7 @@ describe(`challenge-submitter`, () => {
       data: {targetChannelId: c.channelId},
     };
 
-    const objective = await knex.transaction(tx =>
-      ObjectiveModel.insert<DBSubmitChallengeObjective>(obj, false, tx)
-    );
+    const objective = await knex.transaction(tx => ObjectiveModel.insert(obj, false, tx));
 
     await await crankAndAssert(objective, {callsChallenge: false, completesObj: false});
   });
@@ -92,9 +88,7 @@ describe(`challenge-submitter`, () => {
       data: {targetChannelId: c.channelId},
     };
 
-    const objective = await knex.transaction(tx =>
-      ObjectiveModel.insert<DBSubmitChallengeObjective>(obj, false, tx)
-    );
+    const objective = await knex.transaction(tx => ObjectiveModel.insert(obj, false, tx));
     await await crankAndAssert(objective, {
       callsChallenge: true,
       completesObj: true,
@@ -108,7 +102,7 @@ interface AssertionParams {
 }
 
 const crankAndAssert = async (
-  objective: DBSubmitChallengeObjective,
+  objective: WalletObjective<SubmitChallenge>,
   args: AssertionParams
 ): Promise<void> => {
   const completesObj = args.completesObj || false;

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -51,9 +51,11 @@ describe(`challenge-submitter`, () => {
       data: {targetChannelId: c.channelId},
     };
 
-    const wO = await knex.transaction(async tx => ObjectiveModel.insert(obj, false, tx));
+    const walletObjective = await knex.transaction(async tx =>
+      ObjectiveModel.insert(obj, false, tx)
+    );
 
-    await await crankAndAssert(wO, {callsChallenge: false, completesObj: false});
+    await await crankAndAssert(walletObjective, {callsChallenge: false, completesObj: false});
   });
   it(`takes no action if there is an existing challenge`, async () => {
     const c = channel();

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -1,10 +1,12 @@
+import {CloseChannel} from '@statechannels/wallet-core';
+
 import {DBAdmin} from '../../db-admin/db-admin';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {MockChainService} from '../../chain-service';
 import {defaultTestConfig} from '../../config';
 import {createLogger} from '../../logger';
 import {ChainServiceRequest, requestTimeout} from '../../models/chain-service-request';
-import {DBCloseChannelObjective, ObjectiveModel} from '../../models/objective';
+import {WalletObjective, ObjectiveModel} from '../../models/objective';
 import {Store} from '../../wallet/store';
 import {WalletResponse} from '../../wallet/wallet-response';
 import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
@@ -88,7 +90,7 @@ interface SetupParams {
 const setup = async (
   testChan: TestChannel,
   args: SetupParams
-): Promise<DBCloseChannelObjective> => {
+): Promise<WalletObjective<CloseChannel>> => {
   const {participant, statesHeld} = args;
   const totalFunds = args.totalFunds !== undefined ? args.totalFunds : testChan.startBal;
 
@@ -100,7 +102,7 @@ const setup = async (
 
   // add the closeChannel objective and approve
   const objective = await store.transaction(async tx => {
-    const o = await ObjectiveModel.insert<DBCloseChannelObjective>(
+    const o = await ObjectiveModel.insert(
       testChan.closeChannelObjective([participant, 1 - participant]),
       true, // preApproved
       tx
@@ -118,7 +120,7 @@ interface AssertionParams {
 }
 
 const crankAndAssert = async (
-  objective: DBCloseChannelObjective,
+  objective: WalletObjective<CloseChannel>,
   args: AssertionParams
 ): Promise<void> => {
   const statesToSign = args.statesToSign || [];

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,8 +1,8 @@
-import {makeAddress, State} from '@statechannels/wallet-core';
+import {DefundChannel, makeAddress, State} from '@statechannels/wallet-core';
 
 import {defaultTestConfig} from '../..';
 import {createLogger} from '../../logger';
-import {DBDefundChannelObjective, ObjectiveModel} from '../../models/objective';
+import {WalletObjective, ObjectiveModel} from '../../models/objective';
 import {Store} from '../../wallet/store';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
@@ -31,8 +31,8 @@ const FINAL = 10; // this will be A's state to sign
 const testChan = TestChannel.create({aBal: 5, bBal: 5});
 const testChan2 = TestChannel.create({aBal: 5, bBal: 5, finalFrom: FINAL});
 
-let objective: DBDefundChannelObjective;
-let objective2: DBDefundChannelObjective;
+let objective: WalletObjective<DefundChannel>;
+let objective2: WalletObjective<DefundChannel>;
 
 let pushSpy: jest.SpyInstance;
 let withdrawSpy: jest.SpyInstance;
@@ -60,7 +60,7 @@ beforeEach(async () => {
     states: [FINAL, FINAL + 1],
   });
 
-  objective = await ObjectiveModel.insert<DBDefundChannelObjective>(
+  objective = await ObjectiveModel.insert(
     {
       type: 'DefundChannel',
       participants: [],
@@ -70,7 +70,7 @@ beforeEach(async () => {
     knex
   );
 
-  objective2 = await ObjectiveModel.insert<DBDefundChannelObjective>(
+  objective2 = await ObjectiveModel.insert(
     {
       type: 'DefundChannel',
       participants: [],
@@ -207,7 +207,7 @@ async function setAdjudicatorStatus(
   }
 }
 
-async function crankChannelDefunder(objective: DBDefundChannelObjective) {
+async function crankChannelDefunder(objective: WalletObjective<DefundChannel>) {
   return store.transaction(async tx => {
     return channelDefunder.crank(objective, WalletResponse.initialize(), tx);
   });

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -36,23 +36,19 @@ async function ensureCloseObjective(
   participantIndex = 0
 ): Promise<WalletObjective<CloseChannel>> {
   // add the closeChannel objective and approve
-  const o = await ObjectiveModel.insert(
+  return ObjectiveModel.insert(
     channel.closeChannelObjective([participantIndex, 1 - participantIndex]),
     true,
     tx
   );
-  await store.approveObjective(o.objectiveId, tx);
-  return o;
 }
 
 async function ensureDefundObjective(
   channel: TestChannel,
   tx: Transaction
 ): Promise<WalletObjective<DefundChannel>> {
-  // add the defundChannel objective and approve
-  const o = await ObjectiveModel.insert(channel.defundChannelObjective(), false, tx);
-  await store.approveObjective(o.objectiveId, tx);
-  return o;
+  // add a preapproved defundChannel objective and approve
+  return ObjectiveModel.insert(channel.defundChannelObjective(), true, tx);
 }
 
 function testShouldSubmitCollaborativeTx(channel: Channel, order: number[], outcome: boolean) {

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -1,3 +1,4 @@
+import {CloseChannel, DefundChannel} from '@statechannels/wallet-core';
 import {Transaction} from 'objection';
 
 import {defaultTestConfig} from '../..';
@@ -9,11 +10,7 @@ import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {Channel} from '../../models/channel';
 import {Funding} from '../../models/funding';
 import {LedgerRequest} from '../../models/ledger-request';
-import {
-  DBCloseChannelObjective,
-  DBDefundChannelObjective,
-  ObjectiveModel,
-} from '../../models/objective';
+import {ObjectiveModel, WalletObjective} from '../../models/objective';
 import {Store} from '../../wallet/store';
 import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
 import {Defunder, shouldSubmitCollaborativeTx} from '../defunder';
@@ -37,30 +34,32 @@ async function ensureCloseObjective(
   channel: TestChannel,
   tx: Transaction,
   participantIndex = 0
-): Promise<DBCloseChannelObjective> {
-  // add a preapproved closeChannel objective
+): Promise<WalletObjective<CloseChannel>> {
+  // add the closeChannel objective and approve
   const o = await ObjectiveModel.insert(
     channel.closeChannelObjective([participantIndex, 1 - participantIndex]),
     true,
     tx
   );
-  return o as DBCloseChannelObjective;
+  await store.approveObjective(o.objectiveId, tx);
+  return o;
 }
 
 async function ensureDefundObjective(
   channel: TestChannel,
   tx: Transaction
-): Promise<DBDefundChannelObjective> {
-  // add a preapproved defundChannel objective
-  const o = await ObjectiveModel.insert(channel.defundChannelObjective(), true, tx);
-  return o as DBDefundChannelObjective;
+): Promise<WalletObjective<DefundChannel>> {
+  // add the defundChannel objective and approve
+  const o = await ObjectiveModel.insert(channel.defundChannelObjective(), false, tx);
+  await store.approveObjective(o.objectiveId, tx);
+  return o;
 }
 
 function testShouldSubmitCollaborativeTx(channel: Channel, order: number[], outcome: boolean) {
   const objective = ({
     type: 'CloseChannel',
     data: {txSubmitterOrder: order},
-  } as unknown) as DBCloseChannelObjective;
+  } as unknown) as WalletObjective<CloseChannel>;
   expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(outcome);
 }
 
@@ -89,7 +88,7 @@ describe('Collaborative transaction submitter', () => {
 
     const objective4 = {
       type: 'DefundChannel',
-    } as DBDefundChannelObjective;
+    } as WalletObjective<DefundChannel>;
     expect(shouldSubmitCollaborativeTx(channel, objective4)).toEqual(true);
   });
 
@@ -106,7 +105,7 @@ describe('Collaborative transaction submitter', () => {
 
     const objective = {
       type: 'DefundChannel',
-    } as DBDefundChannelObjective;
+    } as WalletObjective<DefundChannel>;
     expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
   });
 
@@ -127,7 +126,7 @@ describe('Collaborative transaction submitter', () => {
 
     const objective = {
       type: 'DefundChannel',
-    } as DBDefundChannelObjective;
+    } as WalletObjective<DefundChannel>;
     expect(shouldSubmitCollaborativeTx(channel, objective)).toEqual(true);
   });
 });

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -1,4 +1,4 @@
-import {BN} from '@statechannels/wallet-core';
+import {BN, OpenChannel} from '@statechannels/wallet-core';
 
 import {ChannelOpener} from '../channel-opener';
 import {Store} from '../../wallet/store';
@@ -8,7 +8,7 @@ import {WalletResponse} from '../../wallet/wallet-response';
 import {TestChannel} from '../../wallet/__test__/fixtures/test-channel';
 import {MockChainService} from '../../chain-service';
 import {createLogger} from '../../logger';
-import {DBOpenChannelObjective} from '../../models/objective';
+import {WalletObjective} from '../../models/objective';
 import {ChainServiceRequest, requestTimeout} from '../../models/chain-service-request';
 import {DBAdmin} from '../..';
 
@@ -150,7 +150,7 @@ interface SetupParams {
   totalFunds?: number;
 }
 
-const setup = async (args: SetupParams): Promise<DBOpenChannelObjective> => {
+const setup = async (args: SetupParams): Promise<WalletObjective<OpenChannel>> => {
   const {participant, statesHeld} = args;
   const totalFunds = args.totalFunds || 0;
 
@@ -164,7 +164,7 @@ interface AssertionParams {
 }
 
 const crankAndAssert = async (
-  objective: DBOpenChannelObjective,
+  objective: WalletObjective<OpenChannel>,
   args: AssertionParams
 ): Promise<void> => {
   const statesToSign = args.statesToSign || [];

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -1,11 +1,11 @@
-import {SignedState, State} from '@statechannels/wallet-core';
+import {SignedState, State, SubmitChallenge} from '@statechannels/wallet-core';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
 
 import {ChainServiceInterface} from '../chain-service';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {Channel} from '../models/channel';
-import {DBSubmitChallengeObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {Cranker, Nothing} from '../objectives/objective-manager';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
@@ -17,7 +17,7 @@ export const enum WaitingFor {
   existingChallenge = 'ChallengeSubmitter.existingChallenge',
 }
 
-export class ChallengeSubmitter implements Cranker<DBSubmitChallengeObjective> {
+export class ChallengeSubmitter implements Cranker<WalletObjective<SubmitChallenge>> {
   constructor(
     private store: Store,
     private chainService: ChainServiceInterface,
@@ -34,7 +34,7 @@ export class ChallengeSubmitter implements Cranker<DBSubmitChallengeObjective> {
     return new ChallengeSubmitter(store, chainService, logger, timingMetrics);
   }
   public async crank(
-    objective: DBSubmitChallengeObjective,
+    objective: WalletObjective<SubmitChallenge>,
     response: WalletResponse,
     tx: Transaction
   ): Promise<WaitingFor | Nothing> {

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -1,11 +1,16 @@
-import {checkThat, isSimpleAllocation, StateVariables} from '@statechannels/wallet-core';
+import {
+  checkThat,
+  CloseChannel,
+  isSimpleAllocation,
+  StateVariables,
+} from '@statechannels/wallet-core';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
 import {isExternalDestination} from '@statechannels/nitro-protocol';
 
 import {Store} from '../wallet/store';
 import {ChainServiceInterface} from '../chain-service';
-import {DBCloseChannelObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {WalletResponse} from '../wallet/wallet-response';
 import {Channel} from '../models/channel';
 import {Cranker, Nothing} from '../objectives/objective-manager';
@@ -18,7 +23,7 @@ export const enum WaitingFor {
   defunding = 'ChannelCloser.defunding',
 }
 
-export class ChannelCloser implements Cranker<DBCloseChannelObjective> {
+export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
   constructor(
     private store: Store,
     private chainService: ChainServiceInterface,
@@ -36,7 +41,7 @@ export class ChannelCloser implements Cranker<DBCloseChannelObjective> {
   }
 
   public async crank(
-    objective: DBCloseChannelObjective,
+    objective: WalletObjective<CloseChannel>,
     response: WalletResponse,
     tx: Transaction
   ): Promise<WaitingFor | Nothing> {
@@ -127,7 +132,7 @@ export class ChannelCloser implements Cranker<DBCloseChannelObjective> {
   }
 
   private async completeObjective(
-    objective: DBCloseChannelObjective,
+    objective: WalletObjective<CloseChannel>,
     channel: Channel,
     tx: Transaction,
     response: WalletResponse

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -1,10 +1,10 @@
 import {Logger} from 'pino';
-import {unreachable} from '@statechannels/wallet-core';
+import {OpenChannel, unreachable} from '@statechannels/wallet-core';
 import _ from 'lodash';
 import {Transaction} from 'objection';
 
 import {Store} from '../wallet/store';
-import {DBOpenChannelObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {WalletResponse} from '../wallet/wallet-response';
 import {ChainServiceInterface} from '../chain-service';
 import {Channel} from '../models/channel';
@@ -19,7 +19,7 @@ export enum WaitingFor {
   funding = 'ChannelOpener.funding', // TODO reuse ChannelFunder.waitingFor,
 }
 
-export class ChannelOpener implements Cranker<DBOpenChannelObjective> {
+export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
   constructor(
     private store: Store,
     private chainService: ChainServiceInterface,
@@ -37,7 +37,7 @@ export class ChannelOpener implements Cranker<DBOpenChannelObjective> {
   }
 
   public async crank(
-    objective: DBOpenChannelObjective,
+    objective: WalletObjective<OpenChannel>,
     response: WalletResponse,
     tx: Transaction
   ): Promise<WaitingFor | Nothing> {
@@ -81,7 +81,7 @@ export class ChannelOpener implements Cranker<DBOpenChannelObjective> {
   }
 
   private async crankChannelFunder(
-    objective: DBOpenChannelObjective,
+    objective: WalletObjective<OpenChannel>,
     channel: Channel,
     response: WalletResponse,
     tx: Transaction

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -1,8 +1,9 @@
+import {DefundChannel} from '@statechannels/wallet-core';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
 
 import {ChainServiceInterface} from '../chain-service';
-import {DBDefundChannelObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {Cranker, Nothing} from '../objectives/objective-manager';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
@@ -13,7 +14,7 @@ export const enum WaitingFor {
   transactionSubmission = 'ChannelDefunder.transactionSubmission',
 }
 
-export class ChannelDefunder implements Cranker<DBDefundChannelObjective> {
+export class ChannelDefunder implements Cranker<WalletObjective<DefundChannel>> {
   constructor(
     private store: Store,
     private chainService: ChainServiceInterface,
@@ -30,7 +31,7 @@ export class ChannelDefunder implements Cranker<DBDefundChannelObjective> {
   }
 
   public async crank(
-    objective: DBDefundChannelObjective,
+    objective: WalletObjective<DefundChannel>,
     response: WalletResponse,
     tx: Transaction
   ): Promise<WaitingFor | Nothing> {

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -1,4 +1,10 @@
-import {BN, isCloseChannel, unreachable} from '@statechannels/wallet-core';
+import {
+  DefundChannel,
+  CloseChannel,
+  BN,
+  isCloseChannel,
+  unreachable,
+} from '@statechannels/wallet-core';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
 
@@ -7,7 +13,7 @@ import {AdjudicatorStatusModel} from '../models/adjudicator-status';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {Channel} from '../models/channel';
 import {LedgerRequest} from '../models/ledger-request';
-import {DBCloseChannelObjective, DBDefundChannelObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {Store} from '../wallet/store';
 
 /**
@@ -26,7 +32,7 @@ import {Store} from '../wallet/store';
  * make the ChannelDefunder protocol aboslete.
  */
 export type DefunderResult = {isChannelDefunded: boolean; didSubmitTransaction: boolean};
-type Objective = DBCloseChannelObjective | DBDefundChannelObjective;
+type Objective = WalletObjective<CloseChannel> | WalletObjective<DefundChannel>;
 
 export class Defunder {
   constructor(

--- a/packages/server-wallet/src/protocols/direct-funder.ts
+++ b/packages/server-wallet/src/protocols/direct-funder.ts
@@ -1,4 +1,4 @@
-import {Address, BN, checkThat, isSimpleAllocation} from '@statechannels/wallet-core';
+import {Address, BN, checkThat, isSimpleAllocation, OpenChannel} from '@statechannels/wallet-core';
 import _ from 'lodash';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
@@ -6,7 +6,7 @@ import {Logger} from 'pino';
 import {ChainServiceInterface} from '../chain-service';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {Channel} from '../models/channel';
-import {DBOpenChannelObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
 
@@ -33,7 +33,7 @@ export class DirectFunder {
    * Returns true if the channel is funded, false otherwise
    */
   public async crank(
-    objective: DBOpenChannelObjective,
+    objective: WalletObjective<OpenChannel>,
     channel: Channel,
     response: WalletResponse,
     tx: Transaction

--- a/packages/server-wallet/src/protocols/ledger-funder.ts
+++ b/packages/server-wallet/src/protocols/ledger-funder.ts
@@ -1,4 +1,4 @@
-import {BN, checkThat, isSimpleAllocation} from '@statechannels/wallet-core';
+import {BN, checkThat, isSimpleAllocation, OpenChannel} from '@statechannels/wallet-core';
 import _ from 'lodash';
 import {Transaction} from 'objection';
 import {Logger} from 'pino';
@@ -6,7 +6,7 @@ import {Logger} from 'pino';
 import {ChainServiceInterface} from '../chain-service';
 import {Channel} from '../models/channel';
 import {LedgerRequest} from '../models/ledger-request';
-import {DBOpenChannelObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {Store} from '../wallet/store';
 import {WalletResponse} from '../wallet/wallet-response';
 
@@ -33,7 +33,7 @@ export class LedgerFunder {
    * Returns true if the channel is funded, false otherwise
    */
   public async crank(
-    objective: DBOpenChannelObjective,
+    objective: WalletObjective<OpenChannel>,
     channel: Channel,
     response: WalletResponse,
     tx: Transaction

--- a/packages/server-wallet/src/wallet/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/challenge.test.ts
@@ -5,7 +5,7 @@ import {DBAdmin} from '../../db-admin/db-admin';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {AdjudicatorStatusModel} from '../../models/adjudicator-status';
 import {Channel} from '../../models/channel';
-import {DBObjective, ObjectiveModel} from '../../models/objective';
+import {WalletObjective, ObjectiveModel} from '../../models/objective';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {alice, bob} from './fixtures/signing-wallets';
@@ -93,7 +93,7 @@ it('creates a defundChannel objective on channel finalized', async () => {
   const objectiveId = `DefundChannel-${c.channelId}`;
   const objective = await ObjectiveModel.forId(objectiveId, w.knex);
 
-  expect(objective).toEqual<DBObjective>({
+  expect(objective).toEqual<WalletObjective>({
     objectiveId,
     status: 'approved',
     type: 'DefundChannel',

--- a/packages/server-wallet/src/wallet/__test__/fixtures/open-channel-objective.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/open-channel-objective.ts
@@ -1,11 +1,13 @@
-import {DBOpenChannelObjective} from '../../../models/objective';
+import {OpenChannel} from '@statechannels/wallet-core';
+
+import {WalletObjective} from '../../../models/objective';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {WaitingFor} from '../../../protocols/channel-opener';
 
 import {alice, bob} from './participants';
 import {fixture} from './utils';
 
-const defaultObjective: DBOpenChannelObjective = {
+const defaultObjective: WalletObjective<OpenChannel> = {
   data: {targetChannelId: channel().channelId, role: 'app', fundingStrategy: 'Direct'},
   participants: [alice(), bob()],
   type: 'OpenChannel',

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-channel.ts
@@ -24,8 +24,8 @@ import {SignedState as WireState, Payload} from '@statechannels/wire-format';
 import {utils} from 'ethers';
 
 import {Channel} from '../../../models/channel';
-import {DBOpenChannelObjective, ObjectiveModel} from '../../../models/objective';
 import {defaultTestConfig} from '../../../config';
+import {WalletObjective, ObjectiveModel} from '../../../models/objective';
 import {SigningWallet} from '../../../models/signing-wallet';
 import {WALLET_VERSION} from '../../../version';
 import {Store} from '../../store';
@@ -264,7 +264,7 @@ export class TestChannel {
   public async insertInto(
     store: Store,
     args: InsertionParams = {}
-  ): Promise<DBOpenChannelObjective> {
+  ): Promise<WalletObjective<OpenChannel>> {
     const {states, participant, bals} = {states: [0], participant: 0, ...args};
 
     // load the signingKey for the appopriate participant
@@ -290,11 +290,7 @@ export class TestChannel {
     });
 
     // insert the OpenChannel objective
-    const objective = await ObjectiveModel.insert<DBOpenChannelObjective>(
-      this.openChannelObjective,
-      true,
-      store.knex
-    );
+    const objective = await ObjectiveModel.insert(this.openChannelObjective, true, store.knex);
 
     return objective;
   }

--- a/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/wallet/__test__/fixtures/test-ledger-channel.ts
@@ -14,7 +14,7 @@ import {Channel} from '../../../models/channel';
 import {defaultTestConfig} from '../../../config';
 import {LedgerProposal} from '../../../models/ledger-proposal';
 import {LedgerRequest} from '../../../models/ledger-request';
-import {DBOpenChannelObjective} from '../../../models/objective';
+import {WalletObjective} from '../../../models/objective';
 import {WALLET_VERSION} from '../../../version';
 import {Store} from '../../store';
 
@@ -123,7 +123,7 @@ export class TestLedgerChannel extends TestChannel {
   public async insertInto(
     store: Store,
     args: InsertionParams = {}
-  ): Promise<DBOpenChannelObjective> {
+  ): Promise<WalletObjective<OpenChannel>> {
     const objective = await super.insertInto(store, args);
     await Channel.setLedger(this.channelId, this.startOutcome.assetHolderAddress, store.knex);
     const {fundingStrategy, fundingLedgerChannelId} = objective.data;

--- a/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/integration/create-channel.test.ts
@@ -1,10 +1,12 @@
+import {OpenChannel} from '@statechannels/wallet-core';
+
 import {Channel} from '../../../models/channel';
 import {Wallet} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {defaultTestConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
-import {DBOpenChannelObjective} from '../../../models/objective';
+import {WalletObjective} from '../../../models/objective';
 import {WaitingFor} from '../../../protocols/channel-opener';
 
 let w: Wallet;
@@ -73,7 +75,7 @@ describe('happy path', () => {
       latestSignedByMe: expectedState,
       supported: undefined,
     });
-    expect(await w.getObjective(objectiveId)).toMatchObject<DBOpenChannelObjective>({
+    expect(await w.getObjective(objectiveId)).toMatchObject<WalletObjective<OpenChannel>>({
       objectiveId,
       createdAt: expect.any(Date),
       progressLastMadeAt: expect.any(Date),

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -39,7 +39,7 @@ import {timerFactory, recordFunctionMetrics, setupDBMetrics, timerFactorySync} f
 import {isReverseSorted, pick} from '../utilities/helpers';
 import {Funding, TransferredOutEntry} from '../models/funding';
 import {Nonce} from '../models/nonce';
-import {ObjectiveModel, DBObjective, isSupportedObjective} from '../models/objective';
+import {ObjectiveModel, WalletObjective, isSupportedObjective} from '../models/objective';
 import {AppBytecode} from '../models/app-bytecode';
 import {LedgerRequest, LedgerRequestType} from '../models/ledger-request';
 import {shouldValidateTransition, validateTransition} from '../utilities/validate-transition';
@@ -269,7 +269,7 @@ export class Store {
     return {states: vars.map(ss => _.merge(ss, channelConstants)), channelState};
   }
 
-  async getObjectivesByIds(objectiveIds: string[]): Promise<DBObjective[]> {
+  async getObjectivesByIds(objectiveIds: string[]): Promise<WalletObjective[]> {
     return ObjectiveModel.forIds(objectiveIds, this.knex);
   }
 
@@ -299,7 +299,7 @@ export class Store {
   ): Promise<{
     channelIds: Bytes32[];
     channelResults: ChannelResult[];
-    storedObjectives: DBObjective[];
+    storedObjectives: WalletObjective[];
   }> {
     return this.knex.transaction(async tx => {
       const channelResults: ChannelResult[] = [];
@@ -314,7 +314,7 @@ export class Store {
       }
 
       const deserializedObjectives = message.objectives?.map(deserializeObjective) || [];
-      const storedObjectives: DBObjective[] = [];
+      const storedObjectives: WalletObjective[] = [];
       for (const o of deserializedObjectives) {
         if (isSupportedObjective(o)) {
           const preApprove = o.type == 'CloseChannel'; // Close channel objectives do not need co-operative approval
@@ -340,7 +340,7 @@ export class Store {
     });
   }
 
-  async getObjectives(channelIds: Bytes32[], tx?: Transaction): Promise<DBObjective[]> {
+  async getObjectives(channelIds: Bytes32[], tx?: Transaction): Promise<WalletObjective[]> {
     return await ObjectiveModel.forChannelIds(channelIds, tx || this.knex);
   }
 
@@ -368,7 +368,7 @@ export class Store {
     }
   }
 
-  async markObjectiveStatus<O extends DBObjective>(
+  async markObjectiveStatus<O extends WalletObjective>(
     objective: O,
     status: 'succeeded' | 'failed',
     tx?: Transaction
@@ -404,7 +404,7 @@ export class Store {
     await AppBytecode.upsertBytecode(chainNetworkId, appDefinition, bytecode, this.knex);
   }
 
-  async getObjective(objectiveId: string, tx?: TransactionOrKnex): Promise<DBObjective> {
+  async getObjective(objectiveId: string, tx?: TransactionOrKnex): Promise<WalletObjective> {
     tx = tx || this.knex; // TODO: make tx required
     return await ObjectiveModel.forId(objectiveId, tx);
   }
@@ -595,7 +595,7 @@ export class Store {
     fundingStrategy: FundingStrategy,
     role: 'app' | 'ledger' = 'app',
     fundingLedgerChannelId?: Bytes32
-  ): Promise<{channel: ChannelState; firstSignedState: SignedState; objective: DBObjective}> {
+  ): Promise<{channel: ChannelState; firstSignedState: SignedState; objective: WalletObjective}> {
     return await this.knex.transaction(async tx => {
       const channel = await createChannel(constants, fundingStrategy, fundingLedgerChannelId, tx);
       const {channelId, participants} = channel;

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -414,7 +414,7 @@ export class Store {
    * @param objectiveId
    * @param tx
    */
-  async getAndLockObjective(objectiveId: string, tx: Transaction): Promise<DBObjective> {
+  async getAndLockObjective(objectiveId: string, tx: Transaction): Promise<WalletObjective> {
     return (await ObjectiveModel.query(tx).findById(objectiveId).forUpdate()).toObjective();
   }
 

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -9,7 +9,7 @@ import {
 } from '@statechannels/client-api-schema';
 import {Address as CoreAddress} from '@statechannels/wallet-core';
 
-import {DBObjective} from '../models/objective';
+import {WalletObjective} from '../models/objective';
 import {Outgoing} from '../protocols/actions';
 import {Bytes32, Uint256} from '../type-aliases';
 
@@ -22,12 +22,12 @@ export interface UpdateChannelFundingParams {
 export type SingleChannelOutput = {
   outbox: Outgoing[];
   channelResult: ChannelResult;
-  newObjective: DBObjective | undefined;
+  newObjective: WalletObjective | undefined;
 };
 export type MultipleChannelOutput = {
   outbox: Outgoing[];
   channelResults: ChannelResult[];
-  newObjectives: DBObjective[];
+  newObjectives: WalletObjective[];
 };
 
 export type Output = SingleChannelOutput | MultipleChannelOutput;
@@ -39,11 +39,11 @@ type ChannelUpdatedEvent = {
 
 type ObjectiveStarted = {
   type: 'objectiveStarted';
-  value: DBObjective;
+  value: WalletObjective;
 };
 type ObjectiveSucceeded = {
   type: 'objectiveSucceeded';
-  value: DBObjective;
+  value: WalletObjective;
 };
 
 export type WalletEvent = ChannelUpdatedEvent | ObjectiveStarted | ObjectiveSucceeded;

--- a/packages/server-wallet/src/wallet/wallet-response.ts
+++ b/packages/server-wallet/src/wallet/wallet-response.ts
@@ -5,7 +5,7 @@ import {Message as WireMessage, SignedState as WireState} from '@statechannels/w
 
 import {Notice, Outgoing} from '../protocols/actions';
 import {Channel} from '../models/channel';
-import {DBObjective, isSharedObjective, toWireObjective} from '../models/objective';
+import {WalletObjective, isSharedObjective, toWireObjective} from '../models/objective';
 import {WALLET_VERSION} from '../version';
 import {ChannelState, toChannelResult} from '../protocols/state';
 
@@ -18,9 +18,9 @@ import {WalletEvent, MultipleChannelOutput, SingleChannelOutput, Output} from '.
 export class WalletResponse {
   _channelResults: Record<string, ChannelResult> = {};
   private queuedMessages: WireMessage[] = [];
-  objectivesToApprove: DBObjective[] = [];
-  createdObjectives: DBObjective[] = [];
-  succeededObjectives: DBObjective[] = [];
+  objectivesToApprove: WalletObjective[] = [];
+  createdObjectives: WalletObjective[] = [];
+  succeededObjectives: WalletObjective[] = [];
   requests: string[] = [];
 
   static initialize(): WalletResponse {
@@ -78,7 +78,11 @@ export class WalletResponse {
   /**
    * Queues an objective to be sent to the opponent
    */
-  queueSendObjective(objective: DBObjective, myIndex: number, participants: Participant[]): void {
+  queueSendObjective(
+    objective: WalletObjective,
+    myIndex: number,
+    participants: Participant[]
+  ): void {
     const myParticipantId = participants[myIndex].participantId;
     if (isSharedObjective(objective)) {
       participants.forEach((p, i) => {
@@ -105,7 +109,7 @@ export class WalletResponse {
    * - notifying the app
    */
   queueCreatedObjective(
-    objective: DBObjective,
+    objective: WalletObjective,
     myIndex: number,
     participants: Participant[]
   ): void {
@@ -117,14 +121,14 @@ export class WalletResponse {
   /**
    * Queues objectives for approval by the user
    */
-  queueReceivedObjective(objective: DBObjective): void {
+  queueReceivedObjective(objective: WalletObjective): void {
     this.objectivesToApprove.push(objective);
   }
 
   /**
    * Queue succeeded objectives, so we can emit events
    */
-  queueSucceededObjective(objective: DBObjective): void {
+  queueSucceededObjective(objective: WalletObjective): void {
     this.succeededObjectives.push(objective);
   }
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -58,7 +58,7 @@ import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
 import {SingleAppUpdater} from '../handlers/single-app-updater';
 import {LedgerManager} from '../protocols/ledger-manager';
-import {DBObjective, ObjectiveModel} from '../models/objective';
+import {WalletObjective, ObjectiveModel} from '../models/objective';
 
 import {Store, AppHandler, MissingAppHandler} from './store';
 import {
@@ -790,9 +790,9 @@ export class SingleThreadedWallet
   /**
    * Gets the objective for a given id.
    *
-   * @returns A promise that resolves to a DBObjective, with a progressLastMadeAt timestamp
+   * @returns A promise that resolves to a WalletObjective, with a progressLastMadeAt timestamp
    */
-  async getObjective(objectiveId: string): Promise<DBObjective> {
+  async getObjective(objectiveId: string): Promise<WalletObjective> {
     return this.store.getObjective(objectiveId);
   }
 


### PR DESCRIPTION
Problems:
1)  it's possible to pass an `OpenChannel` objective to `ObjectiveModel.insert`, but get back something asserted as e.g.  a `DBCloseChannel` objective. 
2) `DBObjective` is a poor of name, since the type is used throughout the wallet and not just in the database / ORM. 

This PR:
- restores the correlation between the input of `ObjectiveModel.insert<>()`and the return value. If you pass in an `OpenChannel` objective (from wallet core), TS will infer that you get back a `WalletObjective<OpenChannel>` (essentially the same thing, but with some `ExtraProperties`). You don't even need to use the `<>`.
- Deprecates DBObjective entirely. I deprecated it in the first commit, and then applied the large number of renaming changes in the second commit. 

Shortcomings: we end up with deeply nested generic types `Promise<WalletObjective<OpenChannel>>`. I think this is probably ok, and probably preferable to having several aliases such as `type OpenChannelWalletObjective = <WalletObjective<OpenChannel>`

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.) // in separate commits but not separate PRs
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
