### PR TITLE
Implement a basic Messaging Service

### DIFF
--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -62,7 +62,7 @@ export async function crashAndRestart(
     {participantId: participantIdB, wallet: peerWallets.b},
   ]);
 
-  messageService =await  TestMessageService.createTestMessageService(handler);
+  messageService =await  TestMessageService.create(handler);
 
 }
 
@@ -112,7 +112,7 @@ export function getPeersSetup(withWalletSeeding = false): jest.Lifecycle {
 
      
   const handler =  createTestMessageHandler(participantWallets);
-  messageService =await  TestMessageService.createTestMessageService(handler);
+  messageService =await  TestMessageService.create(handler);
   };
 }
 

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -8,7 +8,8 @@ import {
   seedBobsSigningWallet,
 } from '../src/db/seeds/1_signing_wallet_seeds';
 import {MessageServiceInterface} from '../src/message-service/types';
-import {setupTestMessagingService} from '../src/__test-with-peers__/utils';
+import { createTestMessageHandler, TestMessageService } from '../src/message-service/test-message-service';
+
 
 interface TestPeerWallets {
   a: Wallet;
@@ -56,10 +57,13 @@ export async function crashAndRestart(
     peerWallets.b = await Wallet.create(bWalletConfig);
   }
   
-  messageService = await setupTestMessagingService([
+  const handler = await createTestMessageHandler([
     {participantId: participantIdA, wallet: peerWallets.a},
     {participantId: participantIdB, wallet: peerWallets.b},
   ]);
+
+  messageService =await  TestMessageService.createTestMessageService(handler);
+
 }
 
 export function getPeersSetup(withWalletSeeding = false): jest.Lifecycle {
@@ -106,7 +110,9 @@ export function getPeersSetup(withWalletSeeding = false): jest.Lifecycle {
       {participantId: participantIdB, wallet: peerWallets.b},
     ];
 
-    messageService = await setupTestMessagingService(participantWallets);
+     
+  const handler =  createTestMessageHandler(participantWallets);
+  messageService =await  TestMessageService.createTestMessageService(handler);
   };
 }
 

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -24,6 +24,7 @@ export const bWalletConfig = overwriteConfigWithDatabaseConnection(defaultTestCo
 export let participantA: Participant;
 export let participantB: Participant;
 export let peerWallets: TestPeerWallets;
+
 /**
  * A messaging service that links the two peer wallets.
  * If this is not used it will have no effect.
@@ -35,15 +36,13 @@ export const participantIdA = 'a';
 export const participantIdB = 'b';
 
 /**
- *
+ * This destroys the peerWallet(s) and the message service and then re-instantiates them.
+ * This mimics a crash and restart
+ * @param walletsToRestart Specifies the peerWallet that will be restarted
  */
 export async function crashAndRestart(
   walletsToRestart: 'A' | 'B' | 'Both' = 'Both'
 ): Promise<void> {
-  // Get all the configs for the wallets
-
-  const {walletConfig: aWalletConfig} = peerWallets.a;
-  const {walletConfig: bWalletConfig} = peerWallets.b;
 
   await messageService.destroy();
 

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -16,7 +16,7 @@ import {
   peerWallets,
 } from '../../../jest/with-peers-setup-teardown';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../../__test__/test-helpers';
-import {expectLatestStateToMatch} from '../utils';
+import {expectLatestStateToMatch, getMessages} from '../utils';
 
 let channelId: string;
 jest.setTimeout(10_000);
@@ -53,7 +53,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
     turnNum: 0,
   });
 
-  await messageService.send(resultA0.outbox.map(o => o.params));
+  await messageService.send(getMessages(resultA0));
 
   await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'proposed',
@@ -70,7 +70,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
     turnNum: 0,
   });
 
-  await messageService.send(resultB1.outbox.map(o => o.params));
+  await messageService.send(getMessages(resultB1));
 
   const depositByA = {
     channelId,
@@ -97,8 +97,8 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
     turnNum: 0,
   });
 
-  await messageService.send(resultA2.outbox.map(o => o.params));
-  await messageService.send(resultB2.outbox.map(o => o.params));
+  await messageService.send(getMessages(resultA2));
+  await messageService.send(getMessages(resultB2));
 
   expect(getChannelResultFor(channelId, resultB2.channelResults)).toMatchObject({
     // Still opening because turnNum 3 is not supported yet (2 is not in the wallet)
@@ -116,7 +116,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
   });
 
   //  PostFund3B <
-  await messageService.send(resultB2.outbox.map(o => o.params));
+  await messageService.send(getMessages(resultB2));
   await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
     turnNum: 3,
@@ -134,7 +134,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
     turnNum: 4,
   });
 
-  await messageService.send(aCloseChannelResult.outbox.map(o => o.params));
+  await messageService.send(getMessages(aCloseChannelResult));
   // B pushed isFinal4, generated countersigned isFinal4
   await expectLatestStateToMatch(channelId, peerWallets.a, {status: 'closed', turnNum: 4});
 });

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -6,21 +6,18 @@ import {
 import {makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, constants, ethers} from 'ethers';
 
-import {Wallet} from '../..';
 import {
+  crashAndRestart,
   getPeersSetup,
+  messageService,
   participantA,
   participantB,
   peersTeardown,
   peerWallets,
 } from '../../../jest/with-peers-setup-teardown';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../../__test__/test-helpers';
+import {expectLatestStateToMatch} from '../utils';
 
-async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
-  const config = wallet.walletConfig;
-  await wallet.destroy();
-  return Wallet.create(config); // Wallet that will "restart"
-}
 let channelId: string;
 jest.setTimeout(10_000);
 
@@ -51,23 +48,20 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
 
   channelId = resultA0.channelResults[0].channelId;
 
-  expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'opening',
     turnNum: 0,
   });
 
-  //    > PreFund0A
-  const resultB0 = await peerWallets.b.pushMessage(
-    getPayloadFor(participantB.participantId, resultA0.outbox)
-  );
+  await messageService.send(resultA0.outbox.map(o => o.params));
 
-  expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'proposed',
     turnNum: 0,
   });
 
-  // Destory Wallet b and restart
-  peerWallets.b = await crashAndRestart(peerWallets.b);
+  // Destroy Wallet b and restart
+  await crashAndRestart('B');
 
   //      PreFund0B
   const resultB1 = await peerWallets.b.joinChannel({channelId});
@@ -76,22 +70,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
     turnNum: 0,
   });
 
