### PR TITLE
Test synchronous LedgerManager logic

### DIFF
--- a/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
@@ -351,7 +351,7 @@ export interface InsertionParams {
 
 export type SignedBy = 0 | 1 | 'both';
 
-interface StateWithBals {
+export interface StateWithBals {
   turn: number;
   bals: Bals;
   signedBy: SignedBy;

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
@@ -16,7 +16,6 @@ import {
   RichLedgerRequest,
 } from '../../../models/ledger-request';
 import {WALLET_VERSION} from '../../../version';
-import {Store} from '../../store';
 
 import {TestChannel, Bals, SignedBy} from './test-channel';
 
@@ -76,26 +75,6 @@ export class TestLedgerChannel extends TestChannel {
     };
   }
 
-  public async insertFundingRequest(
-    store: Store,
-    {channelToBeFunded, amtA, amtB, status, missedOps, lastSeen}: RequestParams
-  ): Promise<RichLedgerRequest> {
-    return LedgerRequest.setRequest(
-      {
-        ledgerChannelId: this.channelId,
-        type: 'fund',
-        channelToBeFunded,
-        amountA: BN.from(amtA),
-        amountB: BN.from(amtB),
-        status,
-        missedOpportunityCount: missedOps || 0,
-        lastSeenAgreedState: lastSeen || null,
-      },
-      store.knex
-    );
-  }
-
-  // Copy-paste from previous method
   public fundingRequest({
     channelToBeFunded,
     amtA,
@@ -114,25 +93,6 @@ export class TestLedgerChannel extends TestChannel {
       missedOpportunityCount: missedOps || 0,
       lastSeenAgreedState: lastSeen || null,
     });
-  }
-
-  public async insertDefundingRequest(
-    store: Store,
-    {channelToBeFunded, amtA, amtB, status, missedOps, lastSeen}: RequestParams
-  ): Promise<RichLedgerRequest> {
-    return LedgerRequest.setRequest(
-      {
-        ledgerChannelId: this.channelId,
-        type: 'defund',
-        channelToBeFunded,
-        amountA: BN.from(amtA),
-        amountB: BN.from(amtB),
-        status,
-        missedOpportunityCount: missedOps || 0,
-        lastSeenAgreedState: lastSeen || null,
-      },
-      store.knex
-    );
   }
 
   // Copy-paste from previous method

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
@@ -76,21 +76,18 @@ export class TestLedgerChannel extends TestChannel {
     store: Store,
     {channelToBeFunded, amtA, amtB, status, missedOps, lastSeen}: RequestParams
   ): Promise<void> {
-    return store.transaction(
-      async tx =>
-        await LedgerRequest.setRequest(
-          {
-            ledgerChannelId: this.channelId,
-            type: 'fund',
-            channelToBeFunded,
-            amountA: BN.from(amtA),
-            amountB: BN.from(amtB),
-            status,
-            missedOpportunityCount: missedOps || 0,
-            lastSeenAgreedState: lastSeen || null,
-          },
-          tx
-        )
+    await LedgerRequest.setRequest(
+      {
+        ledgerChannelId: this.channelId,
+        type: 'fund',
+        channelToBeFunded,
+        amountA: BN.from(amtA),
+        amountB: BN.from(amtB),
+        status,
+        missedOpportunityCount: missedOps || 0,
+        lastSeenAgreedState: lastSeen || null,
+      },
+      store.knex
     );
   }
 
@@ -98,21 +95,18 @@ export class TestLedgerChannel extends TestChannel {
     store: Store,
     {channelToBeFunded, amtA, amtB, status, missedOps, lastSeen}: RequestParams
   ): Promise<void> {
-    return store.transaction(
-      async tx =>
-        await LedgerRequest.setRequest(
-          {
-            ledgerChannelId: this.channelId,
-            type: 'defund',
-            channelToBeFunded,
-            amountA: BN.from(amtA),
-            amountB: BN.from(amtB),
-            status,
-            missedOpportunityCount: missedOps || 0,
-            lastSeenAgreedState: lastSeen || null,
-          },
-          tx
-        )
+    await LedgerRequest.setRequest(
+      {
+        ledgerChannelId: this.channelId,
+        type: 'defund',
+        channelToBeFunded,
+        amountA: BN.from(amtA),
+        amountB: BN.from(amtB),
+        status,
+        missedOpportunityCount: missedOps || 0,
+        lastSeenAgreedState: lastSeen || null,
+      },
+      store.knex
     );
   }
 }

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
@@ -95,6 +95,27 @@ export class TestLedgerChannel extends TestChannel {
     );
   }
 
+  // Copy-paste from previous method
+  public fundingRequest({
+    channelToBeFunded,
+    amtA,
+    amtB,
+    status,
+    missedOps,
+    lastSeen,
+  }: RequestParams): RichLedgerRequest {
+    return LedgerRequest.fromJson({
+      ledgerChannelId: this.channelId,
+      type: 'fund',
+      channelToBeFunded,
+      amountA: BN.from(amtA),
+      amountB: BN.from(amtB),
+      status,
+      missedOpportunityCount: missedOps || 0,
+      lastSeenAgreedState: lastSeen || null,
+    });
+  }
+
   public async insertDefundingRequest(
     store: Store,
     {channelToBeFunded, amtA, amtB, status, missedOps, lastSeen}: RequestParams
@@ -112,6 +133,27 @@ export class TestLedgerChannel extends TestChannel {
       },
       store.knex
     );
+  }
+
+  // Copy-paste from previous method
+  public defundingRequest({
+    channelToBeFunded,
+    amtA,
+    amtB,
+    status,
+    missedOps,
+    lastSeen,
+  }: RequestParams): RichLedgerRequest {
+    return LedgerRequest.fromJson({
+      ledgerChannelId: this.channelId,
+      type: 'defund',
+      channelToBeFunded,
+      amountA: BN.from(amtA),
+      amountB: BN.from(amtB),
+      status,
+      missedOpportunityCount: missedOps || 0,
+      lastSeenAgreedState: lastSeen || null,
+    });
   }
 }
 

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
@@ -10,7 +10,11 @@ import {utils} from 'ethers';
 import {Payload} from '@statechannels/wire-format';
 
 import {defaultTestConfig} from '../../../config';
