### PR TITLE
Add EOA Balances check to deployAndPayout test

### DIFF
--- a/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/deployAndPayout.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/deployAndPayout.test.ts
@@ -54,17 +54,17 @@ const addresses = {
   ERC20: undefined,
 };
 
-const tenPayouts = {ERC20: {}};
+/*const tenPayouts = {ERC20: {}};
 const fiftyPayouts = {ERC20: {}};
 const oneHundredPayouts = {ERC20: {}};
 
-// for (let i = 0; i < 100; i++) {
-//   const destination = randomExternalDestination();
-//   addresses[i.toString()] = destination;
-//   if (i < 10) tenPayouts.ERC20[i.toString()] = 1;
-//   if (i < 50) fiftyPayouts.ERC20[i.toString()] = 1;
-//   if (i < 100) oneHundredPayouts.ERC20[i.toString()] = 1;
-// }
+for (let i = 0; i < 100; i++) {
+  const destination = randomExternalDestination();
+  addresses[i.toString()] = destination;
+  if (i < 10) tenPayouts.ERC20[i.toString()] = 1;
+  if (i < 50) fiftyPayouts.ERC20[i.toString()] = 1;
+  if (i < 100) oneHundredPayouts.ERC20[i.toString()] = 1;
+}*/
 
 // Populate wallets and participants array
 for (let i = 0; i < 3; i++) {

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/deployAndPayout.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/deployAndPayout.test.ts
@@ -10,8 +10,6 @@ import {AllocationAssetOutcome} from '../../../../src/contract/outcome';
 import {State} from '../../../../src/contract/state';
 import {concludePushOutcomeAndTransferAllArgs} from '../../../../src/contract/transaction-creators/nitro-adjudicator';
 import {
-  checkMultipleAssetOutcomeHashes,
-  checkMultipleHoldings,
   compileEventsFromLogs,
   computeOutcome,
   getPlaceHolderContractAddress,
@@ -24,7 +22,7 @@ import {
   setupContracts,
   writeGasConsumption,
 } from '../../../test-helpers';
-import {signStates} from '../../../../src';
+import {convertBytes32ToAddress, signStates} from '../../../../src';
 import {NITRO_MAX_GAS} from '../../../../src/transactions';
 
 const provider = getTestProvider();

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/deployAndPayout.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/deployAndPayout.test.ts
@@ -31,11 +31,11 @@ const provider = getTestProvider();
 let AdjudicatorFactory: Contract;
 let Token: Contract;
 const chainId = process.env.CHAIN_NETWORK_ID;
-const participants = ['', '', ''];
-const wallets = new Array(3);
+const participants: string[] = [];
+const wallets: Wallet[] = [];
 const challengeDuration = 0x1000;
 
-let appDefinition;
+let appDefinition: string;
 
 const addresses = {
   // Channels
@@ -68,8 +68,9 @@ for (let i = 0; i < 100; i++) {
 
 // Populate wallets and participants array
 for (let i = 0; i < 3; i++) {
-  wallets[i] = Wallet.createRandom();
-  participants[i] = wallets[i].address;
+  const rWallet = Wallet.createRandom();
+  wallets.push(rWallet);
+  participants.push(rWallet.address);
 }
 beforeAll(async () => {
   appDefinition = getPlaceHolderContractAddress();

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/transfer.test.ts
@@ -194,7 +194,7 @@ describe('transfer', () => {
         // NOTE: _transferAsset is a NOOP in TESTAssetHolder, so gas costs will be much lower than for a real Asset Holder
         await writeGasConsumption('SingleChannelAdjudicator.transfer.gas.md', name, gasUsed);
         // expect(eventsFromTx).toMatchObject(expectedEvents);
-        // TODO check EOAs have the right balance
+        // Check that EOAs have the right balance
         Object.keys(payouts).forEach(async key => {
           expect(
             (await provider.getBalance(convertBytes32ToAddress(key))).eq(


### PR DESCRIPTION
Initial vs final account balances were not checked in `deployAndPayout.test.ts`. This PR adds this check.

re: #3412

## Shortcomings (Opportunity for future work)
- Accessing, summing, and comparing balances here is not entirely trivial due to the ways that allocation outcomes are represented and handled by different parts of the system.
- The usefulness of this test (and others like it in the codebase) depends on the accuracy of this data fetching.
- This data fetching is approached somewhat ad-hoc throughout the tests

These account balance tests could likely benefit from a deduplication refactor effort.

## How Has This Been Tested?

Tested via manual verification (debugger, console) of recorded and compared balances.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
