### PR TITLE
Remove duplicate funding logic

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -53,7 +53,7 @@ import { SubmitChallenge } from '@statechannels/wallet-core';
 import { SyncChannelParams } from '@statechannels/client-api-schema';
 import { Transaction } from 'objection';
 import { TransactionOrKnex } from 'objection';
-import { Uint256 as Uint256_2 } from '@statechannels/wallet-core';
+import { Uint256 } from '@statechannels/wallet-core';
 import { UpdateChannelParams } from '@statechannels/client-api-schema';
 import { ValidationErrorItem } from 'joi';
 
@@ -176,8 +176,10 @@ export interface EngineInterface {
     syncChannels(chanelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     // (undocumented)
     updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput>;
+    // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
+    updateFundingForChannels(args: HoldingUpdatedArg[]): Promise<MultipleChannelOutput>;
 }
 
 // @public (undocumented)
@@ -343,10 +345,8 @@ export class SingleThreadedEngine extends EventEmitter<EventEmitterType> impleme
     getObjective(objectiveId: string): Promise<WalletObjective>;
     getSigningAddress(): Promise<Address>;
     getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;
-    // Warning: (ae-forgotten-export) The symbol "HoldingUpdatedArg" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    holdingUpdated({ channelId, amount, assetHolderAddress }: HoldingUpdatedArg): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "EngineResponse" needs to be exported by the entry point index.d.ts
+    holdingUpdated({ channelId, amount, assetHolderAddress }: HoldingUpdatedArg, response?: EngineResponse): Promise<SingleChannelOutput>;
     joinChannel({ channelId }: JoinChannelParams): Promise<SingleChannelOutput>;
     joinChannels(channelIds: ChannelId[]): Promise<MultipleChannelOutput>;
     // (undocumented)
@@ -374,20 +374,7 @@ export class SingleThreadedEngine extends EventEmitter<EventEmitterType> impleme
     syncChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     syncObjectives(objectiveIds: string[]): Promise<MultipleChannelOutput>;
     updateChannel({ channelId, allocations, appData, }: UpdateChannelParams): Promise<SingleChannelOutput>;
-    updateChannelFunding(args: UpdateChannelFundingParams): Promise<SingleChannelOutput>;
-    updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
-}
-
-// @public (undocumented)
-export interface UpdateChannelFundingParams {
-    // Warning: (ae-forgotten-export) The symbol "Uint256" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    amount: Uint256;
-    // (undocumented)
-    assetHolderAddress?: Address;
-    // (undocumented)
-    channelId: ChannelId;
+    updateFundingForChannels(args: HoldingUpdatedArg[]): Promise<MultipleChannelOutput>;
 }
 
 // @public (undocumented)
@@ -400,7 +387,7 @@ export function validateEngineConfig(config: Record<string, any>): {
 
 // Warnings were encountered during analysis:
 //
-// src/engine/types.ts:30:3 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
+// src/engine/types.ts:24:3 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -66,10 +66,7 @@ it('Create a directly-funded channel between two engines, of which one crashes m
 
   //      PreFund0B
   const resultB1 = await peerEngines.b.joinChannel({channelId});
-  expect(getChannelResultFor(channelId, [resultB1.channelResult])).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
-  });
+  expect(resultB1.channelResult).toMatchObject({status: 'opening', turnNum: 0});
 
   await messageService.send(getMessages(resultB1));
 
