### PR TITLE
chore: use === instead of == for comparison

### DIFF
--- a/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
+++ b/packages/server-wallet/e2e-test/scripts/generate-profile-data.ts
@@ -23,7 +23,7 @@ const startReceiver = async (
   let server: ChildProcess;
   if (profiling === 'FlameGraph') {
     server = exec(`npx clinic flame --collect-only -- node ./lib/e2e-test/receiver/server.js`);
-  } else if (profiling == 'Doctor') {
+  } else if (profiling === 'Doctor') {
     server = exec(`npx clinic doctor --collect-only -- node  ./lib/e2e-test/receiver/server.js`);
   } else {
     server = exec(

--- a/packages/server-wallet/src/utilities/validate-transition.ts
+++ b/packages/server-wallet/src/utilities/validate-transition.ts
@@ -11,7 +11,7 @@ export function shouldValidateTransition(incomingState: StateWithHash, channel: 
   const {supported, isLedger, fundingStrategy} = channel;
   // TODO: This is a temporary workaround for https://github.com/statechannels/statechannels/issues/2842
   // We should figure out a smarter way of handling this
-  if (fundingStrategy == 'Fake' && incomingState.turnNum === 3) {
+  if (fundingStrategy === 'Fake' && incomingState.turnNum === 3) {
     return false;
   }
 

--- a/packages/server-wallet/src/wallet/store.ts
+++ b/packages/server-wallet/src/wallet/store.ts
@@ -317,7 +317,7 @@ export class Store {
       const storedObjectives: WalletObjective[] = [];
       for (const o of deserializedObjectives) {
         if (isSupportedObjective(o)) {
-          const preApprove = o.type == 'CloseChannel'; // Close channel objectives do not need co-operative approval
+          const preApprove = o.type === 'CloseChannel'; // Close channel objectives do not need co-operative approval
           storedObjectives.push(await ObjectiveModel.insert(o, preApprove, tx));
         } else this.logger.warn('Unsupported objective received');
       }


### PR DESCRIPTION
Note that there are a couple places in the monorepo where a variable is compared with `undefined` via `== undefined`. These comparisons are left as is since maybe `null` is an acceptable value for these comparisons.

```
> null == undefined
true
> null === undefined
false
```