### PR TITLE
[xstate-wallet] Adding channel creation to browser wallet

### DIFF
--- a/packages/interop-tests/jest/jest.config.js
+++ b/packages/interop-tests/jest/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {tsconfig: './tsconfig.json'},
-    window: {localStorage: {}, addEventListener: (_p1, p2) => ({})}
+    window: {localStorage: {}, addEventListener: (_p1, _p2) => ({})}
   },
   globalSetup: '<rootDir>/jest/chain-setup.ts',
   globalTeardown: '<rootDir>/jest/test-teardown.ts'

--- a/packages/interop-tests/jest/jest.config.js
+++ b/packages/interop-tests/jest/jest.config.js
@@ -4,14 +4,17 @@ const root = resolve(__dirname, '../');
 module.exports = {
   rootDir: root,
   testMatch: ['<rootDir>/**/__test__/**/?(*.)test.ts'],
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node',
   transform: {'^.+\\.ts$': 'ts-jest'},
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|ts)$'],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   moduleNameMapper: {
     '.(scss|svg)$': 'identity-obj-proxy'
   },
-  globals: {'ts-jest': {tsconfig: './tsconfig.json'}},
+  globals: {
+    'ts-jest': {tsconfig: './tsconfig.json'},
+    window: {localStorage: {}, addEventListener: (_p1, p2) => ({})}
+  },
   globalSetup: '<rootDir>/jest/chain-setup.ts',
   globalTeardown: '<rootDir>/jest/test-teardown.ts'
 };

