### PR TITLE
Add Jumpstart objectives method

### DIFF
--- a/packages/server-wallet/jest/custom-matchers.ts
+++ b/packages/server-wallet/jest/custom-matchers.ts
@@ -1,4 +1,5 @@
 import { AllocationItem, areAllocationItemsEqual } from "@statechannels/wallet-core";
+import { ObjectiveDoneResult, ObjectiveResult } from "../src/wallet";
 
 expect.extend({
     toContainAllocationItem(received: AllocationItem[], argument: AllocationItem) {
@@ -51,3 +52,43 @@ expect.extend({
     }
   },
 });
+
+expect.extend({
+  toBeObjectiveDoneType: async (
+    received: ObjectiveResult[],
+    expected: ObjectiveDoneResult['type']
+  ) => {
+    const pass = received.length > 0 && received.every(async o => (await o.done).type === expected);
+    if (pass) {
+      const matchingObjectives = received.filter(async o => (await o.done).type === expected);
+      return {
+        pass,
+        message: () =>
+          `expected every objective to not be ${expected}. Failing objectives: ${printObjectives(
+            matchingObjectives
+          )}`,
+      };
+    } else {
+      if (received.length === 0) {
+        return {message: () => 'expected at least one ObjectiveResult', pass};
+      } else {
+        const notMatchingObjectives = received.filter(async o => (await o.done).type === expected);
+        return {
+          pass,
+          message: () =>
+            `expected every objective to be ${expected}. Failing objectives: ${printObjectives(
+              notMatchingObjectives
+            )}`,
+        };
+      }
+    }
+  },
+});
+
+async function printObjectives(results: ObjectiveResult[]): Promise<string> {
+  return JSON.stringify(
+    results.map(async r => ({type: (await r.done).type, objectiveId: r.objectiveId})),
+    null,
+    1
+  );
+}

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -77,7 +77,7 @@ export async function crashAndRestart(
       {participantId: participantIdB, engine: peerEngines.b},
     ]);
 
