### PR TITLE
Add a chainService.checkChainId() and call during wallet creation

### DIFF
--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -19,7 +19,6 @@ import {
 import {BigNumber, constants, Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestConfig} from '../../config';
 import {
   alice,
   alice as aliceParticipant,
@@ -86,7 +85,6 @@ beforeAll(async () => {
     provider: rpcEndpoint,
     pk: process.env.CHAIN_SERVICE_PK ?? ETHERLIME_ACCOUNTS[0].privateKey,
     allowanceMode: 'MaxUint',
-    chainNetworkId: defaultTestConfig().networkConfiguration.chainNetworkID,
   });
   /* eslint-enable no-process-env, @typescript-eslint/no-non-null-assertion */
 });

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -193,6 +193,12 @@ async function setUpConclude(isEth = true) {
   };
 }
 
+describe('chainid mismatch detection', () => {
+  it('throws an error when the chainid is wrong', async () => {
+    await expect(chainService.checkChainId(987654321)).rejects.toThrow('ChainId mismatch');
+  });
+});
+
 describe('fundChannel', () => {
   it('Successfully funds channel with 2 participants, rejects invalid 3rd', async () => {
     const channelId = await waitForChannelFunding(0, 5);

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -4,7 +4,6 @@ import {BN, makeAddress} from '@statechannels/wallet-core';
 import {Contract, providers, Wallet} from 'ethers';
 import _ from 'lodash';
 
-import {defaultTestNetworkConfiguration} from '../../config';
 import {ChainService} from '../chain-service';
 
 const pk = ETHERLIME_ACCOUNTS[0].privateKey;
@@ -31,7 +30,6 @@ beforeEach(() => {
     provider: rpcEndpoint,
     pk: privateKey,
     allowanceMode: 'MaxUint',
-    chainNetworkId: defaultTestNetworkConfiguration.chainNetworkID,
   });
 });
 

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -88,10 +88,9 @@ export class ChainService implements ChainServiceInterface {
     logger,
     blockConfirmations,
     allowanceMode,
-    chainNetworkId,
-  }: Partial<ChainServiceArgs> & {chainNetworkId: number}) {
+  }: Partial<ChainServiceArgs>) {
     if (!pk) throw new Error('ChainService: Private key not provided');
-    this.provider = new providers.JsonRpcProvider(provider, chainNetworkId);
+    this.provider = new providers.JsonRpcProvider(provider);
     this.ethWallet = new NonceManager(new Wallet(pk, this.provider));
     this.blockConfirmations = blockConfirmations ?? 5;
     this.logger = logger
@@ -131,6 +130,14 @@ export class ChainService implements ChainServiceInterface {
     this.provider.on('block', async (blockTag: providers.BlockTag) =>
       this.checkFinalizingChannels(await this.provider.getBlock(blockTag))
     );
+  }
+
+  public async checkChainId(networkChainId: number): Promise<void> {
+    const rpcChainId = (await this.provider.getNetwork()).chainId;
+    if (rpcChainId !== networkChainId)
+      throw Error(
+        `ChainId mismatch: ${networkChainId} is required but provider reports ${rpcChainId}`
+      );
   }
 
   // Only used for unit tests

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -36,6 +36,10 @@ const mockTransactoinResponse: providers.TransactionResponse = {
 };
 
 export class MockChainService implements ChainServiceInterface {
+  async checkChainId(_networkChainId: number): Promise<void> {
+    // noop, a mock chain service will have the "correct" chain id
+  }
+
   fundChannel(_arg: FundChannelArg): Promise<providers.TransactionResponse> {
     return Promise.resolve(mockTransactoinResponse);
   }

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -48,6 +48,7 @@ export interface ChainEventSubscriberInterface {
 }
 
 interface ChainEventEmitterInterface {
+  checkChainId(networkChainId: number): Promise<void>;
   registerChannel(
     channelId: Bytes32,
     assetHolders: Address[],

--- a/packages/server-wallet/src/wallet/__test__/restarting.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/restarting.test.ts
@@ -11,6 +11,7 @@ import {channel} from '../../models/__test__/fixtures/channel';
 import {alice, bob} from './fixtures/signing-wallets';
 import {stateWithHashSignedBy} from './fixtures/states';
 const registerChannelMock = jest.fn();
+const checkChainIdMock = jest.fn();
 // This is based on jest docs on mocking es6 class mocking:
 //https://jestjs.io/docs/en/es6-class-mocks
 jest.mock('../../chain-service/mock-chain-service', () => {
@@ -18,14 +19,14 @@ jest.mock('../../chain-service/mock-chain-service', () => {
     MockChainService: jest.fn().mockImplementation(() => {
       return {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        checkChainId: () => {},
+        checkChainId: checkChainIdMock,
         registerChannel: registerChannelMock,
       };
     }),
   };
 });
 
-test('the wallet registers existing channels with the chain service on starting up', async () => {
+test('the wallet checks the chain id and registers existing channels with the chain service on starting up', async () => {
   await DBAdmin.truncateDataBaseFromKnex(testKnex);
 
   await seedAlicesSigningWallet(testKnex);
@@ -40,6 +41,7 @@ test('the wallet registers existing channels with the chain service on starting 
 
   await waitForExpect(() => {
     expect(registerChannelMock).toHaveBeenCalledWith(c.channelId, [ETH_ASSET_HOLDER_ADDRESS], w);
+    expect(checkChainIdMock).toHaveBeenCalled();
   });
 
   // We explicitly call destroy on knex to avoid triggering any destroy calls on our mocked out chain service

--- a/packages/server-wallet/src/wallet/__test__/restarting.test.ts
+++ b/packages/server-wallet/src/wallet/__test__/restarting.test.ts
@@ -17,6 +17,8 @@ jest.mock('../../chain-service/mock-chain-service', () => {
   return {
     MockChainService: jest.fn().mockImplementation(() => {
       return {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        checkChainId: () => {},
         registerChannel: registerChannelMock,
       };
     }),

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -105,6 +105,8 @@ export class SingleThreadedWallet
   ): Promise<SingleThreadedWallet> {
     const wallet = new SingleThreadedWallet(walletConfig);
 
+    await wallet.chainService.checkChainId(walletConfig.networkConfiguration.chainNetworkID);
+
     await wallet.registerExistingChannelsWithChainService();
     return wallet;
   }
@@ -153,7 +155,6 @@ export class SingleThreadedWallet
       this.chainService = new ChainService({
         ...this.walletConfig.chainServiceConfiguration,
         logger: this.logger,
-        chainNetworkId: this.walletConfig.networkConfiguration.chainNetworkID,
       });
     } else {
       this.chainService = new MockChainService();


### PR DESCRIPTION
Closes #3332. Supercedes the work done in #3328.

Currently, we pass the chain id down to constructor for the ethereum `JsonRPCProvider`. This is good because errors will be thrown in the event that the chain reports a different id to the one passed to it's constructor. But it is bad because the constructor chain is all synchronous, and the errors are thrown asynchronously (they have to be, because they are triggered by RPCs). It's also bad that many errors are thrown. As a consequence, there is no test for this behaviour.

The approach of this PR is to allow the provider to setup without a named chain id (it will just use the one from the chain it talks to, eventually), but to expose an async method which can be used to ensure the chain has the expected id. This async method is called early on in the existing asynchronous `wallet.create()`. This way, a single error will be thrown and we will know precisely where to catch it. In the end, it's now easy to test.


## How Has This Been Tested? 
there is a new test.


---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