--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -172,7 +172,7 @@ it('server wallet creates channel + cooperates with browser wallet to fund chann
 
   await browserWallet.pushMessage(serverMessageToBrowserMessage(output1), 'dummyDomain');
 
-  // TODO: the proper way to do this is to wait for a ChannelProposed or some sort of new objective notification'
+  // TODO: the proper way to do this is to wait for a ChannelProposed or some sort of new objective notification
   await browserWallet.pushMessage(
     {
       jsonrpc: '2.0',

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -141,6 +141,7 @@ export class ChainService implements ChainServiceInterface {
 
   // Only used for unit tests
   destructor(): void {
+    this.provider.polling = false;
     this.provider.removeAllListeners();
     this.addressToContract.forEach(contract => contract.removeAllListeners());
   }

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -59,6 +59,9 @@ export interface Chain {
   getChainInfo: (channelId: string) => Promise<ChannelChainInfo>;
   balanceUpdatedFeed(address: string): Observable<Uint256>;
 
+  /**
+   * Only used for testing
+   */
   destroy(): void;
 }
 
@@ -508,6 +511,9 @@ export class ChainWatcher implements Chain {
     );
   }
 
+  /**
+   * Only used for testing
+   */
   public destroy(): void {
     this.provider.polling = false;
     this._adjudicator?.removeAllListeners();

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -13,7 +13,8 @@ import {
   SignedState,
   SharedObjective,
   Address,
-  DirectFunder
+  DirectFunder,
+  makeAddress
 } from '@statechannels/wallet-core';
 import ReactDOM from 'react-dom';
 import React from 'react';
@@ -134,6 +135,8 @@ export class ChannelWallet {
     const workflowId = this.calculateWorkflowId(request);
     switch (request.type) {
       case 'CREATE_CHANNEL': {
+        // This is wallet 1.0 logic. Leaving for now for reference.
+        /** 
         if (!this.isWorkflowIdInUse(workflowId)) {
           this.startWorkflow(
             Application.workflow(this.store, this.messagingService, request),
@@ -146,6 +149,13 @@ export class ChannelWallet {
             `There is already a workflow running with id ${workflowId}, no new workflow will be spawned`
           );
         }
+        */
+
+        // This wallet 2.0 logic
+        this.store.createAndStoreOpenChannelObjective({
+          ...request,
+          appDefinition: makeAddress(request.appDefinition)
+        });
         break;
       }
       case 'JOIN_CHANNEL':

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -329,6 +329,9 @@ export class ChannelWallet {
     return this.store.richObjectives;
   }
 
+  /**
+   * Only used for testing
+   */
   public destroy(): void {
     this.store.chain.destroy();
   }

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -296,12 +296,16 @@ export class ChannelWallet {
     }
   }
 
-  approveRichObjective(channelId: string) {
+  public async approveRichObjective(channelId: string): Promise<void> {
     const richObjective = this.store.richObjectives[channelId];
     if (!richObjective) {
       throw new Error(`Rich objective must exist for channelId ${channelId}`);
     }
-    this.crankRichObjectives({type: 'Approval'});
+    await this.crankRichObjectives({type: 'Approval'});
+  }
+
+  public getRichObjectives() {
+    return this.store.richObjectives;
   }
 
   /**

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -313,7 +313,8 @@ export class ChannelWallet {
 
     // TODO: need a better way to figure out when to broadcast an objective
     //        since we don't know here if we are the creator of the objective or received the objective from elsewhere
-    if (!richObjective.myIndex) {
+    const amCreator = richObjective.myIndex === 0;
+    if (amCreator) {
       // TODO: generalize to other objectives
       const objectiveToSend: OpenChannel = {
         type: 'OpenChannel',

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -334,8 +334,8 @@ export class ChannelWallet {
     return this.store.richObjectives;
   }
 
-  public async destroy(): Promise<void> {
-    return this.store.chain.destroy();
+  public destroy(): void {
+    this.store.chain.destroy();
   }
 
   /**

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -16,8 +16,9 @@ import {
   DirectFunder,
   makeAddress
 } from '@statechannels/wallet-core';
-import ReactDOM from 'react-dom';
-import React from 'react';
+// TODO: factor UI out of channel-wallet
+// import ReactDOM from 'react-dom';
+// import React from 'react';
 import _ from 'lodash';
 
 import {serializeChannelEntry} from './utils/wallet-core-v0.8.0';
@@ -33,7 +34,8 @@ import {
 import {ADD_LOGS} from './config';
 import {logger} from './logger';
 import {ChainWatcher} from './chain';
-import {Wallet as WalletUi} from './ui/wallet';
+// TODO: factor UI out of channel-wallet
+// import {Wallet as WalletUi} from './ui/wallet';
 
 export interface Workflow {
   id: string;
@@ -209,22 +211,25 @@ export class ChannelWallet {
       .onTransition((state, event) => ADD_LOGS && logTransition(state, event, workflowId))
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))
       .start();
+
+    // TODO: factor UI out of channel wallet
     // TODO: Figure out how to resolve rendering priorities
-    this.renderUI(service);
+    //this.renderUI(service);
 
     const workflow = {id: workflowId, service, domain: 'TODO'};
     this.workflows.push(workflow);
     return workflow;
   }
 
-  private renderUI(machine) {
-    if (document.getElementById('root')) {
-      ReactDOM.render(
-        React.createElement(WalletUi, {workflow: machine}),
-        document.getElementById('root')
-      );
-    }
-  }
+  // TODO: factor UI out of channel wallet
+  // private renderUI(machine) {
+  //   if (document.getElementById('root')) {
+  //     ReactDOM.render(
+  //       React.createElement(WalletUi, {workflow: machine}),
+  //       document.getElementById('root')
+  //     );
+  //   }
+  // }
 
   public onSendMessage(
     callback: (
@@ -306,6 +311,10 @@ export class ChannelWallet {
 
   public getRichObjectives() {
     return this.store.richObjectives;
+  }
+
+  public async destroy(): Promise<void> {
+    return this.store.chain.destroy();
   }
 
   /**

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -44,7 +44,8 @@ export enum Errors {
   invalidTransition = 'Invalid transition',
   invalidAppData = 'Invalid app data',
   emittingDuringTransaction = 'Attempting to emit event during transaction',
-  notMyTurn = "Cannot update channel unless it's your turn"
+  notMyTurn = "Cannot update channel unless it's your turn",
+  objectiveAlreadyExists = 'Objective for a channel id already exists'
 }
 
 export interface DBBackend {

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -72,7 +72,6 @@ export class Store {
    *      - Create getters and setters.
    */
   public richObjectives: Dictionary<DirectFunder.OpenChannelObjective> = {};
-  public depositsSubmitted: Dictionary<Deposit> = {};
 
   /**
    *  END of wallet 2.0

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -49,7 +49,6 @@ export type ChannelLock = {
   release: () => void;
 };
 
-type Deposit = {amountOnChain: Uint256; amountDeposited: Uint256};
 type OpenChanneObjectiveParams = Omit<State, 'turnNum' | 'channelNonce' | 'isFinal'>;
 
 //FIXME


### PR DESCRIPTION
The main goal of this PR is to add the `**browser** wallet creates channel + cooperates with server wallet to fund channel` itnerop test and the browser wallet functionality for the test to pass. Before this PR, `**server** wallet creates channel + cooperates with browser wallet to fund channel` was already passing.

Browser wallet channel creation works as follows:
1. Existing `CreateChannel` JSON RPC API is used for channel creation.
2. On that API invocation, the browser wallet creates and stores a rich `OpenChannelObjective`. The objective is **not** approved.
3. In the test, the objective is approved via an API call to the browser wallet. When the wallet is run in the browser, the objective approval will come from the user clicking an approve button.
4. When the objective is approved, the rich objective is converted to a slim objective that is broadcast to other participants.

Some of the changes in this PR were made in order for the interop tests to pass. Hopefully these changes are somewhat minimal and do not add too much of an additional burden to the reviewer:
1. Interop tests are converted from `jsdom` tests to `node` tests. See https://github.com/statechannels/statechannels/issues/3489.
2. Interop tests refuse to exit cleanly due to ongoing ethers activity. I still do not understand the core root of the problem, but enough changes have been made for the jest process to at least exit with error code 0. We still see the following log lines at the end of interop tests
```
interop-tests: (node:1801) UnhandledPromiseRejectionWarning: Error: missing response (requestBody="{\"method\":\"eth_blockNumber\",\"params\":[],\"id\":113,\"jsonrpc\":\"2.0\"}", requestMethod="POST", serverError={"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8546}, url="http://localhost:8546", code=SERVER_ERROR, version=web/5.0.7)
interop-tests: (node:1801) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 40)
```
