### PR TITLE
chore: remove wallet-core, pure DirectFunder logic from server-wallet

### DIFF
--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -88,18 +88,6 @@ it('Create a directly funded channel between two engines ', async () => {
     turnNum: 3,
   });
 
-  // TODO (DirectFunder) Remove hacky expectation
-  (['a', 'b'] as const).map(key => {
-    const objective = (peerEngines[key] as any).richObjectives[channelId];
-    const signatures = [{signer: expect.any(String)}, {signer: expect.any(String)}];
-    expect(objective).toMatchObject({
-      status: 'success',
-      preFundSetup: {signatures},
-      funding: {amount: BN.from(2), finalized: true},
-      postFundSetup: {signatures},
-    });
-  });
-
   const closeChannelParams: CloseChannelParams = {
     channelId,
   };

--- a/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
@@ -4,8 +4,6 @@ import {
   serializeState,
   serializeAllocation,
   serializeOutcome,
-  DirectFunder,
-  hashState,
 } from '@statechannels/wallet-core';
 import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
 import Objection from 'objection';
@@ -299,52 +297,6 @@ describe('ledger funded app scenarios', () => {
     expect(protocolState).toMatchObject({
       latest: signedPreFS1,
       supported: signedPreFS1,
-    });
-  });
-});
-
-describe('direct-funder', () => {
-  it('signs the prefund setup ', async () => {
-    const appData = '0x0f00';
-    const c = channel({
-      signingAddress: bob().address,
-      vars: [stateWithHashSignedBy([alice()])({appData})],
-    });
-    await Channel.query(w.knex).insert(c);
-    const {channelId} = c;
-
-    await ObjectiveModel.insert(
-      {
-        type: 'OpenChannel',
-        participants: c.participants,
-        data: {
-          targetChannelId: c.channelId,
-          fundingStrategy: 'Direct',
-          role: 'app',
-        },
-      },
-      false,
-      w.knex
-    );
-
-    (w as any).richObjectives[channelId] = DirectFunder.initialize(c.latest, 1);
-
-    await w.joinChannel({channelId});
-
-    const currentState = (w as any).richObjectives[channelId];
-
-    expect(currentState).toBeDefined();
-    expect(currentState).toMatchObject({
-      status: DirectFunder.WaitingFor.safeToDeposit,
-      preFundSetup: {
-        hash: hashState(c.latest),
-        signatures: [
-          {signer: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'},
-          {signer: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9'},
-        ],
-      },
-      funding: {amount: BN.from(0)},
-      postFundSetup: {hash: expect.any(String), signatures: []},
     });
   });
 });

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -3,9 +3,6 @@ import {
   simpleEthAllocation,
   serializeState,
   SignedState,
-  OpenChannel,
-  DirectFunder,
-  hashState,
 } from '@statechannels/wallet-core';
 import {ChannelResult} from '@statechannels/client-api-schema';
 import _ from 'lodash';
@@ -461,27 +458,6 @@ describe('when there is a request provided', () => {
           params: {data: {signedStates: expect.arrayContaining(signedStates)}},
         },
       ],
-    });
-  });
-});
-
-describe('direct-funder', () => {
-  it('stores but does not crank new objectives when they come in', async () => {
-    const signedState = stateSignedBy([bob()])({turnNum: zero, channelNonce: 9001});
-    const targetChannelId = calculateChannelId(signedState);
-    const {participants} = signedState;
-    const objectives: OpenChannel[] = [
-      {type: 'OpenChannel', data: {targetChannelId, fundingStrategy: 'Direct'}, participants},
-    ];
-    const signedStates = [serializeState(signedState)];
-
-    await engine.pushMessage({walletVersion: WALLET_VERSION, objectives, signedStates});
-
-    const currentState = (engine as any).richObjectives[targetChannelId];
-    expect(currentState).toMatchObject({
-      status: DirectFunder.WaitingFor.theirPreFundSetup,
-      myIndex: 0,
-      preFundSetup: {hash: hashState(signedState), signatures: signedState.signatures},
     });
   });
 });


### PR DESCRIPTION
There is a hypothesis that this logic might be causing CI test failures like [this](https://app.circleci.com/pipelines/github/statechannels/statechannels/12545/workflows/dfe9cad8-8b20-488a-ad7e-94eda24ed4ae/jobs/61806) as these failures appear to start with https://github.com/statechannels/statechannels/pull/3439

