### PR TITLE
Fix resource contention between server-wallet and interop-tests packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,9 +141,14 @@ jobs:
       - run:
           name: wallet setup
           working_directory: packages/server-wallet
+          # Create databases for the server-wallet and interop-tests package tests
           command: |
             SERVER_DB_NAME=server_wallet_test yarn db:create $PSQL_ARGS
             SERVER_DB_NAME=server_wallet_test yarn db:migrate
+
+            SERVER_DB_NAME=interop_test yarn db:create $PSQL_ARGS
+            SERVER_DB_NAME=interop_test yarn db:migrate
+
       - run:
           name: test
           command: |

--- a/packages/interop-tests/jest/chain-setup.ts
+++ b/packages/interop-tests/jest/chain-setup.ts
@@ -11,9 +11,9 @@ export default async function setup(): Promise<void> {
     return;
   }
 
-  process.env['CHAIN_NETWORK_ID'] = '9002';
+  process.env['CHAIN_NETWORK_ID'] = '9003';
   process.env['GANACHE_HOST'] = '0.0.0.0';
-  process.env['GANACHE_PORT'] = '8545';
+  process.env['GANACHE_PORT'] = '8546';
   process.env[
     'RPC_ENDPOINT'
   ] = `http://${process.env['GANACHE_HOST']}:${process.env['GANACHE_PORT']}`;

--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -34,6 +34,11 @@ const chainId = process.env.CHAIN_ID;
 if (!rpcEndpoint) throw new Error('RPC_ENDPOINT must be defined');
 
 const serverConfig = defaultTestConfig({
+  databaseConfiguration: {
+    connection: {
+      database: 'interop_test'
+    }
+  },
   networkConfiguration: {
     chainNetworkID: chainId
       ? parseInt(chainId)

--- a/packages/server-wallet/deployment/deploy.ts
+++ b/packages/server-wallet/deployment/deploy.ts
@@ -15,9 +15,10 @@ export type TestNetworkContext = {
 
 export async function deploy(): Promise<TestNetworkContext> {
   const ethereumPrivateKey = ETHERLIME_ACCOUNTS[0].privateKey;
+  const ganachePort = Number(process.env.GANACHE_PORT);
 
   // TODO: best way to configure this?
-  const deployer = new GanacheDeployer(8545, ethereumPrivateKey);
+  const deployer = new GanacheDeployer(ganachePort, ethereumPrivateKey);
   const {EthAssetHolderArtifact, Erc20AssetHolderArtifact} = ContractArtifacts;
 
   const NITRO_ADJUDICATOR_ADDRESS = await deployer.deploy(


### PR DESCRIPTION
In CircleCi, tests for multiple packages run concurrently. Consequently, two packages cannot use the same database for tests or ganache instance.

This PR fixes the errors in https://app.circleci.com/pipelines/github/statechannels/statechannels/12305/workflows/9b433693-aa21-423d-bbc4-03b07b3e3f52/jobs/60258.