-import {LedgerRequest, LedgerRequestStatus} from '../../../models/ledger-request';
+import {
+  LedgerRequest,
+  LedgerRequestStatus,
+  RichLedgerRequest,
+} from '../../../models/ledger-request';
 import {WALLET_VERSION} from '../../../version';
 import {Store} from '../../store';
 
@@ -75,8 +79,8 @@ export class TestLedgerChannel extends TestChannel {
   public async insertFundingRequest(
     store: Store,
     {channelToBeFunded, amtA, amtB, status, missedOps, lastSeen}: RequestParams
-  ): Promise<void> {
-    await LedgerRequest.setRequest(
+  ): Promise<RichLedgerRequest> {
+    return LedgerRequest.setRequest(
       {
         ledgerChannelId: this.channelId,
         type: 'fund',
@@ -94,8 +98,8 @@ export class TestLedgerChannel extends TestChannel {
   public async insertDefundingRequest(
     store: Store,
     {channelToBeFunded, amtA, amtB, status, missedOps, lastSeen}: RequestParams
-  ): Promise<void> {
-    await LedgerRequest.setRequest(
+  ): Promise<RichLedgerRequest> {
+    return LedgerRequest.setRequest(
       {
         ledgerChannelId: this.channelId,
         type: 'defund',

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
@@ -95,7 +95,6 @@ export class TestLedgerChannel extends TestChannel {
     });
   }
 
-  // Copy-paste from previous method
   public defundingRequest({
     channelToBeFunded,
     amtA,

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -248,7 +248,7 @@ export class Store {
   }
 
   async getAndLockChannel(channelId: Bytes32, tx: Transaction): Promise<Channel> {
-    const channel = Channel.query(tx)
+    const channel = await Channel.query(tx)
       .where({channelId})
       .withGraphJoined('adjudicatorStatus')
       .withGraphFetched('signingWallet')
@@ -256,7 +256,7 @@ export class Store {
       .first();
 
     if (!channel) {
-      throw new ChannelError('No channel found with id');
+      throw new ChannelError(`No channel found with id ${channelId}`);
     }
 
     return channel;

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -247,13 +247,19 @@ export class Store {
       .first();
   }
 
-  async getAndLockChannel(channelId: Bytes32, tx: Transaction): Promise<Channel | undefined> {
-    return Channel.query(tx)
+  async getAndLockChannel(channelId: Bytes32, tx: Transaction): Promise<Channel> {
+    const channel = Channel.query(tx)
       .where({channelId})
       .withGraphJoined('adjudicatorStatus')
       .withGraphFetched('signingWallet')
       .forUpdate()
       .first();
+
+    if (!channel) {
+      throw new ChannelError('No channel found with id');
+    }
+
+    return channel;
   }
 
   async getStates(

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -256,7 +256,7 @@ export class Store {
       .first();
 
     if (!channel) {
-      throw new ChannelError(`No channel found with id ${channelId}`);
+      throw new ChannelError('No channel found with id', {channelId});
     }
 
     return channel;

--- a/packages/server-wallet/src/models/ledger-request.ts
+++ b/packages/server-wallet/src/models/ledger-request.ts
@@ -23,6 +23,19 @@ export interface LedgerRequestType {
   type: 'fund' | 'defund';
 }
 
+export interface RichLedgerRequest extends LedgerRequestType {
+  isPending: boolean;
+  isQueued: boolean;
+  isFund: boolean;
+  isDefund: boolean;
+  totalAmount: Uint256;
+
+  // TODO: This should be removed.
+  // This is included for compatibility. It is only used in one place,
+  // when throwing an error.
+  $id: any;
+}
+
 export class LedgerRequest extends Model implements LedgerRequestType {
   channelToBeFunded!: LedgerRequestType['channelToBeFunded'];
   ledgerChannelId!: LedgerRequestType['ledgerChannelId'];

--- a/packages/server-wallet/src/models/ledger-request.ts
+++ b/packages/server-wallet/src/models/ledger-request.ts
@@ -65,8 +65,8 @@ export class LedgerRequest extends Model implements LedgerRequestType {
       lastSeenAgreedState?: null | number;
     },
     tx: TransactionOrKnex
-  ): Promise<void> {
-    await LedgerRequest.query(tx).insert({
+  ): Promise<LedgerRequest> {
+    return LedgerRequest.query(tx).insert({
       ...request,
       missedOpportunityCount: request.missedOpportunityCount || 0,
       lastSeenAgreedState: request.lastSeenAgreedState || null,

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -684,18 +684,18 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
       ]),
     });
 
-    const richRequests: RichLedgerRequest[] = [];
+    const requests: RichLedgerRequest[] = [];
     for (const req of testCase.requestsBefore) {
       const channelToBeFunded = channelLookup.get(req.channelKey);
 
       switch (req.type) {
         case 'fund':
-          richRequests.push(
+          requests.push(
             await ledgerChannel.insertFundingRequest(store, {...req, channelToBeFunded})
           );
           break;
         case 'defund':
-          richRequests.push(
+          requests.push(
             await ledgerChannel.insertDefundingRequest(store, {...req, channelToBeFunded})
           );
           break;
@@ -711,13 +711,6 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     // Collect the correct input to the synchronous logic
     const tx = store.knex as any;
     const ledgerBefore = await store.getAndLockChannel(ledgerChannelId, tx);
-    const requests = await store.getActiveLedgerRequests(ledgerChannelId, tx);
-
-    // REGRESSION TEST
-    expect(requests.map(describeRequest).sort()).toMatchObject(
-      richRequests.map(describeRequest).sort()
-    );
-    // REGRESSION TEST
 
     const states = manager.synchronousCrankLogic(ledgerBefore, requests);
 

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -3,7 +3,7 @@ import {addHash, unreachable} from '@statechannels/wallet-core';
 
 import {SignedBy, StateWithBals, TestChannel} from '../../engine/__test__/fixtures/test-channel';
 import {TestLedgerChannel} from '../../engine/__test__/fixtures/test-ledger-channel';
-import {LedgerRequestStatus, RichLedgerRequest} from '../../models/ledger-request';
+import {LedgerRequestStatus} from '../../models/ledger-request';
 import {LedgerManager} from '../ledger-manager';
 import {Destination} from '../../type-aliases';
 import {State} from '../../models/channel/state';
@@ -520,21 +520,17 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => void {
 
     const myIndex = args.as === 'leader' ? 0 : 1;
 
-    const requests: RichLedgerRequest[] = [];
-    for (const req of testCase.requestsBefore) {
+    const requests = testCase.requestsBefore.map(req => {
       const channelToBeFunded = channelLookup.get(req.channelKey);
-
       switch (req.type) {
         case 'fund':
-          requests.push(ledgerChannel.fundingRequest({...req, channelToBeFunded}));
-          break;
+          return ledgerChannel.fundingRequest({...req, channelToBeFunded});
         case 'defund':
-          requests.push(ledgerChannel.defundingRequest({...req, channelToBeFunded}));
-          break;
+          return ledgerChannel.defundingRequest({...req, channelToBeFunded});
         default:
           unreachable(req.type);
       }
-    }
+    });
 
     const channelId = ledgerChannel.channelId;
     const vars = initialStates

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -607,27 +607,27 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     // console.log('as', args.as);
     const signedStatesBefore = states.map(s => s.signedState).map(addHash);
     signedStatesBefore.forEach(s => (s.signatures = [createSignatureEntry(s, privateKey)]));
-    // console.log('states signed', signedStatesBefore.map(summary));
+    // console.log('states signed', signedStatesBefore.map(_summary));
 
     let statesAfter = ledgerBefore.vars;
-    // console.log('ledger before', ledgerBefore.vars.map(summary));
+    // console.log('ledger before', ledgerBefore.vars.map(_summary));
 
     if (signedStatesBefore.length > 0) {
       signedStatesBefore.map(state => {
-        // console.log('adding', summary(state));
-        // console.log('to', statesAfter.map(summary));
+        // console.log('adding', _summary(state));
+        // console.log('to', statesAfter.map(_summary));
         statesAfter = addState(statesAfter, state);
-        // console.log('gives', statesAfter.map(summary));
+        // console.log('gives', statesAfter.map(_summary));
       });
     } else {
       statesAfter = ledgerBefore.vars;
     }
 
     const ledger = channel({...ledgerBefore.channelConstants, vars: statesAfter});
-    // console.log(signedStatesBefore.map(summary));
-    // console.log('ledger after', ledgerAfter.vars.map(summary));
+    // console.log(signedStatesBefore.map(_summary));
+    // console.log('ledger after', ledgerAfter.vars.map(_summary));
     ledger.vars = clearOldStates(ledger.vars, ledger.support);
-    // console.log('after clearing', ledgerAfter.vars.map(summary));
+    // console.log('after clearing', ledgerAfter.vars.map(_summary));
     // END CODE FOR CREATING CONSISTENCY
 
     // assertions

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -17,28 +17,6 @@ beforeAll(async () => {
   manager = await LedgerManager.create({} as any);
 });
 
-it(
-  'SYNC: will create a proposal from requests in the queue',
-  testLedgerCrank({
-    as: 'leader',
-    before: {
-      agreed: {turn: 5, bals: {a: 5, b: 5, c: 10}},
-      requests: [
-        ['fund', 'd', 1, 1, 'queued'],
-        ['defund', 'c', 5, 5, 'queued'],
-      ],
-    },
-    after: {
-      agreed: {turn: 5, bals: {a: 5, b: 5, c: 10}},
-      proposed: {turn: 6, bals: {a: 9, b: 9, d: 2}},
-      requests: [
-        ['fund', 'd', 1, 1, 'pending', {missedOps: 0, lastSeen: 5}],
-        ['defund', 'c', 5, 5, 'pending', {missedOps: 0, lastSeen: 5}],
-      ],
-    },
-  })
-);
-
 describe('as leader', () => {
   describe('in the accept state', () => {
     it(

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -31,10 +31,6 @@ beforeAll(async () => {
   manager = await LedgerManager.create({store});
 });
 
-beforeEach(async () => {
-  await DBAdmin.truncateDatabase(defaultTestConfig());
-});
-
 afterEach(async () => {
   await DBAdmin.truncateDatabase(defaultTestConfig());
 });

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -591,9 +591,9 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
 
     // Collect the correct input to the synchronous logic
     const tx = store.knex as any;
-    const ledgerBefore = await store.getAndLockChannel(ledgerChannelId, tx);
+    const storedLedger = await store.getAndLockChannel(ledgerChannelId, tx);
 
-    const states = manager.synchronousCrankLogic(ledgerBefore, requests);
+    const states = manager.synchronousCrankLogic(storedLedger, requests);
 
     // BEGIN CODE FOR CREATING CONSISTENCY
     function _summary(s: SignedStateVarsWithHash) {
@@ -609,7 +609,7 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     signedStatesBefore.forEach(s => (s.signatures = [createSignatureEntry(s, privateKey)]));
     // console.log('states signed', signedStatesBefore.map(_summary));
 
-    let statesAfter = ledgerBefore.vars;
+    let statesAfter = storedLedger.vars;
     // console.log('ledger before', ledgerBefore.vars.map(_summary));
 
     if (signedStatesBefore.length > 0) {
@@ -620,10 +620,10 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
         // console.log('gives', statesAfter.map(_summary));
       });
     } else {
-      statesAfter = ledgerBefore.vars;
+      statesAfter = storedLedger.vars;
     }
 
-    const ledger = channel({...ledgerBefore.channelConstants, vars: statesAfter});
+    const ledger = channel({...storedLedger.channelConstants, vars: statesAfter});
     // console.log(signedStatesBefore.map(_summary));
     // console.log('ledger after', ledgerAfter.vars.map(_summary));
     ledger.vars = clearOldStates(ledger.vars, ledger.support);

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -543,10 +543,6 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     // first we need to turn strings like 'c' and 'd' into actual channels in the store
     for (const key of testCase.referencedChannelDests) {
       const appChannel = TestChannel.create({aBal: 5, bBal: 5});
-      await appChannel.insertInto(store, {
-        states: [0, 1],
-        participant: args.as === 'leader' ? 0 : 1,
-      });
       channelLookup.set(key, appChannel.channelId);
     }
 

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -803,6 +803,11 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
       }
 
       checkRequests(requests);
+
+      // BEGIN REGRESSION CHECK
+      // Note that requestsBefore are _modified
+      checkRequests(requestsBefore);
+      // END REGRESSION CHECK
     });
   };
 }

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -542,8 +542,7 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
 
     // first we need to turn strings like 'c' and 'd' into actual channels in the store
     for (const key of testCase.referencedChannelDests) {
-      const appChannel = TestChannel.create({aBal: 5, bBal: 5});
-      channelLookup.set(key, appChannel.channelId);
+      channelLookup.set(key, TestChannel.create({aBal: 5, bBal: 5}).channelId);
     }
 
     // - construct and add the before states

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -587,7 +587,7 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     // crank
     // -----
     const response = EngineResponse.initialize();
-    await LedgerManager.create({store}).crank(ledgerChannel.channelId, response);
+    manager.crank(ledgerChannel.channelId, response);
 
     // assertions
     // ----------

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -37,6 +37,28 @@ afterEach(async () => {
   await DBAdmin.truncateDatabase(defaultTestConfig());
 });
 
+it(
+  'SYNC: will create a proposal from requests in the queue',
+  testSynchronousLogic({
+    as: 'leader',
+    before: {
+      agreed: {turn: 5, bals: {a: 5, b: 5, c: 10}},
+      requests: [
+        ['fund', 'd', 1, 1, 'queued'],
+        ['defund', 'c', 5, 5, 'queued'],
+      ],
+    },
+    after: {
+      agreed: {turn: 5, bals: {a: 5, b: 5, c: 10}},
+      proposed: {turn: 6, bals: {a: 9, b: 9, d: 2}},
+      requests: [
+        ['fund', 'd', 1, 1, 'pending', {missedOps: 0, lastSeen: 5}],
+        ['defund', 'c', 5, 5, 'pending', {missedOps: 0, lastSeen: 5}],
+      ],
+    },
+  })
+);
+
 describe('as leader', () => {
   describe('in the accept state', () => {
     it(
@@ -502,6 +524,118 @@ describe('as follower', () => {
 });
 
 function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
+  return async () => {
+    // setup
+    // -----
+    const testCase = new LedgerCrankTestCase(args);
+
+    // - create skeleton ledgerChannelObject
+    const ledgerChannel = TestLedgerChannel.create({});
+
+    const channelLookup = new ChannelLookup();
+    channelLookup.set('a', ledgerChannel.participantA.destination);
+    channelLookup.set('b', ledgerChannel.participantB.destination);
+
+    // first we need to turn strings like 'c' and 'd' into actual channels in the store
+    for (const key of testCase.referencedChannelDests) {
+      const appChannel = TestChannel.create({aBal: 5, bBal: 5});
+      await appChannel.insertInto(store, {
+        states: [0, 1],
+        participant: args.as === 'leader' ? 0 : 1,
+      });
+      channelLookup.set(key, appChannel.channelId);
+    }
+
+    // - construct and add the before states
+    const stateToParams = (
+      state: StateDesc,
+      type: 'agreed' | 'proposed' | 'counter-proposed'
+    ): any => ({
+      turn: state.turn,
+      bals: Object.keys(state.bals).map(
+        k => [channelLookup.get(k), state.bals[k]] as [string, number]
+      ),
+      signedBy: {agreed: 'both', proposed: 0, 'counter-proposed': 1}[type],
+    });
+    await ledgerChannel.insertInto(store, {
+      participant: args.as === 'leader' ? 0 : 1,
+      states: _.compact([
+        testCase.agreedBefore && stateToParams(testCase.agreedBefore, 'agreed'),
+        testCase.proposedBefore && stateToParams(testCase.proposedBefore, 'proposed'),
+        testCase.counterProposedBefore &&
+          stateToParams(testCase.counterProposedBefore, 'counter-proposed'),
+      ]),
+    });
+
+    for (const req of testCase.requestsBefore) {
+      const channelToBeFunded = channelLookup.get(req.channelKey);
+
+      switch (req.type) {
+        case 'fund':
+          await ledgerChannel.insertFundingRequest(store, {...req, channelToBeFunded});
+          break;
+        case 'defund':
+          await ledgerChannel.insertDefundingRequest(store, {...req, channelToBeFunded});
+          break;
+        default:
+          unreachable(req.type);
+      }
+    }
+
+    // crank
+    // -----
+    const response = EngineResponse.initialize();
+    await LedgerManager.create({store}).crank(ledgerChannel.channelId, response);
+
+    // assertions
+    // ----------
+    await store.transaction(async tx => {
+      // fetch the ledger channel and check that the states are ok
+      const ledger = await store.getChannel(ledgerChannel.channelId, tx);
+      if (!ledger) throw new Error(`Ledger not found`);
+      // get the latest agreed state and the turn number
+      const agreedState = ledger.latestFullySignedState;
+      if (!agreedState) throw new Error(`No latest agreed state`);
+
+      const ledgerStateDesc: LedgerStateDesc = {
+        agreed: toStateDesc(agreedState, channelLookup),
+        requests: [],
+      };
+
+      const proposedState = ledger.uniqueStateAt(agreedState.turnNum + 1);
+      if (proposedState) {
+        expect(proposedState.signerIndices).toEqual([0]);
+        ledgerStateDesc['proposed'] = toStateDesc(proposedState, channelLookup);
+      }
+      const counterProposedState = ledger.uniqueStateAt(agreedState.turnNum + 2);
+      if (counterProposedState) {
+        expect(counterProposedState.signerIndices).toEqual([1]);
+        ledgerStateDesc['counterProposed'] = toStateDesc(counterProposedState, channelLookup);
+      }
+
+      // then fetch the ledger requests and check them
+      const requests = await LedgerRequest.query(tx)
+        .select()
+        .where({ledgerChannelId: ledgerChannel.channelId});
+
+      for (const req of requests) {
+        ledgerStateDesc.requests.push([
+          req.type,
+          channelLookup.getKey(req.channelToBeFunded),
+          Number(req.amountA),
+          Number(req.amountB),
+          req.status,
+          {missedOps: req.missedOpportunityCount, lastSeen: req.lastSeenAgreedState || undefined},
+        ]);
+      }
+      ledgerStateDesc.requests.sort();
+      args.after.requests.sort();
+      expect(ledgerStateDesc).toEqual(args.after);
+    });
+  };
+}
+
+function testSynchronousLogic(args: LedgerCrankTestCaseArgs): () => Promise<void> {
   return async () => {
     // setup
     // -----

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -685,32 +685,20 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     });
 
     const requests: RichLedgerRequest[] = [];
-    const uninsertedRequests: RichLedgerRequest[] = [];
     for (const req of testCase.requestsBefore) {
       const channelToBeFunded = channelLookup.get(req.channelKey);
 
       switch (req.type) {
         case 'fund':
-          requests.push(
-            await ledgerChannel.insertFundingRequest(store, {...req, channelToBeFunded})
-          );
-          uninsertedRequests.push(ledgerChannel.fundingRequest({...req, channelToBeFunded}));
+          requests.push(ledgerChannel.fundingRequest({...req, channelToBeFunded}));
           break;
         case 'defund':
-          requests.push(
-            await ledgerChannel.insertDefundingRequest(store, {...req, channelToBeFunded})
-          );
-          uninsertedRequests.push(ledgerChannel.defundingRequest({...req, channelToBeFunded}));
+          requests.push(ledgerChannel.defundingRequest({...req, channelToBeFunded}));
           break;
         default:
           unreachable(req.type);
       }
     }
-    // REGRESSION TEST
-    expect(requests.map(describeRequest).sort()).toMatchObject(
-      uninsertedRequests.map(describeRequest).sort()
-    );
-    // REGRESSION TEST
 
     // crank
     // -----

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -18,6 +18,7 @@ jest.setTimeout(10_000);
 
 let store: Store;
 
+let manager: LedgerManager;
 beforeAll(async () => {
   await DBAdmin.migrateDatabase(defaultTestConfig());
 });
@@ -30,6 +31,7 @@ beforeEach(async () => {
     '0',
     createLogger(defaultTestConfig())
   );
+  manager = await LedgerManager.create({store});
   await DBAdmin.truncateDatabase(defaultTestConfig());
 });
 
@@ -697,7 +699,7 @@ function testSynchronousLogic(args: LedgerCrankTestCaseArgs): () => Promise<void
     // crank
     // -----
     const response = EngineResponse.initialize();
-    await LedgerManager.create({store}).crank(ledgerChannel.channelId, response);
+    manager.crank(ledgerChannel.channelId, response);
 
     // assertions
     // ----------

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -7,14 +7,9 @@ import {
   unreachable,
 } from '@statechannels/wallet-core';
 
-import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
 import {SignedBy, StateWithBals, TestChannel} from '../../engine/__test__/fixtures/test-channel';
-import {Store} from '../../engine/store';
 import {TestLedgerChannel} from '../../engine/__test__/fixtures/test-ledger-channel';
-import {createLogger} from '../../logger';
 import {LedgerRequestStatus, RichLedgerRequest} from '../../models/ledger-request';
-import {DBAdmin} from '../..';
 import {LedgerManager} from '../ledger-manager';
 import {Destination} from '../../type-aliases';
 import {State} from '../../models/channel/state';
@@ -23,23 +18,9 @@ import {channel} from '../../models/__test__/fixtures/channel';
 
 jest.setTimeout(10_000);
 
-let store: Store;
-
 let manager: LedgerManager;
 beforeAll(async () => {
-  await DBAdmin.migrateDatabase(defaultTestConfig());
-  store = new Store(
-    knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
-    '0',
-    createLogger(defaultTestConfig())
-  );
-  manager = await LedgerManager.create({store});
-});
-
-afterEach(async () => {
-  await DBAdmin.truncateDatabase(defaultTestConfig());
+  manager = await LedgerManager.create({} as any);
 });
 
 it(
@@ -528,8 +509,8 @@ describe('as follower', () => {
   });
 });
 
-function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
-  return async () => {
+function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => void {
+  return () => {
     // setup
     // -----
     const testCase = new LedgerCrankTestCase(args);
@@ -566,10 +547,6 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     ]);
 
     const myIndex = args.as === 'leader' ? 0 : 1;
-    await ledgerChannel.insertInto(store, {
-      participant: myIndex,
-      states: statesToInsert,
-    });
 
     const originalRequests: RichLedgerRequest[] = [];
     for (const req of testCase.requestsBefore) {

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -685,6 +685,7 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
     });
 
     const requests: RichLedgerRequest[] = [];
+    const uninsertedRequests: RichLedgerRequest[] = [];
     for (const req of testCase.requestsBefore) {
       const channelToBeFunded = channelLookup.get(req.channelKey);
 
@@ -693,16 +694,23 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
           requests.push(
             await ledgerChannel.insertFundingRequest(store, {...req, channelToBeFunded})
           );
+          uninsertedRequests.push(ledgerChannel.fundingRequest({...req, channelToBeFunded}));
           break;
         case 'defund':
           requests.push(
             await ledgerChannel.insertDefundingRequest(store, {...req, channelToBeFunded})
           );
+          uninsertedRequests.push(ledgerChannel.defundingRequest({...req, channelToBeFunded}));
           break;
         default:
           unreachable(req.type);
       }
     }
+    // REGRESSION TEST
+    expect(requests.map(describeRequest).sort()).toMatchObject(
+      uninsertedRequests.map(describeRequest).sort()
+    );
+    // REGRESSION TEST
 
     // crank
     // -----

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -21,9 +21,6 @@ let store: Store;
 let manager: LedgerManager;
 beforeAll(async () => {
   await DBAdmin.migrateDatabase(defaultTestConfig());
-});
-
-beforeEach(async () => {
   store = new Store(
     knex,
     defaultTestConfig().metricsConfiguration.timingMetrics,
@@ -32,6 +29,9 @@ beforeEach(async () => {
     createLogger(defaultTestConfig())
   );
   manager = await LedgerManager.create({store});
+});
+
+beforeEach(async () => {
   await DBAdmin.truncateDatabase(defaultTestConfig());
 });
 

--- a/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/ledger-manager.test.ts
@@ -602,7 +602,7 @@ function _testLedgerCrankOld(args: LedgerCrankTestCaseArgs): () => Promise<void>
       const agreedState = ledger.latestFullySignedState;
       if (!agreedState) throw new Error(`No latest agreed state`);
 
-      const ledgerStateDesc: LedgerStateDesc = {
+      const ledgerStateDesc: LedgerStateDescription = {
         agreed: toStateDesc(agreedState, channelLookup),
         requests: [],
       };
@@ -764,7 +764,7 @@ function testLedgerCrank(args: LedgerCrankTestCaseArgs): () => Promise<void> {
       const agreedState = ledger.latestFullySignedState;
       if (!agreedState) throw new Error(`No latest agreed state`);
 
-      const ledgerStateDesc: LedgerStateDesc = {
+      const ledgerStateDesc: LedgerStateDescription = {
         agreed: toStateDesc(agreedState, channelLookup),
         requests: [],
       };
@@ -938,7 +938,7 @@ type StateDesc = {
   bals: Record<string, number>;
 };
 
-interface LedgerStateDesc {
+interface LedgerStateDescription {
   agreed: StateDesc;
   proposed?: StateDesc;
   counterProposed?: StateDesc;
@@ -947,6 +947,6 @@ interface LedgerStateDesc {
 
 interface LedgerCrankTestCaseArgs {
   as: 'leader' | 'follower';
-  before: LedgerStateDesc;
-  after: LedgerStateDesc;
+  before: LedgerStateDescription;
+  after: LedgerStateDescription;
 }

--- a/packages/server-wallet/src/protocols/challenge-submitter.ts
+++ b/packages/server-wallet/src/protocols/challenge-submitter.ts
@@ -41,9 +41,6 @@ export class ChallengeSubmitter implements Cranker<WalletObjective<SubmitChallen
     const {targetChannelId: channelToLock} = objective.data;
 
     const channel = await this.store.getAndLockChannel(channelToLock, tx);
-    if (!channel) {
-      throw new Error('Channel must exist');
-    }
 
     const status = channel.adjudicatorStatus
       ? channel.adjudicatorStatus.toResult().channelMode

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -48,10 +48,6 @@ export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
     const channelToLock = objective.data.targetChannelId;
     const channel = await this.store.getAndLockChannel(channelToLock, tx);
 
-    if (!channel) {
-      throw new Error('Channel must exist');
-    }
-
     response.queueChannel(channel);
 
     await channel.$fetchGraph('funding', {transaction: tx});

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -45,9 +45,6 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
 
     const channel = await this.store.getAndLockChannel(channelToLock, tx);
 
-    if (!channel) {
-      throw new Error(`ChannelOpener can't find channel with id ${channelToLock}`);
-    }
     // always queue the channel if we've potentially touched it
     response.queueChannel(channel);
 

--- a/packages/server-wallet/src/protocols/defund-channel.ts
+++ b/packages/server-wallet/src/protocols/defund-channel.ts
@@ -37,9 +37,6 @@ export class ChannelDefunder implements Cranker<WalletObjective<DefundChannel>> 
   ): Promise<WaitingFor | Nothing> {
     const {targetChannelId: channelId} = objective.data;
     const channel = await this.store.getAndLockChannel(channelId, tx);
-    if (!channel) {
-      throw new Error('Channel must exist');
-    }
 
     await channel.$fetchGraph('funding', {transaction: tx});
     await channel.$fetchGraph('chainServiceRequests', {transaction: tx});

--- a/packages/server-wallet/src/protocols/ledger-manager.ts
+++ b/packages/server-wallet/src/protocols/ledger-manager.ts
@@ -84,7 +84,6 @@ export class LedgerManager {
       const requests = await this.store.getActiveLedgerRequests(ledgerChannelId, tx);
 
       // sanity checks
-      if (!ledger) return [];
       if (!ledger.isRunning) return [];
       if (!ledger.isLedger) return [];
 

--- a/packages/server-wallet/src/protocols/ledger-manager.ts
+++ b/packages/server-wallet/src/protocols/ledger-manager.ts
@@ -69,15 +69,11 @@ import {LedgerRequest} from '../models/ledger-request';
 // accurately update the missedOpportunityCount.
 //
 export class LedgerManager {
-  private store: Store;
-
   static create(params: LedgerManagerParams): LedgerManager {
-    return new this(params);
+    return new this(params.store);
   }
 
-  private constructor({store}: LedgerManagerParams) {
-    this.store = store;
-  }
+  private constructor(private store: Store) {}
 
   async crank(ledgerChannelId: string, response: EngineResponse): Promise<Destination[]> {
     return this.store.transaction(async tx => {

--- a/packages/server-wallet/src/protocols/ledger-manager.ts
+++ b/packages/server-wallet/src/protocols/ledger-manager.ts
@@ -119,7 +119,7 @@ export class LedgerManager {
    * @param requests LedgerRequest model **to be mutated during cranking*
    * @returns states to sign for ledger channel
    */
-  private synchronousCrankLogic(ledger: Channel, requests: RichLedgerRequest[]): State[] {
+  synchronousCrankLogic(ledger: Channel, requests: RichLedgerRequest[]): State[] {
     // determine which state we're in
     const ledgerState = this.determineLedgerState(ledger);
     // what happens next depends on whether we're the leader or follower

--- a/packages/server-wallet/src/protocols/ledger-manager.ts
+++ b/packages/server-wallet/src/protocols/ledger-manager.ts
@@ -115,8 +115,8 @@ export class LedgerManager {
 
   /**
    *
-   * @param ledger Channel model **not mutated during cranking*
-   * @param requests LedgerRequest model **to be mutated during cranking*
+   * @param ledger Channel model **not mutated during cranking**
+   * @param requests LedgerRequest model **to be mutated during cranking**
    * @returns states to sign for ledger channel
    */
   synchronousCrankLogic(ledger: Channel, requests: RichLedgerRequest[]): State[] {


### PR DESCRIPTION
# Description

Currently, `ledger-manager.test.ts` tests `LedgerManager.crank`, which is asynchronous and requires DB access.

This PR exposes the synchronous logic (which accounts for ~90% of the logic of LedgerManager) as a public method, and incrementally refactors `testLedgerCrank` to be a synchronous function. The synchronous logic is purish -- it does not mutate the `Channel` model, but does mutate the `LedgerRequests[]` models that are passed in.

The main motivation of this work is to move the ledger funding protocol into `wallet-core`, where it can be re-used by the `xstate-wallet` package. Secondary benefits are:
1. the tests are significantly faster: with no DB access, I observed a 50% speedup locally. Since it previously took ~60s to run the entire test suite, this is a significant boon to anyone updating the ledger funding logic.
2. the tests do not hit the DB: we can run parallel tests again!
3. the tests are easier to debug: I do not have good success debugging tests that have asynchronous DB access. Pausing the process tends to cause knex timeouts.

The shortcomings of this approach are that the database access used by `LedgerManager.crank` are not tested in `ledger-manager.test.ts`. Since this logic is tested in our `with-peers` integration test, I believe this is an acceptable tradeoff.

## Supporting Changes
1. `TestLedgerChannel` returns `LedgerRequest` models synchronously, without inserting them into the store
2. `getAndLockChannel` always returns a `Channel`. (currently, every callee immediately checks that the return value is truthy, and throws elsewise)

## How Has This Been Tested?

My approach here was to figure out how to accurately construct the test input and output without introducing "regressions". So, I pass through many intermediate states where the test is _testing itself against the old behaviour_.

I believe the `ledger-manager.test.ts` passes on _every commit_.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
