### PR TITLE
[ninja-nitro] Make SingleChannelAdjudicator payable

### DIFF
--- a/packages/nitro-protocol/contracts/ninja-nitro/AdjudicatorFactory.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/AdjudicatorFactory.sol
@@ -35,13 +35,13 @@ contract AdjudicatorFactory {
     }
 
     /// @dev Allows us to get the address for a new channel contract created via `createChannel`
-    function getChannelAddress(bytes32 channelId) external view returns (address) {
-        return Create2.computeAddress(channelId, creationCodeHash);
+    function getChannelAddress(bytes32 channelId) external view returns (address payable) {
+        return payable(Create2.computeAddress(channelId, creationCodeHash));
     }
 
     /// @dev Allows us to create new channel contract and get it all set up in one transaction
-    function createChannel(bytes32 channelId) public returns (address channel) {
-        channel = _deployChannelProxy(channelId);
+    function createChannel(bytes32 channelId) public returns (address payable channel) {
+        channel = payable(_deployChannelProxy(channelId));
         emit ChannelCreation(channel);
     }
 
@@ -56,7 +56,7 @@ contract AdjudicatorFactory {
         uint8[] memory whoSignedWhat,
         SingleChannelAdjudicator.Signature[] memory sigs
     ) public {
-        address channel = _deployChannelProxy(channelId);
+        address payable channel = payable(_deployChannelProxy(channelId));
         SingleChannelAdjudicator(channel).concludeAndTransferAll(
             largestTurnNum,
             fixedPart,

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -17,7 +17,7 @@ contract SingleChannelAdjudicator is
         adjudicatorFactoryAddress = a;
     }
 
-    receive() external payable {}
+    receive() external payable {} // solhint-disable-line no-empty-blocks
 
     /**
      * @notice Verifies a conclusion proof, pays out all assets and selfdestructs

--- a/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/SingleChannelAdjudicator.sol
@@ -17,6 +17,8 @@ contract SingleChannelAdjudicator is
         adjudicatorFactoryAddress = a;
     }
 
+    receive() external payable {}
+
     /**
      * @notice Verifies a conclusion proof, pays out all assets and selfdestructs
      * @dev Verifies a conclusion proof, pays out all assets and selfdestructs

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/deposit.test.ts
@@ -1,0 +1,63 @@
+import {Contract, BigNumber} from 'ethers';
+import AdjudicatorFactoryArtifact from '../../../../artifacts/contracts/ninja-nitro/AdjudicatorFactory.sol/AdjudicatorFactory.json';
+
+import {
+  getTestProvider,
+  randomChannelId,
+  setupContracts,
+  writeGasConsumption,
+} from '../../../test-helpers';
+
+const provider = getTestProvider();
+let AdjudicatorFactory: Contract;
+
+beforeAll(async () => {
+  AdjudicatorFactory = await setupContracts(
+    provider,
+    AdjudicatorFactoryArtifact,
+    process.env.ADJUDICATOR_FACTORY_ADDRESS
+  );
+});
+
+describe('deposit ETH', () => {
+  it('before contract deployed', async () => {
+    const channelId = randomChannelId();
+    const channelAddress = await AdjudicatorFactory.getChannelAddress(channelId);
+    const {gasUsed} = await (
+      await provider.getSigner().sendTransaction({
+        to: channelAddress,
+        value: 5,
+      })
+    ).wait();
+    await writeGasConsumption(
+      'SingleChannelAdjudicator.deposit.gas.md',
+      'ninja deposit (before contract deployed)',
+      gasUsed
+    );
+
+    expect((await provider.getBalance(channelAddress)).eq(BigNumber.from(5))).toBe(true);
+  });
+  it('after contract deployed', async () => {
+    const channelId = randomChannelId();
+    const channelAddress = await AdjudicatorFactory.getChannelAddress(channelId);
+    await (await AdjudicatorFactory.createChannel(channelId)).wait();
+    const {gasUsed} = await (
+      await provider.getSigner().sendTransaction({
+        to: channelAddress,
+        value: 5,
+      })
+    ).wait();
+    await writeGasConsumption(
+      'SingleChannelAdjudicator.deposit.gas.md',
+      'ninja deposit (before contract deployed)',
+      gasUsed
+    );
+
+    expect((await provider.getBalance(channelAddress)).eq(BigNumber.from(5))).toBe(true);
+  });
+});
+// TODO:
+// describe('deposit ERC20 Tokens', () => {
+//   it('before contract deployed', () => {});
+//   it('after contract deployed', () => {});
+// });

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/SingleChannelAdjudicator/deposit.test.ts
@@ -49,7 +49,7 @@ describe('deposit ETH', () => {
     ).wait();
     await writeGasConsumption(
       'SingleChannelAdjudicator.deposit.gas.md',
-      'ninja deposit (before contract deployed)',
+      'ninja deposit (after contract deployed)',
       gasUsed
     );
 


### PR DESCRIPTION
The create2 architecture is pretty interesting!

As is, on the base branch, you can send money (ETH) to a contract before it has been deployed... and you can't send money there after it has been deployed! 🤪 

This PR adds a test to confirm this, and then makes a change to fix the behaviour so we can always send ETH. 


https://docs.soliditylang.org/en/v0.8.3/contracts.html?highlight=receive#receive-ether-function
