### PR TITLE
chore: resintate linting rule

### DIFF
--- a/packages/nitro-protocol/.eslintrc.js
+++ b/packages/nitro-protocol/.eslintrc.js
@@ -4,8 +4,6 @@ const leftoverTsLintRules = {
   '@typescript-eslint/explicit-function-return-type': 'off',
   '@typescript-eslint/no-use-before-define': 'off',
   '@typescript-eslint/ban-ts-ignore': 'off',
-  // TODO: Get rid of this, there are just a small number of cases
-  '@typescript-eslint/no-unused-vars': 'off',
 };
 
 module.exports = {

--- a/packages/nitro-protocol/src/contract/challenge.ts
+++ b/packages/nitro-protocol/src/contract/challenge.ts
@@ -42,7 +42,6 @@ export function getChallengeRegisteredEvent(eventResult: any[]): ChallengeRegist
     fixedPart,
     variableParts: variablePartsUnstructured,
     sigs,
-    whoSignedWhat,
   }: ChallengeRegisteredStruct = eventResult.slice(-1)[0].args;
 
   // Fixed part

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -1,12 +1,11 @@
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, BigNumber, utils} from 'ethers';
+import {Contract, BigNumber} from 'ethers';
 
 import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 import {claimAllArgs} from '../../../src/contract/transaction-creators/asset-holder';
 import {
   allocationToParams,
   AssetOutcomeShortHand,
-  compileEventsFromLogs,
   getRandomNonce,
   getTestProvider,
   guaranteeToParams,

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -1,12 +1,11 @@
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, BigNumber, utils} from 'ethers';
+import {Contract, BigNumber} from 'ethers';
 
 import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 import {claimAllArgs} from '../../../src/contract/transaction-creators/asset-holder';
 import {
   allocationToParams,
   AssetOutcomeShortHand,
-  compileEventsFromLogs,
   getRandomNonce,
   getTestProvider,
   guaranteeToParams,

--- a/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocation.test.ts
@@ -22,7 +22,7 @@ import {computeNewAllocation} from '../../../src/contract/asset-holder';
 
 const randomAllocation = (numAllocationItems: number): AllocationItem[] => {
   return numAllocationItems > 0
-    ? [...Array(numAllocationItems)].map(e => ({
+    ? [...Array(numAllocationItems)].map(() => ({
         destination: randomExternalDestination(),
         amount: BigNumber.from(Math.ceil(Math.random() * 10)).toHexString(),
       }))

--- a/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocationWithGuarantee.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/computeNewAllocationWithGuarantee.test.ts
@@ -30,7 +30,7 @@ import {
 
 const randomAllocation = (numAllocationItems: number): AllocationItem[] => {
   return numAllocationItems > 0
-    ? [...Array(numAllocationItems)].map(e => ({
+    ? [...Array(numAllocationItems)].map(() => ({
         destination: randomExternalDestination(),
         amount: BigNumber.from(Math.ceil(Math.random() * 10)).toHexString(),
       }))

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -1,5 +1,5 @@
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, BigNumber, utils} from 'ethers';
+import {Contract, BigNumber} from 'ethers';
 
 import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 import {
@@ -61,7 +61,7 @@ describe('transfer', () => {
     ${'15. -> reverse order (see 13)'} | ${{c: 3}}  | ${{C: 2, X: 2}}       | ${[1, 0]}    | ${{C: 2, X: 1}} | ${{c: 2, X: 1}} | ${{}}           | ${reason1}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
-    async ({name, heldBefore, setOutcome, indices, newOutcome, heldAfter, payouts, reason}) => {
+    async ({name, heldBefore, setOutcome, indices, newOutcome, heldAfter, reason}) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -72,7 +72,6 @@ describe('transfer', () => {
       setOutcome = replaceAddressesAndBigNumberify(setOutcome, addresses);
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
-      payouts = replaceAddressesAndBigNumberify(payouts, addresses);
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -1,6 +1,5 @@
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, BigNumber, utils} from 'ethers';
-import {defaultAbiCoder} from 'ethers/lib/utils';
+import {Contract, BigNumber} from 'ethers';
 
 import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 import {
@@ -58,7 +57,7 @@ describe('transferAll (using transfer and empty indices array)', () => {
     ${'12. -> 2 chan   full/partial'} | ${{c: 3}}  | ${{C: 2, X: 2}} | ${{C: 0, X: 1}} | ${{c: 0, C: 2, X: 1}} | ${{}}           | ${undefined}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts, events: $events`,
-    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, payouts, reason}) => {
+    async ({name, heldBefore, setOutcome, newOutcome, heldAfter, reason}) => {
       // Compute channelId
       const nonce = getRandomNonce(name);
       const channelId = randomChannelId(nonce);
@@ -69,7 +68,6 @@ describe('transferAll (using transfer and empty indices array)', () => {
       setOutcome = replaceAddressesAndBigNumberify(setOutcome, addresses);
       newOutcome = replaceAddressesAndBigNumberify(newOutcome, addresses);
       heldAfter = replaceAddressesAndBigNumberify(heldAfter, addresses);
-      payouts = replaceAddressesAndBigNumberify(payouts, addresses);
 
       // Reset the holdings (only works on test contract)
       new Set([...Object.keys(heldAfter), ...Object.keys(heldBefore)]).forEach(async key => {

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -272,7 +272,7 @@ describe('challenge with transaction generator', () => {
     ${'challenge(0,1) accepted'}                    | ${[0, 0]} | ${[]}                              | ${[0, 1]} | ${1}
     ${'challenge(1,2) accepted'}                    | ${[0, 0]} | ${[]}                              | ${[1, 2]} | ${0}
     ${'challenge(1,2) accepted, MAX_OUTCOME_ITEMS'} | ${[0, 0]} | ${largeOutcome(MAX_OUTCOME_ITEMS)} | ${[1, 2]} | ${0}
-  `('$description', async ({description, appData, turnNums, challenger}) => {
+  `('$description', async ({appData, turnNums, challenger}) => {
     const transactionRequest: ethers.providers.TransactionRequest = createChallengeTransaction(
       [
         await createSignedCountingAppState(twoPartyChannel, appData[0], turnNums[0]),

--- a/packages/nitro-protocol/test/contracts/ForceMove/requireValidInput.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/requireValidInput.test.ts
@@ -1,4 +1,4 @@
-import {Contract, Wallet} from 'ethers';
+import {Contract} from 'ethers';
 
 import ForceMoveArtifact from '../../../artifacts/contracts/test/TESTForceMove.sol/TESTForceMove.json';
 import {getTestProvider, setupContracts} from '../../test-helpers';

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -1,5 +1,5 @@
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, Wallet, ethers, BigNumber, utils, constants} from 'ethers';
+import {Contract, Wallet, ethers, BigNumber} from 'ethers';
 
 import ETHAssetHolderArtifact from '../../../artifacts/contracts/ETHAssetHolder.sol/ETHAssetHolder.json';
 import ERC20AssetHolderArtifact from '../../../artifacts/contracts/test/TestErc20AssetHolder.sol/TestErc20AssetHolder.json';

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -101,7 +101,7 @@ export const newChallengeRegisteredEvent = (
   channelId: string
 ): Promise<ChallengeRegisteredStruct[keyof ChallengeRegisteredStruct]> => {
   const filter = contract.filters.ChallengeRegistered(channelId);
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     contract.on(
       filter,
       (
@@ -111,8 +111,7 @@ export const newChallengeRegisteredEvent = (
         eventChallengerArg,
         eventIsFinalArg,
         eventFixedPartArg,
-        eventChallengeVariablePartArg,
-        event
+        eventChallengeVariablePartArg
       ) => {
         contract.removeAllListeners(filter);
         resolve([
@@ -134,8 +133,8 @@ export const newChallengeClearedEvent = (
   channelId: string
 ): Promise<ChallengeClearedEvent[keyof ChallengeClearedEvent]> => {
   const filter = contract.filters.ChallengeCleared(channelId);
-  return new Promise((resolve, reject) => {
-    contract.on(filter, (eventChannelId, eventTurnNumRecord, event) => {
+  return new Promise(resolve => {
+    contract.on(filter, (eventChannelId, eventTurnNumRecord) => {
       // Match event for this channel only
       contract.removeAllListeners(filter);
       resolve([eventChannelId, eventTurnNumRecord]);
@@ -148,8 +147,8 @@ export const newConcludedEvent = (
   channelId: string
 ): Promise<[Bytes32]> => {
   const filter = contract.filters.Concluded(channelId);
-  return new Promise((resolve, reject) => {
-    contract.on(filter, (eventChannelId, event) => {
+  return new Promise(resolve => {
+    contract.on(filter, () => {
       // Match event for this channel only
       contract.removeAllListeners(filter);
       resolve([channelId]);
@@ -162,10 +161,10 @@ export const newDepositedEvent = (
   destination: string
 ): Promise<[string, BigNumber, BigNumber]> => {
   const filter = contract.filters.Deposited(destination);
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     contract.on(
       filter,
-      (eventDestination: string, amountDeposited: BigNumber, amountHeld: BigNumber, event) => {
+      (eventDestination: string, amountDeposited: BigNumber, amountHeld: BigNumber) => {
         // Match event for this destination only
         contract.removeAllListeners(filter);
         resolve([eventDestination, amountDeposited, amountHeld]);


### PR DESCRIPTION
We currently have a bunch of unused variables floating around in `nitro-protocol`, as well as a TODO to reinstate a linting rule that would warn us about them. 

This PR reinstates the rule, and quiets the resulting warnings by removing the unused variables. 