### PR TITLE
Include jest typescript folders in linting

### DIFF
--- a/packages/server-wallet/.eslintignore
+++ b/packages/server-wallet/.eslintignore
@@ -5,5 +5,4 @@ node_modules/
 /.etherlime-store/
 /lib/
 /dist/
-/jest/
 /deployment/

--- a/packages/server-wallet/jest/custom-matchers.ts
+++ b/packages/server-wallet/jest/custom-matchers.ts
@@ -1,32 +1,33 @@
-import { AllocationItem, areAllocationItemsEqual } from "@statechannels/wallet-core";
-import { ObjectiveDoneResult, ObjectiveResult } from "../src/wallet";
+import {AllocationItem, areAllocationItemsEqual} from '@statechannels/wallet-core';
+
+import {ObjectiveDoneResult, ObjectiveResult} from '../src/wallet';
 
 expect.extend({
-    toContainAllocationItem(received: AllocationItem[], argument: AllocationItem) {
-      const pass = received.some(areAllocationItemsEqual.bind(null, argument));
-      if (pass) {
-        return {
-          pass: true,
-          message: () =>
-            `expected ${JSON.stringify(received, null, 2)} to not contain ${JSON.stringify(
-              argument,
-              null,
-              2
-            )}`,
-        };
-      } else {
-        return {
-          pass: false,
-          message: () =>
-            `expected ${JSON.stringify(received, null, 2)} to contain ${JSON.stringify(
-              argument,
-              null,
-              2
-            )}`,
-        };
-      }
-    },
-  });
+  toContainAllocationItem(received: AllocationItem[], argument: AllocationItem) {
+    const pass = received.some(areAllocationItemsEqual.bind(null, argument));
+    if (pass) {
+      return {
+        pass: true,
+        message: () =>
+          `expected ${JSON.stringify(received, null, 2)} to not contain ${JSON.stringify(
+            argument,
+            null,
+            2
+          )}`,
+      };
+    } else {
+      return {
+        pass: false,
+        message: () =>
+          `expected ${JSON.stringify(received, null, 2)} to contain ${JSON.stringify(
+            argument,
+            null,
+            2
+          )}`,
+      };
+    }
+  },
+});
 
 // https://medium.com/@andrei.pfeiffer/jest-matching-objects-in-array-50fe2f4d6b98
 expect.extend({

--- a/packages/server-wallet/jest/jest.config.js
+++ b/packages/server-wallet/jest/jest.config.js
@@ -4,7 +4,7 @@ const root = resolve(__dirname, '../');
 module.exports = {
   rootDir: root,
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  setupFilesAfterEnv: ['./jest/custom-matchers.ts','./jest/knex-setup-teardown.ts'],
+  setupFilesAfterEnv: ['./jest/custom-matchers.ts', './jest/knex-setup-teardown.ts'],
   testMatch: ['<rootDir>/**/__test__/**/?(*.)(spec|test).ts'],
   testEnvironment: 'node',
   testURL: 'http://localhost',

--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -1,6 +1,8 @@
 import {configureEnvVariables} from '@statechannels/devtools';
 import Knex from 'knex';
 import _ from 'lodash';
+
+// eslint-disable-next-line import/order
 import {DBAdmin} from '../src/db-admin/db-admin';
 
 configureEnvVariables();
@@ -11,21 +13,20 @@ import {
   DatabaseConfiguration,
 } from '../src/config';
 
-const constructedKnexs: Knex[] = []
+const constructedKnexs: Knex[] = [];
 
 /**
- * 
- * @param databaseConfiguration 
- * 
+ *
+ * @param databaseConfiguration
+ *
  * returns a knex instance which is automatically destroyed after all jest tests have run
  */
-export let constructKnex = (databaseConfiguration: Partial<DatabaseConfiguration>): Knex =>
-  {
-    const knex = Knex(extractDBConfigFromEngineConfig(defaultTestConfig({databaseConfiguration})));
-    constructedKnexs.push(knex)
+export const constructKnex = (databaseConfiguration: Partial<DatabaseConfiguration>): Knex => {
+  const knex = Knex(extractDBConfigFromEngineConfig(defaultTestConfig({databaseConfiguration})));
+  constructedKnexs.push(knex);
 
-    return knex
-  }
+  return knex;
+};
 
 export let testKnex: Knex;
 
@@ -38,5 +39,5 @@ afterAll(async () => {
   // We need to close the db connection after the test suite has run.
   // Otherwise, jest will not exit within the required one second after the test
   // suite has finished
-  await Promise.all(constructedKnexs.map(async knex => knex.destroy()))
+  await Promise.all(constructedKnexs.map(async knex => knex.destroy()));
 });

--- a/packages/server-wallet/jest/test-teardown.ts
+++ b/packages/server-wallet/jest/test-teardown.ts
@@ -1,3 +1,3 @@
-export default async function teardown() {
+export default async function teardown(): Promise<void> {
   await (global as any).__GANACHE_SERVER__?.close();
 }


### PR DESCRIPTION
The `jest` folder is currently excluded from linting which makes editing these files more annoying.

This change simple includes the jest folder typescript files in linting.