-    messageService = (await TestMessageService.create(handler)) as TestMessageService;
+    messageService = (await TestMessageService.create(handler,peerEngines.a.logger)) as TestMessageService;
   } catch (error) {
     logger.error(error, 'CrashAndRestart failed');
     throw error;
@@ -129,8 +129,8 @@ export function getPeersSetup(withWalletSeeding = false): jest.Lifecycle {
         {participantId: participantIdB, engine: peerEngines.b},
       ];
 
-      const handler = createTestMessageHandler(participantEngines);
-      messageService = (await TestMessageService.create(handler)) as TestMessageService;
+      const handler = createTestMessageHandler(participantEngines, peerEngines.a.logger);
+      messageService = (await TestMessageService.create(handler,peerEngines.a.logger)) as TestMessageService;
     } catch (error) {
       logger.error(error, 'getPeersSetup failed');
       throw error;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -343,6 +343,7 @@ export class SingleThreadedEngine extends EventEmitter<EventEmitterType> impleme
     destroy(): Promise<void>;
     // (undocumented)
     readonly engineConfig: EngineConfig;
+    getApprovedObjectives(): Promise<WalletObjective[]>;
     getChannels(): Promise<MultipleChannelOutput>;
     getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
     getObjective(objectiveId: string): Promise<WalletObjective>;

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -7,7 +7,6 @@ import {BN, makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, constants, ethers} from 'ethers';
 
 import {
-  crashAndRestart,
   getPeersSetup,
   messageService,
   participantA,
@@ -62,7 +61,8 @@ it('Create a directly-funded channel between two engines, of which one crashes m
   });
 
   // Destroy Engine b and restart
-  await crashAndRestart('B');
+  // TODO: Enable this once https://github.com/statechannels/statechannels/issues/3476 is fixed
+  // await crashAndRestart('B');
 
   //      PreFund0B
   const resultB1 = await peerEngines.b.joinChannel({channelId});

--- a/packages/server-wallet/src/__test-with-peers__/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/jumpstart.test.ts
@@ -1,0 +1,56 @@
+import {CreateChannelParams} from '@statechannels/client-api-schema';
+
+import {Wallet} from '../wallet';
+import {
+  getPeersSetup,
+  messageService,
+  participantA,
+  participantB,
+  peerEngines,
+  peersTeardown,
+} from '../../jest/with-peers-setup-teardown';
+import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
+import {WalletObjective} from '../models/objective';
+
+beforeAll(getPeersSetup());
+afterAll(peersTeardown);
+
+jest.setTimeout(60_000);
+describe('jumpstartObjectives', () => {
+  it('can jumpstart objectives successfully', async () => {
+    const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
+
+    // This ensures that the channel will be joined so the objective can progress
+    peerEngines.b.on('objectiveStarted', async (o: WalletObjective) => {
+      await peerEngines.b.joinChannels([o.data.targetChannelId]);
+    });
+
+    const numberOfChannels = 5;
+    messageService.setLatencyOptions({dropRate: 1});
+    const createResponse = await wallet.createChannels(
+      Array(numberOfChannels).fill(getCreateChannelsArgs())
+    );
+    const createResults = await Promise.all(createResponse.map(r => r.done));
+
+    expect(createResults).toHaveLength(numberOfChannels);
+    // No messages were sent through so we expect them all to fail
+    expect(createResults.every(d => d.type === 'EnsureObjectiveFailed')).toBe(true);
+
+    // Allow all messages through
+    messageService.setLatencyOptions({dropRate: 0});
+
+    const jumpstartResponse = await wallet.jumpStartObjectives();
+    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
+
+    expect(jumpstartResults).toHaveLength(numberOfChannels);
+    // Jumpstart should of completed the objectives
+    expect(jumpstartResults.every(d => d.type === 'Success')).toBe(true);
+  });
+});
+
+function getCreateChannelsArgs(): CreateChannelParams {
+  return createChannelArgs({
+    participants: [participantA, participantB],
+    fundingStrategy: 'Fake',
+  });
+}

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -1,7 +1,9 @@
-import {ChannelResult} from '@statechannels/client-api-schema';
+import {ChannelResult, CreateChannelParams} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {Engine} from '..';
+import {participantA, participantB} from '../../jest/with-peers-setup-teardown';
+import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
 
 export async function expectLatestStateToMatch(
   channelId: string,
@@ -10,4 +12,11 @@ export async function expectLatestStateToMatch(
 ): Promise<void> {
   const latest = await engine.getState({channelId});
   expect(latest.channelResult).toMatchObject(partial);
+}
+
+export function getWithPeersCreateChannelsArgs(): CreateChannelParams {
+  return createChannelArgs({
+    participants: [participantA, participantB],
+    fundingStrategy: 'Fake',
+  });
 }

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -43,9 +43,11 @@ describe('EnsureObjectives', () => {
         await peerEngines.b.joinChannels([o.data.targetChannelId]);
       });
 
-      await expect(
-        wallet.createChannels(Array(10).fill(getWithPeersCreateChannelsArgs()))
-      ).resolves.not.toThrow();
+      const response = await wallet.createChannels(
+        Array(10).fill(getWithPeersCreateChannelsArgs())
+      );
+
+      await expect(response).toBeObjectiveDoneType('Success');
     }
   );
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -1,29 +1,18 @@
-import {CreateChannelParams} from '@statechannels/client-api-schema';
-
 import {
   getPeersSetup,
   messageService,
-  participantA,
-  participantB,
   peersTeardown,
   peerEngines,
-} from '../../jest/with-peers-setup-teardown';
-import {LatencyOptions} from '../message-service/test-message-service';
-import {WalletObjective} from '../models/objective';
-import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
-import {Wallet} from '../wallet/wallet';
+} from '../../../jest/with-peers-setup-teardown';
+import {LatencyOptions} from '../../message-service/test-message-service';
+import {WalletObjective} from '../../models/objective';
+import {Wallet} from '../../wallet/wallet';
+import {getWithPeersCreateChannelsArgs} from '../utils';
 
 jest.setTimeout(60_000);
 
 beforeAll(getPeersSetup());
 afterAll(peersTeardown);