@@ -117,11 +114,7 @@ it('Create a directly-funded channel between two engines, of which one crashes m
 
   // A generates isFinal4
   const aCloseChannelResult = await peerEngines.a.closeChannel(closeChannelParams);
-
-  expect(getChannelResultFor(channelId, [aCloseChannelResult.channelResult])).toMatchObject({
-    status: 'closing',
-    turnNum: 4,
-  });
+  expect(aCloseChannelResult.channelResult).toMatchObject({status: 'closing', turnNum: 4});
 
   await messageService.send(getMessages(aCloseChannelResult));
   // B pushed isFinal4, generated countersigned isFinal4

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -83,22 +83,17 @@ it('Create a directly-funded channel between two engines, of which one crashes m
   // Then, this would be triggered by B's Chain Service after observing A's deposit
   const depositByB = {channelId, assetHolderAddress, amount: BN.from(2)}; // B sends 1 ETH (2 total)
   // < PostFund3B
-  const resultA2 = await peerEngines.a.updateFundingForChannels([depositByB]);
-  const resultB2 = await peerEngines.b.updateFundingForChannels([depositByB]);
+  const resultA2 = await peerEngines.a.holdingUpdated(depositByB);
+  const resultB2 = await peerEngines.b.holdingUpdated(depositByB);
 
-  expect(getChannelResultFor(channelId, resultA2.channelResults)).toMatchObject({
-    status: 'opening', // Still opening because turnNum 3 is not supported yet, but is signed by A
-    turnNum: 0,
-  });
+  // Still opening because turnNum 3 is not supported yet, but is signed by A
+  expect(resultA2.channelResult).toMatchObject({status: 'opening', turnNum: 0});
 
   await messageService.send(getMessages(resultA2));
   await messageService.send(getMessages(resultB2));
 
-  expect(getChannelResultFor(channelId, resultB2.channelResults)).toMatchObject({
-    // Still opening because turnNum 3 is not supported yet (2 is not in the engine)
-    status: 'opening',
-    turnNum: 0,
-  });
+  // Still opening because turnNum 3 is not supported yet (2 is not in the engine)
+  expect(resultB2.channelResult).toMatchObject({status: 'opening', turnNum: 0});
 
   //  > PostFund3A
   const resultB3 = await peerEngines.b.pushMessage(

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -3,7 +3,7 @@ import {
   CloseChannelParams,
   CreateChannelParams,
 } from '@statechannels/client-api-schema';
-import {makeAddress} from '@statechannels/wallet-core';
+import {BN, makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, constants, ethers} from 'ethers';
 
 import {
@@ -73,22 +73,15 @@ it('Create a directly-funded channel between two engines, of which one crashes m
 
   await messageService.send(getMessages(resultB1));
 
-  const depositByA = {
-    channelId,
-    assetHolderAddress: makeAddress(constants.AddressZero),
-    amount: BigNumber.from(1).toHexString(),
-  }; // A sends 1 ETH (1 total)
+  const assetHolderAddress = makeAddress(constants.AddressZero);
+  const depositByA = {channelId, assetHolderAddress, amount: BN.from(1)}; // A sends 1 ETH (1 total)
 
   // This would have been triggered by A's Chain Service by request
-  await peerEngines.a.updateFundingForChannels([depositByA]);
-  await peerEngines.b.updateFundingForChannels([depositByA]);
+  await peerEngines.a.holdingUpdated(depositByA);
+  await peerEngines.b.holdingUpdated(depositByA);
 
   // Then, this would be triggered by B's Chain Service after observing A's deposit
-  const depositByB = {
-    channelId,
-    assetHolderAddress: makeAddress(constants.AddressZero),
-    amount: BigNumber.from(2).toHexString(),
-  }; // B sends 1 ETH (2 total)
+  const depositByB = {channelId, assetHolderAddress, amount: BN.from(2)}; // B sends 1 ETH (2 total)
   // < PostFund3B
   const resultA2 = await peerEngines.a.updateFundingForChannels([depositByB]);
   const resultB2 = await peerEngines.b.updateFundingForChannels([depositByB]);

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -74,8 +74,8 @@ it('Create a directly funded channel between two engines ', async () => {
     turnNum: 0,
   });
 
-  const resultA2 = await peerEngines.a.updateFundingForChannels([depositByB]);
-  const resultB2 = await peerEngines.b.updateFundingForChannels([depositByB]);
+  const resultA2 = await peerEngines.a.holdingUpdated(depositByB);
+  const resultB2 = await peerEngines.b.holdingUpdated(depositByB);
   await messageService.send(getMessages(resultA2));
   await messageService.send(getMessages(resultB2));
 

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
@@ -79,8 +79,8 @@ const createLedgerChannel = async (aDeposit: number, bDeposit: number): Promise<
     assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
     amount: aDepositAmtETH,
   };
-  await peerEngines.a.updateFundingForChannels([fundingPostADeposit]);
-  await peerEngines.b.updateFundingForChannels([fundingPostADeposit]);
+  await peerEngines.a.holdingUpdated(fundingPostADeposit);
+  await peerEngines.b.holdingUpdated(fundingPostADeposit);
   const fundingPostBDeposit = {
     channelId,
     assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
@@ -86,8 +86,8 @@ const createLedgerChannel = async (aDeposit: number, bDeposit: number): Promise<
     assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
     amount: BN.add(aDepositAmtETH, bDepositAmtETH),
   };
-  const resultA2 = await peerEngines.a.updateFundingForChannels([fundingPostBDeposit]);
-  const resultB3 = await peerEngines.b.updateFundingForChannels([fundingPostBDeposit]);
+  const resultA2 = await peerEngines.a.holdingUpdated(fundingPostBDeposit);
+  const resultB3 = await peerEngines.b.holdingUpdated(fundingPostBDeposit);
   await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, resultA2.outbox));
   await peerEngines.a.pushMessage(getPayloadFor(participantA.participantId, resultB3.outbox));
 

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -40,11 +40,11 @@ export type ChallengeRegisteredArg = {
   challengeStates: SignedState[];
 };
 
-export interface ChainEventSubscriberInterface {
-  holdingUpdated(arg: HoldingUpdatedArg): void;
-  assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg): void;
-  channelFinalized(arg: ChannelFinalizedArg): void;
-  challengeRegistered(arg: ChallengeRegisteredArg): void;
+export interface ChainEventSubscriberInterface<T extends void = void> {
+  holdingUpdated(arg: HoldingUpdatedArg): T;
+  assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg): T;
+  channelFinalized(arg: ChannelFinalizedArg): T;
+  challengeRegistered(arg: ChallengeRegisteredArg): T;
 }
 
 interface ChainEventEmitterInterface {

--- a/packages/server-wallet/src/engine/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/update-funding.test.ts
@@ -124,9 +124,7 @@ it('sends the post fund setup when the funding event is provided', async () => {
   );
 
   const assetHolderAddress = makeAddress(constants.AddressZero);
-  const result = await w.updateFundingForChannels([
-    {channelId, assetHolderAddress, amount: BN.from(4)},
-  ]);
+  const result = await w.holdingUpdated({channelId, assetHolderAddress, amount: BN.from(4)});
 
   await expect(Funding.getFundingAmount(w.knex, channelId, AddressZero)).resolves.toEqual('0x04');
 
@@ -140,7 +138,7 @@ it('sends the post fund setup when the funding event is provided', async () => {
         },
       },
     ],
-    channelResults: [{channelId: c.channelId, turnNum: 0}],
+    channelResult: {channelId: c.channelId, turnNum: 0},
   });
 });
 

