### PR TITLE
chore: Remove DOM Lib from server-wallet tsconfig

### DIFF
--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -36,7 +36,7 @@
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/express": "4.17.1",
     "@types/express-pino-logger": "4.0.2",
-    "@types/jest": "26.0.15",
+    "@types/jest": "26.0.21",
     "@types/lodash": "4.14.161",
     "@types/node": "14.11.2",
     "@types/nodemon": "1.19.0",

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/eslint-plugin": "4.13.0",
     "@typescript-eslint/parser": "4.13.0",
     "autocannon": "6.4.0",
-    "axios": "0.20.0",
+    "axios": "0.21.1",
     "body-parser": "1.19.0",
     "cli-table3": "0.6.0",
     "clinic": "7.0.0",

--- a/packages/server-wallet/src/evm-validator.ts
+++ b/packages/server-wallet/src/evm-validator.ts
@@ -1,3 +1,5 @@
+import {TextDecoder} from 'util';
+
 import {createValidTransitionTransaction, State as NitroState} from '@statechannels/nitro-protocol';
 import * as PureEVM from '@connext/pure-evm-wasm';
 import {BigNumber, utils} from 'ethers';

--- a/packages/server-wallet/tsconfig.json
+++ b/packages/server-wallet/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-
+    // This prevents conflicting @types from the parents node_modules/@types
+        "typeRoots": [
+      "./node_modules/@types"
+    ],
     "allowSyntheticDefaultImports": true,
     "lib": ["ES2019"],
     "target": "es2019",

--- a/packages/server-wallet/tsconfig.json
+++ b/packages/server-wallet/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+
     "allowSyntheticDefaultImports": true,
-    "lib": ["ES2019", "dom"],
+    "lib": ["ES2019"],
     "target": "es2019",
     "module": "commonjs",
     "outDir": "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5645,10 +5645,10 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axios@0.20.0:
-  version "0.20.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+axios@0.21.1:
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,6 +4283,14 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jest@26.0.21":
+  version "26.0.21"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.21.tgz#3a73c2731e7e4f0fbaea56ce7ff8c79cf812bd24"
+  integrity sha512-ab9TyM/69yg7eew9eOwKMUmvIZAKEGZYlq/dhe5/0IMUd/QLJv5ldRMdddSn+u22N13FP3s5jYyktxuBwY0kDA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/jest@26.x":
   version "26.0.14"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz#078695f8f65cb55c5a98450d65083b2b73e5a3f3"


### PR DESCRIPTION
# Description

While working on something else I noticed that the `setTimeout` function returned something different than the typing specified. That is because our `tsconfig` included the `dom` library.

This PR removes the `dom` entry and makes some other changes to support that.

## Changes [Optional] 
1. Remove `dom` entry from `server-wallet` ts-config: 3f57bea
2. Update the `server-wallet` to ignore the '@types' from the parent `node_modules`: 08591df
3. Upgraded some depenencies that were causing type issues: 445de9b & 445de9b
4. Fixed a `TextEncoder` usage so it is compliant with node. : 6a3b63c


## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
