### PR TITLE
Create Channels API

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -189,6 +189,11 @@ export function getDatabaseConnectionConfig(config: EngineConfig): DatabaseConne
     port: number;
 };
 
+// @public (undocumented)
+export function hasNewObjective(response: SingleChannelOutput): response is SingleChannelOutput & {
+    newObjective: WalletObjective;
+};
+
 // @public
 export type IncomingEngineConfig = RequiredEngineConfig & Partial<OptionalEngineConfig>;
 
@@ -330,7 +335,9 @@ export class SingleThreadedEngine extends EventEmitter<EventEmitterType> impleme
     closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     static create(engineConfig: IncomingEngineConfig): Promise<SingleThreadedEngine>;
-    createChannel(args: CreateChannelParams): Promise<MultipleChannelOutput>;
+    createChannel(args: CreateChannelParams): Promise<SingleChannelOutput & {
+        newObjective: WalletObjective;
+    }>;
     createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
     createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
     destroy(): Promise<void>;
@@ -383,7 +390,7 @@ export function validateEngineConfig(config: Record<string, any>): {
 
 // Warnings were encountered during analysis:
 //
-// src/engine/types.ts:23:3 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
+// src/engine/types.ts:72:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -157,12 +157,12 @@ it('Create a directly funded channel between two engines ', async () => {
   // PreFund0
   const preFundA = await a.createChannel(channelParams);
 
-  const channelId = preFundA.channelResults[0].channelId;
+  const channelId = preFundA.channelResult.channelId;
 
   const aBalanceInit = await getBalance(aAddress);
   const bBalanceInit = await getBalance(bAddress);
 
-  expect(getChannelResultFor(channelId, preFundA.channelResults)).toMatchObject({
+  expect(preFundA.channelResult).toMatchObject({
     status: 'opening',
     turnNum: 0,
   });

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -47,7 +47,7 @@ it('Create a directly-funded channel between two engines, of which one crashes m
   // PreFund0
   const resultA0 = await peerEngines.a.createChannel(createChannelParams);
 
-  channelId = resultA0.channelResults[0].channelId;
+  channelId = resultA0.channelResult.channelId;
 
   await expectLatestStateToMatch(channelId, peerEngines.a, {
     status: 'opening',

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -48,7 +48,7 @@ it('Create a directly funded channel between two engines ', async () => {
   // PreFund0
   const resultA0 = await peerEngines.a.createChannel(createChannelParams);
   await messageService.send(getMessages(resultA0));
-  channelId = resultA0.channelResults[0].channelId;
+  channelId = resultA0.channelResult.channelId;
 
   //      PreFund0B
   const resultB1 = await peerEngines.b.joinChannel({channelId});

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -45,7 +45,7 @@ it('Create a fake-funded channel between two engines ', async () => {
   // PreFund0
   const aCreateChannelOutput = await peerEngines.a.createChannel(channelParams);
   await messageService.send(getMessages(aCreateChannelOutput));
-  channelId = aCreateChannelOutput.channelResults[0].channelId;
+  channelId = aCreateChannelOutput.channelResult.channelId;
 
   expectLatestStateToMatch(channelId, peerEngines.a, {
     status: 'opening',

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
@@ -168,7 +168,7 @@ describe('Funding a single channel with 100% of available ledger funds', () => {
     const params = testCreateChannelParams(10, 10, ledgerChannelId);
 
     const {
-      channelResults: [{channelId}],
+      channelResult: {channelId},
       outbox,
     } = await peerEngines.a.createChannel(params);
 
@@ -244,7 +244,7 @@ describe('Funding a single channel with 50% of ledger funds', () => {
     const params = testCreateChannelParams(5, 5, ledgerChannelId);
 
     const {
-      channelResults: [{channelId}],
+      channelResult: {channelId},
       outbox,
     } = await peerEngines.a.createChannel(params);
 
@@ -595,7 +595,7 @@ describe('Funding multiple channels syncronously without enough funds', () => {
     const params = testCreateChannelParams(APP_WANTS, APP_WANTS, ledgerChannelId);
 
     const resultA = await peerEngines.a.createChannel(params);
-    const channelId = resultA.channelResults[0].channelId;
+    const {channelId} = resultA.channelResult;
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, resultA.outbox));
     const resultB = await peerEngines.b.joinChannel({channelId});
 
@@ -636,8 +636,8 @@ describe('Funding multiple channels concurrently (one sided)', () => {
     const create2 = await peerEngines.a.createChannel(params);
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, create2.outbox));
 
-    const channelId1 = create1.channelResults[0].channelId;
-    const channelId2 = create2.channelResults[0].channelId;
+    const channelId1 = create1.channelResult.channelId;
+    const channelId2 = create2.channelResult.channelId;
 
     const {outbox: join1} = await peerEngines.b.joinChannel({channelId: channelId1});
     const {outbox: join2} = await peerEngines.b.joinChannel({channelId: channelId2});
@@ -675,8 +675,8 @@ async function proposeMultipleChannelsToEachother(
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, createA.outbox));
     const createB = await peerEngines.b.createChannel(params);
     await peerEngines.a.pushMessage(getPayloadFor(participantA.participantId, createB.outbox));
-    aToJoin.push(createB.channelResults[0].channelId);
-    bToJoin.push(createA.channelResults[0].channelId);
+    aToJoin.push(createB.channelResult.channelId);
+    bToJoin.push(createA.channelResult.channelId);
   }
   return {aToJoin, bToJoin};
 }
@@ -725,12 +725,12 @@ describe('Funding multiple channels concurrently (two sides)', () => {
     const params = testCreateChannelParams(1, 1, ledgerChannelId);
 
     const {
-      channelResults: [{channelId: channelId1}],
+      channelResult: {channelId: channelId1},
       outbox: outboxA1,
     } = await peerEngines.a.createChannel(params);
 
     const {
-      channelResults: [{channelId: channelId2}],
+      channelResult: {channelId: channelId2},
       outbox: outboxA2,
     } = await peerEngines.a.createChannel(params);
 
@@ -738,12 +738,12 @@ describe('Funding multiple channels concurrently (two sides)', () => {
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, outboxA2));
 
     const {
-      channelResults: [{channelId: channelId3}],
+      channelResult: {channelId: channelId3},
       outbox: outboxB3,
     } = await peerEngines.b.createChannel(params);
 
     const {
-      channelResults: [{channelId: channelId4}],
+      channelResult: {channelId: channelId4},
       outbox: outboxB4,
     } = await peerEngines.b.createChannel(params);
 

--- a/packages/server-wallet/src/__test-with-peers__/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/ensure-objectives.test.ts
@@ -73,8 +73,7 @@ describe('EnsureObjectives', () => {
       await peerEngines.b.joinChannels([channelId]);
     });
 
-    await expect(wallet.createChannels([getCreateChannelsArgs()])).rejects.toThrow(
-      'Unable to ensure objectives'
-    );
+    const {done} = (await wallet.createChannels([getCreateChannelsArgs()]))[0];
+    await expect(done).resolves.toMatchObject({type: 'EnsureObjectiveFailed'});
   });
 });

--- a/packages/server-wallet/src/__test-with-peers__/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/ensure-objectives.test.ts
@@ -8,10 +8,10 @@ import {
   peersTeardown,
   peerEngines,
 } from '../../jest/with-peers-setup-teardown';
-import {Wallet} from '../wallet';
 import {LatencyOptions} from '../message-service/test-message-service';
 import {WalletObjective} from '../models/objective';
 import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
+import {Wallet} from '../wallet';
 
 jest.setTimeout(60_000);
 
@@ -54,7 +54,9 @@ describe('EnsureObjectives', () => {
         await peerEngines.b.joinChannels([o.data.targetChannelId]);
       });
 
-      await expect(wallet.createChannels(getCreateChannelsArgs(), 10)).resolves.not.toThrow();
+      await expect(
+        wallet.createChannels(Array(10).fill(getCreateChannelsArgs()))
+      ).resolves.not.toThrow();
     }
   );
 
@@ -71,7 +73,7 @@ describe('EnsureObjectives', () => {
       await peerEngines.b.joinChannels([channelId]);
     });
 
-    await expect(wallet.createChannels(getCreateChannelsArgs(), 1)).rejects.toThrow(
+    await expect(wallet.createChannels([getCreateChannelsArgs()])).rejects.toThrow(
       'Unable to ensure objectives'
     );
   });

--- a/packages/server-wallet/src/__test-with-peers__/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/ensure-objectives.test.ts
@@ -11,7 +11,7 @@ import {
 import {LatencyOptions} from '../message-service/test-message-service';
 import {WalletObjective} from '../models/objective';
 import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
-import {Wallet} from '../wallet';
+import {Wallet} from '../wallet/wallet';
 
 jest.setTimeout(60_000);
 

--- a/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
@@ -18,7 +18,7 @@ test('Objectives can be synced if a message is lost', async () => {
   // We mimic not receiving a message containing objectives
   const messageToLose = await peerEngines.a.createChannel(createChannelParams);
 
-  const channelId = messageToLose.channelResults[0].channelId;
+  const channelId = messageToLose.channelResult.channelId;
   const objectiveId = `OpenChannel-${channelId}`;
 
   // Only A should have the objective since we "lost" the message
@@ -43,7 +43,7 @@ test('handles the objective being synced even if no message is lost', async () =
 
   const messageResponse = await peerEngines.a.createChannel(createChannelParams);
 
-  const channelId = messageResponse.channelResults[0].channelId;
+  const channelId = messageResponse.channelResult.channelId;
   const objectiveId = `OpenChannel-${channelId}`;
 
   // The initial message is received
@@ -83,7 +83,7 @@ test('Can successfully push the sync objective message multiple times', async ()
   // We mimic not receiving a message containing objectives
   const messageToLose = await peerEngines.a.createChannel(createChannelParams);
 
-  const channelId = messageToLose.channelResults[0].channelId;
+  const channelId = messageToLose.channelResult.channelId;
   const objectiveId = `OpenChannel-${channelId}`;
 
   // Only A should have the objective since we "lost" the message

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -72,6 +72,7 @@ import {
   Output,
   EngineInterface,
   EngineEvent,
+  hasNewObjective,
 } from './types';
 import {EngineResponse} from './engine-response';
 
@@ -438,14 +439,21 @@ export class SingleThreadedEngine
    * @param args - Parameters to create the channel with.
    * @returns A promise that resolves to the channel output.
    */
-  async createChannel(args: CreateChannelParams): Promise<SingleChannelOutput> {
+  async createChannel(
+    args: CreateChannelParams
+  ): Promise<SingleChannelOutput & {newObjective: WalletObjective}> {
     const response = EngineResponse.initialize();
 
     await this._createChannel(response, args, 'app');
 
     // NB: We intentionally do not call this.takeActions, because there are no actions to take when creating a channel.
 
-    return response.singleChannelOutput();
+    const result = response.singleChannelOutput();
+    if (!hasNewObjective(result)) {
+      throw new Error('No new objective created for create channel');
+    } else {
+      return result;
+    }
   }
   /**
    * Creates multiple channels with the same parameters. See {@link SingleThreadedEngine.createChannel}.

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -438,14 +438,14 @@ export class SingleThreadedEngine
    * @param args - Parameters to create the channel with.
    * @returns A promise that resolves to the channel output.
    */
-  async createChannel(args: CreateChannelParams): Promise<MultipleChannelOutput> {
+  async createChannel(args: CreateChannelParams): Promise<SingleChannelOutput> {
     const response = EngineResponse.initialize();
 
     await this._createChannel(response, args, 'app');
 
     // NB: We intentionally do not call this.takeActions, because there are no actions to take when creating a channel.
 
-    return response.multipleChannelOutput();
+    return response.singleChannelOutput();
   }
   /**
    * Creates multiple channels with the same parameters. See {@link SingleThreadedEngine.createChannel}.

--- a/packages/server-wallet/src/engine/types.ts
+++ b/packages/server-wallet/src/engine/types.ts
@@ -66,3 +66,9 @@ export interface EngineInterface {
   pushMessage(m: unknown): Promise<MultipleChannelOutput>;
   pushUpdate(m: unknown): Promise<SingleChannelOutput>;
 }
+
+export function hasNewObjective(
+  response: SingleChannelOutput
+): response is SingleChannelOutput & {newObjective: WalletObjective} {
+  return !!response.newObjective;
+}

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -31,7 +31,7 @@ function extractReferencedChannels(objective: Objective): string[] {
   }
 }
 
-type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
+export type ObjectiveStatus = 'pending' | 'approved' | 'rejected' | 'failed' | 'succeeded';
 
 /**
  * A WalletObjective is a wire objective with a status, waitingFor state-string, timestamps and an objectiveId

--- a/packages/server-wallet/src/wallet/index.ts
+++ b/packages/server-wallet/src/wallet/index.ts
@@ -1,0 +1,2 @@
+export {Wallet} from './wallet';
+export * from './types';

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -38,11 +38,6 @@ export type ObjectiveSuccess = {type: 'Success'};
 export type ObjectiveDoneResult = ObjectiveSuccess | ObjectiveError;
 
 /**
- * TODO: Can the channelId just be on the objective?
- * Or do we anticipate objectives that cover multiple channels?
- */
-
-/**
  * This is what is returned for any objective related API call
  *
  */

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -33,7 +33,7 @@ export type InternalError = {
   error: Error;
 };
 
-export type ObjectiveSuccess = {type: 'Success'};
+export type ObjectiveSuccess = {channelId: string; type: 'Success'};
 
 export type ObjectiveDoneResult = ObjectiveSuccess | ObjectiveError;
 

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -1,0 +1,26 @@
+export type RetryOptions = {
+  /**
+   * The number of attempts to make.
+   */
+  numberOfAttempts: number;
+  /**
+   * The initial delay to use in milliseconds
+   */
+  initialDelay: number;
+
+  /**
+   * The multiple that the delay is multiplied by each time
+   */
+  multiple: number;
+};
+export type EnsureResult = 'Complete' | EnsureObjectiveFailed;
+
+export type EnsureObjectiveFailed = {
+  type: 'EnsureObjectiveFailed';
+  numberOfAttempts: number;
+};
+
+export type CreateChannelResult = {
+  done: Promise<EnsureResult>;
+  channelId: string;
+};

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -1,3 +1,4 @@
+import {CreateChannelParams} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {ObjectiveStatus} from '../models/objective';
@@ -41,21 +42,28 @@ export type ObjectiveDoneResult = ObjectiveSuccess | ObjectiveError;
  * This is what is returned for any objective related API call
  *
  */
-export type ObjectiveResult = {
-  /**
-   * A promise that resolves when the objective is fully completed.
-   * This promise will never reject, if an error occurs the promise will return an ObjectiveError
-   */
-  done: Promise<ObjectiveDoneResult>;
-  /**
-   * The current status of the objective.
-   */
-  currentStatus: ObjectiveStatus;
-  /**
-   * The id of the objective.
-   */
-  objectiveId: string;
+export type ObjectiveResult =
+  | {
+      /**
+       * A promise that resolves when the objective is fully completed.
+       * This promise will never reject, if an error occurs the promise will return an ObjectiveError
+       */
+      done: Promise<ObjectiveDoneResult>;
+      /**
+       * The current status of the objective.
+       */
+      currentStatus: ObjectiveStatus;
+      /**
+       * The id of the objective.
+       */
+      objectiveId: string;
 
-  // The channelId for the objective
-  channelId: string;
-};
+      // The channelId for the objective
+      channelId: string;
+    }
+
+  /**
+   * It's possible that we encounter an error before we have an objectiveId or even a channelId
+   * In that case we return a failed promise and the parameters that caused it
+   */
+  | {done: Promise<ObjectiveError>; channelParameters: CreateChannelParams};

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -1,3 +1,7 @@
+import _ from 'lodash';
+
+import {ObjectiveStatus} from '../models/objective';
+
 export type RetryOptions = {
   /**
    * The number of attempts to make.
@@ -13,14 +17,50 @@ export type RetryOptions = {
    */
   multiple: number;
 };
-export type EnsureResult = 'Complete' | EnsureObjectiveFailed;
+
+export type ObjectiveError = EnsureObjectiveFailed | InternalError;
 
 export type EnsureObjectiveFailed = {
   type: 'EnsureObjectiveFailed';
   numberOfAttempts: number;
 };
 
-export type CreateChannelResult = {
-  done: Promise<EnsureResult>;
+/**
+ * This is the catch-all error that will be returned if some error is thrown and not handled.
+ */
+export type InternalError = {
+  type: 'InternalError';
+  error: Error;
+};
+
+export type ObjectiveSuccess = {type: 'Success'};
+
+export type ObjectiveDoneResult = ObjectiveSuccess | ObjectiveError;
+
+/**
+ * TODO: Can the channelId just be on the objective?
+ * Or do we anticipate objectives that cover multiple channels?
+ */
+
+/**
+ * This is what is returned for any objective related API call
+ *
+ */
+export type ObjectiveResult = {
+  /**
+   * A promise that resolves when the objective is fully completed.
+   * This promise will never reject, if an error occurs the promise will return an ObjectiveError
+   */
+  done: Promise<ObjectiveDoneResult>;
+  /**
+   * The current status of the objective.
+   */
+  currentStatus: ObjectiveStatus;
+  /**
+   * The id of the objective.
+   */
+  objectiveId: string;
+
+  // The channelId for the objective
   channelId: string;
 };

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -85,7 +85,7 @@ export class Wallet {
 
     const {multiple, initialDelay, numberOfAttempts} = this._retryOptions;
     for (let i = 0; i < numberOfAttempts; i++) {
-      if (isComplete) return {type: 'Success'};
+      if (isComplete) return {channelId: objective.data.targetChannelId, type: 'Success'};
       const delayAmount = initialDelay * Math.pow(multiple, i);
       await delay(delayAmount);
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -45,10 +45,6 @@ export class Wallet {
       channelParameters.map(async p => {
         const createResult = await this._engine.createChannel(p);
 
-        // TODO: Modify engine createChannel API result so objective is already returned
-        if (!createResult.newObjective) {
-          throw new Error('Missing objective');
-        }
         const {newObjective, channelResult} = createResult;
 
         return {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -1,40 +1,15 @@
 import {CreateChannelParams, Message} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
-import {MessageServiceInterface} from './message-service/types';
-import {getMessages} from './message-service/utils';
-import {WalletObjective} from './models/objective';
-import {Engine} from './engine';
+import {MessageServiceInterface} from '../message-service/types';
+import {getMessages} from '../message-service/utils';
+import {WalletObjective} from '../models/objective';
+import {Engine} from '../engine';
+
+import {RetryOptions, CreateChannelResult, EnsureResult} from './types';
 
 export const delay = async (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms));
-
-export type RetryOptions = {
-  /**
-   * The number of attempts to make.
-   */
-  numberOfAttempts: number;
-  /**
-   * The initial delay to use in milliseconds
-   */
-  initialDelay: number;
-
-  /**
-   * The multiple that the delay is multiplied by each time
-   */
-  multiple: number;
-};
-type EnsureResult = 'Complete' | EnsureObjectiveFailed;
-
-export type EnsureObjectiveFailed = {
-  type: 'EnsureObjectiveFailed';
-  numberOfAttempts: number;
-};
-
-export type CreateChannelResult = {
-  done: Promise<EnsureResult>;
-  channelId: string;
-};
 
 const DEFAULTS: RetryOptions = {numberOfAttempts: 10, multiple: 2, initialDelay: 50};
 export class Wallet {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -35,8 +35,8 @@ export class Wallet {
 
   /**
    Creates channels using the given parameters.
-   * @param channelParameters
-   * @returns
+   * @param channelParameters The parameters to use for channel creation. A channel will be created for each entry in the array.
+   * @returns A promise that resolves to a collection of ObjectiveResult.
    */
   public async createChannels(
     channelParameters: CreateChannelParams[]


### PR DESCRIPTION
# Description
Introduces the new create channels API on the wallet.

The main focus of this PR was updating the create channels API method to return a result that would be informative and useful. A new `ObjectiveResult` has been introduced that can be returned by the `Wallet` for any objective API calls.

The `ObjectiveResult` contains some basic information: `ChannelId, ObjectiveId, currentStatus` that gives some information about the objective and the current status.

It also includes a `done` promise. This promise resolves when the objective is complete. In the case of `createChannels` it resolves when the channel is fully funded and ready to use. The idea is that there is a simple promise that API users can `await` to get back a channel that is useful.


The `done` promise should **always resolve**. If an error occurs the promise should return an `ObjectiveError`. That way consumers of the API can know exactly what errors to expect.

### Questions
- Is it an antipattern to avoid rejecting in a promise?
-  Right now the `done` promise resolves to `{type:'ObjectiveSuccess}` on success. Should we be returning something different?
- What level of testing do we want? Currently there's just the `ensure-objective` test that calls this new `createChannels`. Should we write unit-level tests or should we focus on a E2E flow?


## :warning: Does this require multiple approvals? [Optional]
Since this is specifying how our API looks it probably makes sense to get input from multiple people.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [ ] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
