### PR TITLE
Add approveObjectives API

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -355,6 +355,11 @@ export type SingleChannelOutput = {
 export class SingleThreadedEngine extends EventEmitter<EventEmitterType> implements EngineInterface, ChainEventSubscriberInterface {
     protected constructor(engineConfig: IncomingEngineConfig);
     addSigningKey(privateKey: PrivateKey): Promise<void>;
+    // (undocumented)
+    approveObjectives(objectiveIds: string[]): Promise<{
+        objectives: WalletObjective[];
+        messages: Message_3[];
+    }>;
     // Warning: (ae-forgotten-export) The symbol "AssetOutcomeUpdatedArg" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -437,6 +442,7 @@ export function validateEngineConfig(config: Record<string, any>): {
 
 // @public (undocumented)
 export class Wallet {
+    approveObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]>;
     // Warning: (ae-forgotten-export) The symbol "MessageServiceInterface" needs to be exported by the entry point index.d.ts
     static create(engine: Engine, messageService: MessageServiceInterface, retryOptions?: Partial<RetryOptions>): Promise<Wallet>;
     createChannels(channelParameters: CreateChannelParams[]): Promise<ObjectiveResult[]>;

--- a/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
@@ -1,0 +1,60 @@
+import _ from 'lodash';
+
+import {Wallet} from '../..';
+import {getPeersSetup, PeerSetup, teardownPeerSetup} from '../../../jest/with-peers-setup-teardown';
+import {getWithPeersCreateChannelsArgs, waitForObjectiveStarted} from '../utils';
+jest.setTimeout(60_000);
+let peerSetup: PeerSetup;
+
+beforeAll(async () => {
+  peerSetup = await getPeersSetup();
+});
+afterAll(async () => {
+  await teardownPeerSetup(peerSetup);
+});
+const DEFAULT__RETRY_OPTIONS = {numberOfAttempts: 100, initialDelay: 50, multiple: 1};
+
+test('approving a completed objective returns immediately', async () => {
+  const {peerEngines, messageService} = peerSetup;
+  messageService.setLatencyOptions({dropRate: 0});
+
+  const wallet = await Wallet.create(peerEngines.a, messageService, DEFAULT__RETRY_OPTIONS);
+  const walletB = await Wallet.create(peerEngines.b, messageService, DEFAULT__RETRY_OPTIONS);
+
+  const createResult = await wallet.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
+
+  const {objectiveId} = createResult[0];
+  await waitForObjectiveStarted([objectiveId], peerEngines.b);
+
+  const approveResult = await walletB.approveObjectives([objectiveId]);
+
+  await expect(createResult).toBeObjectiveDoneType('Success');
+  await expect(approveResult).toBeObjectiveDoneType('Success');
+
+  const secondApprove = await walletB.approveObjectives([objectiveId]);
+  await expect(secondApprove).toBeObjectiveDoneType('Success');
+});
+
+test('can approve the objective multiple times', async () => {
+  const {peerEngines, messageService} = peerSetup;
+
+  const wallet = await Wallet.create(peerEngines.a, messageService, DEFAULT__RETRY_OPTIONS);
+  const walletB = await Wallet.create(peerEngines.b, messageService, DEFAULT__RETRY_OPTIONS);
+
+  const result = await wallet.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
+  const {objectiveId} = result[0];
+  await waitForObjectiveStarted([objectiveId], peerEngines.b);
+
+  await messageService.freeze();
+  const firstResult = await walletB.approveObjectives([objectiveId]);
+  const secondResult = await walletB.approveObjectives([objectiveId]);
+  // The objectives should be approved but should not have progressed further
+  // due to the message service being frozen
+  expect(firstResult[0].currentStatus).toBe('approved');
+  expect(secondResult[0].currentStatus).toBe('approved');
+
+  await messageService.unfreeze();
+
+  await expect(firstResult).toBeObjectiveDoneType('Success');
+  await expect(secondResult).toBeObjectiveDoneType('Success');
+});

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -565,7 +565,7 @@ export class SingleThreadedEngine
 
       await this.takeActions([channelId], response);
     }
-    return {objectives, messages: getMessages(response.multipleChannelOutput().outbox)};
+    return {objectives, messages: getMessages(response.multipleChannelOutput())};
   }
 
   /**

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -555,16 +555,16 @@ export class SingleThreadedEngine
     objectiveIds: string[]
   ): Promise<{objectives: WalletObjective[]; messages: Message[]}> {
     const objectives = await this.store.getObjectivesByIds(objectiveIds);
-
+    const channelIds: string[] = [];
     const response = EngineResponse.initialize();
     for (const objective of objectives) {
-      const {targetChannelId: channelId} = objective.data;
-      await this.registerChannelWithChainService(channelId);
+      const {targetChannelId} = objective.data;
+      channelIds.push(targetChannelId);
+      await this.registerChannelWithChainService(targetChannelId);
 
       await this.store.approveObjective(objective.objectiveId);
-
-      await this.takeActions([channelId], response);
     }
+    await this.takeActions(channelIds, response);
     return {objectives, messages: getMessages(response.multipleChannelOutput())};
   }
 

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -362,7 +362,7 @@ export class Store {
     return LedgerRequest.ledgersWithNewRequestsIds(tx || this.knex);
   }
 
-  async approveObjective(objectiveId: string, tx?: Transaction): Promise<void> {
+  async approveObjective(objectiveId: string, tx?: Transaction): Promise<WalletObjective> {
     const objective = await ObjectiveModel.approve(objectiveId, tx || this.knex);
 
     if (objective.type === 'OpenChannel') {
@@ -384,6 +384,7 @@ export class Store {
         .where({channelId})
         .patch({fundingStrategy, fundingLedgerChannelId});
     }
+    return objective;
   }
 
   async markObjectiveStatus<O extends WalletObjective>(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -127,6 +127,14 @@ export class Wallet {
     objectiveMessages: Message[]
   ): Promise<ObjectiveSuccess | ObjectiveError> {
     try {
+      // If the objective is already done we want to exit immediately
+      if (objective.status === 'succeeded') {
+        this._engine.logger.debug(
+          {objective},
+          'Objective passed into ensureObjective has already succeeded'
+        );
+        return {type: 'Success', channelId: objective.data.targetChannelId};
+      }
       let isComplete = false;
 
       const onObjectiveSucceeded = (o: WalletObjective) => {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -44,14 +44,12 @@ export class Wallet {
   public async approveObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]> {
     const {objectives, messages} = await this._engine.approveObjectives(objectiveIds);
     return Promise.all(
-      objectives.map(async o => {
-        return {
-          objectiveId: o.objectiveId,
-          currentStatus: o.status,
-          channelId: o.data.targetChannelId,
-          done: this.ensureObjective(o, messages),
-        };
-      })
+      objectives.map(async o => ({
+        objectiveId: o.objectiveId,
+        currentStatus: o.status,
+        channelId: o.data.targetChannelId,
+        done: this.ensureObjective(o, messages),
+      }))
     );
   }
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -33,6 +33,14 @@ export class Wallet {
     private _retryOptions: RetryOptions
   ) {}
 
+  /**
+   * Approves an objective that has been proposed by another participant.
+   * Once the objective has been approved progress can be made to completing the objective.
+   * @remarks
+   * This is used to "join" channels by approving a CreateChannel Objective.
+   * @param objectiveIds The ids of the objective you want to approve.
+   * @returns A promise that resolves to a collection of ObjectiveResult.
+   */
   public async approveObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]> {
     const {objectives, messages} = await this._engine.approveObjectives(objectiveIds);
     return Promise.all(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -33,6 +33,20 @@ export class Wallet {
     private _retryOptions: RetryOptions
   ) {}
 
+  public async approveObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]> {
+    const {objectives, messages} = await this._engine.approveObjectives(objectiveIds);
+    return Promise.all(
+      objectives.map(async o => {
+        return {
+          objectiveId: o.objectiveId,
+          currentStatus: o.status,
+          channelId: o.data.targetChannelId,
+          done: this.ensureObjective(o, messages),
+        };
+      })
+    );
+  }
+
   /**
    Creates channels using the given parameters.
    * @param channelParameters The parameters to use for channel creation. A channel will be created for each entry in the array.


### PR DESCRIPTION
This requires #3527 for the tests to pass.

# Description
Introduces a new `approveObjectives` function on the API.

The `approveObjectives`  allows users to approve and make progress on an objective that another participant has approved.

Practically this replaces the `joinChannels` API method.  Instead of calling `joinChannels` on a collection of channelIds we now call `approveObjectives` on a collection of `createChannel` objective ids.


## How Has This Been Tested? 

The `ensure-objective` test suite have been updated to use `approveObjective`.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
