### PR TITLE
Delete statusOf after a successful concludePushOutcomeAndTransferAll 

### DIFF
--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -111,6 +111,10 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
             sigs
         );
         _transferAllFromAllAssetHolders(channelId, outcomeBytes);
+        // Now put the channel back into "Open" mode. This opens up the possibility
+        // of checkpointing, challenging, or concluding again. But the channel is now completely defunded:
+        // So clients have on reason to do that, nor to care if a counterparty does that.
+        delete statusOf[channelId]; // So that this method leaves no trace on chain whatsoever (for this channel)
     }
 
     /**

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -113,7 +113,7 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
         _transferAllFromAllAssetHolders(channelId, outcomeBytes);
         // Now put the channel back into "Open" mode. This opens up the possibility
         // of checkpointing, challenging, or concluding again. But the channel is now completely defunded:
-        // So clients have on reason to do that, nor to care if a counterparty does that.
+        // So clients have no reason to do that, nor to care if a counterparty does that.
         delete statusOf[channelId]; // So that this method leaves no trace on chain whatsoever (for this channel)
     }
 

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -238,16 +238,8 @@ describe('concludePushOutcomeAndTransferAll', () => {
           receipt.gasUsed
         );
 
-        // Compute expected ChannelDataHash
-        const blockTimestamp = (await provider.getBlock(receipt.blockNumber)).timestamp;
-        const expectedFingerprint = channelDataToStatus({
-          turnNumRecord: 0,
-          finalizesAt: blockTimestamp,
-          outcome,
-        });
-
-        // Check fingerprint against the expected value
-        expect(await NitroAdjudicator.statusOf(channelId)).toEqual(expectedFingerprint);
+        // Check fingerprint is reset (gas optimization)
+        expect(await NitroAdjudicator.statusOf(channelId)).toEqual(initialFingerprint);
 
         // Extract logs
         const {logs} = await (await tx).wait();

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -238,6 +238,9 @@ describe('concludePushOutcomeAndTransferAll', () => {
           receipt.gasUsed
         );
 
+        // experiment:
+        const blockTimestamp = (await provider.getBlock(receipt.blockNumber)).timestamp;
+
         // Check fingerprint is reset (gas optimization)
         expect(await NitroAdjudicator.statusOf(channelId)).toEqual(initialFingerprint);
 

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -60,7 +60,7 @@ async function mineBlocks() {
   }
 }
 
-jest.setTimeout(20_000);
+jest.setTimeout(30_000);
 // The test nitro adjudicator allows us to set channel storage
 const testAdjudicator = new Contract(
   nitroAdjudicatorAddress,


### PR DESCRIPTION
This change saves some gas by undoing the write to adjudicator storage that is currently part of `concludePushOutcomeAndTransferAll`.

Currently, gas costs are high and opportunities to reduce them are a priority. Opportunities should be treated with caution, however, since there is a high chance of introducing new attack vectors. 

This approach is good because it saves a substantial amount of gas, and while it does reduce some of the protection offered by our on-chain code, I believe that it does not introduce new attack vectors, or that the new vectors are easily blocked by some small changes to client behaviour. This can be realised by examining our current security assumptions.

A `finalised` status in the adjudicator is a terminal state and [**prevents**](https://docs.statechannels.org/docs/protocol-tutorial/understand-adjudicator-status#channel-modes) basically any change of state in the adjudicator, including:
- challenges
- concludes
- checkpoints
- respond

We need to keep that state in the machine because of the unhappy path to finalisation, a timed-out challenge. When that implicit state transition happens, the stored information **enables** the stored outcome to be "pushed" into asset holders, using `pushOutcome` and `pushOutcomeAndTransferAll`. In the happy path, however, (covered by `concludePushOutcomeAndTransferAll`), the outcome has already been pushed, and all assets have been transferred out of the channel, too). 

This change makes what was previously enabled, disabled, and what was previously prevented, possible. 

As we currently [hint at in the docs](https://docs.statechannels.org/docs/protocol-tutorial/precautions-and-limits#precautions), state channel client code should reject or ignore channels that are proposed with am "old" `channelNonce` (meaning one previously used by the same set of participants on the same chain). Correct clients (those that carefully uphold this principle) are therefore already prevented from depositing assets into an old channel if they only deposit into a channel during the setup stage.

Clients should therefore also be careful not to deposit assets into a channel that has been finalised. (This is almost the same principle, but not quite: a finalized channel may not necessarily be "old" if it is the most recent for a given `participants` array). A downside of the approach of this PR is that currently, clients can reach out to the chain for information on finalised channels. With this change, they will have to track that information themselves.  This does seem, however, very much in the spirit of state channels (why should we pay high costs to make this information public, when it only concerns a small number of parties?).

Another downside of this approach is that we end up doing some work that we potentially don't need to do:
1) computing and setting some storage that ends up being deleted anyway
2) emitting an event despite the lack of any change in state of the contract

I suggest tackling these in follow up work. 

## :warning: Does this require multiple approvals? [Optional]
Please explain which reason, if any, why this requires more than one approval.
- [x] Is it security related? Yes

---
## Checklist:

### Code quality
- [ ] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [ ] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [ ] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [ ] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [ ] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