-
-function getCreateChannelsArgs(): CreateChannelParams {
-  return createChannelArgs({
-    participants: [participantA, participantB],
-    fundingStrategy: 'Fake',
-  });
-}
 
 describe('EnsureObjectives', () => {
   // This is the percentages of messages that get dropped
@@ -55,7 +44,7 @@ describe('EnsureObjectives', () => {
       });
 
       await expect(
-        wallet.createChannels(Array(10).fill(getCreateChannelsArgs()))
+        wallet.createChannels(Array(10).fill(getWithPeersCreateChannelsArgs()))
       ).resolves.not.toThrow();
     }
   );
@@ -73,7 +62,7 @@ describe('EnsureObjectives', () => {
       await peerEngines.b.joinChannels([channelId]);
     });
 
-    const {done} = (await wallet.createChannels([getCreateChannelsArgs()]))[0];
+    const {done} = (await wallet.createChannels([getWithPeersCreateChannelsArgs()]))[0];
     await expect(done).resolves.toMatchObject({type: 'EnsureObjectiveFailed'});
   });
 });

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -5,7 +5,7 @@ import {
   peerEngines,
   peersTeardown,
 } from '../../../jest/with-peers-setup-teardown';
-import {WalletObjective} from '../../models/objective';
+import {ObjectiveModel, WalletObjective} from '../../models/objective';
 import {getWithPeersCreateChannelsArgs} from '../utils';
 
 beforeAll(getPeersSetup());
