### PR TITLE
Swallow knex abort error in test tear down

### DIFF
--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -144,6 +144,13 @@ try{
   await Promise.all([peerEngines.a.destroy(), peerEngines.b.destroy()]);
   await Promise.all([DBAdmin.dropDatabase(aEngineConfig), DBAdmin.dropDatabase(bEngineConfig)]);
   } catch (error) {
+    if (error.message==='aborted'){
+      // When we destroy the engines there still may open knex connections due to our use of delay in the TestMessageService
+      // These throw an abort error that can make the test output messy
+      // We just swallow the error here to avoid it
+      logger.trace({error},'Ignoring knex aborted error');
+      return;
+    }
       logger.error(error, 'peersTeardown failed');
       throw error;
     }


### PR DESCRIPTION
# Description
Swallow the knex abort error when tearing down with peers test.

Occasionally we'll see knex connection pool aborted [errors](https://app.circleci.com/pipelines/github/statechannels/statechannels/12374/workflows/df905483-8ad2-4c5f-811c-75723997f688/jobs/60868/parallel-runs/0/steps/0-104) when destroying the engines in the `with-peers` test.

This is due to the fact that we use a `TestMessageService` that delays message processing. This means we may have an open connection to the database when attempting to destroy the engines.

This change simply swallows the error. Since the error is simply an artifact of our test setup I think this is ok.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
