### PR TITLE
change many forceMove -> challenge

### DIFF
--- a/packages/docs-website/docs/docs/implementation-notes/force-move.md
+++ b/packages/docs-website/docs/docs/implementation-notes/force-move.md
@@ -353,14 +353,14 @@ Although the `outcome` is included in the `state`, we include the `outcomeHash` 
 
 ## Methods
 
-### `forceMove`
+### `challenge`
 
-The `forceMove` function allows anyone holding the appropriate off-chain state to register a challenge on chain, and gives the framework its name. It is designed to ensure that a state channel can progress or be finalized in the event of inactivity on behalf of a participant (e.g. the current mover).
+The `challenge` function allows anyone holding the appropriate off-chain state to register a challenge on chain. It is designed to ensure that a state channel can progress or be finalized in the event of inactivity on behalf of a participant (e.g. the current mover).
 
 The off-chain state is submitted (in an optimized format), and once relevant checks have passed, an `outcome` is registered against the `channelId`, with a finalization time set at some delay after the transaction is processed. This delay allows the challenge to be cleared by a timely and well-formed [respond](#respond) or [checkpoint](#checkpoint) transaction. If no such transaction is forthcoming, the challenge will time out, allowing the `outcome` registered to be finalized. A finalized outcome can then be used to extract funds from the channel.
 
 ```solidity
-    function forceMove(
+    function challenge(
         FixedPart memory fixedPart,
         uint256 largestTurnNum,
         ForceMoveApp.VariablePart[] memory variableParts,
@@ -394,7 +394,7 @@ The challenger needs to sign this data:
 keccak256(abi.encode(challengeStateHash, 'forceMove'))
 ```
 
-in order to form `challengerSig`. This signals their intent to forceMove this channel with this particular state. This mechanism allows the forceMove to be authorized only by a channel participant.
+in order to form `challengerSig`. This signals their intent to challenge this channel with this particular state. This mechanism allows the challenge to be authorized only by a channel participant.
 :::
 
 ### `respond`

--- a/packages/docs-website/docs/docs/implementation-notes/null-app.md
+++ b/packages/docs-website/docs/docs/implementation-notes/null-app.md
@@ -22,6 +22,6 @@ This is only ficticious because, in the current implementation of `ForceMove.sol
 If outcome `o1` is supported, and Alice wants to propose outcome `o2`, then she can simply sign a state with that outcome and broadcast it.
 
 - If everyone signs it, we've reached consensus.
-- If someone doesn't sign it, then `forceMove(s1)` closes the channel with `s1`, since there are no valid transitions.
+- If someone doesn't sign it, then `challenge(s1)` closes the channel with `s1`, since there are no valid transitions.
 
 This is more scalable than an explicit consensus app: In a channel with `n` participants, ForceMove guarantees that any participant can close an app with valid transitions in `O(n)` time. Since there are no valid moves in the null app, anyone can close the null app in `O(1)` time.

--- a/packages/docs-website/docs/docs/protocol-tutorial/finalize-a-channel-sad.md
+++ b/packages/docs-website/docs/docs/protocol-tutorial/finalize-a-channel-sad.md
@@ -24,7 +24,7 @@ The challenger needs to sign this data:
 keccak256(abi.encode(challengeStateHash, 'forceMove'))
 ```
 
-in order to form `challengerSig`. This signals their intent to forceMove this channel with this particular state. This mechanism allows the forceMove to be authorized only by a channel participant.
+in order to form `challengerSig`. This signals their intent to challenge this channel with this particular state. This mechanism allows the challenge to be authorized only by a channel participant.
 :::
 
 We provide a handy utility function `signChallengeMessage` to form this signature.

--- a/packages/docs-website/docs/docs/protocol-tutorial/understand-adjudicator-status.md
+++ b/packages/docs-website/docs/docs/protocol-tutorial/understand-adjudicator-status.md
@@ -101,10 +101,10 @@ These states can be represented in the following state machine:
 <Mermaid chart='
 graph LR
 linkStyle default interpolate basis
-Open -->|forceMove| Challenge
+Open -->|challenge| Challenge
 Open -->|checkpoint| Open
 Open-->|conclude| Finalized
-Challenge-->|forceMove| Challenge
+Challenge-->|challenge| Challenge
 Challenge-->|respond| Open
 Challenge-->|checkpoint| Open
 Challenge-->|conclude| Finalized

--- a/packages/nitro-protocol/notes/blog-posts/gas-optimizations/gas-usage-chart.py
+++ b/packages/nitro-protocol/notes/blog-posts/gas-optimizations/gas-usage-chart.py
@@ -18,7 +18,7 @@ legacy = {
     "deployNitroAdjudicator": 6553512,  # TEST contract
     "deposit": 46750,
     "concludeAndWithdraw": 644147,
-    "forceMove": 677845,
+    "challenge": 677845,
     "respond": 336337,
 }
 
@@ -27,7 +27,7 @@ legacy["deployment"] = legacy["deployNitroAdjudicator"]
 legacy["happyPath"] = legacy["deposit"] + \
     legacy["concludeAndWithdraw"]
 
-legacy["challengePath"] = legacy["forceMove"] + \
+legacy["challengePath"] = legacy["challenge"] + \
     legacy["respond"]
 
 optimized = {
@@ -36,7 +36,7 @@ optimized = {
     "deployAssetHolder": 1831942,
     "deposit": 48996,
     "concludePushOutcomeAndTransferAll": 113797, 
-    "forceMove": 101881,
+    "challenge": 101881,
     "respond": 56706,
 }
 
@@ -46,7 +46,7 @@ optimized["deployment"] = optimized["deployNitroAdjudicator"] + \
 optimized["happyPath"] = optimized["deposit"] + \
     optimized["concludePushOutcomeAndTransferAll"]
 
-optimized["challengePath"] = optimized["forceMove"] + \
+optimized["challengePath"] = optimized["challenge"] + \
     optimized["respond"]
 
 labels = ['Happy Path', 'Challenge Path']

--- a/packages/nitro-protocol/notes/force-move-implementation.md
+++ b/packages/nitro-protocol/notes/force-move-implementation.md
@@ -134,7 +134,7 @@ With these considerations in mind, the ForceMove interface should be something l
 ## Unanswered Questions
 
 1. Should we use time or blocknumber? Time is generally more predictable and nicer to work with in client code but is manipulable by miners :(.
-2. Is it worth optimizing separately for the case n=2 (e.g. with methods `forceMove2` and so on)
+2. Is it worth optimizing separately for the case n=2 (e.g. with methods `challenge2` and so on)
 3. What order should we put states in? (Maybe reverse?)
 4. Should we use abi encode?
 5. We don't technically need to pass the `isFinal` flag into `conclude` - it will only work if it is true. Maybe that's a step too far?

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -1,6 +1,5 @@
-import {Contract, providers, Signature} from 'ethers';
+import {providers, Signature} from 'ethers';
 
-import {Uint256} from './contract/types';
 import {State} from './contract/state';
 import * as forceMoveTrans from './contract/transaction-creators/force-move';
 import * as nitroAdjudicatorTrans from './contract/transaction-creators/nitro-adjudicator';

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -269,9 +269,9 @@ describe('challenge with transaction generator', () => {
   });
   it.each`
     description                                     | appData   | outcome                            | turnNums  | challenger
-    ${'forceMove(0,1) accepted'}                    | ${[0, 0]} | ${[]}                              | ${[0, 1]} | ${1}
-    ${'forceMove(1,2) accepted'}                    | ${[0, 0]} | ${[]}                              | ${[1, 2]} | ${0}
-    ${'forceMove(1,2) accepted, MAX_OUTCOME_ITEMS'} | ${[0, 0]} | ${largeOutcome(MAX_OUTCOME_ITEMS)} | ${[1, 2]} | ${0}
+    ${'challenge(0,1) accepted'}                    | ${[0, 0]} | ${[]}                              | ${[0, 1]} | ${1}
+    ${'challenge(1,2) accepted'}                    | ${[0, 0]} | ${[]}                              | ${[1, 2]} | ${0}
+    ${'challenge(1,2) accepted, MAX_OUTCOME_ITEMS'} | ${[0, 0]} | ${largeOutcome(MAX_OUTCOME_ITEMS)} | ${[1, 2]} | ${0}
   `('$description', async ({description, appData, turnNums, challenger}) => {
     const transactionRequest: ethers.providers.TransactionRequest = createChallengeTransaction(
       [


### PR DESCRIPTION
Following #2963 , I found a few more instances where the old terminology survives. 

As the linked PR does not have a description, I'll record the reasoning here from memory.

It's not ideal to have the same name for a method and a contract. It is also not ideal to use a protocol-specific term where a more self-contained one would do. The change from `forceMove` to `challenge` reduces the overall size of our terminology.
