### PR TITLE
Patch xstate to remove a very noisy warning

### DIFF
--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -86,7 +86,7 @@
     "webpack-manifest-plugin": "2.2.0",
     "webpack-merge": "4.2.2",
     "workbox-webpack-plugin": "5.0.0",
-    "xstate": "4.13.0"
+    "xstate": "4.17.1"
   },
   "devDependencies": {
     "@babel/core": "7.11.4",

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -396,12 +396,13 @@ export function logTransition(state: State<any, any, any, any>, event, id?: stri
     log({id, from, to, context, event}, 'WORKFLOW TRANSITION id %s event %o', id, event.type);
   }
 
-  Object.keys(state.children).forEach(k => {
-    const child = state.children[k];
+  // TODO: this is commented out with the upgrade to xstate@4.17.1 since child.state property does not exist
+  // Object.keys(state.children).forEach(k => {
+  //   const child = state.children[k];
 
-    if (child.state && 'onTransition' in child) {
-      const subId = (child as any).state.configuration[0].id;
-      (child as any).onTransition((state, event) => logTransition(state, event, `${id}/${subId}`));
-    }
-  });
+  //   if (child.state && 'onTransition' in child) {
+  //     const subId = (child as any).state.configuration[0].id;
+  //     (child as any).onTransition((state, event) => logTransition(state, event, `${id}/${subId}`));
+  //   }
+  // });
 }

--- a/packages/xstate-wallet/src/integration-tests/closing.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/closing.test.ts
@@ -18,9 +18,7 @@ import {Player, hookUpMessaging, generateCloseRequest} from './helpers';
 
 jest.setTimeout(30000);
 