-  //  PreFund0B <
-  const resultA1 = await peerWallets.a.pushMessage(
-    getPayloadFor(participantA.participantId, resultB1.outbox)
-  );
-
-  /**
-   * In this case, there is no auto-advancing to the running stage. Instead we have
-   * an intermediate 'opening' stage where each party must fund their channel. A funds
-   * first, and then B funds. A and B both signs turnNum 3 on the call to updateFundingForChannels
-   * and then sends the newly signed state to each other at the same time.
-   */
-
-  expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
-  });
+  await messageService.send(resultB1.outbox.map(o => o.params));
 
   const depositByA = {
     channelId,
@@ -118,6 +97,9 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
     turnNum: 0,
   });
 
+  await messageService.send(resultA2.outbox.map(o => o.params));
+  await messageService.send(resultB2.outbox.map(o => o.params));
+
   expect(getChannelResultFor(channelId, resultB2.channelResults)).toMatchObject({
     // Still opening because turnNum 3 is not supported yet (2 is not in the wallet)
     status: 'opening',
@@ -134,10 +116,8 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
   });
 
   //  PostFund3B <
-  const resultA3 = await peerWallets.a.pushMessage(
-    getPayloadFor(participantA.participantId, resultB2.outbox)
-  );
-  expect(getChannelResultFor(channelId, resultA3.channelResults)).toMatchObject({
+  await messageService.send(resultB2.outbox.map(o => o.params));
+  await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
     turnNum: 3,
   });
@@ -154,23 +134,7 @@ it('Create a directly-funded channel between two wallets, of which one crashes m
     turnNum: 4,
   });
 
-  const bPushMessageResult = await peerWallets.b.pushMessage(
-    getPayloadFor(participantB.participantId, aCloseChannelResult.outbox)
-  );
-
+  await messageService.send(aCloseChannelResult.outbox.map(o => o.params));
   // B pushed isFinal4, generated countersigned isFinal4
