### PR TITLE
Use pure direct funder in xstate wallet

### DIFF
--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -316,7 +316,7 @@ type FundingMilestone = {
   targetTotal: Uint256;
 };
 
-const utils = {
+export const utils = {
   fundingMilestone(state: State, destination: string): FundingMilestone {
     const {allocationItems} = checkThat(state.outcome, isSimpleAllocation);
 

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -66,7 +66,7 @@ export class ChannelWallet {
       this.messagingService.sendMessageNotification(m);
     });
 
-    store.crankObjectiveFeed.subscribe(_.bind(this.crankRichObjective, this));
+    store.crankRichObjectiveFeed.subscribe(_.bind(this.crankRichObjective, this));
 
     // Whenever an OpenChannel objective is received
     // we alert the user that there is a new channel

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -11,12 +11,10 @@ import {
   isOpenChannel,
   OpenChannel,
   SignedState,
-  Uint256,
   SharedObjective,
   Address,
   DirectFunder
 } from '@statechannels/wallet-core';
-import {Dictionary} from '@statechannels/wallet-core/node_modules/@types/lodash';
 import ReactDOM from 'react-dom';
 import React from 'react';
 import _ from 'lodash';

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -12,10 +12,6 @@ import {
   OpenChannel,
   SignedState,
   Uint256,
-  BN,
-  checkThat,
-  isSimpleEthAllocation,
-  Zero,
   SharedObjective,
   Address,
   DirectFunder

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -47,10 +47,8 @@ export type Message = {
   signedStates: SignedState[];
 };
 
-type Deposit = {amountOnChain: Uint256; amountDeposited: Uint256};
 export class ChannelWallet {
   public workflows: Workflow[];
-  protected depositsSubmitted: Dictionary<Deposit> = {};
   static async create(chainAddress?: Address): Promise<ChannelWallet> {
     const chain = new ChainWatcher(chainAddress);
     const store = new Store(chain);
@@ -255,9 +253,9 @@ export class ChannelWallet {
             await Promise.all(action.states.map(state => this.store.addState(state, true)));
             break;
           case 'deposit':
-            if (this.depositsSubmitted[channelId]) {
+            if (this.store.depositsSubmitted[channelId]) {
               throw new Error(
-                `Attempting to submit a deposit for a channel with already submitted deposit ${this.depositsSubmitted[channelId]}`
+                `Attempting to submit a deposit for a channel with already submitted deposit ${this.store.depositsSubmitted[channelId]}`
               );
             }
             const fundingMilestones = DirectFunder.utils.fundingMilestone(
@@ -266,7 +264,7 @@ export class ChannelWallet {
             );
 
             // Record that a deposit will be made
-            this.depositsSubmitted[channelId] = {
+            this.store.depositsSubmitted[channelId] = {
               amountOnChain: fundingMilestones.targetBefore,
               amountDeposited: action.amount
             };

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -66,7 +66,7 @@ export class ChannelWallet {
       this.messagingService.sendMessageNotification(m);
     });
 
-    store.crankRichObjectiveFeed.subscribe(_.bind(this.crankRichObjective, this));
+    store.crankRichObjectiveFeed.subscribe(_.bind(this.crankRichObjectives, this));
 
     // Whenever an OpenChannel objective is received
     // we alert the user that there is a new channel
@@ -233,7 +233,7 @@ export class ChannelWallet {
    *  START of wallet 2.0
    */
 
-  private async crankRichObjective(event: DirectFunder.OpenChannelEvent): Promise<void> {
+  private async crankRichObjectives(event: DirectFunder.OpenChannelEvent): Promise<void> {
     const richObjectives = this.store.richObjectives;
     for (const channelId of Object.keys(richObjectives)) {
       const richObjective = richObjectives[channelId];

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -66,7 +66,7 @@ export class ChannelWallet {
       this.messagingService.sendMessageNotification(m);
     });
 
-    store.crankRichObjectiveFeed.subscribe(_.bind(this.crankRichObjectives, this));
+    store.crankRichObjectivesFeed.subscribe(_.bind(this.crankRichObjectives, this));
 
     // Whenever an OpenChannel objective is received
     // we alert the user that there is a new channel

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -49,6 +49,8 @@ export type ChannelLock = {
   release: () => void;
 };
 
+type Deposit = {amountOnChain: Uint256; amountDeposited: Uint256};
+
 //FIXME
 const track = _.noop;
 const identify = _.noop;
@@ -58,8 +60,18 @@ export class Store {
   readonly chain: Chain;
   private _eventEmitter = new EventEmitter<InternalEvents>();
   private objectives: Objective[] = [];
+
+  /**
+   *  START of wallet 2.0
+   */
   // TODO: this should not be public
   public richObjectives: Dictionary<DirectFunder.OpenChannelObjective> = {};
+  public depositsSubmitted: Dictionary<Deposit> = {};
+
+  /**
+   *  END of wallet 2.0
+   */
+
   constructor(chain?: Chain, backend?: DBBackend) {
     // TODO: We shouldn't default to a fake chain
     // but I didn't feel like updating all the constructor calls

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -42,7 +42,7 @@ interface InternalEvents {
   newObjective: [Objective];
   addToOutbox: [Payload];
   lockUpdated: [ChannelLock];
-  crankObjective: DirectFunder.OpenChannelEvent;
+  crankRichObjectives: DirectFunder.OpenChannelEvent;
 }
 export type ChannelLock = {
   channelId: string;
@@ -154,8 +154,8 @@ export class Store {
     return fromEvent(this._eventEmitter, 'addToOutbox');
   }
 
-  get crankRichObjectiveFeed(): Observable<DirectFunder.OpenChannelEvent> {
-    return fromEvent(this._eventEmitter, 'crankObjective');
+  get crankRichObjectivesFeed(): Observable<DirectFunder.OpenChannelEvent> {
+    return fromEvent(this._eventEmitter, 'crankRichObjectives');
   }
 
   private initializeChannel = (
@@ -571,7 +571,10 @@ export class Store {
     if (objectives) await Promise.all(objectives.map(_.bind(this.addRichObjective, this)));
 
     if (signedStates) {
-      this._eventEmitter.emit('crankObjective', {type: 'StatesReceived', states: signedStates});
+      this._eventEmitter.emit('crankRichObjectives', {
+        type: 'StatesReceived',
+        states: signedStates
+      });
     }
   }
 
@@ -592,7 +595,7 @@ export class Store {
         this.richObjectives[richObjective.channelId] = richObjective;
 
         this.chain.chainUpdatedFeed(richObjective.channelId).subscribe(chainInfo =>
-          this._eventEmitter.emit('crankObjective', {
+          this._eventEmitter.emit('crankRichObjectives', {
             type: 'FundingUpdated',
             amount: chainInfo.amount,
             finalized: true

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -154,7 +154,7 @@ export class Store {
     return fromEvent(this._eventEmitter, 'addToOutbox');
   }
 
-  get crankObjectiveFeed(): Observable<DirectFunder.OpenChannelEvent> {
+  get crankRichObjectiveFeed(): Observable<DirectFunder.OpenChannelEvent> {
     return fromEvent(this._eventEmitter, 'crankObjective');
   }
 

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -64,7 +64,12 @@ export class Store {
   /**
    *  START of wallet 2.0
    */
-  // TODO: this should not be public
+
+  /** TODO:
+   *    These dictionaries should be changed:
+   *      - Store this information in permanent storage instead of memory.
+   *      - Create getters and setters.
+   */
   public richObjectives: Dictionary<DirectFunder.OpenChannelObjective> = {};
   public depositsSubmitted: Dictionary<Deposit> = {};
 


### PR DESCRIPTION
Before this PR, the xstate channel wallet used a quickly implemented direct funder protocol.

This PR brings the newly implemented, pure `DirectFunder` from `wallet-core`  to the `xstate-wallet`. The unmodified interop tests is used to validate that the behavior of the channel wallet is unchanged.