### PR TITLE
chore: clean up db names

### DIFF
--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -13,10 +13,10 @@ interface TestPeerWallets {
 }
 
 export const aWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
-  database: 'SERVER_WALLET_TEST_A',
+  database: 'server_wallet_test_a',
 });
 export const bWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
-  database: 'SERVER_WALLET_TEST_B',
+  database: 'server_wallet_test_b',
 });
 export let participantA: Participant;
 export let participantB: Participant;

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -13,10 +13,10 @@ interface TestPeerWallets {
 }
 
 export const aWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
-  database: 'TEST_A',
+  database: 'SERVER_WALLET_TEST_A',
 });
 export const bWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestConfig(), {
-  database: 'TEST_B',
+  database: 'SERVER_WALLET_TEST_B',
 });
 export let participantA: Participant;
 export let participantB: Participant;

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -37,7 +37,7 @@ let a: Wallet;
 let b: Wallet;
 
 const bWalletConfig: ServerWalletConfig = {
-  ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_B'}),
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'SERVER_WALLET_TEST_B'}),
   chainServiceConfiguration: {
     attachChainService: true,
     provider: rpcEndpoint,
@@ -47,7 +47,7 @@ const bWalletConfig: ServerWalletConfig = {
   },
 };
 const aWalletConfig: ServerWalletConfig = {
-  ...overwriteConfigWithDatabaseConnection(config, {database: 'TEST_A'}),
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'SERVER_WALLET_TEST_A'}),
   chainServiceConfiguration: {
     attachChainService: true,
     provider: rpcEndpoint,

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -37,7 +37,7 @@ let a: Wallet;
 let b: Wallet;
 
 const bWalletConfig: ServerWalletConfig = {
-  ...overwriteConfigWithDatabaseConnection(config, {database: 'SERVER_WALLET_TEST_B'}),
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_b'}),
   chainServiceConfiguration: {
     attachChainService: true,
     provider: rpcEndpoint,
@@ -47,7 +47,7 @@ const bWalletConfig: ServerWalletConfig = {
   },
 };
 const aWalletConfig: ServerWalletConfig = {
-  ...overwriteConfigWithDatabaseConnection(config, {database: 'SERVER_WALLET_TEST_A'}),
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_a'}),
   chainServiceConfiguration: {
     attachChainService: true,
     provider: rpcEndpoint,


### PR DESCRIPTION
All the other DB names in the `server-wallet` are prefixed with `server_wallet`.

 This updates the `TEST_A/B` databases to be named `SERVER_WALLET_TEST_A/B` to follow the existing pattern.