-  expect(getChannelResultFor(channelId, bPushMessageResult.channelResults)).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-  });
-
-  // A pushed the countersigned isFinal4
-  const aPushMessageResult = await peerWallets.a.pushMessage(
-    getPayloadFor(participantA.participantId, bPushMessageResult.outbox)
-  );
-
-  expect(getChannelResultFor(channelId, aPushMessageResult.channelResults)).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-  });
+  await expectLatestStateToMatch(channelId, peerWallets.a, {status: 'closed', turnNum: 4});
 });

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -6,6 +6,7 @@ import {
 import {makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, constants, ethers} from 'ethers';
 
+import {Wallet} from '../..';
 import {
   getPeersSetup,
   participantA,
@@ -13,13 +14,13 @@ import {
   peersTeardown,
   peerWallets,
 } from '../../../jest/with-peers-setup-teardown';
-import {
-  crashAndRestart,
-  getChannelResultFor,
-  getPayloadFor,
-  ONE_DAY,
-} from '../../__test__/test-helpers';
+import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../../__test__/test-helpers';
 
+async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
+  const config = wallet.walletConfig;
+  await wallet.destroy();
+  return Wallet.create(config); // Wallet that will "restart"
+}
 let channelId: string;
 jest.setTimeout(10_000);
 

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -12,7 +12,7 @@ import {
   participantA,
   participantB,
   peersTeardown,
-  messagingService,
+  messageService,
 } from '../../../jest/with-peers-setup-teardown';
 import {getChannelResultFor, ONE_DAY} from '../../__test__/test-helpers';
 import {expectLatestStateToMatch} from '../utils';
@@ -52,12 +52,12 @@ it('Create a directly funded channel between two wallets ', async () => {
   //        A <> B
   // PreFund0
   const resultA0 = await peerWallets.a.createChannel(createChannelParams);
-  await messagingService.send(resultA0.outbox.map(o => o.params));
+  await messageService.send(resultA0.outbox.map(o => o.params));
   channelId = resultA0.channelResults[0].channelId;
 
   //      PreFund0B
   const resultB1 = await peerWallets.b.joinChannel({channelId});
-  await messagingService.send(resultB1.outbox.map(o => o.params));
+  await messageService.send(resultB1.outbox.map(o => o.params));
 
   const depositByA = {
     channelId,
@@ -88,8 +88,8 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   const resultA2 = await peerWallets.a.updateFundingForChannels([depositByB]);
   const resultB2 = await peerWallets.b.updateFundingForChannels([depositByB]);
-  await messagingService.send(resultA2.outbox.map(o => o.params));
-  await messagingService.send(resultB2.outbox.map(o => o.params));
+  await messageService.send(resultA2.outbox.map(o => o.params));
+  await messageService.send(resultB2.outbox.map(o => o.params));
 
   await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
@@ -113,7 +113,7 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   // A generates isFinal4
   const aCloseChannelResult = await peerWallets.a.closeChannel(closeChannelParams);
-  await messagingService.send(aCloseChannelResult.outbox.map(o => o.params));
+  await messageService.send(aCloseChannelResult.outbox.map(o => o.params));
   // it shouldn't error if close channel is called twice
   await peerWallets.a.closeChannel(closeChannelParams);
 

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -12,9 +12,9 @@ import {
   participantA,
   participantB,
   peersTeardown,
+  messagingService,
 } from '../../../jest/with-peers-setup-teardown';
 import {getChannelResultFor, ONE_DAY} from '../../__test__/test-helpers';
-import {setupTestMessagingService} from '../../message-service/test-message-service';
 import {expectLatestStateToMatch} from '../utils';
 
 const {AddressZero} = ethers.constants;
@@ -48,21 +48,16 @@ it('Create a directly funded channel between two wallets ', async () => {
     fundingStrategy: 'Direct',
     challengeDuration: ONE_DAY,
   };
-  const wallets = [
-    {participantId: participantA.participantId, wallet: peerWallets.a},
-    {participantId: participantB.participantId, wallet: peerWallets.b},
-  ];
-  const ms = await setupTestMessagingService(wallets);
 
   //        A <> B
   // PreFund0
   const resultA0 = await peerWallets.a.createChannel(createChannelParams);
-  await ms.send(resultA0.outbox.map(o => o.params));
+  await messagingService.send(resultA0.outbox.map(o => o.params));
   channelId = resultA0.channelResults[0].channelId;
 
   //      PreFund0B
   const resultB1 = await peerWallets.b.joinChannel({channelId});
-  await ms.send(resultB1.outbox.map(o => o.params));
+  await messagingService.send(resultB1.outbox.map(o => o.params));
 
   const depositByA = {
     channelId,
@@ -93,8 +88,8 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   const resultA2 = await peerWallets.a.updateFundingForChannels([depositByB]);
   const resultB2 = await peerWallets.b.updateFundingForChannels([depositByB]);
-  await ms.send(resultA2.outbox.map(o => o.params));
-  await ms.send(resultB2.outbox.map(o => o.params));
+  await messagingService.send(resultA2.outbox.map(o => o.params));
+  await messagingService.send(resultB2.outbox.map(o => o.params));
 
   await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
@@ -118,7 +113,7 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   // A generates isFinal4
   const aCloseChannelResult = await peerWallets.a.closeChannel(closeChannelParams);
-  await ms.send(aCloseChannelResult.outbox.map(o => o.params));
+  await messagingService.send(aCloseChannelResult.outbox.map(o => o.params));
   // it shouldn't error if close channel is called twice
   await peerWallets.a.closeChannel(closeChannelParams);
 

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -15,7 +15,7 @@ import {
   messageService,
 } from '../../../jest/with-peers-setup-teardown';
 import {getChannelResultFor, ONE_DAY} from '../../__test__/test-helpers';
-import {expectLatestStateToMatch} from '../utils';
+import {expectLatestStateToMatch, getMessages} from '../utils';
 
 const {AddressZero} = ethers.constants;
 jest.setTimeout(10_000);
@@ -52,12 +52,12 @@ it('Create a directly funded channel between two wallets ', async () => {
   //        A <> B
   // PreFund0
   const resultA0 = await peerWallets.a.createChannel(createChannelParams);
-  await messageService.send(resultA0.outbox.map(o => o.params));
+  await messageService.send(getMessages(resultA0));
   channelId = resultA0.channelResults[0].channelId;
 
   //      PreFund0B
   const resultB1 = await peerWallets.b.joinChannel({channelId});
-  await messageService.send(resultB1.outbox.map(o => o.params));
+  await messageService.send(getMessages(resultB1));
 
   const depositByA = {
     channelId,
@@ -88,8 +88,8 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   const resultA2 = await peerWallets.a.updateFundingForChannels([depositByB]);
   const resultB2 = await peerWallets.b.updateFundingForChannels([depositByB]);
-  await messageService.send(resultA2.outbox.map(o => o.params));
-  await messageService.send(resultB2.outbox.map(o => o.params));
+  await messageService.send(getMessages(resultA2));
+  await messageService.send(getMessages(resultB2));
 
   await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
@@ -113,7 +113,7 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   // A generates isFinal4
   const aCloseChannelResult = await peerWallets.a.closeChannel(closeChannelParams);
-  await messageService.send(aCloseChannelResult.outbox.map(o => o.params));
+  await messageService.send(getMessages(aCloseChannelResult));
   // it shouldn't error if close channel is called twice
   await peerWallets.a.closeChannel(closeChannelParams);
 

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -15,6 +15,8 @@ import {
 } from '../../../jest/with-peers-setup-teardown';
 import {getChannelResultFor, ONE_DAY} from '../../__test__/test-helpers';
 import {setupTestMessagingService} from '../../message-service/test-message-service';
+import {expectLatestStateToMatch} from '../utils';
+
 const {AddressZero} = ethers.constants;
 jest.setTimeout(10_000);
 
@@ -80,13 +82,11 @@ it('Create a directly funded channel between two wallets ', async () => {
   }; // B sends 1 ETH (2 total)
 
   // Results before funding is complete
-  let aLatestState = await peerWallets.a.getState({channelId});
-  let bLatestState = await peerWallets.b.getState({channelId});
-  expect(aLatestState.channelResult).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'opening',
     turnNum: 0,
   });
-  expect(bLatestState.channelResult).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'opening',
     turnNum: 0,
   });
@@ -96,17 +96,14 @@ it('Create a directly funded channel between two wallets ', async () => {
   await ms.send(resultA2.outbox.map(o => o.params));
   await ms.send(resultB2.outbox.map(o => o.params));
 
-  aLatestState = await peerWallets.a.getState({channelId});
-  bLatestState = await peerWallets.b.getState({channelId});
-  expect(aLatestState.channelResult).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
     turnNum: 3,
   });
-  expect(bLatestState.channelResult).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'running',
     turnNum: 3,
   });
-
   const closeChannelParams: CloseChannelParams = {
     channelId,
   };
@@ -129,16 +126,12 @@ it('Create a directly funded channel between two wallets ', async () => {
     status: 'closing',
     turnNum: 4,
   });
-  aLatestState = await peerWallets.a.getState({channelId});
-  bLatestState = await peerWallets.b.getState({channelId});
-  expect(aLatestState.channelResult).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'closed',
     turnNum: 4,
   });
-
   // A pushed the countersigned isFinal4
-
-  expect(bLatestState.channelResult).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'closed',
     turnNum: 4,
   });

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -6,7 +6,7 @@ import {
 import {makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
-import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../../__test__/test-helpers';
+import {ONE_DAY} from '../../__test__/test-helpers';
 import {
   peerWallets,
   getPeersSetup,
@@ -14,6 +14,8 @@ import {
   participantB,
   peersTeardown,
 } from '../../../jest/with-peers-setup-teardown';
+import {setupTestMessagingService} from '../../message-service/test-message-service';
+import {expectLatestStateToMatch} from '../utils';
 
 let channelId: string;
 
@@ -38,49 +40,40 @@ it('Create a fake-funded channel between two wallets ', async () => {
     challengeDuration: ONE_DAY,
   };
 
+  const wallets = [
+    {participantId: participantA.participantId, wallet: peerWallets.a},
+    {participantId: participantB.participantId, wallet: peerWallets.b},
+  ];
+
+  const ms = await setupTestMessagingService(wallets);
+
   //        A <> B
   // PreFund0
   const aCreateChannelOutput = await peerWallets.a.createChannel(channelParams);
-
+  await ms.send(aCreateChannelOutput.outbox.map(o => o.params));
   channelId = aCreateChannelOutput.channelResults[0].channelId;
 
-  expect(getChannelResultFor(channelId, aCreateChannelOutput.channelResults)).toMatchObject({
+  expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'opening',
     turnNum: 0,
   });
 
   // A sends PreFund0 to B
-  const bProposeChannelPushOutput = await peerWallets.b.pushMessage(
-    getPayloadFor(participantB.participantId, aCreateChannelOutput.outbox)
-  );
-
-  expect(getChannelResultFor(channelId, bProposeChannelPushOutput.channelResults)).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'proposed',
     turnNum: 0,
   });
 
   // after joinChannel, B signs PreFund1 and PostFund3
   const bJoinChannelOutput = await peerWallets.b.joinChannel({channelId});
+  await ms.send(bJoinChannelOutput.outbox.map(o => o.params));
 
-  expect(getChannelResultFor(channelId, [bJoinChannelOutput.channelResult])).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
-  });
-
-  // B sends signed PreFund1 and PostFund3 to A
-  const aPushJoinChannelOutput = await peerWallets.a.pushMessage(
-    getPayloadFor(participantA.participantId, bJoinChannelOutput.outbox)
-  );
-  expect(getChannelResultFor(channelId, aPushJoinChannelOutput.channelResults)).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
     turnNum: 3,
   });
 