-// TODO: unskip test
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip('concludes on their turn', async () => {
+test('concludes on their turn', async () => {
   const fakeChain = new FakeChain();
 
   const playerA = await Player.createPlayer(

--- a/packages/xstate-wallet/src/integration-tests/helpers.ts
+++ b/packages/xstate-wallet/src/integration-tests/helpers.ts
@@ -184,7 +184,7 @@ export function generatePlayerUpdate(
       appData: '0x00',
       allocations: [
         {
-          assetHolderAddress: utils.hexZeroPad('0x00', 32),
+          assetHolderAddress: '0x0000000000000000000000000000000000000000',
           allocationItems: [
             {
               destination: playerA.destination,

--- a/packages/xstate-wallet/src/integration-tests/running.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/running.test.ts
@@ -1,115 +1,109 @@
-test('placeholder test', () => {
-  expect(1).toEqual(1);
+import {simpleEthAllocation, BN, makeAddress} from '@statechannels/wallet-core';
+import {constants} from 'ethers';
+import {StateChannelsError, ErrorCodes} from '@statechannels/client-api-schema';
+
+import {FakeChain} from '../chain';
+import {CHAIN_NETWORK_ID} from '../config';
+
+import {Player, hookUpMessaging, generatePlayerUpdate} from './helpers';
+jest.setTimeout(30000);
+
+const resolveOnError = (player: Player, errorCode: StateChannelsError['code']) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => reject(`Timed out waiting for error code ${errorCode}`), 3000);
+    player.messagingService.outboxFeed.subscribe(message => {
+      if ('error' in message) {
+        if (message.error.code === errorCode) resolve(message.error);
+        else reject(`Expected code ${errorCode} but received code ${message.error.code}`);
+      }
+    });
+  });
+
+const resolveOnResponse = (player: Player) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => reject('Timed out waiting for update channel response'), 3000);
+    player.messagingService.outboxFeed.subscribe(
+      message => 'id' in message && 'result' in message && resolve(message.result)
+    );
+  });
+
+const resolveOnNotification = (player: Player) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => reject('Timed out waiting for channel updated notification'), 3000);
+    player.messagingService.outboxFeed.subscribe(
+      message =>
+        !('id' in message) &&
+        'method' in message &&
+        message.method === 'ChannelUpdated' &&
+        resolve(message.params)
+    );
+  });
+
+test('accepts states when running', async () => {
+  const fakeChain = new FakeChain();
+
+  const playerA = await Player.createPlayer(
+    '0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e',
+    'PlayerA',
+    fakeChain
+  );
+  const playerB = await Player.createPlayer(
+    '0x3341c348ea8ade1ba7c3b6f071bfe9635c544b7fb5501797eaa2f673169a7d0d',
+    'PlayerB',
+    fakeChain
+  );
+  const players = [playerA, playerB];
+  const expectTurnNumber = async (n: number) =>
+    Promise.all(
+      players.map(async player => {
+        expect(player.workflowState).toEqual('running');
+        expect((await player.store.getEntry(channelId)).latest.turnNum).toBe(n);
+      })
+    );
+
+  const amount = BN.from('0x06f05b59d3b20000');
+  const outcome = simpleEthAllocation(players.map(({destination}) => ({destination, amount})));
+
+  hookUpMessaging(playerA, playerB);
+
+  const turnNum = 5;
+
+  const signedState = players.reduce((state, player) => player.signState(state), {
+    outcome,
+    turnNum,
+    appData: '0x00',
+    isFinal: false,
+    participants: [playerA.participant, playerB.participant],
+    challengeDuration: 4,
+    chainId: CHAIN_NETWORK_ID,
+    appDefinition: makeAddress(constants.AddressZero),
+    channelNonce: 4,
+    signatures: []
+  });
+  const {channelId} = await players.map(({store}) => store.addState(signedState))[0];
+  const applicationDomain = 'localhost';
+
+  const context: any = {channelId, applicationDomain, fundingStrategy: 'Direct'};
+  playerA.startAppWorkflow('running', context);
+  playerB.startAppWorkflow('running', context);
+  playerA.workflowMachine?.send('SPAWN_OBSERVERS');
+  playerB.workflowMachine?.send('SPAWN_OBSERVERS');
+
+  const update = generatePlayerUpdate(channelId, playerA.participant, playerB.participant);
+  playerB.messagingService.receiveRequest(update, applicationDomain);
+
+  const expectedCode: ErrorCodes['UpdateChannel']['NotYourTurn'] = 403;
+  await resolveOnError(playerB, expectedCode);
+
+  playerA.messagingService.receiveRequest(update, applicationDomain);
+  await resolveOnResponse(playerA);
+  await resolveOnNotification(playerB);
+
+  await expectTurnNumber(turnNum + 1);
+
+  await playerB.messagingService.receiveRequest(update, applicationDomain);
+  await resolveOnResponse(playerB);
+  await resolveOnNotification(playerA);
+
+  await expectTurnNumber(turnNum + 2);
 });
-
-//TODO: comment back in
-
-// import {simpleEthAllocation, BN} from '@statechannels/wallet-core';
-// import {constants} from 'ethers';
-// import {StateChannelsError, ErrorCodes} from '@statechannels/client-api-schema';
-
-// import {FakeChain} from '../chain';
-// import {CHAIN_NETWORK_ID} from '../config';
-
-// import {Player, hookUpMessaging, generatePlayerUpdate} from './helpers';
-// jest.setTimeout(30000);
-
-// const resolveOnError = (player: Player, errorCode: StateChannelsError['code']) =>
-//   new Promise((resolve, reject) => {
-//     setTimeout(() => reject(`Timed out waiting for error code ${errorCode}`), 3000);
-//     player.messagingService.outboxFeed.subscribe(message => {
-//       if ('error' in message) {
-//         if (message.error.code === errorCode) resolve(message.error);
-//         else reject(`Expected code ${errorCode} but received code ${message.error.code}`);
-//       }
-//     });
-//   });
-
-// const resolveOnResponse = (player: Player) =>
-//   new Promise((resolve, reject) => {
-//     setTimeout(() => reject('Timed out waiting for update channel response'), 3000);
-//     player.messagingService.outboxFeed.subscribe(
-//       message => 'id' in message && 'result' in message && resolve(message.result)
-//     );
-//   });
-
-// const resolveOnNotification = (player: Player) =>
-//   new Promise((resolve, reject) => {
-//     setTimeout(() => reject('Timed out waiting for channel updated notification'), 3000);
-//     player.messagingService.outboxFeed.subscribe(
-//       message =>
-//         !('id' in message) &&
-//         'method' in message &&
-//         message.method === 'ChannelUpdated' &&
-//         resolve(message.params)
-//     );
-//   });
-
-// eslint-disable-next-line jest/no-commented-out-tests
-// test('accepts states when running', async () => {
-//   const fakeChain = new FakeChain();
-
-//   const playerA = await Player.createPlayer(
-//     '0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e',
-//     'PlayerA',
-//     fakeChain
-//   );
-//   const playerB = await Player.createPlayer(
-//     '0x3341c348ea8ade1ba7c3b6f071bfe9635c544b7fb5501797eaa2f673169a7d0d',
-//     'PlayerB',
-//     fakeChain
-//   );
-//   const players = [playerA, playerB];
-//   const expectTurnNumber = async (n: number) =>
-//     Promise.all(
-//       players.map(async player => {
-//         expect(player.workflowState).toEqual('running');
-//         expect((await player.store.getEntry(channelId)).latest.turnNum).toBe(n);
-//       })
-//     );
-
-//   const amount = BN.from('0x06f05b59d3b20000');
-//   const outcome = simpleEthAllocation(players.map(({destination}) => ({destination, amount})));
-
-//   hookUpMessaging(playerA, playerB);
-
-//   const turnNum = 5;
-//   const signedState = players.reduce((state, player) => player.signState(state), {
-//     outcome,
-//     turnNum,
-//     appData: '0x00',
-//     isFinal: false,
-//     participants: [playerA.participant, playerB.participant],
-//     challengeDuration: 4,
-//     chainId: CHAIN_NETWORK_ID,
-//     appDefinition: constants.AddressZero,
-//     channelNonce: 4,
-//     signatures: []
-//   });
-//   const {channelId} = await players.map(({store}) => store.addState(signedState))[0];
-//   const applicationDomain = 'localhost';
-
-//   const context: any = {channelId, applicationDomain, fundingStrategy: 'Direct'};
-//   playerA.startAppWorkflow('running', context);
-//   playerB.startAppWorkflow('running', context);
-//   playerA.workflowMachine?.send('SPAWN_OBSERVERS');
-//   playerB.workflowMachine?.send('SPAWN_OBSERVERS');
-
-//   const update = generatePlayerUpdate(channelId, playerA.participant, playerB.participant);
-//   playerB.messagingService.receiveRequest(update, applicationDomain);
-
-//   const expectedCode: ErrorCodes['UpdateChannel']['NotYourTurn'] = 403;
-//   await resolveOnError(playerB, expectedCode);
-
-//   playerA.messagingService.receiveRequest(update, applicationDomain);
-//   await resolveOnResponse(playerA);
-//   await resolveOnNotification(playerB);
-
-//   await expectTurnNumber(turnNum + 1);
-
-//   await playerB.messagingService.receiveRequest(update, applicationDomain);
-//   await resolveOnResponse(playerB);
-//   await resolveOnNotification(playerA);
-
-//   await expectTurnNumber(turnNum + 2);
-// });

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -47,7 +47,8 @@ const level = window.localStorage.LOG_LEVEL ?? LOG_LEVEL;
 const opts = {name, prettyPrint, browser, level};
 const logger = destination ? pino(opts, destination) : pino(opts);
 logger.on('level-change', (lvl, val, prevLvl, prevVal) => {
-  console.log('wallet: %s (%d) was changed to %s (%d)', lvl, val, prevLvl, prevVal);
+  if (lvl !== prevLvl)
+    console.log('wallet: %s (%d) was changed to %s (%d)', lvl, val, prevLvl, prevVal);
 });
 
 window.addEventListener('message', event => {

--- a/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
@@ -1,330 +1,324 @@
-test('placeholder test', () => {
-  expect(1).toEqual(1);
+/* eslint-disable no-console */
+import {Wallet} from 'ethers';
+import {
+  simpleEthAllocation,
+  makeDestination,
+  State,
+  Objective,
+  DomainBudget,
+  AssetBudget,
+  calculateChannelId,
+  createSignatureEntry,
+  BN,
+  makeAddress
+} from '@statechannels/wallet-core';
+
+import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, WALLET_VERSION} from '../../config';
+import {Backend} from '../dexie-backend';
+import {ChannelStoreEntry} from '../channel-store-entry';
+import {Store, Errors, ObjectStores} from '..';
+const {add} = BN;
+
+require('fake-indexeddb/auto');
+
+const {address: aAddress, privateKey: aPrivateKey} = new Wallet(
+  '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
+); // 0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf
+
+const {address: bAddress, privateKey: bPrivateKey} = new Wallet(
+  '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
+); // 0x2222E21c8019b14dA16235319D34b5Dd83E644A9
+const [aDestination, bDestination] = [aAddress, bAddress].map(makeDestination);
+
+const outcome = simpleEthAllocation([
+  {destination: aDestination, amount: BN.from(5)},
+  {destination: bDestination, amount: BN.from(6)}
+]);
+const turnNum = 4;
+const appData = '0x0abc';
+const isFinal = false;
+const chainId = CHAIN_NETWORK_ID;
+const participants = [
+  {participantId: 'a', destination: aDestination, signingAddress: makeAddress(aAddress)},
+  {participantId: 'b', destination: bDestination, signingAddress: makeAddress(bAddress)}
+];
+const stateVars = {outcome, turnNum, appData, isFinal};
+const channelNonce = 0;
+const appDefinition = makeAddress('0x5409ED021D9299bf6814279A6A1411A7e866A631');
+
+const challengeDuration = CHALLENGE_DURATION;
+const channelConstants = {chainId, participants, channelNonce, appDefinition, challengeDuration};
+const state: State = {...stateVars, ...channelConstants};
+const channelId = calculateChannelId(channelConstants);
+const signature = createSignatureEntry(state, aPrivateKey);
+const signedState = {...state, signatures: [signature]};
+const signedStates = [signedState];
+
+const aStore = async (noPrivateKeys = false) => {
+  const store = new Store(undefined, new Backend());
+  const privateKeys = noPrivateKeys ? undefined : [aPrivateKey];
+  await store.initialize(privateKeys, true);
+  return store;
+};
+
+describe('getAddress', () => {
+  it('returns an address', async () => {
+    const store = await aStore();
+    const address = await store.getAddress();
+
+    expect(address).toEqual(aAddress);
+  });
 });
 
-// TODO: comment back in
+describe('channelUpdatedFeed', () => {
+  test('it fires when a state with the correct channel id is received', async () => {
+    const store = await aStore();
+    return new Promise<void>(resolve => {
+      store.channelUpdatedFeed(channelId).subscribe(x => {
+        expect(x.latest).toMatchObject(state);
+        resolve();
+      });
 
-/* eslint-disable jest/no-commented-out-tests */
+      store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
+    });
+  });
 
-// /* eslint-disable no-console */
-// import {Wallet} from 'ethers';
-// import {
-//   simpleEthAllocation,
-//   makeDestination,
-//   State,
-//   Objective,
-//   DomainBudget,
-//   AssetBudget,
-//   calculateChannelId,
-//   createSignatureEntry,
-//   BN
-// } from '@statechannels/wallet-core';
+  test("it doesn't fire if the channelId doesn't match", async () => {
+    const store = await aStore();
 
-// import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, WALLET_VERSION} from '../../config';
-// import {Backend} from '../dexie-backend';
-// import {ChannelStoreEntry} from '../channel-store-entry';
-// import {Store, Errors, ObjectStores} from '..';
-// const {add} = BN;
+    const outputs: ChannelStoreEntry[] = [];
+    store.channelUpdatedFeed('a-different-channel-id').subscribe(x => outputs.push(x));
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
 
-// require('fake-indexeddb/auto');
+    expect(outputs).toEqual([]);
+  });
+});
 
-// const {address: aAddress, privateKey: aPrivateKey} = new Wallet(
-//   '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
-// ); // 0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf
+//eslint-disable-next-line jest/no-disabled-tests
+test.skip('newObjectiveFeed', async () => {
+  const objective: Objective = {
+    type: 'OpenChannel',
+    participants: [],
+    data: {targetChannelId: 'foo', fundingStrategy: 'Direct'}
+  };
 
-// const {address: bAddress, privateKey: bPrivateKey} = new Wallet(
-//   '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
-// ); // 0x2222E21c8019b14dA16235319D34b5Dd83E644A9
-// const [aDestination, bDestination] = [aAddress, bAddress].map(makeDestination);
+  const store = await aStore();
 
-// const outcome = simpleEthAllocation([
-//   {destination: aDestination, amount: BN.from(5)},
-//   {destination: bDestination, amount: BN.from(6)}
-// ]);
-// const turnNum = 4;
-// const appData = '0x0abc';
-// const isFinal = false;
-// const chainId = CHAIN_NETWORK_ID;
-// const participants = [
-//   {participantId: 'a', destination: aDestination, signingAddress: aAddress},
-//   {participantId: 'b', destination: bDestination, signingAddress: bAddress}
-// ];
-// const stateVars = {outcome, turnNum, appData, isFinal};
-// const channelNonce = 0;
-// const appDefinition = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
+  const outputs: Objective[] = [];
+  store.objectiveFeed.subscribe(x => outputs.push(x));
 
-// const challengeDuration = CHALLENGE_DURATION;
-// const channelConstants = {chainId, participants, channelNonce, appDefinition, challengeDuration};
-// const state: State = {...stateVars, ...channelConstants};
-// const channelId = calculateChannelId(channelConstants);
-// const signature = createSignatureEntry(state, aPrivateKey);
-// const signedState = {...state, signatures: [signature]};
-// const signedStates = [signedState];
+  await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
+  expect(outputs).toEqual([objective]);
 
-// const aStore = async (noPrivateKeys = false) => {
-//   const store = new Store(undefined, new Backend());
-//   const privateKeys = noPrivateKeys ? undefined : [aPrivateKey];
-//   await store.initialize(privateKeys, true);
-//   return store;
-// };
+  // doing it twice doesn't change anything
+  await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
+  expect(outputs).toEqual([objective]);
+});
 
-// describe('getAddress', () => {
-//   it('returns an address', async () => {
-//     const store = await aStore();
-//     const address = await store.getAddress();
+describe('createChannel', () => {
+  it('returns a ChannelStoreEntry', async () => {
+    const store = await aStore();
 
-//     expect(address).toEqual(aAddress);
-//   });
-// });
+    const firstEntry = await store.createChannel(
+      participants,
+      challengeDuration,
+      stateVars,
+      appDefinition
+    );
 
-// describe('channelUpdatedFeed', () => {
-//   test('it fires when a state with the correct channel id is received', async () => {
-//     const store = await aStore();
-//     return new Promise<void>(resolve => {
-//       store.channelUpdatedFeed(channelId).subscribe(x => {
-//         expect(x.latest).toMatchObject(state);
-//         resolve();
-//       });
+    expect(firstEntry.channelId).toMatch(/0x/);
 
-//       store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
-//     });
-//   });
+    const secondEntry = await store.createChannel(
+      participants,
+      challengeDuration,
+      stateVars,
+      appDefinition
+    );
 
-//   test("it doesn't fire if the channelId doesn't match", async () => {
-//     const store = await aStore();
+    expect(firstEntry.channelId).not.toEqual(secondEntry.channelId);
+  });
 
-//     const outputs: ChannelStoreEntry[] = [];
-//     store.channelUpdatedFeed('a-different-channel-id').subscribe(x => outputs.push(x));
-//     await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
+  it("fails if the wallet doesn't hold the private key for any participant", async () => {
+    const store = await aStore(true);
 
-//     expect(outputs).toEqual([]);
-//   });
-// });
+    await expect(
+      store.createChannel(participants, challengeDuration, stateVars, appDefinition)
+    ).rejects.toMatchObject({message: Errors.notInChannel});
+  });
+});
 
-// test('newObjectiveFeed', async () => {
-//   const objective: Objective = {
-//     type: 'OpenChannel',
-//     participants: [],
-//     data: {targetChannelId: 'foo', fundingStrategy: 'Direct'}
-//   };
+describe('signAndAdd', () => {
+  let entry: ChannelStoreEntry;
+  let store: Store;
+  beforeEach(async () => {
+    store = await aStore();
 
-//   const store = await aStore();
+    entry = await store.createChannel(participants, challengeDuration, stateVars, appDefinition);
+  });
+  it('returns the new entry when successful', async () => {
+    const {channelId, latest} = entry;
 
-//   const outputs: Objective[] = [];
-//   store.objectiveFeed.subscribe(x => outputs.push(x));
+    const turnNum = latest.turnNum + 5;
+    const newEntry = await store.signAndAddState(channelId, {...latest, turnNum});
 
-//   await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
-//   expect(outputs).toEqual([objective]);
+    expect(newEntry.latestSignedByMe.turnNum.toString()).toMatch(turnNum.toString());
+  });
 
-//   // doing it twice doesn't change anything
-//   await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
-//   expect(outputs).toEqual([objective]);
-// });
+  it('reverts if the state is stale', async () => {
+    const {channelId, latest} = entry;
+    const expectStateTurnNums = async turnNums =>
+      expect((await store.getEntry(channelId)).sortedStates.map(s => s.turnNum)).toEqual(turnNums);
 
-// describe('createChannel', () => {
-//   it('returns a ChannelStoreEntry', async () => {
-//     const store = await aStore();
+    await expectStateTurnNums([latest.turnNum]);
 
-//     const firstEntry = await store.createChannel(
-//       participants,
-//       challengeDuration,
-//       stateVars,
-//       appDefinition
-//     );
+    const turnNum = latest.turnNum + 5;
+    const {latestSignedByMe} = await store.signAndAddState(channelId, {...latest, turnNum});
+    await expectStateTurnNums([turnNum, latest.turnNum]);
 
-//     expect(firstEntry.channelId).toMatch(/0x/);
+    const staleTurnNum = latestSignedByMe.turnNum - 2;
 
-//     const secondEntry = await store.createChannel(
-//       participants,
-//       challengeDuration,
-//       stateVars,
-//       appDefinition
-//     );
+    await expect(store.signAndAddState(channelId, latest)).rejects.toThrow(Errors.staleState);
+    await expect(
+      store.signAndAddState(channelId, {...latest, turnNum: staleTurnNum})
+    ).rejects.toThrow(Errors.staleState);
 
-//     expect(firstEntry.channelId).not.toEqual(secondEntry.channelId);
-//   });
+    await expectStateTurnNums([turnNum, latest.turnNum]);
+  });
+});
 
-//   it("fails if the wallet doesn't hold the private key for any participant", async () => {
-//     const store = await aStore(true);
+describe('pushMessage', () => {
+  it('stores states', async () => {
+    const store = await aStore();
+    await store.createChannel(
+      signedState.participants,
+      signedState.challengeDuration,
+      {...signedState, turnNum: 0},
+      signedState.appDefinition
+    );
 
-//     await expect(
-//       store.createChannel(participants, challengeDuration, stateVars, appDefinition)
-//     ).rejects.toMatchObject({message: Errors.notInChannel});
-//   });
-// });
+    const nextState = {...state, turnNum: state.turnNum + 2};
+    await store.pushMessage({
+      walletVersion: WALLET_VERSION,
+      signedStates: [
+        {
+          ...nextState,
+          signatures: [createSignatureEntry(nextState, bPrivateKey)]
+        }
+      ]
+    });
+    expect((await store.getEntry(channelId)).latest).toMatchObject(nextState);
+  });
 
-// describe('signAndAdd', () => {
-//   let entry: ChannelStoreEntry;
-//   let store: Store;
-//   beforeEach(async () => {
-//     store = await aStore();
+  it('creates a channel if it receives states for a new channel', async () => {
+    const store = await aStore();
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
+    expect(await store.getEntry(channelId)).not.toBeUndefined();
+  });
+});
 
-//     entry = await store.createChannel(participants, challengeDuration, stateVars, appDefinition);
-//   });
-//   it('returns the new entry when successful', async () => {
-//     const {channelId, latest} = entry;
+describe('getBudget', () => {
+  it('returns an address', async () => {
+    const store = await aStore();
+    const budget: DomainBudget = {
+      domain: 'localhost',
+      hubAddress: 'foo',
+      forAsset: {
+        ETH: {
+          assetHolderAddress: 'home',
+          availableSendCapacity: BN.from(10),
+          availableReceiveCapacity: BN.from(5),
+          channels: {}
+        }
+      }
+    };
+    await store.createBudget(budget);
 
-//     const turnNum = latest.turnNum + 5;
-//     const newEntry = await store.signAndAddState(channelId, {...latest, turnNum});
+    const storedBudget = await store.getBudget(budget.domain);
 
-//     expect(newEntry.latestSignedByMe.turnNum.toString()).toMatch(turnNum.toString());
-//   });
+    const {availableReceiveCapacity, availableSendCapacity} = storedBudget?.forAsset
+      .ETH as AssetBudget;
+    expect(add(availableReceiveCapacity, availableSendCapacity)).toBe(BN.from(15));
+  });
+});
 
-//   it('reverts if the state is stale', async () => {
-//     const {channelId, latest} = entry;
-//     const expectStateTurnNums = async turnNums =>
-//       expect((await store.getEntry(channelId)).sortedStates.map(s => s.turnNum)).toEqual(turnNums);
+describe('setLedger', () => {
+  it('works', async () => {
+    const store = await aStore();
 
-//     await expectStateTurnNums([latest.turnNum]);
+    await store.addState(signedState);
+    await store.setLedger(channelId);
+    expect((await store.getLedger(participants[1].participantId)).channelId).toEqual(channelId);
+  });
+});
 
-//     const turnNum = latest.turnNum + 5;
-//     const {latestSignedByMe} = await store.signAndAddState(channelId, {...latest, turnNum});
-//     await expectStateTurnNums([turnNum, latest.turnNum]);
+const getBackend = (store: Store) => (store as any).backend as Backend;
 
-//     const staleTurnNum = latestSignedByMe.turnNum - 2;
+describe('transactions', () => {
+  // TODO:
+  // These tests generally pass, but something is going wrong with the
+  // expectations on promise rejections
+  // expect(...).rejects.toThrow('someMessage')
+  // will fail if 'someMessage' is incorrect, but if it is correct, then
+  // 1. the test passes
+  // 2. either jest or dexie warns about an unhandled rejection
+  let warner;
+  beforeAll(() => {
+    warner = console.warn;
+    console.warn = () => console.error('Suppressing fire');
+  });
+  afterAll(() => (console.warn = warner.bind(console)));
 
-//     await expect(store.signAndAddState(channelId, latest)).rejects.toThrow(Errors.staleState);
-//     await expect(
-//       store.signAndAddState(channelId, {...latest, turnNum: staleTurnNum})
-//     ).rejects.toThrow(Errors.staleState);
+  let backend: Backend;
+  beforeEach(async () => {
+    backend = getBackend(await aStore());
+  });
 
-//     await expectStateTurnNums([turnNum, latest.turnNum]);
-//   });
-// });
+  it('works', async () => {
+    const result = await backend.transaction('readwrite', [ObjectStores.ledgers], async () => {
+      await backend.setLedger('foo', 'bar');
 
-// describe('pushMessage', () => {
-//   it('stores states', async () => {
-//     const store = await aStore();
-//     await store.createChannel(
-//       signedState.participants,
-//       signedState.challengeDuration,
-//       {...signedState, turnNum: 0},
-//       signedState.appDefinition
-//     );
+      return await backend.getLedger('foo');
+    });
 
-//     const nextState = {...state, turnNum: state.turnNum + 2};
-//     await store.pushMessage({
-//       walletVersion: WALLET_VERSION,
-//       signedStates: [
-//         {
-//           ...nextState,
-//           signatures: [createSignatureEntry(nextState, bPrivateKey)]
-//         }
-//       ]
-//     });
-//     expect((await store.getEntry(channelId)).latest).toMatchObject(nextState);
-//   });
+    expect(result).toEqual('bar');
+  });
 
-//   it('creates a channel if it receives states for a new channel', async () => {
-//     const store = await aStore();
-//     await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
-//     expect(await store.getEntry(channelId)).not.toBeUndefined();
-//   });
-// });
+  it('throws when writing during a readwrite transaction', async () =>
+    expect(
+      backend.transaction(
+        'readonly',
+        [ObjectStores.ledgers],
+        async () => await backend.setLedger('foo', 'bar')
+      )
+    ).rejects.toThrow('Transaction is readonly'));
 
-// describe('getBudget', () => {
-//   it('returns an address', async () => {
-//     const store = await aStore();
-//     const budget: DomainBudget = {
-//       domain: 'localhost',
-//       hubAddress: 'foo',
-//       forAsset: {
-//         ETH: {
-//           assetHolderAddress: 'home',
-//           availableSendCapacity: BN.from(10),
-//           availableReceiveCapacity: BN.from(5),
-//           channels: {}
-//         }
-//       }
-//     };
-//     await store.createBudget(budget);
+  it('throws when accessing stores not whitelisted', async () =>
+    expect(
+      backend.transaction(
+        'readonly',
+        [ObjectStores.ledgers],
+        async () => await backend.getPrivateKey('foo')
+      )
+    ).rejects.toThrow('NotFoundError:'));
 
-//     const storedBudget = await store.getBudget(budget.domain);
+  it('throws when aborted', () =>
+    expect(
+      backend.transaction('readonly', [ObjectStores.ledgers], async tx => {
+        tx.abort();
 
-//     const {availableReceiveCapacity, availableSendCapacity} = storedBudget?.forAsset
-//       .ETH as AssetBudget;
-//     expect(add(availableReceiveCapacity, availableSendCapacity)).toBe(BN.from(15));
-//   });
-// });
+        return;
+      })
+    ).rejects.toThrow('Transaction committed too early.'));
 
-// describe('setLedger', () => {
-//   it('works', async () => {
-//     const store = await aStore();
-
-//     await store.addState(signedState);
-//     await store.setLedger(channelId);
-//     expect((await store.getLedger(participants[1].participantId)).channelId).toEqual(channelId);
-//   });
-// });
-
-// const getBackend = (store: Store) => (store as any).backend as Backend;
-
-// describe('transactions', () => {
-//   // TODO:
-//   // These tests generally pass, but something is going wrong with the
-//   // expectations on promise rejections
-//   // expect(...).rejects.toThrow('someMessage')
-//   // will fail if 'someMessage' is incorrect, but if it is correct, then
-//   // 1. the test passes
-//   // 2. either jest or dexie warns about an unhandled rejection
-//   let warner;
-//   beforeAll(() => {
-//     warner = console.warn;
-//     console.warn = () => console.error('Suppressing fire');
-//   });
-//   afterAll(() => (console.warn = warner.bind(console)));
-
-//   let backend: Backend;
-//   beforeEach(async () => {
-//     backend = getBackend(await aStore());
-//   });
-
-//   it('works', async () => {
-//     const result = await backend.transaction('readwrite', [ObjectStores.ledgers], async () => {
-//       await backend.setLedger('foo', 'bar');
-
-//       return await backend.getLedger('foo');
-//     });
-
-//     expect(result).toEqual('bar');
-//   });
-
-//   it('throws when writing during a readwrite transaction', async () =>
-//     expect(
-//       backend.transaction(
-//         'readonly',
-//         [ObjectStores.ledgers],
-//         async () => await backend.setLedger('foo', 'bar')
-//       )
-//     ).rejects.toThrow('Transaction is readonly'));
-
-//   it('throws when accessing stores not whitelisted', async () =>
-//     expect(
-//       backend.transaction(
-//         'readonly',
-//         [ObjectStores.ledgers],
-//         async () => await backend.getPrivateKey('foo')
-//       )
-//     ).rejects.toThrow('NotFoundError:'));
-
-//   it('throws when aborted', () =>
-//     expect(
-//       backend.transaction('readonly', [ObjectStores.ledgers], async tx => {
-//         tx.abort();
-
-//         return;
-//       })
-//     ).rejects.toThrow('Transaction committed too early.'));
-
-//   it('throws when awaiting an external async call', () =>
-//     expect(
-//       backend.transaction(
-//         'readonly',
-//         [ObjectStores.ledgers],
-//         () =>
-//           new Promise(resolve => {
-//             setTimeout(resolve, 100);
-//           })
-//       )
-//     ).rejects.toThrow('Transaction committed too early.'));
-// });
+  it('throws when awaiting an external async call', () =>
+    expect(
+      backend.transaction(
+        'readonly',
+        [ObjectStores.ledgers],
+        () =>
+          new Promise(resolve => {
+            setTimeout(resolve, 100);
+          })
+      )
+    ).rejects.toThrow('Transaction committed too early.'));
+});

--- a/packages/xstate-wallet/src/store/tests/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/memory-store.test.ts
@@ -1,174 +1,168 @@
-test('placeholder test', () => {
-  expect(1).toEqual(1);
+import {
+  simpleEthAllocation,
+  makeDestination,
+  calculateChannelId,
+  createSignatureEntry,
+  State,
+  Objective,
+  BN,
+  makeAddress
+} from '@statechannels/wallet-core';
+import {Wallet} from 'ethers';
+
+import {ChannelStoreEntry} from '../channel-store-entry';
+import {MemoryBackend as Backend} from '../memory-backend';
+import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, WALLET_VERSION} from '../../config';
+import {Errors} from '..';
+
+import {Store} from './../store';
+
+const {address: aAddress, privateKey: aPrivateKey} = new Wallet(
+  '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
+); // 0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf
+
+const {address: bAddress, privateKey: bPrivateKey} = new Wallet(
+  '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
+); // 0x2222E21c8019b14dA16235319D34b5Dd83E644A9
+const [aDestination, bDestination] = [aAddress, bAddress].map(makeDestination); // for convenience
+
+const outcome = simpleEthAllocation([
+  {destination: aDestination, amount: BN.from(5)},
+  {destination: bDestination, amount: BN.from(6)}
+]);
+const turnNum = 4;
+const appData = '0x0abc';
+const isFinal = false;
+const chainId = CHAIN_NETWORK_ID;
+const participants = [
+  {participantId: 'a', destination: aDestination, signingAddress: makeAddress(aAddress)},
+  {participantId: 'b', destination: bDestination, signingAddress: makeAddress(bAddress)}
+];
+const stateVars = {outcome, turnNum, appData, isFinal};
+const channelNonce = 0;
+const appDefinition = makeAddress('0x5409ED021D9299bf6814279A6A1411A7e866A631');
+
+const challengeDuration = CHALLENGE_DURATION;
+const channelConstants = {chainId, participants, channelNonce, appDefinition, challengeDuration};
+const state: State = {...stateVars, ...channelConstants};
+const channelId = calculateChannelId(channelConstants);
+const signature = createSignatureEntry(state, aPrivateKey);
+const signedState = {...state, signatures: [signature]};
+const signedStates = [signedState];
+
+const aStore = async (noPrivateKeys = false) => {
+  const store = new Store(undefined, new Backend());
+  const privateKeys = noPrivateKeys ? undefined : [aPrivateKey];
+  await store.initialize(privateKeys, true);
+  return store;
+};
+
+describe('getAddress', () => {
+  it('returns an address', async () => {
+    const store = await aStore();
+    const address = await store.getAddress();
+
+    expect(address).toEqual(aAddress);
+  });
 });
 
-// TODO: comment back in
+describe('channelUpdatedFeed', () => {
+  test('it fires when a state with the correct channel id is received', async () => {
+    const store = await aStore();
+    const outputs: ChannelStoreEntry[] = [];
+    store.channelUpdatedFeed(channelId).subscribe(x => {
+      outputs.push(x);
+    });
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
 
-/* eslint-disable jest/no-commented-out-tests */
+    expect(outputs[0].latest).toMatchObject(state);
+  });
 
-// import {
-//   simpleEthAllocation,
-//   makeDestination,
-//   calculateChannelId,
-//   createSignatureEntry,
-//   State,
-//   Objective,
-//   BN
-// } from '@statechannels/wallet-core';
-// import {Wallet} from 'ethers';
+  test("it doesn't fire if the channelId doesn't match", async () => {
+    const store = await aStore();
 
-// import {ChannelStoreEntry} from '../channel-store-entry';
-// import {MemoryBackend as Backend} from '../memory-backend';
-// import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, WALLET_VERSION} from '../../config';
-// import {Errors} from '..';
+    const outputs: ChannelStoreEntry[] = [];
+    store.channelUpdatedFeed('a-different-channel-id').subscribe(x => outputs.push(x));
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
 
-// import {Store} from './../store';
+    expect(outputs).toEqual([]);
+  });
+});
 
-// const {address: aAddress, privateKey: aPrivateKey} = new Wallet(
-//   '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
-// ); // 0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf
+//eslint-disable-next-line jest/no-disabled-tests
+test.skip('newObjectiveFeed', async () => {
+  const objective: Objective = {
+    type: 'OpenChannel',
+    participants: [],
+    data: {targetChannelId: 'foo', fundingStrategy: 'Direct'}
+  };
 
-// const {address: bAddress, privateKey: bPrivateKey} = new Wallet(
-//   '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
-// ); // 0x2222E21c8019b14dA16235319D34b5Dd83E644A9
-// const [aDestination, bDestination] = [aAddress, bAddress].map(makeDestination); // for convenience
+  const store = await aStore();
 
-// const outcome = simpleEthAllocation([
-//   {destination: aDestination, amount: BN.from(5)},
-//   {destination: bDestination, amount: BN.from(6)}
-// ]);
-// const turnNum = 4;
-// const appData = '0x0abc';
-// const isFinal = false;
-// const chainId = CHAIN_NETWORK_ID;
-// const participants = [
-//   {participantId: 'a', destination: aDestination, signingAddress: aAddress},
-//   {participantId: 'b', destination: bDestination, signingAddress: bAddress}
-// ];
-// const stateVars = {outcome, turnNum, appData, isFinal};
-// const channelNonce = 0;
-// const appDefinition = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
+  const outputs: Objective[] = [];
+  store.objectiveFeed.subscribe(x => outputs.push(x));
 
-// const challengeDuration = CHALLENGE_DURATION;
-// const channelConstants = {chainId, participants, channelNonce, appDefinition, challengeDuration};
-// const state: State = {...stateVars, ...channelConstants};
-// const channelId = calculateChannelId(channelConstants);
-// const signature = createSignatureEntry(state, aPrivateKey);
-// const signedState = {...state, signatures: [signature]};
-// const signedStates = [signedState];
+  await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
+  expect(outputs).toEqual([objective]);
 
-// const aStore = async (noPrivateKeys = false) => {
-//   const store = new Store(undefined, new Backend());
-//   const privateKeys = noPrivateKeys ? undefined : [aPrivateKey];
-//   await store.initialize(privateKeys, true);
-//   return store;
-// };
+  // doing it twice doesn't change anything
+  await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
+  expect(outputs).toEqual([objective]);
+});
 
-// describe('getAddress', () => {
-//   it('returns an address', async () => {
-//     const store = await aStore();
-//     const address = await store.getAddress();
+describe('createChannel', () => {
+  it('returns a channel-store-entry', async () => {
+    const store = await aStore();
 
-//     expect(address).toEqual(aAddress);
-//   });
-// });
+    const firstEntry = await store.createChannel(
+      participants,
+      challengeDuration,
+      stateVars,
+      appDefinition
+    );
 
-// describe('channelUpdatedFeed', () => {
-//   test('it fires when a state with the correct channel id is received', async () => {
-//     const store = await aStore();
-//     const outputs: ChannelStoreEntry[] = [];
-//     store.channelUpdatedFeed(channelId).subscribe(x => {
-//       outputs.push(x);
-//     });
-//     await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
+    expect(firstEntry.channelId).toMatch(/0x/);
 
-//     expect(outputs[0].latest).toMatchObject(state);
-//   });
+    const secondEntry = await store.createChannel(
+      participants,
+      challengeDuration,
+      stateVars,
+      appDefinition
+    );
 
-//   test("it doesn't fire if the channelId doesn't match", async () => {
-//     const store = await aStore();
+    expect(firstEntry.channelId).not.toEqual(secondEntry.channelId);
+  });
 
-//     const outputs: ChannelStoreEntry[] = [];
-//     store.channelUpdatedFeed('a-different-channel-id').subscribe(x => outputs.push(x));
-//     await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
+  it("fails if the wallet doesn't hold the private key for any participant", async () => {
+    const store = await aStore(true);
 
-//     expect(outputs).toEqual([]);
-//   });
-// });
+    await expect(
+      store.createChannel(participants, challengeDuration, stateVars, appDefinition)
+    ).rejects.toMatchObject({message: Errors.notInChannel});
+  });
+});
 
-// test('newObjectiveFeed', async () => {
-//   const objective: Objective = {
-//     type: 'OpenChannel',
-//     participants: [],
-//     data: {targetChannelId: 'foo', fundingStrategy: 'Direct'}
-//   };
+describe('pushMessage', () => {
+  it('stores states', async () => {
+    const store = await aStore();
+    await store.createChannel(
+      signedState.participants,
+      signedState.challengeDuration,
+      {...signedState, turnNum: 0},
+      signedState.appDefinition
+    );
 
-//   const store = await aStore();
+    const nextState = {...state, turnNum: state.turnNum + 2};
+    await store.pushMessage({
+      walletVersion: WALLET_VERSION,
+      signedStates: [{...nextState, signatures: [createSignatureEntry(nextState, bPrivateKey)]}]
+    });
+    expect((await store.getEntry(channelId)).latest).toMatchObject(nextState);
+  });
 
-//   const outputs: Objective[] = [];
-//   store.objectiveFeed.subscribe(x => outputs.push(x));
-
-//   await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
-//   expect(outputs).toEqual([objective]);
-
-//   // doing it twice doesn't change anything
-//   await store.pushMessage({walletVersion: WALLET_VERSION, objectives: [objective]});
-//   expect(outputs).toEqual([objective]);
-// });
-
-// describe('createChannel', () => {
-//   it('returns a channel-store-entry', async () => {
-//     const store = await aStore();
-
-//     const firstEntry = await store.createChannel(
-//       participants,
-//       challengeDuration,
-//       stateVars,
-//       appDefinition
-//     );
-
-//     expect(firstEntry.channelId).toMatch(/0x/);
-
-//     const secondEntry = await store.createChannel(
-//       participants,
-//       challengeDuration,
-//       stateVars,
-//       appDefinition
-//     );
-
-//     expect(firstEntry.channelId).not.toEqual(secondEntry.channelId);
-//   });
-
-//   it("fails if the wallet doesn't hold the private key for any participant", async () => {
-//     const store = await aStore(true);
-
-//     await expect(
-//       store.createChannel(participants, challengeDuration, stateVars, appDefinition)
-//     ).rejects.toMatchObject({message: Errors.notInChannel});
-//   });
-// });
-
-// describe('pushMessage', () => {
-//   it('stores states', async () => {
-//     const store = await aStore();
-//     await store.createChannel(
-//       signedState.participants,
-//       signedState.challengeDuration,
-//       {...signedState, turnNum: 0},
-//       signedState.appDefinition
-//     );
-
-//     const nextState = {...state, turnNum: state.turnNum + 2};
-//     await store.pushMessage({
-//       walletVersion: WALLET_VERSION,
-//       signedStates: [{...nextState, signatures: [createSignatureEntry(nextState, bPrivateKey)]}]
-//     });
-//     expect((await store.getEntry(channelId)).latest).toMatchObject(nextState);
-//   });
-
-//   it('creates a channel if it receives states for a new channel', async () => {
-//     const store = await aStore();
-//     await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
-//     expect(await store.getEntry(channelId)).not.toBeUndefined();
-//   });
-// });
+  it('creates a channel if it receives states for a new channel', async () => {
+    const store = await aStore();
+    await store.pushMessage({walletVersion: WALLET_VERSION, signedStates});
+    expect(await store.getEntry(channelId)).not.toBeUndefined();
+  });
+});

--- a/packages/xstate-wallet/src/ui/selectors.ts
+++ b/packages/xstate-wallet/src/ui/selectors.ts
@@ -2,7 +2,6 @@ import {DomainBudget, unreachable, Uint256} from '@statechannels/wallet-core';
 import {Interpreter} from 'xstate';
 
 import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
-import {WorkflowState as CCCWorkflowState} from '../workflows/confirm';
 import {
   WorkflowState as AppWorkflowState,
   StateValue as AppStateValue
@@ -18,12 +17,6 @@ export function getApplicationStateValue(
   }
 }
 
-export function getConfirmCreateChannelState(
-  applicationWorkflowState: AppWorkflowState
-): CCCWorkflowState {
-  return applicationWorkflowState.children[Object.keys(applicationWorkflowState.children)[0]]
-    .state as CCCWorkflowState;
-}
 export function getConfirmCreateChannelService(
   applicationWorkflowState: AppWorkflowState
 ): Interpreter<any> {

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -136,15 +136,15 @@ const generateConfig = (
         failure: {},
         joining: {
           on: {
-            '': [
-              {target: 'failure', cond: guards.isLedgerFunding}, // TODO: Should we even support ledger funding?
-              {target: 'done', cond: guards.amCreator}
-            ],
             JOIN_CHANNEL: {
               target: 'settingDomain',
               actions: [actions.assignRequestId, actions.sendJoinChannelResponse]
             }
-          }
+          },
+          always: [
+            {target: 'failure', cond: guards.isLedgerFunding}, // TODO: Should we even support ledger funding?
+            {target: 'done', cond: guards.amCreator}
+          ]
         },
         settingDomain: {invoke: {src: 'setapplicationDomain', onDone: 'done'}},
         done: {type: 'final'}

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -164,7 +164,6 @@ const generateConfig = (
       invoke: {src: 'invokeCreateChannelConfirmation', onDone: 'creatingChannel'}
     },
     creatingChannel: {
-      on: {'': {target: 'fundingChannel', cond: guards.amJoiner}},
       invoke: {
         data: (_, event) => event.data,
         src: 'createChannel',
@@ -172,7 +171,8 @@ const generateConfig = (
           target: 'fundingChannel',
           actions: [actions.assignChannelId, actions.sendCreateChannelResponse]
         }
-      }
+      },
+      always: {target: 'fundingChannel', cond: guards.amJoiner}
     },
     fundingChannel: {
       invoke: {

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -157,7 +157,10 @@ const generateConfig = (
     confirmingWithUser: {
       // FIXME We should keep track of whether the UI was turned on in the context.
       // That way, at the end, we know whether we have to send hideUI
-      entry: [actions.displayUi, 'assignUIState'],
+
+      // TODO: implement assignUIState
+      // entry: [actions.displayUi, 'assignUIState'],
+      entry: [actions.displayUi],
       invoke: {src: 'invokeCreateChannelConfirmation', onDone: 'creatingChannel'}
     },
     creatingChannel: {

--- a/packages/xstate-wallet/src/workflows/support-state.ts
+++ b/packages/xstate-wallet/src/workflows/support-state.ts
@@ -1,11 +1,19 @@
-import {AnyEventObject, AssignAction, MachineConfig, assign, spawn, Machine, Actor} from 'xstate';
+import {
+  AnyEventObject,
+  AssignAction,
+  MachineConfig,
+  assign,
+  spawn,
+  Machine,
+  ActorRef
+} from 'xstate';
 import {filter, map} from 'rxjs/operators';
 import {statesEqual, calculateChannelId, State} from '@statechannels/wallet-core';
 
 import {Store} from '../store';
 const WORKFLOW = 'support-state';
 
-export type Init = {state: State; observer?: Actor<any, any>};
+export type Init = {state: State; observer?: ActorRef<any, any>};
 type HasChannelId = Init & {channelId: string};
 
 /*

--- a/packages/xstate-wallet/src/workflows/virtual-defunding-as-hub.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-defunding-as-hub.ts
@@ -119,7 +119,8 @@ const defundGuarantors: StateNodeConfig<any, any, any> = {
     defundLeft: getDataAndInvoke({src: defundLeftGuarantor.name}, {src: supportState.name}),
     defundRight: getDataAndInvoke({src: defundRightGuarantor.name}, {src: supportState.name})
   },
-  exit: 'deleteChannels',
+  // TODO: implement deleteChannels
+  // exit: 'deleteChannels',
   onDone: 'success'
 };
 

--- a/packages/xstate-wallet/src/workflows/virtual-defunding-as-leaf.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-defunding-as-leaf.ts
@@ -108,8 +108,9 @@ const defundTarget: StateNodeConfig<any, any, any> = _.merge(
     {src: finalJointChannelUpdate.name},
     {src: Services.supportState},
     'defundGuarantor'
-  ),
-  {exit: ['deleteTargetChannel']}
+  )
+  // TODO: implement deleteTargetChannel
+  // {exit: ['deleteTargetChannel']}
 );
 
 const defundGuarantorInLedger = (store: Store) => async ({
@@ -163,7 +164,9 @@ const defundGuarantor: StateNodeConfig<any, any, any> = {
     ),
     done: {type: 'final'}
   },
-  exit: ['deleteJointChannel', 'deleteGuarantorChannel', releaseLock.name],
+  // TODO: implement deleteJointChannel and deleteJointChannel
+  // exit: ['deleteJointChannel', 'deleteJointChannel', releaseLock.name],
+  exit: [releaseLock.name],
   onDone: 'releaseFundsFromBudget'
 };
 

--- a/patches/xstate+4.17.1.patch
+++ b/patches/xstate+4.17.1.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/xstate/lib/interpreter.js b/node_modules/xstate/lib/interpreter.js
+index 030bc44..c8c7eba 100644
+--- a/node_modules/xstate/lib/interpreter.js
++++ b/node_modules/xstate/lib/interpreter.js
+@@ -1074,8 +1074,8 @@ function spawn(entity, nameOrOptions) {
+     var resolvedOptions = resolveSpawnOptions(nameOrOptions);
+     return serviceScope.consume(function (service) {
+         if (!environment_1.IS_PRODUCTION) {
+-            var isLazyEntity = utils_1.isMachine(entity) || utils_1.isFunction(entity);
+-            utils_1.warn(!!service || isLazyEntity, "Attempted to spawn an Actor (ID: \"" + (utils_1.isMachine(entity) ? entity.id : 'undefined') + "\") outside of a service. This will have no effect.");
++            // var isLazyEntity = utils_1.isMachine(entity) || utils_1.isFunction(entity);
++            // utils_1.warn(!!service || isLazyEntity, "Attempted to spawn an Actor (ID: \"" + (utils_1.isMachine(entity) ? entity.id : 'undefined') + "\") outside of a service. This will have no effect.");
+         }
+         if (service) {
+             return service.spawn(entity, resolvedOptions.name, resolvedOptions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -31464,10 +31464,10 @@ xregexp@^4.3.0:
   dependencies:
     "@babel/runtime-corejs3" "^7.12.1"
 
-xstate@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.npmjs.org/xstate/-/xstate-4.13.0.tgz#0be22ceb8bae2bc6a025fab330fe44204d76771c"
-  integrity sha512-UnUJJzP2KTPqnmxIoD/ymXtpy/hehZnUlO6EXqWC/72XkPb15p9Oz/X4WhS3QE+by7NP+6b5bCi/GTGFzm5D+A==
+xstate@4.17.1:
+  version "4.17.1"
+  resolved "https://registry.npmjs.org/xstate/-/xstate-4.17.1.tgz#f027b51ee35dae28954d27ad09f37b4d5d5ce40f"
+  integrity sha512-3q7so9qAKFnz9/t7BNQXQtV+9fwDATCOkC+0tAvVqczboEbu6gz2dvPPVCCkj55Hyzgro9aSOntGSPGLei82BA==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Note that https://github.com/statechannels/statechannels/pull/3453 preceeds this PR.

When unit tests for xstate wallet are run, we see a warning that floods the logs:
```
  console.warn
    Warning: Attempted to spawn an Actor (ID: "undefined") outside of a service. This will have no effect.

      61 |     spawnObserver: assign<HasChannelId>((ctx: HasChannelId) => ({
      62 |       ...ctx,
    > 63 |       observer: !ctx.observer ? spawn(notifyWhenSupported(store, ctx)) : ctx.observer
         |                                 ^
      64 |     }))
      65 |   }
      66 | });

      at Object.warn (../../node_modules/xstate/lib/utils.js:451:26)
      at ../../node_modules/xstate/lib/interpreter.js:1078:21
      at Object.consume (../../node_modules/xstate/lib/serviceScope.js:16:38)
      at Object.spawn (../../node_modules/xstate/lib/interpreter.js:1075:25)
      at src/workflows/support-state.ts:63:33
      at ../../node_modules/xstate/lib/utils.js:410:33
          at Array.reduce (<anonymous>)
      at Object.updateContext (../../node_modules/xstate/lib/utils.js:400:25)
      at Object.resolveActions (../../node_modules/xstate/lib/actions.js:409:19)
      at StateNode.Object.<anonymous>.StateNode.resolveTransition (../../node_modules/xstate/lib/StateNode.js:793:35)
      at StateNode.Object.<anonymous>.StateNode.getInitialState (../../node_modules/xstate/lib/StateNode.js:1032:21)
      at StateNode.get (../../node_modules/xstate/lib/StateNode.js:1052:25)
      at ../../node_modules/xstate/lib/Actor.js:44:123
```

After playing around with the `support-state` machine, it is not clear to me how to refactor that code to not trigger the warning. It also appears that [the warning is harmless](https://github.com/davidkpiano/xstate/issues/1429#issuecomment-707959160).

This PR:
- Patches xstate to remove the warning.
- Upgrades xstate dependency to the latest so that that we are patching recent code.