### PR TITLE
ci: fix mixmatch in cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ save_dep: &save_dep
 
 restore_dep: &restore_dep
   restore_cache:
-    key: v11-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v12-dependency-cache-{{ checksum "yarn.lock" }}
 
 # END MACROS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ postgres: &postgres
 
 save_dep: &save_dep
   save_cache:
-    key: v12-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v13-dependency-cache-{{ checksum "yarn.lock" }}
     paths:
       - node_modules
       - packages/client-api-schema/node_modules
@@ -41,7 +41,7 @@ save_dep: &save_dep
 
 restore_dep: &restore_dep
   restore_cache:
-    key: v12-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v13-dependency-cache-{{ checksum "yarn.lock" }}
 
 # END MACROS
 


### PR DESCRIPTION
I have noticed an uptick in the time taken to complete the `prepare` step on circle.

We are currently not updating the cache key that we try to load from, so we almost never get a hit and never benefit from caching. This should fix that and hopefully make that step run faster. 