### PR TITLE
chore: add helper config for ninja-nitro tests

### DIFF
--- a/packages/nitro-protocol/config/jest/jest.ninja-nitro.config.js
+++ b/packages/nitro-protocol/config/jest/jest.ninja-nitro.config.js
@@ -1,0 +1,6 @@
+var config = require('./jest.config');
+config.testMatch = ['<rootDir>/test/**/ninja-nitro/**/*.test.ts'];
+config.reporters = ['default'];
+config.globalSetup = '<rootDir>/jest/contract-test-setup.ts';
+config.globalTeardown = '<rootDir>/jest/contract-test-teardown.ts';
+module.exports = config;

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -96,7 +96,8 @@
     "test:ci": "yarn test:ci:app && yarn test:ci:contracts",
     "test:ci:app": "yarn test:app --all --ci --bail --maxWorkers=4",
     "test:ci:contracts": "yarn test:contracts --all --ci --bail --maxWorkers=4",
-    "test:contracts": "jest -c ./config/jest/jest.contracts.config.js"
+    "test:contracts": "jest -c ./config/jest/jest.contracts.config.js",
+    "test:ninja-nitro": "jest -c ./config/jest/jest.ninja-nitro.config.js"
   },
   "types": "lib/src/index.d.ts"
 }


### PR DESCRIPTION
## Problem

I was having some confusion / trouble when attempting to run specific test files, owing to the `yarn test` script calling multiple test configurations and not passing arguments to each.

This config handles specific-file arguments, and serves as a convenient shorthand for running 

## Shortcomings

Adding more configuration increases mental load. In the event that ninja-nitro is replaces nitro, maybe the distinction between existing test configurations and this one disappears, and this config should be removed.

## How Has This Been Tested? [Optional] 

The new configuration runs the expected tests.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
