### PR TITLE
Implement pure-function DirectFunder in wallet-core

### DIFF
--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -172,7 +172,7 @@ export function openChannelCranker(
     return {objective, actions};
   }
 
-  // Now that
+  // Now that the channel is funded, it's safe to sign the postFS
   if (!signedbyMe(objective, 'postFS', me.signingAddress)) {
     signStateAction('postFS', myPrivateKey, objective, actions);
   }

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -23,7 +23,7 @@ export enum WaitingFor {
 
 const enum Hashes {
   preFundSetup = 'preFundSetup',
-  postFundSetup = 'postFS'
+  postFundSetup = 'postFundSetup'
 }
 
 export type OpenChannelObjective = {
@@ -37,7 +37,7 @@ export type OpenChannelObjective = {
   funding: {amount: Uint256; finalized: boolean};
   // TODO: (ChainService) We will need to store funding requests once this gets hooked up to a chain service
   fundingRequests: {tx: string}[];
-  postFS: SignedStateHash;
+  postFundSetup: SignedStateHash;
 };
 
 export type Action =
@@ -117,12 +117,15 @@ export function openChannelCranker(
             objective.preFundSetup.signatures,
             signatures
           );
-        } else if (hash === objective.postFS.hash) {
-          objective.postFS.signatures = mergeSignatures(objective.postFS.signatures, signatures);
+        } else if (hash === objective.postFundSetup.hash) {
+          objective.postFundSetup.signatures = mergeSignatures(
+            objective.postFundSetup.signatures,
+            signatures
+          );
         } else {
           // TODO: (Errors) Enter an error state here
           throw new Error(
-            `Unexpected state hash ${hash}. Expecting ${objective.preFundSetup.hash} or ${objective.postFS.hash}`
+            `Unexpected state hash ${hash}. Expecting ${objective.preFundSetup.hash} or ${objective.postFundSetup.hash}`
           );
         }
       }

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -1,0 +1,189 @@
+import {ethers} from 'ethers';
+import * as _ from 'lodash';
+
+import {Message} from '../wire-protocol';
+import {BN} from '../bignumber';
+import {addHash, hashState, signState} from '../state-utils';
+import {Address, SignatureEntry, State, StateWithHash, Uint256} from '../types';
+import {serializeMessage} from '../serde/wire-format/serialize';
+
+const WALLET_VERSION = 'pure-function-protocol'; // FIXME where does this come from?
+type Outgoing = any; // FIXME
+
+// FIXME: For the purpose of prototyping, I am ignoring blockchain events.
+type OpenChannelEvent = Message;
+
+type SignedStateHash = {hash: string; signatures: SignatureEntry[]};
+
+export type OpenChannelObjective = {
+  channelId: string;
+  openingState: State;
+  preFS: SignedStateHash;
+  // FIXME: The asset class is _ignored_ here.
+  funding: {amount: Uint256; finalized: boolean};
+  fundingRequests: {tx: string}[];
+  postFS: SignedStateHash;
+};
+
+type Action =
+  | {type: 'sendMessage'; message: Outgoing['params']}
+  // FIXME: What data is required here?
+  | {type: 'deposit'; amount: Uint256};
+
+type Result = {
+  // FIXME: The statuses could be named, like "waitingForDeposit", "waitingForPostFS", etc.
+  status: 'inProgress' | 'success' | 'error';
+  objective: OpenChannelObjective;
+  actions: Action[];
+};
+
+/**
+ *
+ * @param objective
+ * @param event
+ * @param myPrivateKey
+ * @returns Result
+ *
+ * A wallet implementation can then use the result with this sequence of asynchronous operations
+ * 1. record the new objective state as well as the resulting actions
+ * 2. trigger the resulting actions asynchronously
+ * 3. mark the actions as being successful
+ *
+ * If the wallet crashes after 1 & before 3, the wallet can decide to re-trigger
+ * the actions on a case-by-case basis, based on whether the action is safe to
+ * re-trigger.
+ */
+export function openChannelCranker(
+  objective: OpenChannelObjective,
+  event: OpenChannelEvent,
+  myPrivateKey: string
+): Result {
+  const {address} = new ethers.Wallet(myPrivateKey);
+  const me: Address = address as Address;
+
+  // First, receive the message
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const signedState = event.signedStates![0];
+  const hash = hashState(signedState);
+  const {signatures} = signedState;
+
+  if (hash === objective.preFS.hash) {
+    objective.preFS.signatures = mergeSignatures(objective.preFS.signatures, signatures);
+  } else if (hash === objective.postFS.hash) {
+    objective.postFS.signatures = mergeSignatures(objective.postFS.signatures, signatures);
+  } else {
+    throw new Error(
+      `Unexpected state hash ${hash}. Expecting ${objective.preFS.hash} or ${objective.postFS.hash}`
+    );
+  }
+
+  // Then, react:
+  const actions: Action[] = [];
+
+  if (!signedbyMe(objective, 'preFS', me)) {
+    signStateAction('preFS', myPrivateKey, objective, actions);
+  }
+
+  if (!completed(objective, 'preFS')) {
+    return {status: 'inProgress', objective, actions};
+  }
+
+  // Mostly copied from server-wallet/src/protocols/direct-funder
+  const {funding} = objective;
+  const {targetBefore, targetAfter, targetTotal} = utils.fundingMilestone(objective.openingState);
+  // if we're fully funded, we're done
+  if (BN.gte(funding.amount, targetTotal) && funding.finalized) {
+    // This is the only path where the channel is directly funded,
+    // so we move onto postFS
+    // The rest of the paths should **return**.
+  }
+  // if it isn't my turn yet, take no action
+  else if (BN.lt(funding.amount, targetBefore)) {
+    return {status: 'inProgress', objective, actions};
+  }
+  // if my deposit is already on chain, take no action
+  else if (BN.gte(funding.amount, targetAfter)) {
+    return {status: 'inProgress', objective, actions};
+  }
+  // if there's an outstanding chain request, take no action
+  // FIXME: This assumes that each participant deposits exactly once per channel
+  else if (objective.fundingRequests.length === 1) {
+    // FIXME: This should handle timed out
+    return {status: 'inProgress', objective, actions};
+  } else {
+    // otherwise, deposit
+    const amount = BN.sub(targetAfter, funding.amount); // previous checks imply this is >0
+    actions.push({type: 'deposit', amount});
+    return {status: 'inProgress', objective, actions};
+  }
+
+  // Now that
+  if (!signedbyMe(objective, 'postFS', me)) {
+    signStateAction('postFS', myPrivateKey, objective, actions);
+  }
+
+  if (!completed(objective, 'postFS')) {
+    return {status: 'inProgress', objective, actions};
+  } else {
+    return {status: 'success', objective, actions};
+  }
+}
+
+function signedbyMe(
+  objective: OpenChannelObjective,
+  step: 'preFS' | 'postFS',
+  me: Address
+): boolean {
+  return objective[step].signatures.map(e => e.signer).includes(me);
+}
+
+function completed(objective: OpenChannelObjective, step: 'preFS' | 'postFS'): boolean {
+  const {openingState: firstState} = objective;
+  return objective[step].signatures.length === firstState.participants.length;
+}
+
+function signStateAction(
+  key: 'preFS' | 'postFS',
+  myPrivateKey: string,
+  objective: OpenChannelObjective,
+  actions: Action[]
+): Action[] {
+  const {openingState: firstState, channelId} = objective;
+  const {address} = new ethers.Wallet(myPrivateKey);
+  const me: Address = address as Address;
+
+  const turnNum = key === 'preFS' ? 0 : 2 * firstState.participants.length - 1;
+  const state: StateWithHash = addHash({...firstState, turnNum});
+  const signature = signState(state, myPrivateKey);
+  const entry = {signature, signer: me};
+  objective[key].signatures.push(entry);
+
+  const message = serializeMessage(
+    WALLET_VERSION,
+    {walletVersion: WALLET_VERSION, signedStates: [{...state, signatures: [entry]}]},
+    'you',
+    'me',
+    channelId
+  );
+
+  actions.push({type: 'sendMessage', message});
+
+  return actions;
+}
+
+function mergeSignatures(left: SignatureEntry[], right: SignatureEntry[]): SignatureEntry[] {
+  return _.uniqBy(_.concat(left, right), entry => entry.signer);
+}
+
+type FundingMilestone = {
+  targetBefore: Uint256;
+  targetAfter: Uint256;
+  targetTotal: Uint256;
+};
+
+const utils = {
+  fundingMilestone(_state: State): FundingMilestone {
+    throw 'funding milestone unimplemented';
+  }
+};

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -75,10 +75,12 @@ export type OpenChannelResult = {
  * re-trigger.
  */
 export function openChannelCranker(
-  objective: OpenChannelObjective,
+  currentObjectiveState: OpenChannelObjective,
   event: OpenChannelEvent,
   myPrivateKey: string
 ): OpenChannelResult {
+  const objective = _.cloneDeep(currentObjectiveState);
+
   const {participants} = objective.openingState;
   const me = participants[objective.myIndex];
 

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -98,12 +98,19 @@ export function openChannelCranker(
         const hash = hashState(signedState);
         const {signatures} = signedState;
 
+        for (const signature of signatures) {
+          if (!participants.find(p => p.signingAddress === signature.signer)) {
+            // TODO: (Errors) Enter an error state here
+            throw new Error('received a signature from a non-participant');
+          }
+        }
+
         if (hash === objective.preFS.hash) {
           objective.preFS.signatures = mergeSignatures(objective.preFS.signatures, signatures);
         } else if (hash === objective.postFS.hash) {
           objective.postFS.signatures = mergeSignatures(objective.postFS.signatures, signatures);
         } else {
-          // TODO: Enter an error state here
+          // TODO: (Errors) Enter an error state here
           throw new Error(
             `Unexpected state hash ${hash}. Expecting ${objective.preFS.hash} or ${objective.postFS.hash}`
           );

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -30,7 +30,7 @@ export type Action =
   // FIXME: What data is required here?
   | {type: 'deposit'; amount: Uint256};
 
-type Result = {
+export type OpenChannelResult = {
   // FIXME: The statuses could be named, like "waitingForDeposit", "waitingForPostFS", etc.
   status: 'inProgress' | 'success' | 'error';
   objective: OpenChannelObjective;
@@ -57,7 +57,7 @@ export function openChannelCranker(
   objective: OpenChannelObjective,
   event: OpenChannelEvent,
   myPrivateKey: string
-): Result {
+): OpenChannelResult {
   const {participants} = objective.openingState;
   const me = participants[objective.myIndex];
 

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -8,7 +8,6 @@ import {Address, SignatureEntry, State, StateWithHash, Uint256} from '../types';
 
 type AddressedMessage = {recipient: string; message: Message};
 
-// FIXME: For the purpose of prototyping, I am ignoring blockchain events.
 export type OpenChannelEvent =
   | {type: 'MessageReceived'; message: Message}
   | {type: 'FundingUpdated'; amount: Uint256; finalized: boolean};
@@ -21,19 +20,20 @@ export type OpenChannelObjective = {
   myIndex: number;
 
   preFS: SignedStateHash;
-  // FIXME: The asset class is _ignored_ here.
+  // TODO: (ChainService) The asset class is _ignored_ here.
   funding: {amount: Uint256; finalized: boolean};
+  // TODO: (ChainService) We will need to store funding requests once this gets hooked up to a chain service
   fundingRequests: {tx: string}[];
   postFS: SignedStateHash;
 };
 
 export type Action =
   | {type: 'sendMessage'; message: AddressedMessage}
-  // FIXME: What data is required here?
+  // TODO: (ChainService) We will need to include more data once this gets hooked up to a chain service
   | {type: 'deposit'; amount: Uint256};
 
 export type OpenChannelResult = {
-  // FIXME: The statuses could be named, like "waitingForDeposit", "waitingForPostFS", etc.
+  // TODO: The statuses could be named, like "waitingForDeposit", "waitingForPostFS", etc.
   status: 'inProgress' | 'success' | 'error';
   objective: OpenChannelObjective;
   actions: Action[];
@@ -71,10 +71,9 @@ export function openChannelCranker(
       objective.funding.finalized = event.finalized;
       break;
     case 'MessageReceived': {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      // FIXME: Assume there's only one signed state
       const {signedStates} = event.message;
 
+      // TODO: Assume there's only one signed state
       if (signedStates && signedStates[0]) {
         const signedState = signedStates[0];
         const hash = hashState(signedState);
@@ -128,9 +127,9 @@ export function openChannelCranker(
     return {status: 'inProgress', objective, actions};
   }
   // if there's an outstanding chain request, take no action
-  // FIXME: This assumes that each participant deposits exactly once per channel
+  // TODO: (ChainService) This assumes that each participant deposits exactly once per channel
   else if (objective.fundingRequests.length === 1) {
-    // FIXME: This should handle timed out
+    // TODO: (ChainService) This should handle timed out funding requests
     return {status: 'inProgress', objective, actions};
   } else {
     // otherwise, deposit

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -22,7 +22,7 @@ export enum WaitingFor {
 }
 
 const enum Hashes {
-  preFundSetup = 'preFS',
+  preFundSetup = 'preFundSetup',
   postFundSetup = 'postFS'
 }
 
@@ -32,7 +32,7 @@ export type OpenChannelObjective = {
   openingState: State;
   myIndex: number;
 
-  preFS: SignedStateHash;
+  preFundSetup: SignedStateHash;
   // TODO: (ChainService) The asset class is _ignored_ here.
   funding: {amount: Uint256; finalized: boolean};
   // TODO: (ChainService) We will need to store funding requests once this gets hooked up to a chain service
@@ -112,14 +112,17 @@ export function openChannelCranker(
           }
         }
 
-        if (hash === objective.preFS.hash) {
-          objective.preFS.signatures = mergeSignatures(objective.preFS.signatures, signatures);
+        if (hash === objective.preFundSetup.hash) {
+          objective.preFundSetup.signatures = mergeSignatures(
+            objective.preFundSetup.signatures,
+            signatures
+          );
         } else if (hash === objective.postFS.hash) {
           objective.postFS.signatures = mergeSignatures(objective.postFS.signatures, signatures);
         } else {
           // TODO: (Errors) Enter an error state here
           throw new Error(
-            `Unexpected state hash ${hash}. Expecting ${objective.preFS.hash} or ${objective.postFS.hash}`
+            `Unexpected state hash ${hash}. Expecting ${objective.preFundSetup.hash} or ${objective.postFS.hash}`
           );
         }
       }

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -12,7 +12,7 @@ export type OpenChannelEvent =
   | {type: 'MessageReceived'; message: Message}
   | {type: 'FundingUpdated'; amount: Uint256; finalized: boolean};
 
-type SignedStateHash = {hash: string; signatures: SignatureEntry[]};
+export type SignedStateHash = {hash: string; signatures: SignatureEntry[]};
 
 export enum WaitingFor {
   theirPreFundSetup = 'DirectFunder.theirPreFundSetup',

--- a/packages/wallet-core/src/state-utils.ts
+++ b/packages/wallet-core/src/state-utils.ts
@@ -22,7 +22,8 @@ import {
   SimpleAllocation,
   SignatureEntry,
   makeAddress,
-  Address
+  Address,
+  Hashed
 } from './types';
 import {BN} from './bignumber';
 
@@ -242,3 +243,8 @@ export function nextState(state: State, outcome: Outcome): State {
 
   return {...state, turnNum: state.turnNum + 1, outcome};
 }
+
+export const addHash = <T extends State = State>(s: T): T & Hashed => ({
+  ...s,
+  stateHash: hashState(s)
+});

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -56,7 +56,7 @@ const initial: OpenChannelObjective = {
   openingState,
   status: WaitingFor.theirPreFundSetup,
   myIndex: 0,
-  preFS: {hash: richPreFS.stateHash, signatures: []},
+  preFundSetup: {hash: richPreFS.stateHash, signatures: []},
   funding: {amount: BN.from(0), finalized: true},
   fundingRequests: [],
   postFS: {hash: richPostFS.stateHash, signatures: []}
@@ -99,7 +99,7 @@ test('pure objective cranker', () => {
     nullEvent,
     {
       status: WaitingFor.theirPreFundSetup,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [{signer: participants.A.signingAddress}]
       },
@@ -117,7 +117,7 @@ test('pure objective cranker', () => {
     output.actions[0],
     {
       status: WaitingFor.safeToDeposit,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -138,7 +138,7 @@ test('pure objective cranker', () => {
     output.actions[0],
     {
       status: WaitingFor.channelFunded,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -160,7 +160,7 @@ test('pure objective cranker', () => {
     alicesDeposit,
     {
       status: WaitingFor.channelFunded,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -181,7 +181,7 @@ test('pure objective cranker', () => {
     alicesDeposit,
     {
       status: WaitingFor.channelFunded,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -203,7 +203,7 @@ test('pure objective cranker', () => {
     bobsDeposit,
     {
       status: WaitingFor.channelFunded,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -224,7 +224,7 @@ test('pure objective cranker', () => {
     bobsDeposit,
     {
       status: WaitingFor.channelFunded,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -250,7 +250,7 @@ test('pure objective cranker', () => {
     finalFundingEvent,
     {
       status: WaitingFor.theirPostFundState,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -272,7 +272,7 @@ test('pure objective cranker', () => {
     finalFundingEvent,
     {
       status: WaitingFor.theirPostFundState,
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -294,7 +294,7 @@ test('pure objective cranker', () => {
     bobsPostFS,
     {
       status: 'success',
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -321,7 +321,7 @@ test('pure objective cranker', () => {
     alicesPostFS,
     {
       status: 'success',
-      preFS: {
+      preFundSetup: {
         hash: richPreFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -59,7 +59,7 @@ const initial: OpenChannelObjective = {
   preFundSetup: {hash: richPreFS.stateHash, signatures: []},
   funding: {amount: BN.from(0), finalized: true},
   fundingRequests: [],
-  postFS: {hash: richPostFS.stateHash, signatures: []}
+  postFundSetup: {hash: richPostFS.stateHash, signatures: []}
 };
 
 test('pure objective cranker', () => {
@@ -105,7 +105,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(0), finalized: true},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: []}
+      postFundSetup: {hash: richPostFS.stateHash, signatures: []}
     },
     [{type: 'sendMessage', message: {recipient: 'bob', message: expect.any(Object)}}]
   );
@@ -126,7 +126,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(0), finalized: true},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: []}
+      postFundSetup: {hash: richPostFS.stateHash, signatures: []}
     },
     [{type: 'sendMessage', message: {recipient: 'alice'}}]
   );
@@ -147,7 +147,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(0), finalized: true},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: []}
+      postFundSetup: {hash: richPostFS.stateHash, signatures: []}
     },
     [{type: 'deposit', amount: BN.from(1)}]
   );
@@ -169,7 +169,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(1), finalized: false},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: []}
+      postFundSetup: {hash: richPostFS.stateHash, signatures: []}
     },
     []
   );
@@ -190,7 +190,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(1), finalized: false},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: []}
+      postFundSetup: {hash: richPostFS.stateHash, signatures: []}
     },
     [{type: 'deposit', amount: BN.from(2)}]
   );
@@ -212,7 +212,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(3), finalized: false},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: []}
+      postFundSetup: {hash: richPostFS.stateHash, signatures: []}
     },
     []
   );
@@ -233,7 +233,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(3), finalized: false},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: []}
+      postFundSetup: {hash: richPostFS.stateHash, signatures: []}
     },
     []
   );
@@ -259,7 +259,10 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(3), finalized: true},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: [{signer: participants.B.signingAddress}]}
+      postFundSetup: {
+        hash: richPostFS.stateHash,
+        signatures: [{signer: participants.B.signingAddress}]
+      }
     },
     [{type: 'sendMessage', message: {recipient: 'alice'}}]
   );
@@ -281,7 +284,10 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(3), finalized: true},
       fundingRequests: [],
-      postFS: {hash: richPostFS.stateHash, signatures: [{signer: participants.A.signingAddress}]}
+      postFundSetup: {
+        hash: richPostFS.stateHash,
+        signatures: [{signer: participants.A.signingAddress}]
+      }
     },
     [{type: 'sendMessage', message: {recipient: 'bob'}}]
   );
@@ -303,7 +309,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(3), finalized: true},
       fundingRequests: [],
-      postFS: {
+      postFundSetup: {
         hash: richPostFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},
@@ -330,7 +336,7 @@ test('pure objective cranker', () => {
       },
       funding: {amount: BN.from(3), finalized: true},
       fundingRequests: [],
-      postFS: {
+      postFundSetup: {
         hash: richPostFS.stateHash,
         signatures: [
           {signer: participants.A.signingAddress},

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -226,7 +226,107 @@ test('pure objective cranker', () => {
     },
     []
   );
+  const finalFundingEvent: OpenChannelEvent = {
+    type: 'FundingUpdated',
+    amount: currentState.B.funding.amount,
+    finalized: true
+  };
 
+  // 8. Bob receives deposit action 2 (FINALIZED), triggers postFS action 1
+  output = crankAndExpect(
+    'B',
+    currentState,
+    finalFundingEvent,
+    {
+      preFS: {
+        hash: richPreFS.stateHash,
+        signatures: [
+          {signer: participants.A.signingAddress},
+          {signer: participants.B.signingAddress}
+        ]
+      },
+      funding: {amount: BN.from(3), finalized: true},
+      fundingRequests: [],
+      postFS: {hash: richPostFS.stateHash, signatures: [{signer: participants.B.signingAddress}]}
+    },
+    [{type: 'sendMessage', message: {recipient: 'alice'}}]
+  );
+  const bobsPostFS = output.actions[0];
+
+  // 9. Alice receives deposit action 2 (FINALIZED), triggers postFS action 2
+  output = crankAndExpect(
+    'A',
+    currentState,
+    finalFundingEvent,
+    {
+      preFS: {
+        hash: richPreFS.stateHash,
+        signatures: [
+          {signer: participants.A.signingAddress},
+          {signer: participants.B.signingAddress}
+        ]
+      },
+      funding: {amount: BN.from(3), finalized: true},
+      fundingRequests: [],
+      postFS: {hash: richPostFS.stateHash, signatures: [{signer: participants.A.signingAddress}]}
+    },
+    [{type: 'sendMessage', message: {recipient: 'bob'}}]
+  );
+  const alicesPostFS = output.actions[0];
+
+  // 10. Alice receives postFS event 1, is finished
+  output = crankAndExpect(
+    'A',
+    currentState,
+    bobsPostFS,
+    {
+      preFS: {
+        hash: richPreFS.stateHash,
+        signatures: [
+          {signer: participants.A.signingAddress},
+          {signer: participants.B.signingAddress}
+        ]
+      },
+      funding: {amount: BN.from(3), finalized: true},
+      fundingRequests: [],
+      postFS: {
+        hash: richPostFS.stateHash,
+        signatures: [
+          {signer: participants.A.signingAddress},
+          {signer: participants.B.signingAddress}
+        ]
+      }
+    },
+    []
+  );
+
+  // 11. Bob receives postFS event 1, is finished
+  output = crankAndExpect(
+    'B',
+    currentState,
+    alicesPostFS,
+    {
+      preFS: {
+        hash: richPreFS.stateHash,
+        signatures: [
+          {signer: participants.A.signingAddress},
+          {signer: participants.B.signingAddress}
+        ]
+      },
+      funding: {amount: BN.from(3), finalized: true},
+      fundingRequests: [],
+      postFS: {
+        hash: richPostFS.stateHash,
+        signatures: [
+          {signer: participants.A.signingAddress},
+          {signer: participants.B.signingAddress}
+        ]
+      }
+    },
+    []
+  );
+
+  // To satisfy a jest ts-lint rule, we need to put a token expectation within the test block
   expect(output).toBeDefined();
 });
 

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -2,7 +2,7 @@ import {ethers} from 'ethers';
 import * as _ from 'lodash';
 
 import {unreachable} from '../utils';
-import {addHash, calculateChannelId, createSignatureEntry, signState} from '../state-utils';
+import {addHash, calculateChannelId} from '../state-utils';
 import {BN} from '../bignumber';
 import {
   Action,

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -1,0 +1,71 @@
+import {ethers} from 'ethers';
+import * as _ from 'lodash';
+
+import {addHash} from '../state-utils';
+import {BN} from '../bignumber';
+import {openChannelCranker, OpenChannelObjective} from '../protocols/direct-funder';
+import {Address, makeAddress, SimpleAllocation, State} from '../types';
+
+import {ONE_DAY, participants, signStateHelper} from './test-helpers';
+const {A: participantA, B: participantB} = participants;
+
+const {AddressZero} = ethers.constants;
+jest.setTimeout(10_000);
+
+let channelId: string;
+
+test('pure objective cranker', () => {
+  const outcome: SimpleAllocation = {
+    type: 'SimpleAllocation',
+    allocationItems: [
+      {destination: participantA.destination, amount: BN.from(1)},
+      {destination: participantB.destination, amount: BN.from(1)}
+    ],
+    assetHolderAddress: makeAddress(AddressZero) // must be even length
+  };
+
+  const openingState: State = {
+    participants: [participantA, participantB],
+    chainId: '0x01',
+    challengeDuration: ONE_DAY,
+    channelNonce: 0,
+    appDefinition: ethers.constants.AddressZero as Address,
+    appData: makeAddress(AddressZero), // must be even length
+    turnNum: 0,
+    outcome,
+    isFinal: false
+  };
+
+  const richPreFS = addHash(openingState);
+  const richPostFS = addHash({...openingState, turnNum: 3});
+
+  const objective: OpenChannelObjective = {
+    channelId,
+    openingState,
+    preFS: {hash: richPreFS.stateHash, signatures: []},
+    funding: {amount: BN.from(0), finalized: true},
+    fundingRequests: [],
+    postFS: {hash: richPostFS.stateHash, signatures: []}
+  };
+
+  expect(
+    openChannelCranker(
+      objective,
+      {signedStates: [signStateHelper(richPreFS, 'A')]},
+      participantA.privateKey
+    )
+  ).toMatchObject({
+    actions: [],
+    objective: {
+      preFS: {hash: richPreFS.stateHash, signatures: [{signer: participants.A.signingAddress}]}
+    }
+  });
+
+  expect(() =>
+    openChannelCranker(
+      objective,
+      {signedStates: [signStateHelper(richPreFS, 'B')]},
+      participantA.privateKey
+    )
+  ).toThrow('funding milestone unimplemented');
+});

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -9,7 +9,8 @@ import {
   openChannelCranker,
   OpenChannelEvent,
   OpenChannelObjective,
-  OpenChannelResult
+  OpenChannelResult,
+  WaitingFor
 } from '../protocols/direct-funder';
 import {Address, makeAddress, SimpleAllocation, State} from '../types';
 
@@ -53,6 +54,7 @@ test('pure objective cranker', () => {
   const initial: OpenChannelObjective = {
     channelId,
     openingState,
+    status: WaitingFor.theirPreFundSetup,
     myIndex: 0,
     preFS: {hash: richPreFS.stateHash, signatures: []},
     funding: {amount: BN.from(0), finalized: true},
@@ -94,6 +96,7 @@ test('pure objective cranker', () => {
     currentState,
     nullEvent,
     {
+      status: WaitingFor.theirPreFundSetup,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [{signer: participants.A.signingAddress}]
@@ -111,6 +114,7 @@ test('pure objective cranker', () => {
     currentState,
     output.actions[0],
     {
+      status: WaitingFor.safeToDeposit,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -131,6 +135,7 @@ test('pure objective cranker', () => {
     currentState,
     output.actions[0],
     {
+      status: WaitingFor.channelFunded,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -152,6 +157,7 @@ test('pure objective cranker', () => {
     currentState,
     alicesDeposit,
     {
+      status: WaitingFor.channelFunded,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -172,6 +178,7 @@ test('pure objective cranker', () => {
     currentState,
     alicesDeposit,
     {
+      status: WaitingFor.channelFunded,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -193,6 +200,7 @@ test('pure objective cranker', () => {
     currentState,
     bobsDeposit,
     {
+      status: WaitingFor.channelFunded,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -213,6 +221,7 @@ test('pure objective cranker', () => {
     currentState,
     bobsDeposit,
     {
+      status: WaitingFor.channelFunded,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -238,6 +247,7 @@ test('pure objective cranker', () => {
     currentState,
     finalFundingEvent,
     {
+      status: WaitingFor.theirPostFundState,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -259,6 +269,7 @@ test('pure objective cranker', () => {
     currentState,
     finalFundingEvent,
     {
+      status: WaitingFor.theirPostFundState,
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -280,6 +291,7 @@ test('pure objective cranker', () => {
     currentState,
     bobsPostFS,
     {
+      status: 'success',
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [
@@ -306,6 +318,7 @@ test('pure objective cranker', () => {
     currentState,
     alicesPostFS,
     {
+      status: 'success',
       preFS: {
         hash: richPreFS.stateHash,
         signatures: [

--- a/packages/wallet-core/src/tests/test-helpers.ts
+++ b/packages/wallet-core/src/tests/test-helpers.ts
@@ -20,6 +20,14 @@ export const participants = {
     destination: makeDestination(
       '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
     )
+  },
+  H: {
+    privateKey: '0xc9a5f30ceaf2a0ccbb30d50aa9de3f273aa6e76f89e26090c42775e9647f5b6a',
+    signingAddress: makeAddress('0x33335846dd121B14B4C313Cb6b766F09e75890dF'),
+    participantId: 'hub',
+    destination: makeDestination(
+      '0x00000000000000000000000000000000000000000000000000000000000ffff3'
+    )
   }
 };
 

--- a/packages/wallet-core/src/tests/test-helpers.ts
+++ b/packages/wallet-core/src/tests/test-helpers.ts
@@ -8,7 +8,7 @@ export const participants = {
   A: {
     privateKey: '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318',
     signingAddress: makeAddress('0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'),
-    participantId: 'a',
+    participantId: 'alice',
     destination: makeDestination(
       '0x00000000000000000000000000000000000000000000000000000000000aaaa1'
     )
@@ -16,7 +16,7 @@ export const participants = {
   B: {
     privateKey: '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727',
     signingAddress: makeAddress('0x2222E21c8019b14dA16235319D34b5Dd83E644A9'),
-    participantId: 'b',
+    participantId: 'bob',
     destination: makeDestination(
       '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
     )

--- a/packages/wallet-core/src/tests/test-helpers.ts
+++ b/packages/wallet-core/src/tests/test-helpers.ts
@@ -1,0 +1,31 @@
+import {createSignatureEntry} from '../state-utils';
+import {makeAddress, SignedState, State} from '../types';
+import {makeDestination} from '../utils';
+
+export const ONE_DAY = 86400;
+
+export const participants = {
+  A: {
+    privateKey: '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318',
+    signingAddress: makeAddress('0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'),
+    participantId: 'a',
+    destination: makeDestination(
+      '0x00000000000000000000000000000000000000000000000000000000000aaaa1'
+    )
+  },
+  B: {
+    privateKey: '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727',
+    signingAddress: makeAddress('0x2222E21c8019b14dA16235319D34b5Dd83E644A9'),
+    participantId: 'b',
+    destination: makeDestination(
+      '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
+    )
+  }
+};
+
+type Peer = keyof typeof participants;
+export function signStateHelper(state: State, by: Peer): SignedState {
+  const entry = createSignatureEntry(state, participants[by].privateKey);
+
+  return {...state, signatures: [entry]};
+}


### PR DESCRIPTION
# Description
This implements one pure-function variation of a direct-funder "protocol", which is the first step towards #3418.

This introduces a "rich objective" data structure called, for lack of more creativity, an `OpenChannelObjective`. (I suggest we review terminology here.) This "rich objective" stores:
- the target channel id
- the goal starting state of the target channel
- my index in the channel

It then stores some additional data:
- signatures on the expected preFS state's hash
- on-chain funding status
- funding requests submitted
- signatures on the expected postFS state's hash

The cranker receives the current "objective state" as well as an event. This updates the "objective state" and generates some actions. (In other words, the cranker is a state chart!)

This implementation is a deviation from the current wallet behaviour. The current wallet
1. adds arbitrary states into the `Store`, or updates the funding on the channel
2. runs the objective cranker, asynchronously triggering actions as well as updating the store

IE. in my implementation here, 1 & 2 are both consumed by the logic of the cranker. This allows the cranker to **reject state updates that are not a part of the objective**. (I would suggest _aborting the protocol_ in this event, as it is a sign that your peer is not functioning according to the protocol.) In other words, states are _whitelisted_ while the objective is running.

### What are the benefits?
See [here](https://www.notion.so/statechannels/RFC-10-State-Channel-Protocol-SCP-fc7e468a160c45bcbf5b28653dcf7ff6#8d4e0c219c854b64b289c64dfeacbf29).

### How is the rich objective meant to be stored?
This change does not prescribe how the rich objective is meant to be stored in the DB.

The naive way is to directly store the rich objective in the DB. This is an _easy_ solution, and may be preferred. Indeed, it would mean that to crank an objective, we would only need to execute one, easy query.

However, there is no reason we cannot use the current `channels` table in either the Postgres store or the Dexie backend to store the pre/postFS states + funding data. We would then need to write "adapter code" to compute the rich data structure accepted by the cranker.

Storing the updated rich objective within the current `channels` table is more subtle, but still fine. Considering the recommendation [here](https://www.notion.so/statechannels/RFC-8-Securing-Private-StateChannel-Key-c4f2945172d84db2b84220d64502e38c#8dfd6d2275714c2399655a7c6738248d), a wallet will likely provide a `Keyring` that will be used to (asynchronously) sign states. In this case, we would probably change the cranker to _declare which hashes the keyring should sign_, rather than accept a private key by the cranker. In this case, when the cranker generates a `SendState` action, the imperative shell would
1. use the keyring to sign the state
2. attach the signature to the given state, and send the message
3. attach the signature to the given state, and store it in the `channels` table
This can be factored out to be re-usable by any protocol (or even an `AppManager`)

The naive approach is my preference, as it is easy to write, and also _limits what states you have to consider_ via the schema itself. On the contrary, if we fetch a record from the `channels` table, where an arbitrary bag of states can be stored, we have to ask these kinds of questions about code:
- do we have a supported state?
- if not, what's the turn number & outcome of the latest state?
- does the latest state match with the state we agreed to open the channel with?
- is the outcome even an allocation outcome? maybe it's a guarantor channel?
We can choose to ignore these questions via type assertions, but I think that's worse than creating a whitelist of the explicit states you're expecting, and comparing them against that!

It is a **shortcoming** of this approach that we either need to write an awkward adapter or change our storage to use this cranker.

## How Has This Been Tested? [Optional] 

I hand-wrote a specific sequence of events in `direct-funder.test.ts`. As indicated there, a more robust test of the protocol would consider all of the permutations of the order of events. I suggest this as future work. 

## :warning: Does this require multiple approvals? [Optional]
I think so? It is a significant change to wallet design.

I have not quite finished this [design doc](https://www.notion.so/statechannels/RFC-10-State-Channel-Protocol-SCP-fc7e468a160c45bcbf5b28653dcf7ff6), but it might still be worth a read.

---
## Checklist:

### Code quality
- [ ] ~I have separated logic changes from refactor changes (formatting, renames, etc.)~
- [ ] ~I have written clear commit messages~
       My apologies. I am out of practice writing code, and impatiently put this together.
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
