### PR TITLE
test: log out gas cost for increaseAllowance

### DIFF
--- a/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
@@ -68,7 +68,17 @@ describe('deposit', () => {
     await expect(balance.gte(held.add(amount))).toBe(true);
 
     // Increase allowance
-    await (await Token.increaseAllowance(ERC20AssetHolder.address, held.add(amount))).wait(); // Approve enough for setup and main test
+    const {gasUsed: increaseAllowanceGasUsed} = await (
+      await Token.increaseAllowance(ERC20AssetHolder.address, held.add(amount))
+    ).wait(); // Approve enough for setup and main test
+
+    if (!reasonString) {
+      await writeGasConsumption(
+        'erc20-deposit.gas.md',
+        'Token.increaseAllowance',
+        increaseAllowanceGasUsed
+      );
+    }
 
     // Check allowance updated
     const allowance = BigNumber.from(


### PR DESCRIPTION
This change means that we record the amount of gas spent on approving tokens for an ERC20AssetHolder as [an artifact of our CI test suite](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5d85227bbc97ad5ba7cf4fb2/6061c70816220a0c872a496f-0-build/artifacts/home/circleci/project/packages/nitro-protocol/gas-artifacts/erc20-deposit.gas.md?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20210330T141252Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20210330%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=e92b4c32f340ddbc65d15bc4bf1b7043f03b4ea3c5453df091b8e5ecff663066). In fact we tend to use the [`increaseAllowance` method](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/243adff49ce1700e0ecb99fe522fb16cff1d1ddc/contracts/token/ERC20/ERC20.sol#L158-L173) rather than the `approve` method. 

This is an important quantity to measure, since it is a necessary cost incurred in the current architecture, but that we aren't currently recording. 

