### PR TITLE
Update wallet-core eslint

### DIFF
--- a/packages/wallet-core/.eslintrc.js
+++ b/packages/wallet-core/.eslintrc.js
@@ -11,7 +11,11 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     'no-restricted-imports': ['error', {patterns: ['**/lib', '**/src']}],
-    'arrow-body-style': 'error'
+    'arrow-body-style': 'error',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {argsIgnorePattern: '^_', varsIgnorePattern: '^_'}
+    ]
   },
   overrides: [
     {

--- a/packages/wallet-core/.eslintrc.js
+++ b/packages/wallet-core/.eslintrc.js
@@ -16,13 +16,8 @@ module.exports = {
   overrides: [
     {
       // process.env allowed in tests
-      files: ['*.test.ts'],
+      files: ['*.test.ts', 'src/config.ts'],
       rules: {'no-process-env': 'off'}
     },
-    {
-      // process.env allowed in src/config.js
-      files: ['src/config.ts'],
-      rules: {'no-process-env': 'off'}
-    }
   ]
 };


### PR DESCRIPTION
- DRY up `no-process-env` override
- enable the `no-unused-vars` rule in wallet-core
   The level is intentionally set as error to prevent silly time-wasting:
https://app.circleci.com/pipelines/github/statechannels/statechannels/12395/workflows/5d7beef2-0fd2-4d37-af4a-eeaeadf41df0/jobs/60969/parallel-runs/0/steps/0-106