--- a/packages/server-wallet/src/engine/__test__/integration/update-funding.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/update-funding.test.ts
@@ -123,12 +123,9 @@ it('sends the post fund setup when the funding event is provided', async () => {
     w.knex
   );
 
+  const assetHolderAddress = makeAddress(constants.AddressZero);
   const result = await w.updateFundingForChannels([
-    {
-      channelId: c.channelId,
-      assetHolderAddress: makeAddress(constants.AddressZero),
-      amount: BN.from(4),
-    },
+    {channelId, assetHolderAddress, amount: BN.from(4)},
   ]);
 
   await expect(Funding.getFundingAmount(w.knex, channelId, AddressZero)).resolves.toEqual('0x04');

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -994,7 +994,7 @@ export class SingleThreadedEngine
   }
 
   /**
-   * Update the engine's knowledge about the funding for a channel.
+   * Update the engine's knowledge about the on-chain funding for a channel.
    *
    * @param args - An object specifying the channelId, asset holder address and amount.
    * @returns A promise that resolves to a channel output.

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -13,7 +13,6 @@ import {
   validatePayload,
   Outcome,
   convertToParticipant,
-  BN,
   makeAddress,
   Address as CoreAddress,
   PrivateKey,
@@ -1005,7 +1004,7 @@ export class SingleThreadedEngine
     {channelId, amount, assetHolderAddress}: HoldingUpdatedArg,
     response = EngineResponse.initialize()
   ): Promise<void> {
-    await this.store.updateFunding(channelId, BN.from(amount), assetHolderAddress);
+    await this.store.updateFunding(channelId, amount, assetHolderAddress);
     await this.takeActions([channelId], response);
 
     response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -30,7 +30,7 @@ import * as Either from 'fp-ts/lib/Either';
 import Knex from 'knex';
 import _ from 'lodash';
 import EventEmitter from 'eventemitter3';
-import {ethers, constants, BigNumber, utils} from 'ethers';
+import {ethers, BigNumber, utils} from 'ethers';
 import {Logger} from 'pino';
 import {OpenChannel, Payload as WirePayload} from '@statechannels/wire-format';
 import {ValidationErrorItem} from 'joi';
@@ -72,7 +72,6 @@ import {
   MultipleChannelOutput,
   Output,
   EngineInterface,
-  UpdateChannelFundingParams,
   EngineEvent,
 } from './types';
 import {EngineResponse} from './engine-response';
@@ -395,45 +394,13 @@ export class SingleThreadedEngine
    * @param args - A list of objects, each specifying the channelId, asset holder address and amount.
    * @returns A promise that resolves to a channel output.
    */
