### PR TITLE
separate ninja-nitro test setup

### DIFF
--- a/packages/nitro-protocol/config/jest/jest.contracts.config.js
+++ b/packages/nitro-protocol/config/jest/jest.contracts.config.js
@@ -1,5 +1,6 @@
 var config = require('./jest.config');
 config.testMatch = ['<rootDir>/test/contracts/**/*.test.ts'];
+config.testPathIgnorePatterns = ['ninja-nitro'];
 config.reporters = ['default'];
 config.globalSetup = '<rootDir>/jest/contract-test-setup.ts';
 config.globalTeardown = '<rootDir>/jest/contract-test-teardown.ts';

--- a/packages/nitro-protocol/config/jest/jest.ninja-nitro.config.js
+++ b/packages/nitro-protocol/config/jest/jest.ninja-nitro.config.js
@@ -1,6 +1,6 @@
 var config = require('./jest.config');
 config.testMatch = ['<rootDir>/test/**/ninja-nitro/**/*.test.ts'];
 config.reporters = ['default'];
-config.globalSetup = '<rootDir>/jest/contract-test-setup.ts';
+config.globalSetup = '<rootDir>/jest/ninja-nitro-contract-test-setup.ts';
 config.globalTeardown = '<rootDir>/jest/contract-test-teardown.ts';
 module.exports = config;

--- a/packages/nitro-protocol/deployment/deploy-ninja-nitro-contracts.ts
+++ b/packages/nitro-protocol/deployment/deploy-ninja-nitro-contracts.ts
@@ -1,13 +1,22 @@
 // NOTE: this script manages deploying contracts for testing purposes ONLY
 // DO NOT USE THIS SCRIPT TO DEPLOY CONTRACTS TO PRODUCTION NETWORKS
