### PR TITLE
Fix onOpenChannelObjective in xstate wallet

### DIFF
--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -269,13 +269,14 @@ export class ChannelWallet {
       this.store.chain.chainUpdatedFeed(channelId).subscribe({
         next: chainInfo => this.onFundingUpdate(channelId, chainInfo)
       });
+      this.registeredChannels.add(channelId);
     }
     const pk = await this.store.getPrivateKey(await this.store.getAddress());
     const depositInfo = await this.getDepositInfo(channelId);
 
     const response = this.crankOpenChannelObjective(
       channel,
-      this.channelFunding[channelId],
+      this.channelFunding[channelId] ?? {amountOnChain: '0x0'},
       depositInfo,
       pk
     );


### PR DESCRIPTION
2 bugs fixes are:
- add channel to `registeredChannels` list after the channel is registered with the chain watcher.
- `channelFunding` is undefined for a channel before a chain event is observed or a deposit is triggered. This PR accounts for this situation.