-  // A sends PostFund2 to B
-  const bPushPostFundOutput = await peerWallets.b.pushMessage(
-    getPayloadFor(participantB.participantId, aPushJoinChannelOutput.outbox)
-  );
-  expect(getChannelResultFor(channelId, bPushPostFundOutput.channelResults)).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'running',
     turnNum: 3,
   });
@@ -91,28 +84,14 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // A generates isFinal4
   const aCloseChannelResult = await peerWallets.a.closeChannel(closeChannelParams);
+  await ms.send(aCloseChannelResult.outbox.map(o => o.params));
 
-  expect(getChannelResultFor(channelId, [aCloseChannelResult.channelResult])).toMatchObject({
-    status: 'closing',
-    turnNum: 4,
-  });
-
-  const bPushMessageResult = await peerWallets.b.pushMessage(
-    getPayloadFor(participantB.participantId, aCloseChannelResult.outbox)
-  );
-
-  // B pushed isFinal4, generated countersigned isFinal4
-  expect(getChannelResultFor(channelId, bPushMessageResult.channelResults)).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'closed',
     turnNum: 4,
   });
 
-  // A pushed the countersigned isFinal4
-  const aPushMessageResult = await peerWallets.a.pushMessage(
-    getPayloadFor(participantA.participantId, bPushMessageResult.outbox)
-  );
-
-  expect(getChannelResultFor(channelId, aPushMessageResult.channelResults)).toMatchObject({
+  await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'closed',
     turnNum: 4,
   });

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -13,7 +13,7 @@ import {
   participantA,
   participantB,
   peersTeardown,
-  messagingService,
+  messageService,
 } from '../../../jest/with-peers-setup-teardown';
 import {expectLatestStateToMatch} from '../utils';
 
@@ -43,7 +43,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
   //        A <> B
   // PreFund0
   const aCreateChannelOutput = await peerWallets.a.createChannel(channelParams);
