### PR TITLE
Add approved field to OpenChannelObjective

### DIFF
--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -127,6 +127,15 @@ it('server + browser wallet interoperability test', async () => {
   });
 
   await browserWallet.pushMessage(serverMessageToBrowserMessage(output1), 'dummyDomain');
+  await browserWallet.pushMessage(
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'JoinChannel',
+      params: {channelId: output1.channelResult.channelId}
+    },
+    'dummyDomain'
+  );
 
   /** This is fragile. We are waiting for the third channelUpdated event. Note that these events consistently arrive in the following order.
    *  But the events are not guaranteed to arrive in this order:

--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -127,6 +127,8 @@ it('server + browser wallet interoperability test', async () => {
   });
 
   await browserWallet.pushMessage(serverMessageToBrowserMessage(output1), 'dummyDomain');
+
+  // TODO: the proper way to do this is to wait for a ChannelProposed or some sort of new objective notification
   await browserWallet.pushMessage(
     {
       jsonrpc: '2.0',

--- a/packages/wallet-core/.vscode/launch.json
+++ b/packages/wallet-core/.vscode/launch.json
@@ -27,7 +27,6 @@
         "--config=${workspaceFolder}/config/jest/jest.config.js",
         "--runInBand",
         "--env=jsdom",
-        "--watch",
         "${relativeFile}"
       ],
       "skipFiles": ["<node_internals>/**/*.js", "node_modules"],

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -47,7 +47,8 @@ export type OpenChannelObjective = {
 
 export function initialize(
   openingState: State | SignedState,
-  myIndex: number
+  myIndex: number,
+  approved = false
 ): OpenChannelObjective {
   if (openingState.turnNum !== 0) {
     throw new Error(`Unexpected state due to turnNum ${openingState.turnNum}`);
@@ -65,7 +66,7 @@ export function initialize(
     'signatures' in openingState ? mergeSignatures([], openingState.signatures) : [];
 
   return {
-    approved: false,
+    approved,
     channelId: calculateChannelId(openingState),
     myIndex,
     openingState: _.omit(openingState, 'signatures'),

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -171,7 +171,7 @@ describe('cranking', () => {
         ]
       }
     });
-    const zeroOutcome = {...initialize(signStateHelper(zeroOutcomeState, 'A'), 1), approved: true};
+    const zeroOutcome = initialize(signStateHelper(zeroOutcomeState, 'A'), 1, true);
 
     const aliceSignedPre = objectiveFixture({
       status: WaitingFor.theirPreFundSetup,

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -259,7 +259,8 @@ describe('cranking', () => {
       
 
       [ msg = 'Receiving a preFundSetup state',
-             approved,          sendState(richPreFS.stateSignedBy('B')), {preFundSetup: richPreFS.signedBy('A', 'B')}, [{type: 'sendStates'}, {type: 'deposit'}] ],
+             notApproved,    sendState(richPreFS.stateSignedBy('B')), {preFundSetup: richPreFS.signedBy('B')},      [] ],
+      [ msg, approved,       sendState(richPreFS.stateSignedBy('B')), {preFundSetup: richPreFS.signedBy('A', 'B')}, [{type: 'sendStates'}, {type: 'deposit'}] ],
       [ msg, aliceSignedPre, sendState(richPreFS.stateSignedBy('B')), {preFundSetup: richPreFS.signedBy('A', 'B')}, [{type: 'deposit'}] ],
 
 

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -66,7 +66,7 @@ export class ChannelWallet {
       this.messagingService.sendMessageNotification(m);
     });
 
-    store.crankRichObjectivesFeed.subscribe(this.crankRichObjectives);
+    store.crankRichObjectivesFeed.subscribe(_.bind(this.crankRichObjectives, this));
 
     // Whenever an OpenChannel objective is received
     // we alert the user that there is a new channel

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -66,7 +66,7 @@ export class ChannelWallet {
       this.messagingService.sendMessageNotification(m);
     });
 
-    store.crankRichObjectivesFeed.subscribe(_.bind(this.crankRichObjectives, this));
+    store.crankRichObjectivesFeed.subscribe(this.crankRichObjectives);
 
     // Whenever an OpenChannel objective is received
     // we alert the user that there is a new channel

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -149,7 +149,11 @@ export class ChannelWallet {
         break;
       }
       case 'JOIN_CHANNEL':
-        this.getWorkflow(this.calculateWorkflowId(request)).service.send(request);
+        // This is wallet 1.0 logic. Leaving for now for reference.
+        // this.getWorkflow(this.calculateWorkflowId(request)).service.send(request);
+
+        // This wallet 2.0 logic
+        this.approveRichObjective(request.channelId);
         break;
       case 'APPROVE_BUDGET_AND_FUND': {
         const workflow = this.startWorkflow(
@@ -233,6 +237,8 @@ export class ChannelWallet {
    *  START of wallet 2.0
    */
 
+  // TODO: an event should be associated with a single objective. In other words, this function should not
+  //        map an event to all stored objectives
   private async crankRichObjectives(event: DirectFunder.OpenChannelEvent): Promise<void> {
     const richObjectives = this.store.richObjectives;
     for (const channelId of Object.keys(richObjectives)) {
@@ -278,6 +284,14 @@ export class ChannelWallet {
         }
       }
     }
+  }
+
+  approveRichObjective(channelId: string) {
+    const richObjective = this.store.richObjectives[channelId];
+    if (!richObjective) {
+      throw new Error(`Rich objective must exist for channelId ${channelId}`);
+    }
+    this.crankRichObjectives({type: 'Approval'});
   }
 
   /**


### PR DESCRIPTION
When a wallet receives an open channel objective, the wallet should:
1. Store the objective.
2. Notify the application of the objective.
3. Not take any actions before the application approves the objective.

It is likely that the `approved` field belongs on all objective types. But, for now, we are only considering the open channel objective.

This PR adds objective approval to `OpenChannelObjective` while leaving xstate-wallet api unchanged. 