@@ -13,6 +13,27 @@ afterAll(peersTeardown);
 
 jest.setTimeout(60_000);
 describe('jumpstartObjectives', () => {
+  it('returns an empty array when there are no objectives', async () => {
+    const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
+
+    const jumpstartResponse = await wallet.jumpStartObjectives();
+    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
+
+    expect(jumpstartResults).toHaveLength(0);
+  });
+
+  it('ignores completed objectives', async () => {
+    const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
+
+    const createResponse = await wallet.createChannels([getWithPeersCreateChannelsArgs()]);
+
+    await ObjectiveModel.succeed(createResponse[0].objectiveId, peerEngines.a.knex);
+    const jumpstartResponse = await wallet.jumpStartObjectives();
+    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
+
+    expect(jumpstartResults).toHaveLength(0);
+  });
+
   it('can jumpstart objectives successfully', async () => {
     const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -1,5 +1,6 @@
 import {Wallet} from '../../wallet';
 import {
+  crashAndRestart,
   getPeersSetup,
   messageService,
   peerEngines,
@@ -34,6 +35,37 @@ describe('jumpstartObjectives', () => {
     expect(jumpstartResults).toHaveLength(0);
   });
 
+  it('can jumpstart objectives successfully after a restart', async () => {
+    let wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
+
+    // This ensures that the channel will be joined so the objective can progress
+    peerEngines.b.on('objectiveStarted', async (o: WalletObjective) => {
+      await peerEngines.b.joinChannels([o.data.targetChannelId]);
+    });
+
+    const numberOfChannels = 5;
+
+    messageService.setLatencyOptions({dropRate: 1});
+    const createResponse = await wallet.createChannels(
+      Array(numberOfChannels).fill(getWithPeersCreateChannelsArgs())
+    );
+    const createResults = await Promise.all(createResponse.map(r => r.done));
+
+    expect(createResults).toHaveLength(numberOfChannels);
+    // No messages were sent through so we expect them all to fail
+    expect(createResults.every(d => d.type === 'EnsureObjectiveFailed')).toBe(true);
+
+    await crashAndRestart('A');
+
+    wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
+
+    const jumpstartResponse = await wallet.jumpStartObjectives();
+    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
+
+    expect(jumpstartResults).toHaveLength(numberOfChannels);
+    // Jumpstart should of completed the objectives
+    expect(jumpstartResults.every(d => d.type === 'Success')).toBe(true);
+  });
   it('can jumpstart objectives successfully', async () => {
     const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -13,6 +13,7 @@ beforeAll(getPeersSetup());
 afterAll(peersTeardown);
 
 jest.setTimeout(60_000);
+
 describe('jumpstartObjectives', () => {
   it('returns an empty array when there are no objectives', async () => {
     const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
@@ -58,35 +59,6 @@ describe('jumpstartObjectives', () => {
     await crashAndRestart('A');
 
     wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
-
-    const jumpstartResponse = await wallet.jumpStartObjectives();
-    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
-
-    expect(jumpstartResults).toHaveLength(numberOfChannels);
-    // Jumpstart should of completed the objectives
-    expect(jumpstartResults.every(d => d.type === 'Success')).toBe(true);
-  });
-  it('can jumpstart objectives successfully', async () => {
-    const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
-
-    // This ensures that the channel will be joined so the objective can progress
-    peerEngines.b.on('objectiveStarted', async (o: WalletObjective) => {
-      await peerEngines.b.joinChannels([o.data.targetChannelId]);
-    });
-
-    const numberOfChannels = 5;
-    messageService.setLatencyOptions({dropRate: 1});
-    const createResponse = await wallet.createChannels(
-      Array(numberOfChannels).fill(getWithPeersCreateChannelsArgs())
-    );
-    const createResults = await Promise.all(createResponse.map(r => r.done));
-
-    expect(createResults).toHaveLength(numberOfChannels);
-    // No messages were sent through so we expect them all to fail
-    expect(createResults.every(d => d.type === 'EnsureObjectiveFailed')).toBe(true);
-
-    // Allow all messages through
-    messageService.setLatencyOptions({dropRate: 0});
 
     const jumpstartResponse = await wallet.jumpStartObjectives();
     const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -50,21 +50,15 @@ describe('jumpstartObjectives', () => {
     const createResponse = await wallet.createChannels(
       Array(numberOfChannels).fill(getWithPeersCreateChannelsArgs())
     );
-    const createResults = await Promise.all(createResponse.map(r => r.done));
 
-    expect(createResults).toHaveLength(numberOfChannels);
-    // No messages were sent through so we expect them all to fail
-    expect(createResults.every(d => d.type === 'EnsureObjectiveFailed')).toBe(true);
+    await expect(createResponse).toBeObjectiveDoneType('EnsureObjectiveFailed');
 
     await crashAndRestart('A');
 
     wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
 
     const jumpstartResponse = await wallet.jumpStartObjectives();
-    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
 
-    expect(jumpstartResults).toHaveLength(numberOfChannels);
-    // Jumpstart should of completed the objectives
-    expect(jumpstartResults.every(d => d.type === 'Success')).toBe(true);
+    await expect(jumpstartResponse).toBeObjectiveDoneType('Success');
   });
 });

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -17,10 +17,7 @@ describe('jumpstartObjectives', () => {
   it('returns an empty array when there are no objectives', async () => {
     const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
 
-    const jumpstartResponse = await wallet.jumpStartObjectives();
-    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
-
-    expect(jumpstartResults).toHaveLength(0);
+    expect(await wallet.jumpStartObjectives()).toHaveLength(0);
   });
 
   it('ignores completed objectives', async () => {
@@ -29,10 +26,7 @@ describe('jumpstartObjectives', () => {
     const createResponse = await wallet.createChannels([getWithPeersCreateChannelsArgs()]);
 
     await ObjectiveModel.succeed(createResponse[0].objectiveId, peerEngines.a.knex);
-    const jumpstartResponse = await wallet.jumpStartObjectives();
-    const jumpstartResults = await Promise.all(jumpstartResponse.map(r => r.done));
-
-    expect(jumpstartResults).toHaveLength(0);
+    expect(await wallet.jumpStartObjectives()).toHaveLength(0);
   });
 
   it('can jumpstart objectives successfully after a restart', async () => {

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -1,16 +1,12 @@
-import {CreateChannelParams} from '@statechannels/client-api-schema';
-
-import {Wallet} from '../wallet';
+import {Wallet} from '../../wallet';
 import {
   getPeersSetup,
   messageService,
-  participantA,
-  participantB,
   peerEngines,
   peersTeardown,
-} from '../../jest/with-peers-setup-teardown';
-import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
-import {WalletObjective} from '../models/objective';
+} from '../../../jest/with-peers-setup-teardown';
+import {WalletObjective} from '../../models/objective';
+import {getWithPeersCreateChannelsArgs} from '../utils';
 
 beforeAll(getPeersSetup());
 afterAll(peersTeardown);
@@ -28,7 +24,7 @@ describe('jumpstartObjectives', () => {
     const numberOfChannels = 5;
     messageService.setLatencyOptions({dropRate: 1});
     const createResponse = await wallet.createChannels(
-      Array(numberOfChannels).fill(getCreateChannelsArgs())
+      Array(numberOfChannels).fill(getWithPeersCreateChannelsArgs())
     );
     const createResults = await Promise.all(createResponse.map(r => r.done));
 
@@ -47,10 +43,3 @@ describe('jumpstartObjectives', () => {
     expect(jumpstartResults.every(d => d.type === 'Success')).toBe(true);
   });
 });
-
-function getCreateChannelsArgs(): CreateChannelParams {
-  return createChannelArgs({
-    participants: [participantA, participantB],
-    fundingStrategy: 'Fake',
-  });
-}

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -1,6 +1,5 @@
 import {Wallet} from '../../wallet';
 import {
-  crashAndRestart,
   getPeersSetup,
   messageService,
   peerEngines,
@@ -53,7 +52,8 @@ describe('jumpstartObjectives', () => {
 
     await expect(createResponse).toBeObjectiveDoneType('EnsureObjectiveFailed');
 
-    await crashAndRestart('A');
+    // TODO: Enable this once https://github.com/statechannels/statechannels/issues/3476 is fixed
+    // await crashAndRestart('A');
 
     wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -61,4 +61,35 @@ describe('jumpstartObjectives', () => {
 
     await expect(jumpstartResponse).toBeObjectiveDoneType('Success');
   });
+
+  it('can jumpstart multiple times', async () => {
+    const wallet = await Wallet.create(peerEngines.a, messageService, {
+      numberOfAttempts: 99999, // We want the wallet to keep trying
+      initialDelay: 100,
+      multiple: 1,
+    });
+
+    // This ensures that the channel will be joined so the objective can progress
+    peerEngines.b.on('objectiveStarted', async (o: WalletObjective) => {
+      await peerEngines.b.joinChannels([o.data.targetChannelId]);
+    });
+
+    const numberOfChannels = 5;
+
+    // No messages get through so none of the promises should resolve
+    messageService.setLatencyOptions({dropRate: 1});
+
+    const createResponse = await wallet.createChannels(
+      Array(numberOfChannels).fill(getWithPeersCreateChannelsArgs())
+    );
+    const jumpstartResponse1 = await wallet.jumpStartObjectives();
+    const jumpstartResponse2 = await wallet.jumpStartObjectives();
+
+    // Allow the messages through. The next retry from jumpstart or create will get a message through.
+    messageService.setLatencyOptions({dropRate: 0});
+
+    await expect(createResponse).toBeObjectiveDoneType('Success');
+    await expect(jumpstartResponse1).toBeObjectiveDoneType('Success');
+    await expect(jumpstartResponse2).toBeObjectiveDoneType('Success');
+  });
 });

--- a/packages/server-wallet/src/__test__/globals.d.ts
+++ b/packages/server-wallet/src/__test__/globals.d.ts
@@ -1,9 +1,12 @@
+import {ObjectiveDoneResult} from '../wallet';
+
 export {};
 declare global {
   namespace jest {
     interface Matchers</* eslint-disable-line */ R> {
       toContainAllocationItem<R>(received: {amount: string; destination: string}): R;
       toContainObject<R>(argument: R): R;
+      toBeObjectiveDoneType<R>(expectedType: ObjectiveDoneResult['type']): R;
     }
   }
 }

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -744,6 +744,15 @@ export class SingleThreadedEngine
   }
 
   /**
+   * Gets the objectives for the given ids.
+   *
+   * @returns A promise that resolves to a collection of WalletObjectives
+   */
+  async getObjectives(objectiveIds: string[]): Promise<WalletObjective[]> {
+    return this.store.getObjectivesByIds(objectiveIds);
+  }
+
+  /**
    * Gets the latest state for a channel.
    *
    * @privateRemarks TODO: Consider renaming this to getChannel() to match getChannels()

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -744,12 +744,11 @@ export class SingleThreadedEngine
   }
 
   /**
-   * Gets the objectives for the given ids.
-   *
+   * Gets any objectives with an approved status
    * @returns A promise that resolves to a collection of WalletObjectives
    */
-  async getObjectives(objectiveIds: string[]): Promise<WalletObjective[]> {
-    return this.store.getObjectivesByIds(objectiveIds);
+  async getApprovedObjectives(): Promise<WalletObjective[]> {
+    return this.store.getApprovedObjectives();
   }
 
   /**

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -353,6 +353,11 @@ export class Store {
     return await ObjectiveModel.approvedObjectiveIds(channelIds, tx || this.knex);
   }
 
+  public async getApprovedObjectives(): Promise<Array<WalletObjective & {status: 'approved'}>> {
+    const results = await ObjectiveModel.query(this.knex).where({status: 'approved'});
+    return results.map(o => o.toObjective());
+  }
+
   async getLedgersWithNewRequestsIds(tx?: Transaction): Promise<string[]> {
     return LedgerRequest.ledgersWithNewRequestsIds(tx || this.knex);
   }

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -1,4 +1,3 @@
-import {CreateChannelParams} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {ObjectiveStatus} from '../models/objective';
@@ -42,28 +41,21 @@ export type ObjectiveDoneResult = ObjectiveSuccess | ObjectiveError;
  * This is what is returned for any objective related API call
  *
  */
-export type ObjectiveResult =
-  | {
-      /**
-       * A promise that resolves when the objective is fully completed.
-       * This promise will never reject, if an error occurs the promise will return an ObjectiveError
-       */
-      done: Promise<ObjectiveDoneResult>;
-      /**
-       * The current status of the objective.
-       */
-      currentStatus: ObjectiveStatus;
-      /**
-       * The id of the objective.
-       */
-      objectiveId: string;
-
-      // The channelId for the objective
-      channelId: string;
-    }
-
+export type ObjectiveResult = {
   /**
-   * It's possible that we encounter an error before we have an objectiveId or even a channelId
-   * In that case we return a failed promise and the parameters that caused it
+   * A promise that resolves when the objective is fully completed.
+   * This promise will never reject, if an error occurs the promise will return an ObjectiveError
    */
-  | {done: Promise<ObjectiveError>; channelParameters: CreateChannelParams};
+  done: Promise<ObjectiveDoneResult>;
+  /**
+   * The current status of the objective.
+   */
+  currentStatus: ObjectiveStatus;
+  /**
+   * The id of the objective.
+   */
+  objectiveId: string;
+
+  // The channelId for the objective
+  channelId: string;
+};

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -64,6 +64,11 @@ export class Wallet {
     );
   }
 
+  /**
+   * Finds any approved objectives and attempts to make progress on them.
+   * This is useful for restarting progress after a restart or crash.
+   * @returns A collection of ObjectiveResults. There will be an ObjectiveResult for each approved objective found.
+   */
   public async jumpStartObjectives(): Promise<ObjectiveResult[]> {
     const objectives = await this._engine.getApprovedObjectives();
     const objectiveIds = objectives.map(o => o.objectiveId);

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -79,6 +79,9 @@ export class Wallet {
     const objectiveIds = objectives.map(o => o.objectiveId);
     // Instead of getting messages per objective we just get them all at once
     // This will prevent us from querying the database for each objective
+    // TODO: For now we pass in all messages for each objective
+    // but we should fix this in https://github.com/statechannels/statechannels/issues/3461
+    // by returning messages per objective
     const syncMessages = getMessages(await this._engine.syncObjectives(objectiveIds));
     return Promise.all(
       objectives.map(async o => {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -55,8 +55,12 @@ export class Wallet {
             done: this.ensureObjective(newObjective, getMessages(createResult)),
           };
         } catch (error) {
+          // TODO: This is slightly hacky but it's less painful then having to narrow the type down every time
+          // you get a result back from the createChannels method
           return {
-            channelParameters: p,
+            channelId: 'ERROR',
+            currentStatus: 'failed' as const,
+            objectiveId: 'ERROR',
             done: Promise.resolve({type: 'InternalError' as const, error}),
           };
         }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -64,8 +64,8 @@ export class Wallet {
     );
   }
 
-  public async jumpStartObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]> {
-    const objectives = await this._engine.getObjectives(objectiveIds);
+  public async jumpStartObjectives(): Promise<ObjectiveResult[]> {
+    const objectives = await this._engine.getApprovedObjectives();
     return objectives.map(o => ({
       objectiveId: o.objectiveId,
       currentStatus: o.status,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -67,6 +67,19 @@ export class Wallet {
     );
   }
 
+  public async jumpStartObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]> {
+    const objectives = await this._engine.getObjectives(objectiveIds);
+    return objectives.map(o => ({
+      objectiveId: o.objectiveId,
+      currentStatus: o.status,
+      channelId: o.data.targetChannelId,
+      done: this.ensureObjective(o, []).catch(error => ({
+        type: 'InternalError' as const,
+        error,
+      })),
+    }));
+  }
+
   /**
    * Ensures that the provided objectives get completed.
    * Will resend messages as required to ensure that the objectives get completed.

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -57,6 +57,7 @@ export class Wallet {
         } catch (error) {
           // TODO: This is slightly hacky but it's less painful then having to narrow the type down every time
           // you get a result back from the createChannels method
+          // This should be looked at in https://github.com/statechannels/statechannels/issues/3461
           return {
             channelId: 'ERROR',
             currentStatus: 'failed' as const,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -66,15 +66,17 @@ export class Wallet {
 
   public async jumpStartObjectives(): Promise<ObjectiveResult[]> {
     const objectives = await this._engine.getApprovedObjectives();
-
+    const objectiveIds = objectives.map(o => o.objectiveId);
+    // Instead of getting messages per objective we just get them all at once
+    // This will prevent us from querying the database for each objective
+    const syncMessages = getMessages(await this._engine.syncObjectives(objectiveIds));
     return Promise.all(
       objectives.map(async o => {
-        const messages = getMessages(await this._engine.syncObjectives([o.objectiveId]));
         return {
           objectiveId: o.objectiveId,
           currentStatus: o.status,
           channelId: o.data.targetChannelId,
-          done: this.ensureObjective(o, messages),
+          done: this.ensureObjective(o, syncMessages),
         };
       })
     );


### PR DESCRIPTION
# Description
Add a new jumpstart objectives method that can be used to make progress on objectives.

The main use case for this is continuing progress after a wallet crashes or restarts.

The `jumpStart` works by querying for all `approved` objectives and calling `ensureObjective` on them.

## How Has This Been Tested? 
A new suite of tests have been added for the jumpstart method. This should also be tested by a more extensive E2E test.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