-  await messagingService.send(aCreateChannelOutput.outbox.map(o => o.params));
+  await messageService.send(aCreateChannelOutput.outbox.map(o => o.params));
   channelId = aCreateChannelOutput.channelResults[0].channelId;
 
   expectLatestStateToMatch(channelId, peerWallets.a, {
@@ -59,7 +59,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // after joinChannel, B signs PreFund1 and PostFund3
   const bJoinChannelOutput = await peerWallets.b.joinChannel({channelId});
-  await messagingService.send(bJoinChannelOutput.outbox.map(o => o.params));
+  await messageService.send(bJoinChannelOutput.outbox.map(o => o.params));
 
   await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
@@ -77,7 +77,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // A generates isFinal4
   const aCloseChannelResult = await peerWallets.a.closeChannel(closeChannelParams);
-  await messagingService.send(aCloseChannelResult.outbox.map(o => o.params));
+  await messageService.send(aCloseChannelResult.outbox.map(o => o.params));
 
   await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'closed',

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -13,8 +13,8 @@ import {
   participantA,
   participantB,
   peersTeardown,
+  messagingService,
 } from '../../../jest/with-peers-setup-teardown';
-import {setupTestMessagingService} from '../../message-service/test-message-service';
 import {expectLatestStateToMatch} from '../utils';
 
 let channelId: string;
@@ -40,17 +40,10 @@ it('Create a fake-funded channel between two wallets ', async () => {
     challengeDuration: ONE_DAY,
   };
 
-  const wallets = [
-    {participantId: participantA.participantId, wallet: peerWallets.a},
-    {participantId: participantB.participantId, wallet: peerWallets.b},
-  ];
-
-  const ms = await setupTestMessagingService(wallets);
-
   //        A <> B
   // PreFund0
   const aCreateChannelOutput = await peerWallets.a.createChannel(channelParams);
-  await ms.send(aCreateChannelOutput.outbox.map(o => o.params));
+  await messagingService.send(aCreateChannelOutput.outbox.map(o => o.params));
   channelId = aCreateChannelOutput.channelResults[0].channelId;
 
   expectLatestStateToMatch(channelId, peerWallets.a, {
@@ -66,7 +59,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // after joinChannel, B signs PreFund1 and PostFund3
   const bJoinChannelOutput = await peerWallets.b.joinChannel({channelId});
-  await ms.send(bJoinChannelOutput.outbox.map(o => o.params));
+  await messagingService.send(bJoinChannelOutput.outbox.map(o => o.params));
 
   await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
@@ -84,7 +77,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // A generates isFinal4
   const aCloseChannelResult = await peerWallets.a.closeChannel(closeChannelParams);
-  await ms.send(aCloseChannelResult.outbox.map(o => o.params));
+  await messagingService.send(aCloseChannelResult.outbox.map(o => o.params));
 
   await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'closed',

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -15,7 +15,7 @@ import {
   peersTeardown,
   messageService,
 } from '../../../jest/with-peers-setup-teardown';
-import {expectLatestStateToMatch} from '../utils';
+import {expectLatestStateToMatch, getMessages} from '../utils';
 
 let channelId: string;
 
@@ -43,7 +43,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
   //        A <> B
   // PreFund0
   const aCreateChannelOutput = await peerWallets.a.createChannel(channelParams);
-  await messageService.send(aCreateChannelOutput.outbox.map(o => o.params));
+  await messageService.send(getMessages(aCreateChannelOutput));
   channelId = aCreateChannelOutput.channelResults[0].channelId;
 
   expectLatestStateToMatch(channelId, peerWallets.a, {
@@ -59,7 +59,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // after joinChannel, B signs PreFund1 and PostFund3
   const bJoinChannelOutput = await peerWallets.b.joinChannel({channelId});
-  await messageService.send(bJoinChannelOutput.outbox.map(o => o.params));
+  await messageService.send(getMessages(bJoinChannelOutput));
 
   await expectLatestStateToMatch(channelId, peerWallets.a, {
     status: 'running',
@@ -77,7 +77,7 @@ it('Create a fake-funded channel between two wallets ', async () => {
 
   // A generates isFinal4
   const aCloseChannelResult = await peerWallets.a.closeChannel(closeChannelParams);
-  await messageService.send(aCloseChannelResult.outbox.map(o => o.params));
+  await messageService.send(getMessages(aCloseChannelResult));
 
   await expectLatestStateToMatch(channelId, peerWallets.b, {
     status: 'closed',

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
@@ -2,10 +2,9 @@ import {CreateChannelParams} from '@statechannels/client-api-schema';
 import {BN, makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {ethers} from 'ethers';
 
-import {Outgoing} from '../..';
+import {Outgoing, Wallet} from '../..';
 import {Bytes32} from '../../type-aliases';
 import {
-  crashAndRestart,
   getChannelResultFor,
   getPayloadFor,
   interParticipantChannelResultsAreEqual,
@@ -21,7 +20,11 @@ import {
   aWalletConfig,
   bWalletConfig,
 } from '../../../jest/with-peers-setup-teardown';
-
+async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
+  const config = wallet.walletConfig;
+  await wallet.destroy();
+  return Wallet.create(config); // Wallet that will "restart"
+}
 const ETH_ASSET_HOLDER_ADDRESS = makeAddress(ethers.constants.AddressZero);
 
 const tablesUsingLedgerChannels = ['channels', 'ledger_requests', 'ledger_proposals'];

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
@@ -20,6 +20,8 @@ import {
   aWalletConfig,
   bWalletConfig,
 } from '../../../jest/with-peers-setup-teardown';
+// TODO: this is temporary. This test file is refactored in
+// https://github.com/statechannels/statechannels/pull/3287
 async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
   const config = wallet.walletConfig;
   await wallet.destroy();

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -43,13 +43,13 @@ export function setupTestMessagingService(
   if (!hasUniqueWallets) {
     throw new Error('Duplicate wallets');
   }
-  const messageHandler: MessageHandler = async (to, message, me) => {
-    const matching = wallets.find(w => w.participantId === to);
+  const messageHandler: MessageHandler = async (message, me) => {
+    const matching = wallets.find(w => w.participantId === message.recipient);
 
     if (!matching) {
-      throw new Error(`Invalid to value ${to}`);
+      throw new Error(`Invalid to value ${message.recipient}`);
     }
-    const result = await matching.wallet.pushMessage(message);
+    const result = await matching.wallet.pushMessage(message.data);
 
     await me.send(result.outbox.map(o => o.params));
   };

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -1,4 +1,5 @@
 import {ChannelResult} from '@statechannels/client-api-schema';
+import _ from 'lodash';
 
 import {Wallet} from '..';
 import {TestMessageService} from '../message-service/test-message-service';
@@ -31,8 +32,17 @@ export async function expectLatestStateToMatch(
 export function setupTestMessagingService(
   wallets: {participantId: string; wallet: Wallet}[]
 ): Promise<MessageServiceInterface> {
+  const hasUniqueParticipants = new Set(wallets.map(w => w.participantId)).size === wallets.length;
+  const hasUniqueWallets = new Set(wallets.map(w => w.wallet)).size === wallets.length;
+
+  if (!hasUniqueParticipants) {
+    throw new Error('Duplicate participant ids');
+  }
+
+  if (!hasUniqueWallets) {
+    throw new Error('Duplicate wallets');
+  }
   const messageHandler: MessageHandler = async (to, message, me) => {
-    // TODO: This assumes only 1 matching wallet.
     const matching = wallets.find(w => w.participantId === to);
 
     if (!matching) {

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -1,0 +1,13 @@
+import {ChannelResult} from '@statechannels/client-api-schema';
+
+import {Wallet} from '..';
+
+// TODO: Is there a cleaner way of writing this?
+export async function expectLatestStateToMatch(
+  channelId: string,
+  wallet: Wallet,
+  partial: Partial<ChannelResult>
+): Promise<void> {
+  const latest = await wallet.getState({channelId});
+  expect(latest.channelResult).toMatchObject(partial);
+}

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -1,6 +1,8 @@
 import {ChannelResult} from '@statechannels/client-api-schema';
 
 import {Wallet} from '..';
+import {TestMessageService} from '../message-service/test-message-service';
+import {MessageHandler, MessageServiceInterface} from '../message-service/types';
 
 // TODO: Is there a cleaner way of writing this?
 export async function expectLatestStateToMatch(
@@ -10,4 +12,35 @@ export async function expectLatestStateToMatch(
 ): Promise<void> {
   const latest = await wallet.getState({channelId});
   expect(latest.channelResult).toMatchObject(partial);
+}
+
+/**
+ * This is a helper method that sets up a message service for a collection of wallets.
+ * Whenever handleMessages or send are called they are pushed into the appropriate wallet.
+ * Any response to the pushMessage is then sent to the other participants
+ * @param wallets The collection of wallets that will be communicating. A participantId must be provided for each wallet.
+ * @returns A messaging service that can be used to send messages.
+ * @example
+ * const ms = setupTestMessagingService(...bla);
+ * const result = wallet.createChannel(..bla);
+ *
+ * // This will send all the messages from the result of the create channel call
+ * // and will handle any responses to those messages and so on...
+ * await ms.handleMessages(result.outbox);
+ */
+export function setupTestMessagingService(
+  wallets: {participantId: string; wallet: Wallet}[]
+): Promise<MessageServiceInterface> {
+  const messageHandler: MessageHandler = async (to, message, me) => {
+    // TODO: This assumes only 1 matching wallet.
+    const matching = wallets.find(w => w.participantId === to);
+
+    if (!matching) {
+      throw new Error(`Invalid to value ${to}`);
+    }
+    const result = await matching.wallet.pushMessage(message);
+
+    await me.send(result.outbox.map(o => o.params));
+  };
+  return TestMessageService.createTestMessageService(messageHandler);
 }

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -7,7 +7,6 @@ import {MessageHandler, MessageServiceInterface} from '../message-service/types'
 import {Notice} from '../protocols/actions';
 import {MultipleChannelOutput, SingleChannelOutput} from '../wallet';
 
-// TODO: Is there a cleaner way of writing this?
 export async function expectLatestStateToMatch(
   channelId: string,
   wallet: Wallet,

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -1,9 +1,11 @@
-import {ChannelResult} from '@statechannels/client-api-schema';
+import {ChannelResult, Message} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {Wallet} from '..';
 import {TestMessageService} from '../message-service/test-message-service';
 import {MessageHandler, MessageServiceInterface} from '../message-service/types';
+import {Notice} from '../protocols/actions';
+import {MultipleChannelOutput, SingleChannelOutput} from '../wallet';
 
 // TODO: Is there a cleaner way of writing this?
 export async function expectLatestStateToMatch(
@@ -53,4 +55,23 @@ export function setupTestMessagingService(
     await me.send(result.outbox.map(o => o.params));
   };
   return TestMessageService.createTestMessageService(messageHandler);
+}
+
+function isOutput(something: any): something is SingleChannelOutput | MultipleChannelOutput {
+  return 'outbox' in something;
+}
+
+/**
+ * Takes in a variety of results and gets the messages that can be passed into the message service
+ * @param outputOrOutbox Either the output of the API or the outbox
+ * @returns messages that can be passed into the message service
+ */
+export function getMessages(
+  outputOrOutbox: SingleChannelOutput | MultipleChannelOutput | Notice[]
+): Message[] {
+  if (isOutput(outputOrOutbox)) {
+    return outputOrOutbox.outbox.map(o => o.params);
+  } else {
+    return outputOrOutbox.map(o => o.params);
+  }
 }

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -2,8 +2,6 @@ import {ChannelResult, Message} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {Wallet} from '..';
-import {TestMessageService} from '../message-service/test-message-service';
-import {MessageHandler, MessageServiceInterface} from '../message-service/types';
 import {Notice} from '../protocols/actions';
 import {MultipleChannelOutput, SingleChannelOutput} from '../wallet';
 
@@ -14,46 +12,6 @@ export async function expectLatestStateToMatch(
 ): Promise<void> {
   const latest = await wallet.getState({channelId});
   expect(latest.channelResult).toMatchObject(partial);
-}
-
-/**
- * This is a helper method that sets up a message service for a collection of wallets.
- * Whenever handleMessages or send are called they are pushed into the appropriate wallet.
- * Any response to the pushMessage is then sent to the other participants
- * @param wallets The collection of wallets that will be communicating. A participantId must be provided for each wallet.
- * @returns A messaging service that can be used to send messages.
- * @example
- * const ms = setupTestMessagingService(...bla);
- * const result = wallet.createChannel(..bla);
- *
- * // This will send all the messages from the result of the create channel call
- * // and will handle any responses to those messages and so on...
- * await ms.handleMessages(result.outbox);
- */
-export function setupTestMessagingService(
-  wallets: {participantId: string; wallet: Wallet}[]
-): Promise<MessageServiceInterface> {
-  const hasUniqueParticipants = new Set(wallets.map(w => w.participantId)).size === wallets.length;
-  const hasUniqueWallets = new Set(wallets.map(w => w.wallet)).size === wallets.length;
-
-  if (!hasUniqueParticipants) {
-    throw new Error('Duplicate participant ids');
-  }
-
-  if (!hasUniqueWallets) {
-    throw new Error('Duplicate wallets');
-  }
-  const messageHandler: MessageHandler = async (message, me) => {
-    const matching = wallets.find(w => w.participantId === message.recipient);
-
-    if (!matching) {
-      throw new Error(`Invalid to value ${message.recipient}`);
-    }
-    const result = await matching.wallet.pushMessage(message.data);
-
-    await me.send(result.outbox.map(o => o.params));
-  };
-  return TestMessageService.createTestMessageService(messageHandler);
 }
 
 function isOutput(something: any): something is SingleChannelOutput | MultipleChannelOutput {

--- a/packages/server-wallet/src/__test__/test-helpers.ts
+++ b/packages/server-wallet/src/__test__/test-helpers.ts
@@ -35,12 +35,6 @@ export function getSignedStateFor(channelId: string, outbox: Outgoing[]): Signed
   return filteredSignedStates[0];
 }
 
-export async function crashAndRestart(wallet: Wallet): Promise<Wallet> {
-  const config = wallet.walletConfig;
-  await wallet.destroy();
-  return Wallet.create(config); // Wallet that will "restart"
-}
-
 export async function interParticipantChannelResultsAreEqual(a: Wallet, b: Wallet): Promise<void> {
   const {channelResults: aChannelResults} = await a.getChannels();
   const {channelResults: bChannelResults, outbox: bOutbox} = await b.getChannels();

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -5,7 +5,7 @@ import {MessageHandler, MessageServiceInterface} from './types';
 
 export class TestMessageService implements MessageServiceInterface {
   protected constructor(private _receive: MessageHandler) {}
-  protected destroyed = false;
+
   static async createTestMessageService(
     incomingMessageHandler: MessageHandler
   ): Promise<MessageServiceInterface> {
@@ -20,6 +20,7 @@ export class TestMessageService implements MessageServiceInterface {
   }
 
   async destroy(): Promise<void> {
+    // This prevents any more progress from being made
     this._receive = async () => _.noop();
   }
 }

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import {MessageHandler, MessageServiceInterface} from './types';
 
 export class TestMessageService implements MessageServiceInterface {
-  protected constructor(private _receive: MessageHandler) {}
+  protected constructor(private _handleMessage: MessageHandler) {}
 
   static async createTestMessageService(
     incomingMessageHandler: MessageHandler
@@ -15,12 +15,12 @@ export class TestMessageService implements MessageServiceInterface {
 
   async send(messages: Message[]): Promise<void> {
     for (const message of messages) {
-      await this._receive(message, this);
+      await this._handleMessage(message, this);
     }
   }
 
   async destroy(): Promise<void> {
     // This prevents any more progress from being made
-    this._receive = async () => _.noop();
+    this._handleMessage = async () => _.noop();
   }
 }

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -1,12 +1,11 @@
 import {Message} from '@statechannels/client-api-schema';
-
-import {Wallet} from '../wallet';
+import _ from 'lodash';
 
 import {MessageHandler, MessageServiceInterface} from './types';
 
 export class TestMessageService implements MessageServiceInterface {
   protected constructor(private _receive: MessageHandler) {}
-
+  protected destroyed = false;
   static async createTestMessageService(
     messageHandler: MessageHandler
   ): Promise<MessageServiceInterface> {
@@ -19,35 +18,8 @@ export class TestMessageService implements MessageServiceInterface {
       await this._receive(message.recipient, message.data, this);
     }
   }
-}
 
-/**
- * This is a helper method that sets up a message service for a collection of wallets.
- * Whenever handleMessages or send are called they are pushed into the appropriate wallet.
- * Any response to the pushMessage is then sent to the other participants
- * @param wallets The collection of wallets that will be communicating. A participantId must be provided for each wallet.
- * @returns A messaging service that can be used to send messages.
- * @example
- * const ms = setupTestMessagingService(...bla);
- * const result = wallet.createChannel(..bla);
- *
- * // This will send all the messages from the result of the create channel call
- * // and will handle any responses to those messages and so on...
- * await ms.handleMessages(result.outbox);
- */
-export function setupTestMessagingService(
-  wallets: {participantId: string; wallet: Wallet}[]
-): Promise<MessageServiceInterface> {
-  const messageHandler: MessageHandler = async (to, message, me) => {
-    // TODO: This assumes only 1 matching wallet.
-    const matching = wallets.find(w => w.participantId === to);
-
-    if (!matching) {
-      throw new Error(`Invalid to value ${to}`);
-    }
-    const result = await matching.wallet.pushMessage(message);
-
-    await me.send(result.outbox.map(o => o.params));
-  };
-  return TestMessageService.createTestMessageService(messageHandler);
+  async destroy(): Promise<void> {
+    this._receive = async () => _.noop();
+  }
 }

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -2,14 +2,14 @@ import {Message} from '@statechannels/client-api-schema';
 
 import {Wallet} from '../wallet';
 
-import {MessageHandler, MessagingServiceInterface} from './types';
+import {MessageHandler, MessageServiceInterface} from './types';
 
-export class TestMessageService implements MessagingServiceInterface {
+export class TestMessageService implements MessageServiceInterface {
   protected constructor(private _receive: MessageHandler) {}
 
-  static async createTestMessagingService(
+  static async createTestMessageService(
     messageHandler: MessageHandler
-  ): Promise<MessagingServiceInterface> {
+  ): Promise<MessageServiceInterface> {
     const service = new TestMessageService(messageHandler);
     return service;
   }
@@ -37,7 +37,7 @@ export class TestMessageService implements MessagingServiceInterface {
  */
 export function setupTestMessagingService(
   wallets: {participantId: string; wallet: Wallet}[]
-): Promise<MessagingServiceInterface> {
+): Promise<MessageServiceInterface> {
   const messageHandler: MessageHandler = async (to, message, me) => {
     // TODO: This assumes only 1 matching wallet.
     const matching = wallets.find(w => w.participantId === to);
@@ -49,5 +49,5 @@ export function setupTestMessagingService(
 
     await me.send(result.outbox.map(o => o.params));
   };
-  return TestMessageService.createTestMessagingService(messageHandler);
+  return TestMessageService.createTestMessageService(messageHandler);
 }

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -15,7 +15,7 @@ export class TestMessageService implements MessageServiceInterface {
 
   async send(messages: Message[]): Promise<void> {
     for (const message of messages) {
-      await this._receive(message.recipient, message.data, this);
+      await this._receive(message, this);
     }
   }
 

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -19,9 +19,7 @@ export class TestMessageService implements MessageServiceInterface {
     this._handleMessage = async message => handleMessage(message, this);
   }
 
-  static async createTestMessageService(
-    incomingMessageHandler: MessageHandler
-  ): Promise<MessageServiceInterface> {
+  static async create(incomingMessageHandler: MessageHandler): Promise<MessageServiceInterface> {
     const service = new TestMessageService(incomingMessageHandler);
     return service;
   }

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -11,7 +11,13 @@ import {MessageHandler, MessageServiceInterface} from './types';
  * The message service is responsible for calling pushMessage on the appropriate wallets.
  */
 export class TestMessageService implements MessageServiceInterface {
-  protected constructor(private _handleMessage: MessageHandler) {}
+  private _handleMessage: (message: Message) => Promise<void>;
+  protected constructor(handleMessage: MessageHandler) {
+    // We always pass a reference to the messageService when calling handleMessage
+    // This allows the MessageHandler function to easily call messageHandler.send
+    // We just bind that here for convenience.
+    this._handleMessage = async message => handleMessage(message, this);
+  }
 
   static async createTestMessageService(
     incomingMessageHandler: MessageHandler
@@ -22,7 +28,7 @@ export class TestMessageService implements MessageServiceInterface {
 
   async send(messages: Message[]): Promise<void> {
     for (const message of messages) {
-      await this._handleMessage(message, this);
+      await this._handleMessage(message);
     }
   }
 

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -7,9 +7,9 @@ export class TestMessageService implements MessageServiceInterface {
   protected constructor(private _receive: MessageHandler) {}
   protected destroyed = false;
   static async createTestMessageService(
-    messageHandler: MessageHandler
+    incomingMessageHandler: MessageHandler
   ): Promise<MessageServiceInterface> {
-    const service = new TestMessageService(messageHandler);
+    const service = new TestMessageService(incomingMessageHandler);
     return service;
   }
 

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -1,0 +1,53 @@
+import {Message} from '@statechannels/client-api-schema';
+
+import {Wallet} from '../wallet';
+
+import {MessageHandler, MessagingServiceInterface} from './types';
+
+export class TestMessageService implements MessagingServiceInterface {
+  protected constructor(private _receive: MessageHandler) {}
+
+  static async createTestMessagingService(
+    messageHandler: MessageHandler
+  ): Promise<MessagingServiceInterface> {
+    const service = new TestMessageService(messageHandler);
+    return service;
+  }
+
+  async send(messages: Message[]): Promise<void> {
+    for (const message of messages) {
+      await this._receive(message.recipient, message.data, this);
+    }
+  }
+}
+
+/**
+ * This is a helper method that sets up a message service for a collection of wallets.
+ * Whenever handleMessages or send are called they are pushed into the appropriate wallet.
+ * Any response to the pushMessage is then sent to the other participants
+ * @param wallets The collection of wallets that will be communicating. A participantId must be provided for each wallet.
+ * @returns A messaging service that can be used to send messages.
+ * @example
+ * const ms = setupTestMessagingService(...bla);
+ * const result = wallet.createChannel(..bla);
+ *
+ * // This will send all the messages from the result of the create channel call
+ * // and will handle any responses to those messages and so on...
+ * await ms.handleMessages(result.outbox);
+ */
+export function setupTestMessagingService(
+  wallets: {participantId: string; wallet: Wallet}[]
+): Promise<MessagingServiceInterface> {
+  const messageHandler: MessageHandler = async (to, message, me) => {
+    // TODO: This assumes only 1 matching wallet.
+    const matching = wallets.find(w => w.participantId === to);
+
+    if (!matching) {
+      throw new Error(`Invalid to value ${to}`);
+    }
+    const result = await matching.wallet.pushMessage(message);
+
+    await me.send(result.outbox.map(o => o.params));
+  };
+  return TestMessageService.createTestMessagingService(messageHandler);
+}

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -1,8 +1,15 @@
 import {Message} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
+import {Wallet} from '..';
+
 import {MessageHandler, MessageServiceInterface} from './types';
 
+/**
+ * A basic message service that is responsible for sending and receiving messages for a collection of wallets.
+ * All the wallets will share the same message service.
+ * The message service is responsible for calling pushMessage on the appropriate wallets.
+ */
 export class TestMessageService implements MessageServiceInterface {
   protected constructor(private _handleMessage: MessageHandler) {}
 
@@ -24,3 +31,43 @@ export class TestMessageService implements MessageServiceInterface {
     this._handleMessage = async () => _.noop();
   }
 }
+
+/**
+ * This is a helper method that sets up a message service for a collection of wallets.
+ * Whenever handleMessages or send are called they are pushed into the appropriate wallet.
+ * Any response to the pushMessage is then sent to the other participants
+ * @param wallets The collection of wallets that will be communicating. A participantId must be provided for each wallet.
+ * @returns A messaging service that is responsible for calling pushMessage on the correct wallet.
+ * @example
+ * const handler = createTestMessageHandler(..bla)
+ * const ms = createTestMessageHandler(handler)
+ * const result = wallet.createChannel(..bla);
+ *
+ * // This will send all the messages from the result of the create channel call
+ * // and will handle any responses to those messages and so on...
+ * await ms.handleMessages(result.outbox);
+ */
+export const createTestMessageHandler = (
+  wallets: {participantId: string; wallet: Wallet}[]
+): MessageHandler => {
+  const hasUniqueParticipants = new Set(wallets.map(w => w.participantId)).size === wallets.length;
+  const hasUniqueWallets = new Set(wallets.map(w => w.wallet)).size === wallets.length;
+
+  if (!hasUniqueParticipants) {
+    throw new Error('Duplicate participant ids');
+  }
+
+  if (!hasUniqueWallets) {
+    throw new Error('Duplicate wallets');
+  }
+  return async (message, me) => {
+    const matching = wallets.find(w => w.participantId === message.recipient);
+
+    if (!matching) {
+      throw new Error(`Invalid recipient ${message.recipient}`);
+    }
+    const result = await matching.wallet.pushMessage(message.data);
+
+    await me.send(result.outbox.map(o => o.params));
+  };
+};

--- a/packages/server-wallet/src/message-service/types.ts
+++ b/packages/server-wallet/src/message-service/types.ts
@@ -27,4 +27,9 @@ export interface MessageServiceInterface {
    * @param messages The collection of messages to send
    */
   send(message: Message[]): Promise<void>;
+
+  /**
+   * This is called when the message service is no longer needed
+   */
+  destroy(): Promise<void>;
 }

--- a/packages/server-wallet/src/message-service/types.ts
+++ b/packages/server-wallet/src/message-service/types.ts
@@ -1,0 +1,30 @@
+import {Message} from '@statechannels/client-api-schema';
+
+/**
+ * This is the handler that any messaging service implementation should call when receiving a message
+ * The handler is responsible for pushing the message into the appropriate wallet
+ */
+export type MessageHandler = (
+  // Including the to makes it easier for a messaging service to handle multiple wallets if it chooses to do so
+  to: string,
+  message: unknown,
+  messageService: MessagingServiceInterface
+) => Promise<void>;
+
+/**
+ * A MessageServiceFactory is responsible for generating a MessageService.
+ * Eventually the wallet will require a MessageServiceFactory.
+ * The wallet will use it to construct the messagingService that it can use to send messages.
+ * messageHandler should be triggered whenever the messaging service receives a message.
+ */
+export type MessageServiceFactory = (
+  messageHandler: MessageHandler
+) => Promise<MessagingServiceInterface>;
+
+export interface MessagingServiceInterface {
+  /**
+   * Sends out the messages to the specified by participants.
+   * @param messages The collection of messages to send
+   */
+  send(message: Message[]): Promise<void>;
+}

--- a/packages/server-wallet/src/message-service/types.ts
+++ b/packages/server-wallet/src/message-service/types.ts
@@ -8,7 +8,7 @@ export type MessageHandler = (
   // Including the to makes it easier for a messaging service to handle multiple wallets if it chooses to do so
   to: string,
   message: unknown,
-  messageService: MessagingServiceInterface
+  messageService: MessageServiceInterface
 ) => Promise<void>;
 
 /**
@@ -19,9 +19,9 @@ export type MessageHandler = (
  */
 export type MessageServiceFactory = (
   messageHandler: MessageHandler
-) => Promise<MessagingServiceInterface>;
+) => Promise<MessageServiceInterface>;
 
-export interface MessagingServiceInterface {
+export interface MessageServiceInterface {
   /**
    * Sends out the messages to the specified by participants.
    * @param messages The collection of messages to send

--- a/packages/server-wallet/src/message-service/types.ts
+++ b/packages/server-wallet/src/message-service/types.ts
@@ -18,7 +18,7 @@ export type MessageHandler = (
  * messageHandler should be triggered whenever the messaging service receives a message.
  */
 export type MessageServiceFactory = (
-  messageHandler: MessageHandler
+  incomingMessageHandler: MessageHandler
 ) => Promise<MessageServiceInterface>;
 
 export interface MessageServiceInterface {

--- a/packages/server-wallet/src/message-service/types.ts
+++ b/packages/server-wallet/src/message-service/types.ts
@@ -5,9 +5,7 @@ import {Message} from '@statechannels/client-api-schema';
  * The handler is responsible for pushing the message into the appropriate wallet
  */
 export type MessageHandler = (
-  // Including the to makes it easier for a messaging service to handle multiple wallets if it chooses to do so
-  to: string,
-  message: unknown,
+  message: Message,
   messageService: MessageServiceInterface
 ) => Promise<void>;
 


### PR DESCRIPTION
# Description
Introduces a new message service responsible for sending messages between participants.

This introduces the concept of a "MessageService". The responsibility of this message service is to send messages to opponents and trigger the `incomingMessageHandler` when receiving a message.

Longer-term the `wallet` will accept a `MessageServiceFactory`  from the `app`. This allows the `wallet` to create a message service while supplying a callback that can push the message into the wallet.

The initial implementation is a `TestMessageService` used for the majority of the `with-peers` tests. (Ledger funding was skipped since we expect it to change drastically soon). 

## Changes 
1. New `MessageServiceInterface` and associated types.
2. New `TestMessageService`
3. Updated `with-peer` tests to use `TestMessageService`

## How Has This Been Tested? 

The `TestMessageService` is used in `with-peers` test.

Unit tests for the `TestMessageService` have been omitted since it's only used in tests.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