-  public async updateFundingForChannels(
-    args: UpdateChannelFundingParams[]
-  ): Promise<MultipleChannelOutput> {
+  public async updateFundingForChannels(args: HoldingUpdatedArg[]): Promise<MultipleChannelOutput> {
     const response = EngineResponse.initialize();
 
-    await Promise.all(args.map(a => this._updateChannelFunding(a, response)));
+    await Promise.all(args.map(a => this.holdingUpdated(a, response)));
 
     return response.multipleChannelOutput();
   }
-
-  /**
-   * Update the engine's knowledge about the funding for a channel.
-   *
-   * @param args - An object specifying the channelId, asset holder address and amount.
-   * @returns A promise that resolves to a channel output.
-   */
-  public async updateChannelFunding(
-    args: UpdateChannelFundingParams
-  ): Promise<SingleChannelOutput> {
-    const response = EngineResponse.initialize();
-
-    await this._updateChannelFunding(args, response);
-
-    return response.singleChannelOutput();
-  }
-
-  private async _updateChannelFunding(
-    {channelId, assetHolderAddress, amount}: UpdateChannelFundingParams,
-    response: EngineResponse
-  ): Promise<void> {
-    await this.store.updateFunding(
-      channelId,
-      BN.from(amount),
-      assetHolderAddress || makeAddress(constants.AddressZero)
-    );
-
-    await this.takeActions([channelId], response);
-  }
-
   /**
    * Get the signing address for this engine, or create it if it does not exist.
    *
@@ -1027,10 +994,17 @@ export class SingleThreadedEngine
     response.succeededObjectives.map(o => this.emit('objectiveSucceeded', o));
   }
 
+  /**
+   * Update the engine's knowledge about the funding for a channel.
+   *
+   * @param args - An object specifying the channelId, asset holder address and amount.
+   * @returns A promise that resolves to a channel output.
+   */
   // ChainEventSubscriberInterface implementation
-  async holdingUpdated({channelId, amount, assetHolderAddress}: HoldingUpdatedArg): Promise<void> {
-    const response = EngineResponse.initialize();
-
+  async holdingUpdated(
+    {channelId, amount, assetHolderAddress}: HoldingUpdatedArg,
+    response = EngineResponse.initialize()
+  ): Promise<void> {
     await this.store.updateFunding(channelId, BN.from(amount), assetHolderAddress);
     await this.takeActions([channelId], response);
 

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -1003,11 +1003,15 @@ export class SingleThreadedEngine
   async holdingUpdated(
     {channelId, amount, assetHolderAddress}: HoldingUpdatedArg,
     response = EngineResponse.initialize()
-  ): Promise<void> {
+  ): Promise<SingleChannelOutput> {
     await this.store.updateFunding(channelId, amount, assetHolderAddress);
     await this.takeActions([channelId], response);
 
     response.channelUpdatedEvents().forEach(event => this.emit('channelUpdated', event.value));
+
+    // holdingUpdated may be called by updateChannelsForFunding, which therefore includes
+    // multiple channel output. So, we set strict to false
+    return response.singleChannelOutput(false);
   }
 
   async assetOutcomeUpdated({

--- a/packages/server-wallet/src/engine/types.ts
+++ b/packages/server-wallet/src/engine/types.ts
@@ -7,17 +7,11 @@ import {
   ChannelId,
   ChannelResult,
 } from '@statechannels/client-api-schema';
-import {Address as CoreAddress} from '@statechannels/wallet-core';
 
+import {HoldingUpdatedArg} from '../chain-service';
 import {WalletObjective} from '../models/objective';
 import {Outgoing} from '../protocols/actions';
-import {Bytes32, Uint256} from '../type-aliases';
-
-export interface UpdateChannelFundingParams {
-  channelId: ChannelId;
-  assetHolderAddress?: CoreAddress;
-  amount: Uint256;
-}
+import {Bytes32} from '../type-aliases';
 
 export type SingleChannelOutput = {
   outbox: Outgoing[];
@@ -69,7 +63,8 @@ export interface EngineInterface {
 
   challenge(channelId: string): Promise<SingleChannelOutput>;
 
-  updateFundingForChannels(args: UpdateChannelFundingParams[]): Promise<MultipleChannelOutput>;
+  // TODO: This should live on a TestEngine interface
+  updateFundingForChannels(args: HoldingUpdatedArg[]): Promise<MultipleChannelOutput>;
   // Engine <-> Engine communication
   pushMessage(m: unknown): Promise<MultipleChannelOutput>;
   pushUpdate(m: unknown): Promise<SingleChannelOutput>;

--- a/packages/server-wallet/src/engine/types.ts
+++ b/packages/server-wallet/src/engine/types.ts
@@ -63,7 +63,7 @@ export interface EngineInterface {
 
   challenge(channelId: string): Promise<SingleChannelOutput>;
 
-  // TODO: This should live on a TestEngine interface
+  // TODO: Should this live on a TestEngineInterface?
   updateFundingForChannels(args: HoldingUpdatedArg[]): Promise<MultipleChannelOutput>;
   // Engine <-> Engine communication
   pushMessage(m: unknown): Promise<MultipleChannelOutput>;


### PR DESCRIPTION
# Description

There were two ways of "updating the channel funding" at the engine level. This removes one, and keeps the `ChainServiceSubscriberInterface` implementation, called `holdingUpdated`.

It is important to test `holdingUpdated`, because that is the function that gets called when the chain service notices that holdings are updated. Using the (removed) `updateChannelFunding` introduced the risk of using untested code.

The `ChainServiceSubscriberInterface` is more flexible as a generic interface. The `ChainService` doesn't need to know that `Engine.holdingUpdated` also accepts an optional `EngineResponse` and returns a `SingleChannelOutput`, but consumers of the `Engine` (mostly tests?) can take advantage of this to remove some indirection.

I intentionally stopped short of removing `updateChannelFundingFor`, as I was unsure of the original intent of this function. (I think that function can be removed entirely?)

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
