### PR TITLE
chore: remove unused jest.stress.config file

### DIFF
--- a/packages/server-wallet/jest/jest.stress.config.js
+++ b/packages/server-wallet/jest/jest.stress.config.js
@@ -1,3 +1,0 @@
-const config = require('./jest.e2e.config');
-config.testMatch = ['<rootDir>/e2e-test/stress.test.ts?(x)'];
-module.exports = config;


### PR DESCRIPTION
## Problem

Unused code test config file can confuse or obscure actual test configuation

## Solution

Remove `server-wallet/jest/jest.stress.config.js`

It is not immediately obvious that this file is unused, but:

- its testMatch glob does not map to any files in the repository
- test:stress in package.json does not refer to it
- circleCI config.yml runs test:stress and does not refer to it

File as-is is a source of confusion wrt structure of test suites

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have linked to all relevant issues (can be 0)
- [x] I have added all dependent tickets (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