-import {GanacheDeployer} from '@statechannels/devtools';
+import {GanacheDeployer, ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
+import {Wallet} from 'ethers';
 
 import {getTestProvider, setupContracts, writeGasConsumption} from '../test/test-helpers';
 import adjudicatorFactoryArtifact from '../artifacts/contracts/ninja-nitro/AdjudicatorFactory.sol/AdjudicatorFactory.json';
 import singleChannelAdjudicatorArtifact from '../artifacts/contracts/ninja-nitro/SingleChannelAdjudicator.sol/SingleChannelAdjudicator.json';
+import tokenArtifact from '../artifacts/contracts/Token.sol/Token.json';
 
 export async function deploy(): Promise<Record<string, string>> {
   const deployer = new GanacheDeployer(Number(process.env.GANACHE_PORT));
+
+  const TEST_TOKEN_ADDRESS = await deployer.deploy(
+    tokenArtifact as any,
+    {},
+    new Wallet(ETHERLIME_ACCOUNTS[0].privateKey).address
+  );
+
   const ADJUDICATOR_FACTORY_ADDRESS = await deployer.deploy(adjudicatorFactoryArtifact as any);
   const adjudicatorFactoryDeploymentGas = await deployer.etherlimeDeployer.estimateGas(
     adjudicatorFactoryArtifact as any
@@ -46,5 +55,6 @@ export async function deploy(): Promise<Record<string, string>> {
   return {
     SINGLE_CHANNEL_ADJUDICATOR_MASTERCOPY_ADDRESS,
     ADJUDICATOR_FACTORY_ADDRESS,
+    TEST_TOKEN_ADDRESS,
   };
 }

--- a/packages/nitro-protocol/deployment/deploy-ninja-nitro-contracts.ts
+++ b/packages/nitro-protocol/deployment/deploy-ninja-nitro-contracts.ts
@@ -41,7 +41,7 @@ export async function deploy(): Promise<Record<string, string>> {
   writeGasConsumption('MasterCopy.gas.md', 'deployment', masterCopyDeploymentGas);
   console.log(`\nDeploying MasterCopy... (cost estimated to be ${masterCopyDeploymentGas})\n`);
 
-  // The following lines are not strictly part of deployment, but they constiture a crucial one-time setup
+  // The following lines are not strictly part of deployment, but they constitute a crucial one-time setup
   // for the contracts. The factory needs to know the address of the mastercopy, and this is provided by calling
   // the setup method on the factory:
   const provider = getTestProvider();

--- a/packages/nitro-protocol/deployment/deploy-ninja-nitro-contracts.ts
+++ b/packages/nitro-protocol/deployment/deploy-ninja-nitro-contracts.ts
@@ -1,0 +1,50 @@
+// NOTE: this script manages deploying contracts for testing purposes ONLY
+// DO NOT USE THIS SCRIPT TO DEPLOY CONTRACTS TO PRODUCTION NETWORKS
+import {GanacheDeployer} from '@statechannels/devtools';
+
+import {getTestProvider, setupContracts, writeGasConsumption} from '../test/test-helpers';
+import adjudicatorFactoryArtifact from '../artifacts/contracts/ninja-nitro/AdjudicatorFactory.sol/AdjudicatorFactory.json';
+import singleChannelAdjudicatorArtifact from '../artifacts/contracts/ninja-nitro/SingleChannelAdjudicator.sol/SingleChannelAdjudicator.json';
+
+export async function deploy(): Promise<Record<string, string>> {
+  const deployer = new GanacheDeployer(Number(process.env.GANACHE_PORT));
+  const ADJUDICATOR_FACTORY_ADDRESS = await deployer.deploy(adjudicatorFactoryArtifact as any);
+  const adjudicatorFactoryDeploymentGas = await deployer.etherlimeDeployer.estimateGas(
+    adjudicatorFactoryArtifact as any
+  );
+  writeGasConsumption('AdjudicatorFactory.gas.md', 'deployment', adjudicatorFactoryDeploymentGas);
+  console.log(
+    `\nDeploying AdjudicatorFactory... (cost estimated to be ${adjudicatorFactoryDeploymentGas})\n`
+  );
+
+  const SINGLE_CHANNEL_ADJUDICATOR_MASTERCOPY_ADDRESS = await deployer.deploy(
+    singleChannelAdjudicatorArtifact as any,
+    {},
+    ADJUDICATOR_FACTORY_ADDRESS // The mastercopy requires the adjudicator factory address as a constructor arg
+    // It will be "baked into" the bytecode of the Mastercopy
+  );
+
+  const masterCopyDeploymentGas = await deployer.etherlimeDeployer.estimateGas(
+    singleChannelAdjudicatorArtifact as any,
+    {},
+    ADJUDICATOR_FACTORY_ADDRESS as any
+  );
+  writeGasConsumption('MasterCopy.gas.md', 'deployment', masterCopyDeploymentGas);
+  console.log(`\nDeploying MasterCopy... (cost estimated to be ${masterCopyDeploymentGas})\n`);
+
+  // The following lines are not strictly part of deployment, but they constiture a crucial one-time setup
+  // for the contracts. The factory needs to know the address of the mastercopy, and this is provided by calling
+  // the setup method on the factory:
+  const provider = getTestProvider();
+  const AdjudicatorFactory = await setupContracts(
+    provider,
+    adjudicatorFactoryArtifact,
+    ADJUDICATOR_FACTORY_ADDRESS
+  );
+  await (await AdjudicatorFactory.setup(SINGLE_CHANNEL_ADJUDICATOR_MASTERCOPY_ADDRESS)).wait();
+
+  return {
+    SINGLE_CHANNEL_ADJUDICATOR_MASTERCOPY_ADDRESS,
+    ADJUDICATOR_FACTORY_ADDRESS,
+  };
+}

--- a/packages/nitro-protocol/jest/ninja-nitro-contract-test-setup.ts
+++ b/packages/nitro-protocol/jest/ninja-nitro-contract-test-setup.ts
@@ -1,0 +1,16 @@
+import {GanacheServer, configureEnvVariables} from '@statechannels/devtools';
+import {deploy} from '../deployment/deploy-ninja-nitro-contracts';
+
+export default async function setup() {
+  configureEnvVariables();
+  const ganacheServer = new GanacheServer(
+    Number(process.env.GANACHE_PORT),
+    Number(process.env.CHAIN_NETWORK_ID)
+  );
+  await ganacheServer.ready();
+
+  const deployedArtifacts = await deploy();
+
+  process.env = {...process.env, ...deployedArtifacts};
+  (global as any).__GANACHE_SERVER__ = ganacheServer;
+}

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -93,7 +93,7 @@
     "prettier:write": "prettier --write './contracts/**/*.sol'",
     "test": "yarn test:contracts && yarn test:app --all",
     "test:app": "jest -c ./config/jest/jest.config.js",
-    "test:ci": "yarn test:ci:app && yarn test:ci:contracts",
+    "test:ci": "yarn test:ci:app && yarn test:ci:contracts && yarn test:ninja-nitro",
     "test:ci:app": "yarn test:app --all --ci --bail --maxWorkers=4",
     "test:ci:contracts": "yarn test:contracts --all --ci --bail --maxWorkers=4",
     "test:contracts": "jest -c ./config/jest/jest.contracts.config.js",


### PR DESCRIPTION
The aim is to have the ninja-nitro as loosely coupled to the existing code as possible, to avoid confusion. All ninja-nitro code can be in appropriately namespaced files / folders.