### PR TITLE
fix: do not use system user for postgres

### DIFF
--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -79,8 +79,8 @@
   },
   "main": "lib/src/index.js",
   "scripts": {
-    "db:create": "createdb $SERVER_DB_NAME",
-    "db:drop": "dropdb $SERVER_DB_NAME",
+    "db:create": "createdb $SERVER_DB_NAME -U postgres",
+    "db:drop": "dropdb $SERVER_DB_NAME -U postgres",
     "db:migrate": "npx knex migrate:latest --cwd src/db-admin",
     "db:rollback": "npx knex migrate:rollback --cwd src/db-admin",
     "db:seed": "npx knex seed:run --cwd src/db-admin",


### PR DESCRIPTION
The below issue was flagged when attempting to get @NiloCK's Ubuntu machine to pass all wallet tests.

Database manipulations occur either via:
1. Postgres db commands such as `createdb`/`dropdb`
1. `knex`

Different postgres users are used throughout the codebase:
1. In some cases `postgres` user is hardcoded.
2. In some cases, server wallet database configuration is respected. This happens when `knex` is used for database manipulations. The default user for the server wallet database configuration is `postgres`. 
3. In some cases, the system user is used.

This PR eliminates case 3.