### PR TITLE
[ninja-nitro] Implement claim

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -11,6 +11,14 @@ import './interfaces/IForceMoveApp.sol';
 contract ForceMove is IForceMove {
     mapping(bytes32 => bytes32) public statusOf;
 
+    struct ChannelData {
+        uint48 turnNumRecord;
+        uint48 finalizesAt;
+        bytes32 stateHash; // keccak256(abi.encode(State))
+        address challengerAddress;
+        bytes32 outcomeHash;
+    }
+
     // Public methods:
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -37,14 +37,6 @@ interface IForceMove {
         bytes32 outcomeHash;
     }
 
-    struct ChannelData {
-        uint48 turnNumRecord;
-        uint48 finalizesAt;
-        bytes32 stateHash; // keccak256(abi.encode(State))
-        address challengerAddress;
-        bytes32 outcomeHash;
-    }
-
     enum ChannelMode {Open, Challenge, Finalized}
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -45,6 +45,14 @@ interface IForceMove {
         bytes32 outcomeHash;
     }
 
+    struct ChannelDataLite {
+        uint48 turnNumRecord;
+        uint48 finalizesAt;
+        bytes32 stateHash; // keccak256(abi.encode(State))
+        address challengerAddress;
+        bytes outcomeBytes;
+    }
+
     enum ChannelMode {Open, Challenge, Finalized}
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -45,14 +45,6 @@ interface IForceMove {
         bytes32 outcomeHash;
     }
 
-    struct ChannelDataLite {
-        uint48 turnNumRecord;
-        uint48 finalizesAt;
-        bytes32 stateHash; // keccak256(abi.encode(State))
-        address challengerAddress;
-        bytes outcomeBytes;
-    }
-
     enum ChannelMode {Open, Challenge, Finalized}
 
     /**

--- a/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
@@ -151,10 +151,8 @@ contract OutcomeTransformations {
         pure
         returns (Outcome.OutcomeItem[] memory newOutcome, Outcome.OutcomeItem[] memory payOuts)
     {
-        require(
-            initialHoldings.length == indices.length && outcome.length == indices.length,
-            'holdings/indices length mismatch'
-        );
+        require(initialHoldings.length == indices.length, 'holdings/indices length mismatch');
+        require(outcome.length == indices.length, 'outcome/indices length mismatch');
         require(outcome.length == guarantorOutcome.length, 'outcomes length mismatch');
         newOutcome = new Outcome.OutcomeItem[](outcome.length);
         payOuts = new Outcome.OutcomeItem[](outcome.length);

--- a/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
@@ -136,7 +136,7 @@ contract OutcomeTransformations {
      * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
      * @param initialHoldings list of assets held on chain for the channel, for each asset.
      * @param outcome initial outcome stored on chain for the channel.
-     * @param targetChannelId the channelId of the target channel (used to validate th guarantee) TODO: remove?
+     * @param targetChannelId the channelId of the target channel (used to validate every guarantee in the guarantorOutcome, which much target the same channel)
      * @param indices list of list of indices expressing which destinations in the allocation should be paid out for each asset.
      * @param guarantorOutcome the outcome containing a guarantee which will be claimed for each asset.
      */
@@ -184,7 +184,7 @@ contract OutcomeTransformations {
                 gAssetOutcome.allocationOrGuaranteeBytes,
                 (Outcome.Guarantee)
             );
-            require(guarantee.targetChannelId == targetChannelId, 'incorret target channel');
+            require(guarantee.targetChannelId == targetChannelId, 'incorrect target channel');
             Outcome.AllocationItem[] memory allocation = abi.decode(
                 assetOutcome.allocationOrGuaranteeBytes,
                 (Outcome.AllocationItem[])

--- a/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
@@ -134,15 +134,15 @@ contract OutcomeTransformations {
 
     /**
      * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
-     * @param initialHoldings initial quantity of each asset held on chain for the channel. Order matches that of outcome.
-     * @param outcome initial outcome stored on chain for the channel.
+     * @param initialHoldings initial quantity of each asset held on chain for the guarantor channel. Order matches that of outcome.
+     * @param targetOutcome initial outcome stored on chain for the target channel.
      * @param targetChannelId the channelId of the target channel (used to validate every guarantee in the guarantorOutcome, which much target the same channel)
      * @param indices list of list of indices expressing which destinations in the allocation should be paid out for each asset.
      * @param guarantorOutcome the outcome containing a guarantee which will be claimed for each asset.
      */
     function _computeNewOutcomeAfterClaim(
         uint256[] memory initialHoldings,
-        Outcome.OutcomeItem[] memory outcome,
+        Outcome.OutcomeItem[] memory targetOutcome,
         bytes32 targetChannelId,
         uint256[][] memory indices,
         Outcome.OutcomeItem[] memory guarantorOutcome
@@ -152,18 +152,18 @@ contract OutcomeTransformations {
         returns (Outcome.OutcomeItem[] memory newOutcome, Outcome.OutcomeItem[] memory payOuts)
     {
         require(initialHoldings.length == indices.length, 'holdings/indices length mismatch');
-        require(outcome.length == indices.length, 'outcome/indices length mismatch');
-        require(outcome.length == guarantorOutcome.length, 'outcomes length mismatch');
-        newOutcome = new Outcome.OutcomeItem[](outcome.length);
-        payOuts = new Outcome.OutcomeItem[](outcome.length);
+        require(targetOutcome.length == indices.length, 'outcome/indices length mismatch');
+        require(targetOutcome.length == guarantorOutcome.length, 'outcomes length mismatch');
+        newOutcome = new Outcome.OutcomeItem[](targetOutcome.length);
+        payOuts = new Outcome.OutcomeItem[](targetOutcome.length);
         // loop over tokens
-        for (uint256 i = 0; i < outcome.length; i++) {
+        for (uint256 i = 0; i < targetOutcome.length; i++) {
             require(
-                outcome[i].assetHolderAddress == guarantorOutcome[i].assetHolderAddress,
+                targetOutcome[i].assetHolderAddress == guarantorOutcome[i].assetHolderAddress,
                 'mismatched assets'
             );
             Outcome.AssetOutcome memory assetOutcome = abi.decode(
-                outcome[i].assetOutcomeBytes,
+                targetOutcome[i].assetOutcomeBytes,
                 (Outcome.AssetOutcome)
             );
             require(
@@ -199,7 +199,7 @@ contract OutcomeTransformations {
             );
 
             newOutcome[i] = Outcome.OutcomeItem(
-                outcome[i].assetHolderAddress,
+                targetOutcome[i].assetHolderAddress,
                 abi.encode(
                     Outcome.AssetOutcome(
                         uint8(Outcome.AssetOutcomeType.Allocation),
@@ -209,7 +209,7 @@ contract OutcomeTransformations {
             );
 
             payOuts[i] = Outcome.OutcomeItem(
-                outcome[i].assetHolderAddress,
+                targetOutcome[i].assetHolderAddress,
                 abi.encode(
                     Outcome.AssetOutcome(
                         uint8(Outcome.AssetOutcomeType.Allocation),

--- a/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
@@ -4,9 +4,16 @@ pragma experimental ABIEncoderV2;
 
 import '../Outcome.sol';
 
+/**
+ * @dev Pure functions which compute an updated outcome (or part of an outcome) to be stored after a transfer or claim operation.
+ */
 contract OutcomeTransformations {
-    // Outcome transformation functions (pure)
-
+    /**
+     * @dev Computes the new allocation that should be stored against a channel after a transfer is made.
+     * @param initialHoldings initial number of assets held on chain for the channel.
+     * @param allocation initial allocation stored on chain for the channel (for a particular asset).
+     * @param indices list of indices expressing which destinations in the allocation should be paid out.
+     */
     function _computeNewAllocation(
         uint256 initialHoldings,
         Outcome.AllocationItem[] memory allocation,
@@ -54,6 +61,13 @@ contract OutcomeTransformations {
         }
     }
 
+    /**
+     * @dev Computes the new allocation that should be stored against a target channel after a claim is made on its guarantor.
+     * @param initialHoldings initial number of assets held on chain for the channel.
+     * @param allocation initial allocation stored on chain for the channel (for a particular asset).
+     * @param indices list of indices expressing which destinations in the allocation should be paid out.
+     * @param guarantee the guarantee which will be claimed (for a particular asset).
+     */
     function _computeNewAllocationWithGuarantee(
         uint256 initialHoldings,
         Outcome.AllocationItem[] memory allocation,
@@ -118,6 +132,14 @@ contract OutcomeTransformations {
         }
     }
 
+    /**
+     * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
+     * @param initialHoldings list of assets held on chain for the channel, for each asset.
+     * @param outcome initial outcome stored on chain for the channel.
+     * @param targetChannelId the channelId of the target channel (used to validate th guarantee) TODO: remove?
+     * @param indices list of list of indices expressing which destinations in the allocation should be paid out for each asset.
+     * @param guarantorOutcome the outcome containing a guarantee which will be claimed for each asset.
+     */
     function _computeNewOutcomeAfterClaim(
         uint256[] memory initialHoldings,
         Outcome.OutcomeItem[] memory outcome,

--- a/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.4;
+pragma experimental ABIEncoderV2;
+
+import '../Outcome.sol';
+
+contract OutcomeTransformations {
+    // Outcome transformation functions (pure)
+
+    function _computeNewAllocation(
+        uint256 initialHoldings,
+        Outcome.AllocationItem[] memory allocation,
+        uint256[] memory indices
+    )
+        public
+        pure
+        returns (
+            Outcome.AllocationItem[] memory newAllocation,
+            bool safeToDelete,
+            uint256[] memory payouts,
+            uint256 totalPayouts
+        )
+    {
+        // `indices == []` means "pay out to all"
+        // Note: by initializing payouts to be an array of fixed length, its entries are initialized to be `0`
+        payouts = new uint256[](indices.length > 0 ? indices.length : allocation.length);
+        totalPayouts = 0;
+        newAllocation = new Outcome.AllocationItem[](allocation.length);
+        safeToDelete = true; // switched to false if there is an item remaining with amount > 0
+        uint256 surplus = initialHoldings; // tracks funds available during calculation
+        uint256 k = 0; // indexes the `indices` array
+
+        // loop over allocations and decrease surplus
+        for (uint256 i = 0; i < allocation.length; i++) {
+            // copy destination part
+            newAllocation[i].destination = allocation[i].destination;
+            // compute new amount part
+            uint256 affordsForDestination = min(allocation[i].amount, surplus);
+            if ((indices.length == 0) || ((k < indices.length) && (indices[k] == i))) {
+                // found a match
+                // reduce the current allocationItem.amount
+                newAllocation[i].amount = allocation[i].amount - affordsForDestination;
+                // increase the relevant payout
+                payouts[k] = affordsForDestination;
+                totalPayouts += affordsForDestination;
+                // move on to the next supplied index
+                ++k;
+            } else {
+                newAllocation[i].amount = allocation[i].amount;
+            }
+            if (newAllocation[i].amount != 0) safeToDelete = false;
+            // decrease surplus by the current amount if possible, else surplus goes to zero
+            surplus -= affordsForDestination;
+        }
+    }
+
+    function _computeNewAllocationWithGuarantee(
+        uint256 initialHoldings,
+        Outcome.AllocationItem[] memory allocation,
+        uint256[] memory indices,
+        Outcome.Guarantee memory guarantee // TODO this could just accept guarantee.destinations ?
+    )
+        public
+        pure
+        returns (
+            Outcome.AllocationItem[] memory newAllocation,
+            bool safeToDelete,
+            Outcome.AllocationItem[] memory payOuts
+        )
+    {
+        // `indices == []` means "pay out to all"
+        // Note: by initializing payOuts to be an array of fixed length, its entries are initialized to be `0`
+        newAllocation = new Outcome.AllocationItem[](allocation.length);
+        payOuts = new Outcome.AllocationItem[](
+            indices.length > 0 ? indices.length : allocation.length
+        );
+        safeToDelete = true; // switched to false if there is an item remaining with amount > 0
+        uint256 surplus = initialHoldings; // tracks funds available during calculation
+        uint256 k = 0; // indexes the `indices` array
+
+        // copy allocation
+        for (uint256 i = 0; i < allocation.length; i++) {
+            newAllocation[i].destination = allocation[i].destination;
+            newAllocation[i].amount = allocation[i].amount;
+        }
+
+        // for each guarantee destination
+        for (uint256 j = 0; j < guarantee.destinations.length; j++) {
+            if (surplus == 0) break;
+            for (uint256 i = 0; i < newAllocation.length; i++) {
+                if (surplus == 0) break;
+                // search for it in the allocation
+                if (guarantee.destinations[j] == newAllocation[i].destination) {
+                    // if we find it, compute new amount
+                    uint256 affordsForDestination = min(allocation[i].amount, surplus);
+                    // decrease surplus by the current amount regardless of hitting a specified index
+                    surplus -= affordsForDestination;
+                    if ((indices.length == 0) || ((k < indices.length) && (indices[k] == i))) {
+                        // only if specified in supplied indices, or we if we are doing "all"
+                        // reduce the new allocationItem.amount
+                        newAllocation[i].amount -= affordsForDestination;
+                        // increase the relevant payout
+                        payOuts[k].destination = allocation[i].destination;
+                        payOuts[k].amount += affordsForDestination;
+                        // move on to the next supplied index
+                        ++k;
+                    }
+                    break; // start again with the next guarantee destination
+                }
+            }
+        }
+
+        for (uint256 i = 0; i < allocation.length; i++) {
+            if (newAllocation[i].amount != 0) {
+                safeToDelete = false;
+                break;
+            }
+        }
+    }
+
+    function _computeNewOutcomeAfterClaim(
+        uint256[] memory initialHoldings,
+        Outcome.OutcomeItem[] memory outcome,
+        bytes32 targetChannelId,
+        uint256[][] memory indices,
+        Outcome.OutcomeItem[] memory guarantorOutcome
+    )
+        public
+        pure
+        returns (Outcome.OutcomeItem[] memory newOutcome, Outcome.OutcomeItem[] memory payOuts)
+    {
+        require(
+            initialHoldings.length == indices.length && outcome.length == indices.length,
+            'holdings/indices length mismatch'
+        );
+        require(outcome.length == guarantorOutcome.length, 'outcomes length mismatch');
+        newOutcome = new Outcome.OutcomeItem[](outcome.length);
+        payOuts = new Outcome.OutcomeItem[](outcome.length);
+        // loop over tokens
+        for (uint256 i = 0; i < outcome.length; i++) {
+            require(
+                outcome[i].assetHolderAddress == guarantorOutcome[i].assetHolderAddress,
+                'mismatched assets'
+            );
+            Outcome.AssetOutcome memory assetOutcome = abi.decode(
+                outcome[i].assetOutcomeBytes,
+                (Outcome.AssetOutcome)
+            );
+            require(
+                assetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
+                'not an allocation'
+            );
+            Outcome.AssetOutcome memory gAssetOutcome = abi.decode(
+                guarantorOutcome[i].assetOutcomeBytes,
+                (Outcome.AssetOutcome)
+            );
+            require(
+                gAssetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Guarantee),
+                'not a guarantee'
+            );
+            Outcome.Guarantee memory guarantee = abi.decode(
+                gAssetOutcome.allocationOrGuaranteeBytes,
+                (Outcome.Guarantee)
+            );
+            require(guarantee.targetChannelId == targetChannelId, 'incorret target channel');
+            Outcome.AllocationItem[] memory allocation = abi.decode(
+                assetOutcome.allocationOrGuaranteeBytes,
+                (Outcome.AllocationItem[])
+            );
+            (
+                Outcome.AllocationItem[] memory newAllocation, // TODO make use of safeToDelete
+                ,
+                Outcome.AllocationItem[] memory payouts
+            ) = _computeNewAllocationWithGuarantee(
+                initialHoldings[i],
+                allocation,
+                indices[i],
+                guarantee
+            );
+
+            newOutcome[i] = Outcome.OutcomeItem(
+                outcome[i].assetHolderAddress,
+                abi.encode(
+                    Outcome.AssetOutcome(
+                        uint8(Outcome.AssetOutcomeType.Allocation),
+                        abi.encode(newAllocation)
+                    )
+                )
+            );
+
+            payOuts[i] = Outcome.OutcomeItem(
+                outcome[i].assetHolderAddress,
+                abi.encode(
+                    Outcome.AssetOutcome(
+                        uint8(Outcome.AssetOutcomeType.Allocation),
+                        abi.encode(payouts)
+                    )
+                )
+            );
+        }
+    }
+
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? b : a;
+    }
+}

--- a/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/OutcomeTransformations.sol
@@ -10,7 +10,7 @@ import '../Outcome.sol';
 contract OutcomeTransformations {
     /**
      * @dev Computes the new allocation that should be stored against a channel after a transfer is made.
-     * @param initialHoldings initial number of assets held on chain for the channel.
+     * @param initialHoldings initial quantity of a given asset held on chain for the channel.
      * @param allocation initial allocation stored on chain for the channel (for a particular asset).
      * @param indices list of indices expressing which destinations in the allocation should be paid out.
      */
@@ -63,7 +63,7 @@ contract OutcomeTransformations {
 
     /**
      * @dev Computes the new allocation that should be stored against a target channel after a claim is made on its guarantor.
-     * @param initialHoldings initial number of assets held on chain for the channel.
+     * @param initialHoldings initial quantity of a given asset held on chain for the channel.
      * @param allocation initial allocation stored on chain for the channel (for a particular asset).
      * @param indices list of indices expressing which destinations in the allocation should be paid out.
      * @param guarantee the guarantee which will be claimed (for a particular asset).
@@ -134,7 +134,7 @@ contract OutcomeTransformations {
 
     /**
      * @dev Computes the new outcome that should be stored against a target channel after a claim is made on its guarantor.
-     * @param initialHoldings list of assets held on chain for the channel, for each asset.
+     * @param initialHoldings initial quantity of each asset held on chain for the channel. Order matches that of outcome.
      * @param outcome initial outcome stored on chain for the channel.
      * @param targetChannelId the channelId of the target channel (used to validate every guarantee in the guarantorOutcome, which much target the same channel)
      * @param indices list of list of indices expressing which destinations in the allocation should be paid out for each asset.

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -54,8 +54,8 @@ contract SingleChannelAdjudicator is
     }
 
     /**
-     * @notice Triggers transferAll in all external Asset Holder contracts specified in a given outcome for a given channelId.
-     * @dev Triggers transferAll in  all external Asset Holder contracts specified in a given outcome for a given channelId.
+     * @notice Pays out all allocations for all assets in the supplied outcome
+     * @dev Pays out all allocations for all assets in the supplied outcome
      * @param outcome An array of Outcome.OutcomeItem structs.
      */
     function _transferAllAssets(Outcome.OutcomeItem[] memory outcome) internal {

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -162,7 +162,7 @@ contract SingleChannelAdjudicator is
      * @param destination The destination to be converted.
      * @return The rightmost 160 bits of the input string.
      */
-    function _bytes32ToAddress(bytes32 destination) internal pure returns (address payable) {
+    function _bytes32ToAddress(bytes32 destination) internal pure returns (address) {
         return address(uint160(uint256(destination)));
     }
 
@@ -551,10 +551,10 @@ contract SingleChannelAdjudicator is
             guaranteeCDL.outcomeBytes,
             (Outcome.OutcomeItem[])
         );
-        address payable guarantor = AdjudicatorFactory(adjudicatorFactoryAddress).getChannelAddress(
+        address guarantor = AdjudicatorFactory(adjudicatorFactoryAddress).getChannelAddress(
             guarantorChannelId
         );
-        address payable targetChannelAddress = AdjudicatorFactory(adjudicatorFactoryAddress)
+        address targetChannelAddress = AdjudicatorFactory(adjudicatorFactoryAddress)
             .getChannelAddress(targetChannelId);
         require(address(this) == targetChannelAddress, 'incorrect target channel address');
         _requireMatchingStorage(

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -308,6 +308,9 @@ contract SingleChannelAdjudicator is
         return newAllocation;
     }
 
+    /**
+     * @notice Pays out assets according to the supplied payouts, only if this channel has been finalized as a guarantor channel, and only if supplied by the __target__ of this channel
+     */
     function payOutTarget(
         bytes32 guarantorChannelId,
         ChannelDataLite calldata cDL,

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -21,6 +21,14 @@ contract SingleChannelAdjudicator is
 
     receive() external payable {} // solhint-disable-line no-empty-blocks
 
+    struct ChannelDataAlt {
+        uint48 turnNumRecord;
+        uint48 finalizesAt;
+        bytes32 stateHash; // keccak256(abi.encode(State))
+        address challengerAddress;
+        bytes outcomeBytes;
+    }
+
     /**
      * @notice Verifies a conclusion proof, pays out all assets and selfdestructs
      * @dev Verifies a conclusion proof, pays out all assets and selfdestructs
@@ -313,7 +321,7 @@ contract SingleChannelAdjudicator is
      */
     function payOutTarget(
         bytes32 guarantorChannelId,
-        ChannelDataLite calldata cDL,
+        ChannelDataAlt calldata cDL,
         Outcome.OutcomeItem[] memory payouts
     ) external {
         Outcome.OutcomeItem[] memory guarantorOutcome = abi.decode(
@@ -351,8 +359,8 @@ contract SingleChannelAdjudicator is
     function claim(
         bytes32 guarantorChannelId,
         bytes32 targetChannelId,
-        ChannelDataLite calldata guaranteeCDL,
-        ChannelDataLite calldata targetCDL,
+        ChannelDataAlt calldata guaranteeCDL,
+        ChannelDataAlt calldata targetCDL,
         uint256[][] memory indices
     ) external {
         // CHECKS

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -371,7 +371,7 @@ contract SingleChannelAdjudicator is
             guaranteeCDL.outcomeBytes,
             (Outcome.OutcomeItem[])
         );
-        address guarantor = AdjudicatorFactory(adjudicatorFactoryAddress).getChannelAddress(
+        address payable guarantor = AdjudicatorFactory(adjudicatorFactoryAddress).getChannelAddress(
             guarantorChannelId
         );
         address targetChannelAddress = AdjudicatorFactory(adjudicatorFactoryAddress)

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -179,8 +179,8 @@ contract SingleChannelAdjudicator is ForceMove, OutcomeTransformations {
      * @param destination The destination to be converted.
      * @return The rightmost 160 bits of the input string.
      */
-    function _bytes32ToAddress(bytes32 destination) internal pure returns (address) {
-        return address(uint160(uint256(destination)));
+    function _bytes32ToAddress(bytes32 destination) internal pure returns (address payable) {
+        return payable(uint160(uint256(destination)));
     }
 
     function _requireChannelIdMatchesContract(bytes32 channelId) internal view {

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -9,10 +9,7 @@ import './AdjudicatorFactory.sol';
 import './OutcomeTransformations.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
-contract SingleChannelAdjudicator is
-    ForceMove,
-    OutcomeTransformations //, IAssetHolder { // TODO
-{
+contract SingleChannelAdjudicator is ForceMove, OutcomeTransformations {
     address public immutable adjudicatorFactoryAddress;
 
     constructor(address a) {

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -371,11 +371,9 @@ contract SingleChannelAdjudicator is
             guaranteeCDL.outcomeBytes,
             (Outcome.OutcomeItem[])
         );
-        address payable guarantor = AdjudicatorFactory(adjudicatorFactoryAddress).getChannelAddress(
-            guarantorChannelId
-        );
-        address targetChannelAddress = AdjudicatorFactory(adjudicatorFactoryAddress)
-            .getChannelAddress(targetChannelId);
+        AdjudicatorFactory adjudicatorFactory = AdjudicatorFactory(adjudicatorFactoryAddress);
+        address payable guarantor = adjudicatorFactory.getChannelAddress(guarantorChannelId);
+        address targetChannelAddress = adjudicatorFactory.getChannelAddress(targetChannelId);
         require(address(this) == targetChannelAddress, 'incorrect target channel address');
         _requireMatchingStorage(
             ChannelData(

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -6,10 +6,12 @@ import '../interfaces/IAssetHolder.sol';
 import '../ForceMove.sol';
 import '../Outcome.sol';
 import './AdjudicatorFactory.sol';
+import './OutcomeTransformations.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 contract SingleChannelAdjudicator is
-    ForceMove //, IAssetHolder { // TODO
+    ForceMove,
+    OutcomeTransformations //, IAssetHolder { // TODO
 {
     address public immutable adjudicatorFactoryAddress;
 
@@ -306,199 +308,6 @@ contract SingleChannelAdjudicator is
         return newAllocation;
     }
 
-    function _computeNewOutcomeAfterClaim(
-        uint256[] memory initialHoldings,
-        Outcome.OutcomeItem[] memory outcome,
-        bytes32 targetChannelId,
-        uint256[][] memory indices,
-        Outcome.OutcomeItem[] memory guarantorOutcome
-    )
-        public
-        pure
-        returns (Outcome.OutcomeItem[] memory newOutcome, Outcome.OutcomeItem[] memory payOuts)
-    {
-        require(
-            initialHoldings.length == indices.length && outcome.length == indices.length,
-            'holdings/indices length mismatch'
-        );
-        require(outcome.length == guarantorOutcome.length, 'outcomes length mismatch');
-        newOutcome = new Outcome.OutcomeItem[](outcome.length);
-        payOuts = new Outcome.OutcomeItem[](outcome.length);
-        // loop over tokens
-        for (uint256 i = 0; i < outcome.length; i++) {
-            require(
-                outcome[i].assetHolderAddress == guarantorOutcome[i].assetHolderAddress,
-                'mismatched assets'
-            );
-            Outcome.AssetOutcome memory assetOutcome = abi.decode(
-                outcome[i].assetOutcomeBytes,
-                (Outcome.AssetOutcome)
-            );
-            require(
-                assetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
-                'not an allocation'
-            );
-            Outcome.AssetOutcome memory gAssetOutcome = abi.decode(
-                guarantorOutcome[i].assetOutcomeBytes,
-                (Outcome.AssetOutcome)
-            );
-            require(
-                gAssetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Guarantee),
-                'not a guarantee'
-            );
-            Outcome.Guarantee memory guarantee = abi.decode(
-                gAssetOutcome.allocationOrGuaranteeBytes,
-                (Outcome.Guarantee)
-            );
-            require(guarantee.targetChannelId == targetChannelId, 'incorret target channel');
-            Outcome.AllocationItem[] memory allocation = abi.decode(
-                assetOutcome.allocationOrGuaranteeBytes,
-                (Outcome.AllocationItem[])
-            );
-            (
-                Outcome.AllocationItem[] memory newAllocation, // TODO make use of safeToDelete
-                ,
-                Outcome.AllocationItem[] memory payouts
-            ) = _computeNewAllocationWithGuarantee(
-                initialHoldings[i],
-                allocation,
-                indices[i],
-                guarantee
-            );
-
-            newOutcome[i] = Outcome.OutcomeItem(
-                outcome[i].assetHolderAddress,
-                abi.encode(
-                    Outcome.AssetOutcome(
-                        uint8(Outcome.AssetOutcomeType.Allocation),
-                        abi.encode(newAllocation)
-                    )
-                )
-            );
-
-            payOuts[i] = Outcome.OutcomeItem(
-                outcome[i].assetHolderAddress,
-                abi.encode(
-                    Outcome.AssetOutcome(
-                        uint8(Outcome.AssetOutcomeType.Allocation),
-                        abi.encode(payouts)
-                    )
-                )
-            );
-        }
-    }
-
-    function _computeNewAllocation(
-        uint256 initialHoldings,
-        Outcome.AllocationItem[] memory allocation,
-        uint256[] memory indices
-    )
-        public
-        pure
-        returns (
-            Outcome.AllocationItem[] memory newAllocation,
-            bool safeToDelete,
-            uint256[] memory payouts,
-            uint256 totalPayouts
-        )
-    {
-        // `indices == []` means "pay out to all"
-        // Note: by initializing payouts to be an array of fixed length, its entries are initialized to be `0`
-        payouts = new uint256[](indices.length > 0 ? indices.length : allocation.length);
-        totalPayouts = 0;
-        newAllocation = new Outcome.AllocationItem[](allocation.length);
-        safeToDelete = true; // switched to false if there is an item remaining with amount > 0
-        uint256 surplus = initialHoldings; // tracks funds available during calculation
-        uint256 k = 0; // indexes the `indices` array
-
-        // loop over allocations and decrease surplus
-        for (uint256 i = 0; i < allocation.length; i++) {
-            // copy destination part
-            newAllocation[i].destination = allocation[i].destination;
-            // compute new amount part
-            uint256 affordsForDestination = min(allocation[i].amount, surplus);
-            if ((indices.length == 0) || ((k < indices.length) && (indices[k] == i))) {
-                // found a match
-                // reduce the current allocationItem.amount
-                newAllocation[i].amount = allocation[i].amount - affordsForDestination;
-                // increase the relevant payout
-                payouts[k] = affordsForDestination;
-                totalPayouts += affordsForDestination;
-                // move on to the next supplied index
-                ++k;
-            } else {
-                newAllocation[i].amount = allocation[i].amount;
-            }
-            if (newAllocation[i].amount != 0) safeToDelete = false;
-            // decrease surplus by the current amount if possible, else surplus goes to zero
-            surplus -= affordsForDestination;
-        }
-    }
-
-    function _computeNewAllocationWithGuarantee(
-        uint256 initialHoldings,
-        Outcome.AllocationItem[] memory allocation,
-        uint256[] memory indices,
-        Outcome.Guarantee memory guarantee // TODO this could just accept guarantee.destinations ?
-    )
-        public
-        pure
-        returns (
-            Outcome.AllocationItem[] memory newAllocation,
-            bool safeToDelete,
-            Outcome.AllocationItem[] memory payOuts
-        )
-    {
-        // `indices == []` means "pay out to all"
-        // Note: by initializing payOuts to be an array of fixed length, its entries are initialized to be `0`
-        newAllocation = new Outcome.AllocationItem[](allocation.length);
-        payOuts = new Outcome.AllocationItem[](
-            indices.length > 0 ? indices.length : allocation.length
-        );
-        safeToDelete = true; // switched to false if there is an item remaining with amount > 0
-        uint256 surplus = initialHoldings; // tracks funds available during calculation
-        uint256 k = 0; // indexes the `indices` array
-
-        // copy allocation
-        for (uint256 i = 0; i < allocation.length; i++) {
-            newAllocation[i].destination = allocation[i].destination;
-            newAllocation[i].amount = allocation[i].amount;
-        }
-
-        // for each guarantee destination
-        for (uint256 j = 0; j < guarantee.destinations.length; j++) {
-            if (surplus == 0) break;
-            for (uint256 i = 0; i < newAllocation.length; i++) {
-                if (surplus == 0) break;
-                // search for it in the allocation
-                if (guarantee.destinations[j] == newAllocation[i].destination) {
-                    // if we find it, compute new amount
-                    uint256 affordsForDestination = min(allocation[i].amount, surplus);
-                    // decrease surplus by the current amount regardless of hitting a specified index
-                    surplus -= affordsForDestination;
-                    if ((indices.length == 0) || ((k < indices.length) && (indices[k] == i))) {
-                        // only if specified in supplied indices, or we if we are doing "all"
-                        // reduce the new allocationItem.amount
-                        newAllocation[i].amount -= affordsForDestination;
-                        // increase the relevant payout
-                        payOuts[k].destination = allocation[i].destination;
-                        payOuts[k].amount += affordsForDestination;
-                        // move on to the next supplied index
-                        ++k;
-                    }
-                    break; // start again with the next guarantee destination
-                }
-            }
-        }
-
-        for (uint256 i = 0; i < allocation.length; i++) {
-            if (newAllocation[i].amount != 0) {
-                safeToDelete = false;
-                break;
-            }
-        }
-    }
-
     function payOutTarget(
         bytes32 guarantorChannelId,
         ChannelDataLite calldata cDL,
@@ -605,10 +414,6 @@ contract SingleChannelAdjudicator is
         for (uint256 i = 0; i + 1 < indices.length; i++) {
             require(indices[i] < indices[i + 1], 'Indices must be sorted');
         }
-    }
-
-    function min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? b : a;
     }
 
     function _transferAsset(

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -318,11 +318,11 @@ contract SingleChannelAdjudicator is ForceMove, OutcomeTransformations {
      */
     function payOutTarget(
         bytes32 guarantorChannelId,
-        ChannelDataAlt calldata cDL,
+        ChannelDataAlt calldata channelDataAlt,
         Outcome.OutcomeItem[] memory payouts
     ) external {
         Outcome.OutcomeItem[] memory guarantorOutcome = abi.decode(
-            cDL.outcomeBytes,
+            channelDataAlt.outcomeBytes,
             (Outcome.OutcomeItem[])
         );
         Outcome.AssetOutcome memory gAssetOutcome = abi.decode(
@@ -336,13 +336,13 @@ contract SingleChannelAdjudicator is ForceMove, OutcomeTransformations {
         address targetChannelAddress = AdjudicatorFactory(adjudicatorFactoryAddress)
             .getChannelAddress(guarantee.targetChannelId);
         require(msg.sender == targetChannelAddress, 'only the target channel is auth');
-        bytes32 outcomeHash = keccak256(cDL.outcomeBytes);
+        bytes32 outcomeHash = keccak256(channelDataAlt.outcomeBytes);
         _requireMatchingStorage(
             ChannelData(
-                cDL.turnNumRecord,
-                cDL.finalizesAt,
-                cDL.stateHash,
-                cDL.challengerAddress,
+                channelDataAlt.turnNumRecord,
+                channelDataAlt.finalizesAt,
+                channelDataAlt.stateHash,
+                channelDataAlt.challengerAddress,
                 outcomeHash
             ),
             guarantorChannelId

--- a/packages/nitro-protocol/deployment/deploy-test-contracts.ts
+++ b/packages/nitro-protocol/deployment/deploy-test-contracts.ts
@@ -106,6 +106,7 @@ export async function deploy(): Promise<Record<string, string>> {
     ADJUDICATOR_FACTORY_ADDRESS
   );
   await (await AdjudicatorFactory.setup(SINGLE_CHANNEL_ADJUDICATOR_MASTERCOPY_ADDRESS)).wait();
+  // TODO for production deploys, ideally we call this method in the same transaction as deploying the factory (prevents frontrunning)
   // END Ninja-Nitro section
 
   return {

--- a/packages/nitro-protocol/src/ninja-nitro/helpers.ts
+++ b/packages/nitro-protocol/src/ninja-nitro/helpers.ts
@@ -1,0 +1,84 @@
+import {BigNumber, constants} from 'ethers';
+
+import {AllocationItem, Guarantee} from '../contract/outcome';
+
+/**
+ *
+ * Emulates solidity code. TODO replace with PureEVM implementation?
+ * @param initialHoldings
+ * @param allocation
+ * @param indices
+ */
+export function computeNewAllocationWithGuarantee(
+  initialHoldings: string,
+  allocation: AllocationItem[], // we must index this with a JS number that is less than 2**32 - 1
+  indices: number[],
+  guarantee: Guarantee
+): {newAllocation: AllocationItem[]; deleted: boolean; payOuts: AllocationItem[]} {
+  let safeToDelete = true;
+  let surplus = BigNumber.from(initialHoldings);
+  let k = 0;
+
+  // copy allocation
+  const newAllocation: AllocationItem[] = [];
+  const payOuts: AllocationItem[] = [];
+  const payOutsLength = indices.length > 0 ? indices.length : allocation.length;
+  for (let i = 0; i < payOutsLength; i++) {
+    // This mirrors the way arrays are intialized in solidity
+    payOuts.push({
+      destination: constants.HashZero,
+      amount: '0x00',
+    });
+  }
+  for (let i = 0; i < allocation.length; i++) {
+    newAllocation.push({
+      destination: allocation[i].destination,
+      amount: allocation[i].amount,
+    });
+  }
+
+  // for each guarantee destination
+  for (let j = 0; j < guarantee.destinations.length; j++) {
+    if (surplus.isZero()) break;
+    for (let i = 0; i < newAllocation.length; i++) {
+      if (surplus.isZero()) break;
+      // search for it in the allocation
+      if (
+        BigNumber.from(guarantee.destinations[j]).eq(BigNumber.from(newAllocation[i].destination))
+      ) {
+        // if we find it, compute new amount
+        const affordsForDestination = min(BigNumber.from(newAllocation[i].amount), surplus);
+        // decrease surplus by the current amount regardless of hitting a specified index
+        surplus = surplus.sub(affordsForDestination);
+        if (indices.length === 0 || (k < indices.length && indices[k] === i)) {
+          // only if specified in supplied indices, or we if we are doing "all"
+          // reduce the current allocationItem.amount
+          newAllocation[i].amount = BigNumber.from(newAllocation[i].amount)
+            .sub(affordsForDestination)
+            .toHexString();
+          // increase the relevant payout
+          payOuts[k].destination = allocation[i].destination;
+          payOuts[k].amount = affordsForDestination.toHexString();
+          ++k;
+        }
+        break;
+      }
+    }
+  }
+
+  for (let i = 0; i < allocation.length; i++) {
+    if (!BigNumber.from(newAllocation[i].amount).isZero()) {
+      safeToDelete = false;
+      break;
+    }
+  }
+
+  return {
+    newAllocation,
+    deleted: safeToDelete,
+    payOuts,
+  };
+}
+function min(a: BigNumber, b: BigNumber) {
+  return a.gt(b) ? b : a;
+}

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
@@ -158,8 +158,8 @@ describe('claim (ETH only)', () => {
       }
       // Compute an appropriate allocation outcome for the target (using only ETH)
       const allocation = [];
-      Object.keys(tOutcomeBefore).forEach(key =>
-        allocation.push({destination: key, amount: tOutcomeBefore[key]})
+      Object.keys(tOutcomeBefore).forEach(destination =>
+        allocation.push({destination, amount: tOutcomeBefore[destination]})
       );
       const targetOutcome: Outcome = [
         {assetHolderAddress: constants.AddressZero, allocationItems: allocation},
@@ -198,8 +198,8 @@ describe('claim (ETH only)', () => {
 
         // Check new outcomeHash
         const newAllocation = [];
-        Object.keys(tOutcomeAfter).forEach(key =>
-          newAllocation.push({destination: key, amount: tOutcomeAfter[key]})
+        Object.keys(tOutcomeAfter).forEach(destination =>
+          newAllocation.push({destination, amount: tOutcomeAfter[destination]})
         );
         const outcome: Outcome = [
           {assetHolderAddress: constants.AddressZero, allocationItems: newAllocation},
@@ -214,9 +214,9 @@ describe('claim (ETH only)', () => {
         expect(await target.statusOf()).toEqual(expectedFingerprint);
 
         const balancesAfter = await getBalances(payouts);
-        Object.keys(payouts).forEach(key =>
-          expect(BigNumber.from(balancesAfter[key])).toEqual(
-            BigNumber.from(balancesBefore[key]).add(BigNumber.from(payouts[key]))
+        Object.keys(payouts).forEach(destination =>
+          expect(BigNumber.from(balancesAfter[destination])).toEqual(
+            BigNumber.from(balancesBefore[destination]).add(BigNumber.from(payouts[destination]))
           )
         );
       }
@@ -227,8 +227,8 @@ describe('claim (ETH only)', () => {
 async function getBalances(payouts: AssetOutcomeShortHand) {
   const balances: Record<string, BigNumber> = {};
   await Promise.all(
-    Object.keys(payouts).map(async key => {
-      balances[key] = await provider.getBalance(convertBytes32ToAddress(key));
+    Object.keys(payouts).map(async destination => {
+      balances[destination] = await provider.getBalance(convertBytes32ToAddress(destination));
     })
   );
   return balances;

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
@@ -1,0 +1,297 @@
+import {expectRevert} from '@statechannels/devtools';
+import {Contract, BigNumber, Wallet, constants, BigNumberish} from 'ethers';
+
+import {getFixedPart, hashAppPart, State} from '../../../../src/contract/state';
+import SingleChannelAdjudicatorArtifact from '../../../../artifacts/contracts/ninja-nitro/SingleChannelAdjudicator.sol/SingleChannelAdjudicator.json';
+import AdjudicatorFactoryArtifact from '../../../../artifacts/contracts/ninja-nitro/AdjudicatorFactory.sol/AdjudicatorFactory.json';
+import {
+  AssetOutcomeShortHand,
+  finalizedFingerprint,
+  getRandomNonce,
+  getTestProvider,
+  randomExternalDestination,
+  replaceAddressesAndBigNumberify,
+  setupContracts,
+  writeGasConsumption,
+} from '../../../test-helpers';
+import {
+  Channel,
+  channelDataToStatus,
+  convertBytes32ToAddress,
+  encodeOutcome,
+  getChannelId,
+  hashOutcome,
+  Outcome,
+  signState,
+} from '../../../../src';
+import {Address, Bytes, Bytes32, Uint48} from '../../../../src/contract/types';
+
+export interface ChannelDataLite {
+  turnNumRecord: Uint48;
+  finalizesAt: Uint48;
+  stateHash: Bytes32;
+  challengerAddress: Address;
+  outcomeBytes: Bytes;
+}
+
+const provider = getTestProvider();
+const addresses = {
+  // Channels
+  t: undefined, // Target
+  g: undefined, // Guarantor
+  // Externals
+  I: randomExternalDestination(),
+  A: randomExternalDestination(),
+  B: randomExternalDestination(),
+};
+
+let AdjudicatorFactory: Contract;
+const chainId = process.env.CHAIN_NETWORK_ID;
+const participants = ['', ''];
+const wallets = new Array<Wallet>(2);
+for (let i = 0; i < 2; i++) {
+  wallets[i] = Wallet.createRandom();
+  participants[i] = wallets[i].address;
+}
+
+beforeAll(async () => {
+  AdjudicatorFactory = await setupContracts(
+    provider,
+    AdjudicatorFactoryArtifact,
+    process.env.ADJUDICATOR_FACTORY_ADDRESS
+  );
+});
+
+const reason5 = 'status(ChannelData)!=storage';
+const reason6 = 'status(ChannelData)!=storage';
+
+// NOTES
+// Amounts are valueString representations of wei
+// This test constructs Outcomes with length 1, with the AssetHolderAddress set to indicate ETH
+// (namely, the zero address)
+describe('claim (ETH only)', () => {
+  it.each`
+    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts   | reason
+    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
+    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}} | ${undefined}
+    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
+    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}} | ${undefined}
+    ${'5. target channel not finalized'}               | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}} | ${reason5}
+    ${'6. guarantor channel not finalized'}            | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}} | ${reason6}
+    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}} | ${undefined}
+    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}} | ${undefined}
+  `(
+    '$name',
+    async ({
+      name,
+      heldBefore,
+      guaranteeDestinations,
+      tOutcomeBefore,
+      indices,
+      tOutcomeAfter,
+      heldAfter,
+      payouts,
+      reason,
+    }: {
+      name;
+      heldBefore: AssetOutcomeShortHand;
+      guaranteeDestinations;
+      tOutcomeBefore: AssetOutcomeShortHand;
+      indices: number[];
+      tOutcomeAfter: AssetOutcomeShortHand;
+      heldAfter: AssetOutcomeShortHand;
+      payouts: AssetOutcomeShortHand;
+      reason;
+    }) => {
+      const target = new TestChannel(getRandomNonce(name));
+      const guarantor = new TestChannel(getRandomNonce(name + 'g'));
+      addresses.t = target.id;
+      addresses.g = guarantor.id;
+      // Transform input data (unpack addresses and BigNumber amounts)
+      [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [
+        heldBefore,
+        tOutcomeBefore,
+        tOutcomeAfter,
+        heldAfter,
+        payouts,
+      ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
+      guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
+      // Fund the guarantor channel
+      await guarantor.depositETH(heldBefore[guarantor.id]);
+      // DEPLOY GUARANTOR CHANNEL
+      await guarantor.deploy();
+      // Compute an appropriate guarantee for the guarantor (using only ETH)
+      const guarantee = {
+        destinations: guaranteeDestinations,
+        targetChannelId: target.id,
+      };
+      const guarantorOutcome: Outcome = [{assetHolderAddress: constants.AddressZero, guarantee}];
+      if (guaranteeDestinations.length > 0) {
+        // CONCLUDE GUARANTOR CHANNEL
+        await guarantor.conclude(guarantorOutcome);
+      } else guarantor.outcome = guarantorOutcome; // Set this so that the claim tx should revert in the way we expect
+      // Compute an appropriate allocation outcome for the target (using only ETH)
+      const allocation = [];
+      Object.keys(tOutcomeBefore).forEach(key =>
+        allocation.push({destination: key, amount: tOutcomeBefore[key]})
+      );
+      const targetOutcome: Outcome = [
+        {assetHolderAddress: constants.AddressZero, allocationItems: allocation},
+      ];
+
+      // DEPLOY TARGET CHANNEL
+      await target.deploy();
+      // CONCLUDE TARGET CHANNEL
+      if (Object.keys(tOutcomeBefore).length > 0) {
+        await target.conclude(targetOutcome);
+      }
+
+      const tx = target.claimTx(guarantor, indices);
+      // Call method in a slightly different way if expecting a revert
+      if (reason) {
+        await expectRevert(() => tx, reason);
+      } else {
+        const balancesBefore = await getBalances(payouts);
+        // Extract logs
+        const {events: eventsFromTx, gasUsed} = await (await tx).wait();
+        await writeGasConsumption('SingleChannelAdjudicator.claim.gas.md', name, gasUsed);
+
+        // Check new outcomeHash
+        const newAllocation = [];
+        Object.keys(tOutcomeAfter).forEach(key =>
+          newAllocation.push({destination: key, amount: tOutcomeAfter[key]})
+        );
+        const outcome: Outcome = [
+          {assetHolderAddress: constants.AddressZero, allocationItems: newAllocation},
+        ];
+        const expectedFingerprint = channelDataToStatus({
+          turnNumRecord: 0,
+          finalizesAt: target.finalizesAt,
+          outcome,
+        });
+        // Check fingerprint against the expected value
+        // NOTE that allocations for zero amounts are left in place
+        expect(await target.statusOf()).toEqual(expectedFingerprint);
+
+        const balancesAfter = await getBalances(payouts);
+        Object.keys(payouts).forEach(key =>
+          expect(BigNumber.from(balancesAfter[key])).toEqual(
+            BigNumber.from(balancesBefore[key]).add(BigNumber.from(payouts[key]))
+          )
+        );
+      }
+    }
+  );
+});
+
+async function getBalances(payouts: AssetOutcomeShortHand) {
+  const balances: Record<string, BigNumber> = {};
+  await Promise.all(
+    Object.keys(payouts).map(async key => {
+      balances[key] = await provider.getBalance(convertBytes32ToAddress(key));
+    })
+  );
+  return balances;
+}
+/**
+ * Combines off chain and on chain channel properties and operations
+ */
+class TestChannel {
+  channel: Channel;
+  id: string;
+  address: string = undefined;
+  factory: Contract;
+  adjudicator?: Contract = undefined;
+  turnNumRecord = 5;
+  finalizesAt = 0;
+  outcome: Outcome = [];
+  constructor(channelNonce: number) {
+    this.channel = {chainId, participants, channelNonce};
+    this.id = getChannelId(this.channel);
+    this.factory = setupContracts(
+      provider,
+      AdjudicatorFactoryArtifact,
+      process.env.ADJUDICATOR_FACTORY_ADDRESS
+    );
+  }
+
+  async getAddress() {
+    this.address = this.address ?? (await AdjudicatorFactory.getChannelAddress(this.id));
+    return this.address;
+  }
+
+  /**
+   * Deploys an instance of a SingleChannelAdjudicator for this channel
+   */
+  async deploy() {
+    await (await this.factory.createChannel(this.id)).wait();
+    this.adjudicator = setupContracts(
+      provider,
+      SingleChannelAdjudicatorArtifact,
+      await this.getAddress()
+    );
+  }
+
+  /**
+   * Deposits wei
+   * @param amount number of wei
+   */
+  async depositETH(amount: BigNumberish) {
+    await (
+      await provider.getSigner().sendTransaction({
+        to: await this.getAddress(),
+        value: amount,
+      })
+    ).wait();
+  }
+  async conclude(outcome: Outcome) {
+    const states: State[] = [
+      {
+        isFinal: true,
+        channel: this.channel,
+        outcome: outcome,
+        appDefinition: constants.AddressZero,
+        appData: '0x',
+        challengeDuration: 0x1000,
+        turnNum: this.turnNumRecord,
+      },
+    ];
+    const sigs = [
+      signState(states[0], wallets[0].privateKey).signature,
+      signState(states[0], wallets[1].privateKey).signature,
+    ];
+    const {blockNumber} = await (
+      await this.adjudicator.conclude(
+        this.turnNumRecord,
+        getFixedPart(states[0]),
+        hashAppPart(states[0]),
+        hashOutcome(outcome),
+        1,
+        [0, 0],
+        sigs
+      )
+    ).wait();
+    this.finalizesAt = (await provider.getBlock(blockNumber)).timestamp;
+    this.outcome = outcome;
+  }
+  claimTx(guarantor: TestChannel, indices: number[]) {
+    const guaranteeCDL: ChannelDataLite = {
+      turnNumRecord: 0, // when collaboratively concluding, turnNumRecord is set to zero
+      finalizesAt: guarantor.finalizesAt,
+      stateHash: constants.HashZero, // when collaboratively concluding, stateHash is set to zero,
+      challengerAddress: constants.AddressZero, // when collaboratively concluding, challengerAddress is set to zero,
+      outcomeBytes: encodeOutcome(guarantor.outcome),
+    };
+    const targetCDL: ChannelDataLite = {
+      turnNumRecord: 0, // when collaboratively concluding, turnNumRecord is set to zero
+      finalizesAt: this.finalizesAt,
+      stateHash: constants.HashZero, // when collaboratively concluding, stateHash is set to zero,
+      challengerAddress: constants.AddressZero, // when collaboratively concluding, challengerAddress is set to zero,
+      outcomeBytes: encodeOutcome(this.outcome),
+    };
+    return this.adjudicator.claim(guarantor.id, this.id, guaranteeCDL, targetCDL, [indices]);
+  }
+  async statusOf() {
+    return this.adjudicator.statusOf(this.id);
+  }
+}

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
@@ -62,8 +62,7 @@ beforeAll(async () => {
   );
 });
 
-const reason5 = 'status(ChannelData)!=storage';
-const reason6 = 'status(ChannelData)!=storage';
+const incorrectStorage = 'status(ChannelData)!=storage';
 
 // NOTES
 // Amounts are valueString representations of wei
@@ -71,15 +70,23 @@ const reason6 = 'status(ChannelData)!=storage';
 // (namely, the zero address)
 describe('claim (ETH only)', () => {
   it.each`
-    name                                               | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts   | reason
-    ${'1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
-    ${'2. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}} | ${undefined}
-    ${'3. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
-    ${'4. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}} | ${undefined}
-    ${'5. target channel not finalized'}               | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}} | ${reason5}
-    ${'6. guarantor channel not finalized'}            | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}} | ${reason6}
-    ${'7. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}} | ${undefined}
-    ${'8. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}} | ${undefined}
+    name                                                | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
+    ${'1. straight-through guarantee, 3 destinations'}  | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'2. swap guarantee,             2 destinations'}  | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${'3. swap guarantee,             3 destinations'}  | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'4. straight-through guarantee, 2 destinations'}  | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${'5. target channel not finalized'}                | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${incorrectStorage}
+    ${'6. guarantor channel not finalized'}             | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${incorrectStorage}
+    ${'7. swap guarantee, overfunded, 2 destinations'}  | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${'8. underspecified guarantee, overfunded      '}  | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${'9. straight-through guarantee, 3 destinations'}  | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'10. swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${'11. swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'12. straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${'13. allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${incorrectStorage}
+    ${'14. guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${incorrectStorage}
+    ${'15. swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
   `(
     '$name',
     async ({

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/claim.test.ts
@@ -114,7 +114,7 @@ describe('claim (ETH only)', () => {
       const guarantor = new TestChannel(getRandomNonce(name + 'g'));
       addresses.t = target.id;
       addresses.g = guarantor.id;
-      // Transform input data (unpack addresses and BigNumber amounts)
+      // Transform input data (unpack addresses and BigNumberify amounts)
       [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [
         heldBefore,
         tOutcomeBefore,
@@ -124,7 +124,7 @@ describe('claim (ETH only)', () => {
       ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
       guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
       // Fund the guarantor channel
-      let gasUsed;
+      let gasUsed: BigNumber;
       gasUsed = await guarantor.depositETH(heldBefore[guarantor.id]);
       await writeGasConsumption(
         'SingleChannelAdjudicator.claim.gas.md',
@@ -152,7 +152,10 @@ describe('claim (ETH only)', () => {
           name + ': conclude Guarantor',
           gasUsed
         );
-      } else guarantor.outcome = guarantorOutcome; // Set this so that the claim tx should revert in the way we expect
+      } else {
+        // Set this so that the claim tx should revert in the way we expect
+        guarantor.outcome = guarantorOutcome;
+      }
       // Compute an appropriate allocation outcome for the target (using only ETH)
       const allocation = [];
       Object.keys(tOutcomeBefore).forEach(key =>
@@ -186,7 +189,7 @@ describe('claim (ETH only)', () => {
       } else {
         const balancesBefore = await getBalances(payouts);
         // Extract logs
-        const {events: eventsFromTx, gasUsed} = await (await tx).wait();
+        const {gasUsed} = await (await tx).wait();
         await writeGasConsumption(
           'SingleChannelAdjudicator.claim.gas.md',
           name + ': Target. claim ',
@@ -236,7 +239,7 @@ async function getBalances(payouts: AssetOutcomeShortHand) {
 class TestChannel {
   channel: Channel;
   id: string;
-  address: string = undefined;
+  protected address: string = undefined;
   factory: Contract;
   adjudicator?: Contract = undefined;
   turnNumRecord = 5;

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/computeNewAllocationWithGuarantee.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/computeNewAllocationWithGuarantee.test.ts
@@ -1,8 +1,9 @@
 import {Contract, BigNumber} from 'ethers';
 import shuffle from 'lodash.shuffle';
 
+import {computeNewAllocationWithGuarantee} from '../../../../src/ninja-nitro/helpers';
+import {AllocationItem, Guarantee, randomChannelId} from '../../../../src';
 import {getTestProvider, setupContracts, randomExternalDestination} from '../../../test-helpers';
-// eslint-disable-next-line import/order
 import SingleChannelAdjudicatorArtifact from '../../../../artifacts/contracts/ninja-nitro/SingleChannelAdjudicator.sol/SingleChannelAdjudicator.json';
 
 const provider = getTestProvider();
@@ -16,12 +17,6 @@ beforeAll(async () => {
     process.env.SINGLE_CHANNEL_ADJUDICATOR_MASTERCOPY_ADDRESS
   );
 });
-
-import {AllocationItem, Guarantee, randomChannelId} from '../../../../src';
-import {
-  computeNewAllocation,
-  computeNewAllocationWithGuarantee,
-} from '../../../../src/contract/asset-holder';
 
 const randomAllocation = (numAllocationItems: number): AllocationItem[] => {
   return numAllocationItems > 0
@@ -63,7 +58,7 @@ describe('AsserHolder._computeNewAllocationWithGuarantee', () => {
       allocation,
       indices,
       guarantee
-    )) as ReturnType<typeof computeNewAllocation>;
+    )) as ReturnType<typeof computeNewAllocationWithGuarantee>;
 
     expect(result).toBeDefined();
     expect(result.newAllocation).toMatchObject(
@@ -72,10 +67,13 @@ describe('AsserHolder._computeNewAllocationWithGuarantee', () => {
         amount: BigNumber.from(a.amount),
       }))
     );
+
     expect((result as any).safeToDelete).toEqual(locallyComputedNewAllocation.deleted);
-    expect(result.totalPayouts).toEqual(BigNumber.from(locallyComputedNewAllocation.totalPayouts));
-    expect(result.payouts).toMatchObject(
-      locallyComputedNewAllocation.payouts.map(p => BigNumber.from(p))
+    expect(result.payOuts).toMatchObject(
+      locallyComputedNewAllocation.payOuts.map(a => ({
+        ...a,
+        amount: BigNumber.from(a.amount),
+      }))
     );
   });
 });

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -50,11 +50,11 @@ export const getTestProvider = (): ethers.providers.JsonRpcProvider => {
   return new ethers.providers.JsonRpcProvider(`http://localhost:${process.env.GANACHE_PORT}`);
 };
 
-export async function setupContracts(
+export function setupContracts(
   provider: ethers.providers.JsonRpcProvider,
   artifact: {abi: ethers.ContractInterface},
   address: string
-): Promise<ethers.Contract> {
+): ethers.Contract {
   const signer = provider.getSigner(0);
   // TODO: We should be use the address env variables instead of the address on the artifact
   const contract = new ethers.Contract(address, artifact.abi, signer);


### PR DESCRIPTION
This PR introduces a new `claim.test.ts` file, in the ninja-nitro folder. The test cases are identical to those targeting our existing `AssetHolder.sol` contract (including the `claimAll` ones). The test script itself is necessarily quite different, and has been completely rewritten. 

This PR also makes the required changes to `SingleChannelAdjudicator.sol` to get the tests to pass. The reason why this wasn't a relatively simple copy-paste job (as it was with `transfer`), is that `claim` involves two channels: in the new design this means it involves two instances of the `SingleChannelAdjudicator`. One of those channels (the guarantor) holds the funds; the other (the target) must have its outcome (`status`) mutated. 

The solution here is to call `claim` on the target channel. This triggers the usual checks on the `status` of the `target`; reads the `holdings` of the guarantor; computes a new outcome (using a newly introduced helper function); stores it; and then calls into a new method on the `guarantor`, passing in a `payOuts` object. The guarantor then verifies its own `status`, and checks that the message sender is the target channel, which it trusts. It then pays out according to the request. 

Things to bear in mind / choices:
* the implementation requires that all `guarantees` in the `guarantorOutcome` (there is one for each asset) are targeting the same channel.
* the test suite only explores a set of examples with a single asset (ETH). I would suggest we hold off on writing multi-asset tests of this behaviour for now, given the scope of this spike. The implementation of this PR does support multiple assets, though.

### Changes in more detail: 
* new `OutcomeTransformations` contract containing pure functions for computing new outcomes
* `_computeNewAllocationWithGuarantee` copy/pasted from existing Nitro implementation, but the return type has been modified (`payOuts` is now an `Outcome`). Off-chain Typescript counterpart updated and unit test updated .
* `computeNewOutcomeAfterClaim` is a new helper function that loops over each asset. No unit test for this, as yet. 



This is rather unavoidably a large PR; but is is part of a spike and a larger PR that is only adding code. Therefore it is useful to define the acceptance criteria for this PR. I think it would be most useful to consider:

* are there security holes in this implementation?
* does the test suite have adequate coverage?
