### PR TITLE
Don't run knex-setup-teardown for with-peers test

### DIFF
--- a/packages/server-wallet/jest/jest.with-peers.config.js
+++ b/packages/server-wallet/jest/jest.with-peers.config.js
@@ -1,3 +1,5 @@
 const config = require('./jest.config');
 config.testMatch = ['<rootDir>/src/**/__test-with-peers__/**/?(*.)test.ts'];
+// We don't want to run ./jest/knex-setup-teardown.ts' as it assumes a database called SERVER_WALLET
+config.setupFilesAfterEnv = ['./jest/custom-matchers.ts'];
 module.exports = config;

--- a/packages/server-wallet/jest/jest.with-peers.config.js
+++ b/packages/server-wallet/jest/jest.with-peers.config.js
@@ -1,5 +1,5 @@
 const config = require('./jest.config');
 config.testMatch = ['<rootDir>/src/**/__test-with-peers__/**/?(*.)test.ts'];
-// We don't want to run ./jest/knex-setup-teardown.ts' as it assumes a database called SERVER_WALLET
+// We don't want to run ./jest/knex-setup-teardown.ts' as it assumes a database called server_wallet_test
 config.setupFilesAfterEnv = ['./jest/custom-matchers.ts'];
 module.exports = config;


### PR DESCRIPTION
# Description
Stops the `knex-setup-teardown` for running with the `with-peers` tests.

The `with-peers` tests use their own databases instead of `server_wallet_test `. So when `knex-setup-teardown` runs it results in a lot of [errors](https://circleci.com/api/v1.1/project/github/statechannels/statechannels/59915/output/104/0?file=true&allocation-id=605ce537d2e8bd5c218de1f4-0-build%2F4C7CA54) due to trying to connect to `server_wallet_test` which does not exist for the `with-peers` tests.



