### PR TITLE
Refactor with peers to no longer rely on global variables

### DIFF
--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -51,7 +51,12 @@ export type PeerSetup = {
 
 export const participantIdA = 'a';
 export const participantIdB = 'b';
-
+const destinationA = makeDestination(
+  '0x00000000000000000000000000000000000000000000000000000000000aaaa1'
+);
+const destinationB = makeDestination(
+  '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
+);
 /**
  * This destroys the peerEngine(s) and the message service and then re-instantiates them.
  * This mimics a crash and restart
@@ -85,16 +90,12 @@ export async function crashAndRestart(
     const participantA = {
       signingAddress: await a.getSigningAddress(),
       participantId: participantIdA,
-      destination: makeDestination(
-        '0x00000000000000000000000000000000000000000000000000000000000aaaa1'
-      ),
+      destination: destinationA,
     };
     const participantB = {
       signingAddress: await b.getSigningAddress(),
       participantId: participantIdB,
-      destination: makeDestination(
-        '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
-      ),
+      destination: destinationB,
     };
 
     const messageService = (await TestMessageService.create(
@@ -140,16 +141,12 @@ export async function getPeersSetup(withWalletSeeding = false): Promise<PeerSetu
     const participantA = {
       signingAddress: await peerEngines.a.getSigningAddress(),
       participantId: participantIdA,
-      destination: makeDestination(
-        '0x00000000000000000000000000000000000000000000000000000000000aaaa1'
-      ),
+      destination: destinationA,
     };
     const participantB = {
       signingAddress: await peerEngines.b.getSigningAddress(),
       participantId: participantIdB,
-      destination: makeDestination(
-        '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
-      ),
+      destination: destinationB,
     };
 
     const participantEngines = [

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -160,6 +160,10 @@ export async function getPeersSetup(withWalletSeeding = false): Promise<PeerSetu
 }
 
 export const peersTeardown = async (peerSetup: PeerSetup): Promise<void> => {
+  if (!peerSetup) {
+    logger.warn('No PeerSetup so no teardown needed');
+    return;
+  }
   try {
     const {messageService, peerEngines} = peerSetup;
     await messageService.destroy();

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -64,26 +64,19 @@ export async function crashAndRestart(
   try {
     await oldPeerSetup.messageService.destroy();
 
-    const restartA = enginesToRestart==='A' || enginesToRestart==='Both';
-    const restartB = enginesToRestart==='B' || enginesToRestart==='Both';
-    
-    if(restartA){
-    await   oldPeerSetup.peerEngines.a.destroy();
+    const restartA = enginesToRestart === 'A' || enginesToRestart === 'Both';
+    const restartB = enginesToRestart === 'B' || enginesToRestart === 'Both';
+
+    if (restartA) {
+      await oldPeerSetup.peerEngines.a.destroy();
     }
-    if (restartB){
+    if (restartB) {
       await oldPeerSetup.peerEngines.b.destroy();
     }
-    const a =
-    restartA
-        ? await Engine.create(aEngineConfig)
-        : oldPeerSetup.peerEngines.a;
+    const a = restartA ? await Engine.create(aEngineConfig) : oldPeerSetup.peerEngines.a;
 
-    const b =
-    restartB
-        ? await Engine.create(bEngineConfig)
-        : oldPeerSetup.peerEngines.b;
+    const b = restartB ? await Engine.create(bEngineConfig) : oldPeerSetup.peerEngines.b;
 
-        
     const handler = await createTestMessageHandler([
       {participantId: participantIdA, engine: a},
       {participantId: participantIdB, engine: b},
@@ -103,7 +96,7 @@ export async function crashAndRestart(
         '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
       ),
     };
-    
+
     const messageService = (await TestMessageService.create(
       handler,
       a.logger

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -183,7 +183,7 @@ export async function getPeersSetup(withWalletSeeding = false): Promise<PeerSetu
   }
 }
 
-export const peersTeardown = async (peerSetup: PeerSetup): Promise<void> => {
+export const teardownPeerSetup = async (peerSetup: PeerSetup): Promise<void> => {
   if (!peerSetup) {
     logger.warn('No PeerSetup so no teardown needed');
     return;

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -98,10 +98,7 @@ export async function crashAndRestart(
       destination: destinationB,
     };
 
-    const messageService = (await TestMessageService.create(
-      handler,
-      a.logger
-    )) as TestMessageService;
+    const messageService = await TestMessageService.create(handler, a.logger);
     return {
       peerEngines: {a, b},
       messageService,
@@ -155,10 +152,7 @@ export async function getPeersSetup(withWalletSeeding = false): Promise<PeerSetu
     ];
 
     const handler = createTestMessageHandler(participantEngines, peerEngines.a.logger);
-    const messageService = (await TestMessageService.create(
-      handler,
-      peerEngines.a.logger
-    )) as TestMessageService;
+    const messageService = await TestMessageService.create(handler, peerEngines.a.logger);
 
     logger.trace('getPeersSetup complete');
     return {

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -6,14 +6,7 @@ import {
 import {BN, makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, constants, ethers} from 'ethers';
 
-import {
-  getPeersSetup,
-  messageService,
-  participantA,
-  participantB,
-  peersTeardown,
-  peerEngines,
-} from '../../../jest/with-peers-setup-teardown';
+import {PeerSetup, getPeersSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
 import {getMessages} from '../../message-service/utils';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../../__test__/test-helpers';
 import {expectLatestStateToMatch} from '../utils';
@@ -21,10 +14,16 @@ import {expectLatestStateToMatch} from '../utils';
 let channelId: string;
 jest.setTimeout(10_000);
 
-beforeAll(getPeersSetup());
-afterAll(peersTeardown);
+let peerSetup: PeerSetup;
+beforeAll(async () => {
+  peerSetup = await getPeersSetup();
+});
+afterAll(async () => {
+  await peersTeardown(peerSetup);
+});
 
 it('Create a directly-funded channel between two engines, of which one crashes midway through ', async () => {
+  const {participantA, participantB, messageService, peerEngines} = peerSetup;
   const allocation: Allocation = {
     allocationItems: [
       {destination: participantA.destination, amount: BigNumber.from(1).toHexString()},

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -9,7 +9,7 @@ import {BigNumber, constants, ethers} from 'ethers';
 import {
   PeerSetup,
   getPeersSetup,
-  peersTeardown,
+  teardownPeerSetup,
   crashAndRestart,
 } from '../../../jest/with-peers-setup-teardown';
 import {getMessages} from '../../message-service/utils';
@@ -24,7 +24,7 @@ beforeAll(async () => {
   peerSetup = await getPeersSetup();
 });
 afterAll(async () => {
-  await peersTeardown(peerSetup);
+  await teardownPeerSetup(peerSetup);
 });
 
 it('Create a directly-funded channel between two engines, of which one crashes midway through ', async () => {

--- a/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/crash-tolerance/crash-tolerance.test.ts
@@ -6,7 +6,12 @@ import {
 import {BN, makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, constants, ethers} from 'ethers';
 
-import {PeerSetup, getPeersSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
+import {
+  PeerSetup,
+  getPeersSetup,
+  peersTeardown,
+  crashAndRestart,
+} from '../../../jest/with-peers-setup-teardown';
 import {getMessages} from '../../message-service/utils';
 import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../../__test__/test-helpers';
 import {expectLatestStateToMatch} from '../utils';
@@ -60,8 +65,7 @@ it('Create a directly-funded channel between two engines, of which one crashes m
   });
 
   // Destroy Engine b and restart
-  // TODO: Enable this once https://github.com/statechannels/statechannels/issues/3476 is fixed
-  // await crashAndRestart('B');
+  peerSetup = await crashAndRestart(peerSetup, 'B');
 
   //      PreFund0B
   const resultB1 = await peerEngines.b.joinChannel({channelId});

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -6,14 +6,7 @@ import {
 import {BN, makeAddress} from '@statechannels/wallet-core';
 import {ethers} from 'ethers';
 
-import {
-  peerEngines,
-  getPeersSetup,
-  participantA,
-  participantB,
-  peersTeardown,
-  messageService,
-} from '../../../jest/with-peers-setup-teardown';
+import {getPeersSetup, PeerSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
 import {getMessages} from '../../message-service/utils';
 import {getChannelResultFor, ONE_DAY} from '../../__test__/test-helpers';
 import {expectLatestStateToMatch} from '../utils';
@@ -22,11 +15,16 @@ const {AddressZero} = ethers.constants;
 jest.setTimeout(10_000);
 
 let channelId: string;
-
-beforeAll(getPeersSetup());
-afterAll(peersTeardown);
+let peerSetup: PeerSetup;
+beforeAll(async () => {
+  peerSetup = await getPeersSetup();
+});
+afterAll(async () => {
+  await peersTeardown(peerSetup);
+});
 
 it('Create a directly funded channel between two engines ', async () => {
+  const {participantA, participantB, messageService, peerEngines} = peerSetup;
   const allocation: Allocation = {
     allocationItems: [
       {destination: participantA.destination, amount: BN.from(1)},

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/direct-funding.test.ts
@@ -6,7 +6,7 @@ import {
 import {BN, makeAddress} from '@statechannels/wallet-core';
 import {ethers} from 'ethers';
 
-import {getPeersSetup, PeerSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
+import {getPeersSetup, PeerSetup, teardownPeerSetup} from '../../../jest/with-peers-setup-teardown';
 import {getMessages} from '../../message-service/utils';
 import {getChannelResultFor, ONE_DAY} from '../../__test__/test-helpers';
 import {expectLatestStateToMatch} from '../utils';
@@ -20,7 +20,7 @@ beforeAll(async () => {
   peerSetup = await getPeersSetup();
 });
 afterAll(async () => {
-  await peersTeardown(peerSetup);
+  await teardownPeerSetup(peerSetup);
 });
 
 it('Create a directly funded channel between two engines ', async () => {

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -7,25 +7,24 @@ import {makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
 import {ONE_DAY} from '../../__test__/test-helpers';
-import {
-  peerEngines,
-  getPeersSetup,
-  participantA,
-  participantB,
-  peersTeardown,
-  messageService,
-} from '../../../jest/with-peers-setup-teardown';
+import {getPeersSetup, peersTeardown, PeerSetup} from '../../../jest/with-peers-setup-teardown';
 import {expectLatestStateToMatch} from '../utils';
 import {getMessages} from '../../message-service/utils';
 
 let channelId: string;
-
-beforeAll(getPeersSetup());
-afterAll(peersTeardown);
+let peerSetup: PeerSetup;
+beforeAll(async () => {
+  peerSetup = await getPeersSetup();
+});
+afterAll(async () => {
+  await peersTeardown(peerSetup);
+});
 
 it('Create a fake-funded channel between two engines ', async () => {
   const assetHolderAddress = makeAddress(constants.AddressZero);
   const aBal = BigNumber.from(1).toHexString();
+
+  const {participantA, participantB, peerEngines, messageService} = peerSetup;
 
   const allocation: Allocation = {
     allocationItems: [{destination: participantA.destination, amount: aBal}],

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -7,7 +7,7 @@ import {makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
 import {ONE_DAY} from '../../__test__/test-helpers';
-import {getPeersSetup, peersTeardown, PeerSetup} from '../../../jest/with-peers-setup-teardown';
+import {getPeersSetup, teardownPeerSetup, PeerSetup} from '../../../jest/with-peers-setup-teardown';
 import {expectLatestStateToMatch} from '../utils';
 import {getMessages} from '../../message-service/utils';
 
@@ -17,7 +17,7 @@ beforeAll(async () => {
   peerSetup = await getPeersSetup();
 });
 afterAll(async () => {
-  await peersTeardown(peerSetup);
+  await teardownPeerSetup(peerSetup);
 });
 
 it('Create a fake-funded channel between two engines ', async () => {

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
@@ -13,7 +13,7 @@ import {
 import {DBAdmin} from '../../db-admin/db-admin';
 import {
   getPeersSetup,
-  peersTeardown,
+  teardownPeerSetup,
   aEngineConfig,
   bEngineConfig,
   PeerSetup,
@@ -41,7 +41,7 @@ beforeAll(async () => {
   peerSetup = await getPeersSetup();
 });
 afterAll(async () => {
-  await peersTeardown(peerSetup);
+  await teardownPeerSetup(peerSetup);
 });
 /**
  * Create a directly funded channel that will be used as the ledger channel.

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/ledger-funding.test.ts
@@ -12,13 +12,11 @@ import {
 } from '../../__test__/test-helpers';
 import {DBAdmin} from '../../db-admin/db-admin';
 import {
-  peerEngines,
   getPeersSetup,
   peersTeardown,
-  participantA,
-  participantB,
   aEngineConfig,
   bEngineConfig,
+  PeerSetup,
 } from '../../../jest/with-peers-setup-teardown';
 // TODO: this is temporary. This test file is refactored in
 // https://github.com/statechannels/statechannels/pull/3287
@@ -38,15 +36,24 @@ const tablesUsingLedgerChannels = [
 
 jest.setTimeout(10_000);
 
-beforeAll(getPeersSetup());
-afterAll(peersTeardown);
-
+let peerSetup: PeerSetup;
+beforeAll(async () => {
+  peerSetup = await getPeersSetup();
+});
+afterAll(async () => {
+  await peersTeardown(peerSetup);
+});
 /**
  * Create a directly funded channel that will be used as the ledger channel.
  *
  * Note that this is just a simplification of the direct-funding test.
  */
-const createLedgerChannel = async (aDeposit: number, bDeposit: number): Promise<string> => {
+const createLedgerChannel = async (
+  peerSetup: PeerSetup,
+  aDeposit: number,
+  bDeposit: number
+): Promise<string> => {
+  const {participantA, participantB, peerEngines} = peerSetup;
   const aDepositAmtETH = BN.from(aDeposit);
   const bDepositAmtETH = BN.from(bDeposit);
   const ledgerChannelArgs = {
@@ -99,34 +106,43 @@ const createLedgerChannel = async (aDeposit: number, bDeposit: number): Promise<
 };
 
 const testCreateChannelParams = (
+  peerSetup: PeerSetup,
   aAllocation: number,
   bAllocation: number,
   ledgerChannelId: string
-): CreateChannelParams => ({
-  participants: [participantA, participantB],
-  allocations: [
-    {
-      allocationItems: [
-        {
-          destination: participantA.destination,
-          amount: BN.from(aAllocation),
-        },
-        {
-          destination: participantB.destination,
-          amount: BN.from(bAllocation),
-        },
-      ],
-      assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS, // must be even length
-    },
-  ],
-  appDefinition: ethers.constants.AddressZero,
-  appData: '0x00', // must be even length
-  fundingStrategy: 'Ledger',
-  fundingLedgerChannelId: ledgerChannelId,
-  challengeDuration: ONE_DAY,
-});
+): CreateChannelParams => {
+  const {participantA, participantB} = peerSetup;
+  return {
+    participants: [participantA, participantB],
+    allocations: [
+      {
+        allocationItems: [
+          {
+            destination: participantA.destination,
+            amount: BN.from(aAllocation),
+          },
+          {
+            destination: participantB.destination,
+            amount: BN.from(bAllocation),
+          },
+        ],
+        assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS, // must be even length
+      },
+    ],
+    appDefinition: ethers.constants.AddressZero,
+    appData: '0x00', // must be even length
+    fundingStrategy: 'Ledger',
+    fundingLedgerChannelId: ledgerChannelId,
+    challengeDuration: ONE_DAY,
+  };
+};
 
-async function exchangeMessagesBetweenAandB(bToA: Outgoing[][], aToB: Outgoing[][]) {
+async function exchangeMessagesBetweenAandB(
+  peerSetup: PeerSetup,
+  bToA: Outgoing[][],
+  aToB: Outgoing[][]
+) {
+  const {participantA, participantB, peerEngines} = peerSetup;
   while (aToB.length + bToA.length > 0) {
     const nextMessageFromB = bToA.shift();
     const nextMessageFromA = aToB.shift();
@@ -164,8 +180,9 @@ describe('Funding a single channel with 100% of available ledger funds', () => {
   });
 
   it('can fund and close channel by ledger between two engines ', async () => {
-    ledgerChannelId = await createLedgerChannel(10, 10);
-    const params = testCreateChannelParams(10, 10, ledgerChannelId);
+    const {participantA, participantB, peerEngines} = peerSetup;
+    ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
+    const params = testCreateChannelParams(peerSetup, 10, 10, ledgerChannelId);
 
     const {
       channelResult: {channelId},
@@ -176,7 +193,7 @@ describe('Funding a single channel with 100% of available ledger funds', () => {
 
     const {outbox: join} = await peerEngines.b.joinChannel({channelId});
 
-    await exchangeMessagesBetweenAandB([join], []);
+    await exchangeMessagesBetweenAandB(peerSetup, [join], []);
     // so the problem is that we don't end up ledger funded here
 
     const {channelResults} = await peerEngines.a.getChannels();
@@ -202,7 +219,7 @@ describe('Funding a single channel with 100% of available ledger funds', () => {
 
     const {outbox: close} = await peerEngines.a.closeChannel({channelId: appChannelId});
 
-    await exchangeMessagesBetweenAandB([], [close]);
+    await exchangeMessagesBetweenAandB(peerSetup, [], [close]);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults: channelResults2} = await peerEngines.a.getChannels();
@@ -240,8 +257,9 @@ describe('Funding a single channel with 50% of ledger funds', () => {
   });
 
   it('can fund a channel by ledger between two engines ', async () => {
-    ledgerChannelId = await createLedgerChannel(10, 10);
-    const params = testCreateChannelParams(5, 5, ledgerChannelId);
+    const {peerEngines, participantA, participantB} = peerSetup;
+    ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
+    const params = testCreateChannelParams(peerSetup, 5, 5, ledgerChannelId);
 
     const {
       channelResult: {channelId},
@@ -252,7 +270,7 @@ describe('Funding a single channel with 50% of ledger funds', () => {
 
     const {outbox: join} = await peerEngines.b.joinChannel({channelId});
 
-    await exchangeMessagesBetweenAandB([join], []);
+    await exchangeMessagesBetweenAandB(peerSetup, [join], []);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
 
@@ -287,9 +305,10 @@ describe('Funding a single channel with 50% of ledger funds', () => {
   });
 
   it('closing said channel', async () => {
+    const {peerEngines, participantA, participantB} = peerSetup;
     const {outbox: close} = await peerEngines.a.closeChannel({channelId: appChannelId});
 
-    await exchangeMessagesBetweenAandB([], [close]);
+    await exchangeMessagesBetweenAandB(peerSetup, [], [close]);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults} = await peerEngines.a.getChannels();
@@ -326,18 +345,19 @@ describe('Closing a ledger channel and preventing it from being used again', () 
   });
 
   it('can close a ledger channel and fail to fund a new channel ', async () => {
-    const ledgerChannelId = await createLedgerChannel(10, 10);
+    const {peerEngines, participantB} = peerSetup;
+    const ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
     const {outbox} = await peerEngines.a.closeChannel({channelId: ledgerChannelId});
     const {outbox: close} = await peerEngines.b.pushMessage(
       getPayloadFor(participantB.participantId, outbox)
     );
-    await exchangeMessagesBetweenAandB([close], []);
+    await exchangeMessagesBetweenAandB(peerSetup, [close], []);
     const {channelResult: ledger} = await peerEngines.a.getState({channelId: ledgerChannelId});
     expect(ledger).toMatchObject({
       turnNum: 4,
       status: 'closed',
     });
-    const params = testCreateChannelParams(10, 10, ledgerChannelId);
+    const params = testCreateChannelParams(peerSetup, 10, 10, ledgerChannelId);
     await expect(peerEngines.a.createChannel(params)).rejects.toThrow(/closed/);
     await expect(peerEngines.a.createChannels(params, 1)).rejects.toThrow(/closed/);
   });
@@ -354,15 +374,16 @@ describe('Funding multiple channels synchronously (in bulk)', () => {
   });
 
   it(`can fund ${N} channels created in bulk by Alice`, async () => {
-    ledgerChannelId = await createLedgerChannel(4, 4);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines, participantB} = peerSetup;
+    ledgerChannelId = await createLedgerChannel(peerSetup, 4, 4);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
     const resultA = await peerEngines.a.createChannels(params, N);
     const channelIds = resultA.channelResults.map(c => c.channelId);
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, resultA.outbox));
     const resultB = await peerEngines.b.joinChannels(channelIds);
 
-    await exchangeMessagesBetweenAandB([resultB.outbox], []);
+    await exchangeMessagesBetweenAandB(peerSetup, [resultB.outbox], []);
 
     const {channelResults} = await peerEngines.a.getChannels();
 
@@ -395,8 +416,10 @@ describe('Funding multiple channels synchronously (in bulk)', () => {
   });
 
   it('can close them all (concurrently!)', async () => {
+    const {peerEngines, participantA, participantB} = peerSetup;
     // ⚠️ This results in several messages back and forth
     await exchangeMessagesBetweenAandB(
+      peerSetup,
       [],
       await Promise.all(
         appChannelIds.map(async channelId => (await peerEngines.a.closeChannel({channelId})).outbox)
@@ -444,15 +467,16 @@ describe('Funding multiple channels concurrently (in bulk)', () => {
   });
 
   it(`can fund ${N * 2} channels created in bulk by Alice`, async () => {
-    ledgerChannelId = await createLedgerChannel(N * 2, N * 2);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines, participantB} = peerSetup;
+    ledgerChannelId = await createLedgerChannel(peerSetup, N * 2, N * 2);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
     const createMessageAndJoinBatch = async (): Promise<Bytes32[]> => {
       const {outbox, channelResults} = await peerEngines.a.createChannels(params, N);
       const channelIds = channelResults.map(c => c.channelId);
       await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, outbox));
       const joinResults = await peerEngines.b.joinChannels(channelIds);
-      await exchangeMessagesBetweenAandB([joinResults.outbox], []);
+      await exchangeMessagesBetweenAandB(peerSetup, [joinResults.outbox], []);
       return channelIds;
     };
 
@@ -493,8 +517,10 @@ describe('Funding multiple channels concurrently (in bulk)', () => {
   });
 
   it('can close them all (concurrently!)', async () => {
+    const {peerEngines, participantA, participantB} = peerSetup;
     // ⚠️ This results in several messages back and forth
     await exchangeMessagesBetweenAandB(
+      peerSetup,
       [],
       await Promise.all(
         appChannelIds.map(async channelId => (await peerEngines.a.closeChannel({channelId})).outbox)
@@ -537,15 +563,16 @@ describe('Funding multiple channels syncronously without enough funds', () => {
   });
 
   it(`can fund 4 channels created in bulk by Alice, rejecting 2 with no funds`, async () => {
-    const ledgerChannelId = await createLedgerChannel(2, 2);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines, participantB} = peerSetup;
+    const ledgerChannelId = await createLedgerChannel(peerSetup, 2, 2);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
     const resultA0 = await peerEngines.a.createChannels(params, 4); // 2 channels will be unfunded
     const channelIds = resultA0.channelResults.map(c => c.channelId);
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, resultA0.outbox));
     const resultB1 = await peerEngines.b.joinChannels(channelIds);
 
-    await exchangeMessagesBetweenAandB([resultB1.outbox], []);
+    await exchangeMessagesBetweenAandB(peerSetup, [resultB1.outbox], []);
 
     const {channelResults} = await peerEngines.a.getChannels();
 
@@ -591,15 +618,16 @@ describe('Funding multiple channels syncronously without enough funds', () => {
     const LEDGER_HAS = 2;
     const APP_WANTS = 10000000; // > 2
 
-    const ledgerChannelId = await createLedgerChannel(LEDGER_HAS, LEDGER_HAS);
-    const params = testCreateChannelParams(APP_WANTS, APP_WANTS, ledgerChannelId);
+    const ledgerChannelId = await createLedgerChannel(peerSetup, LEDGER_HAS, LEDGER_HAS);
+    const params = testCreateChannelParams(peerSetup, APP_WANTS, APP_WANTS, ledgerChannelId);
 
+    const {peerEngines, participantB} = peerSetup;
     const resultA = await peerEngines.a.createChannel(params);
     const {channelId} = resultA.channelResult;
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, resultA.outbox));
     const resultB = await peerEngines.b.joinChannel({channelId});
 
-    await exchangeMessagesBetweenAandB([resultB.outbox], []);
+    await exchangeMessagesBetweenAandB(peerSetup, [resultB.outbox], []);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults} = await peerEngines.a.getChannels();
@@ -627,8 +655,9 @@ describe('Funding multiple channels concurrently (one sided)', () => {
   });
 
   it('can fund 2 channels by ledger both proposed by the same wallet', async () => {
-    const ledgerChannelId = await createLedgerChannel(10, 10);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines, participantB} = peerSetup;
+    const ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
     const create1 = await peerEngines.a.createChannel(params);
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, create1.outbox));
@@ -642,7 +671,7 @@ describe('Funding multiple channels concurrently (one sided)', () => {
     const {outbox: join1} = await peerEngines.b.joinChannel({channelId: channelId1});
     const {outbox: join2} = await peerEngines.b.joinChannel({channelId: channelId2});
 
-    await exchangeMessagesBetweenAandB([join1, join2], []);
+    await exchangeMessagesBetweenAandB(peerSetup, [join1, join2], []);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults} = await peerEngines.a.getChannels();
@@ -665,12 +694,14 @@ describe('Funding multiple channels concurrently (one sided)', () => {
 });
 
 async function proposeMultipleChannelsToEachother(
+  peerSetup: PeerSetup,
   params: CreateChannelParams,
   N = 2 // Total number of channels = 2 * N
 ): Promise<{aToJoin: Bytes32[]; bToJoin: Bytes32[]}> {
   const aToJoin = [];
   const bToJoin = [];
   for (let i = 0; i < N; i++) {
+    const {peerEngines, participantA, participantB} = peerSetup;
     const createA = await peerEngines.a.createChannel(params);
     await peerEngines.b.pushMessage(getPayloadFor(participantB.participantId, createA.outbox));
     const createB = await peerEngines.b.createChannel(params);
@@ -688,18 +719,19 @@ describe('Funding multiple channels concurrently (two sides)', () => {
   });
 
   it('can fund 2 channels by ledger each proposed by the other', async () => {
-    const ledgerChannelId = await createLedgerChannel(10, 10);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines} = peerSetup;
+    const ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
     const {
       bToJoin: [channelId1],
       aToJoin: [channelId2],
-    } = await proposeMultipleChannelsToEachother(params, 1);
+    } = await proposeMultipleChannelsToEachother(peerSetup, params, 1);
 
     const {outbox: joinB} = await peerEngines.b.joinChannel({channelId: channelId1});
     const {outbox: joinA} = await peerEngines.a.joinChannel({channelId: channelId2});
 
-    await exchangeMessagesBetweenAandB([joinB], [joinA]);
+    await exchangeMessagesBetweenAandB(peerSetup, [joinB], [joinA]);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults} = await peerEngines.a.getChannels();
@@ -721,8 +753,9 @@ describe('Funding multiple channels concurrently (two sides)', () => {
   });
 
   it('can fund 4 channels by ledger, 2 created concurrently at a time', async () => {
-    const ledgerChannelId = await createLedgerChannel(10, 10);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines, participantA, participantB} = peerSetup;
+    const ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
     const {
       channelResult: {channelId: channelId1},
@@ -755,7 +788,7 @@ describe('Funding multiple channels concurrently (two sides)', () => {
     const {outbox: joinA3} = await peerEngines.a.joinChannel({channelId: channelId3});
     const {outbox: joinA4} = await peerEngines.a.joinChannel({channelId: channelId4});
 
-    await exchangeMessagesBetweenAandB([joinB1, joinB2], [joinA3, joinA4]);
+    await exchangeMessagesBetweenAandB(peerSetup, [joinB1, joinB2], [joinA3, joinA4]);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults} = await peerEngines.a.getChannels();
@@ -777,10 +810,11 @@ describe('Funding multiple channels concurrently (two sides)', () => {
   });
 
   it('can fund 4 channels by ledger, 1 created at a time, using joinChannel', async () => {
-    const ledgerChannelId = await createLedgerChannel(10, 10);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines, participantA, participantB} = peerSetup;
+    const ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
-    const {aToJoin, bToJoin} = await proposeMultipleChannelsToEachother(params);
+    const {aToJoin, bToJoin} = await proposeMultipleChannelsToEachother(peerSetup, params);
 
     const joinB1 = await peerEngines.b.joinChannel({channelId: bToJoin[0]});
     const joinA2 = await peerEngines.a.joinChannel({channelId: aToJoin[0]});
@@ -790,7 +824,7 @@ describe('Funding multiple channels concurrently (two sides)', () => {
     const messagesAwillSendToB = [joinA2.outbox, joinA4.outbox];
     const messagesBwillSendToA = [joinB1.outbox, joinB3.outbox];
 
-    await exchangeMessagesBetweenAandB(messagesBwillSendToA, messagesAwillSendToB);
+    await exchangeMessagesBetweenAandB(peerSetup, messagesBwillSendToA, messagesAwillSendToB);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults} = await peerEngines.a.getChannels();
@@ -824,10 +858,11 @@ describe('Funding multiple channels concurrently (two sides)', () => {
   });
 
   it('can fund 4 channels by ledger, 1 created at a time, using joinChannels', async () => {
-    const ledgerChannelId = await createLedgerChannel(10, 10);
-    const params = testCreateChannelParams(1, 1, ledgerChannelId);
+    const {peerEngines, participantA, participantB} = peerSetup;
+    const ledgerChannelId = await createLedgerChannel(peerSetup, 10, 10);
+    const params = testCreateChannelParams(peerSetup, 1, 1, ledgerChannelId);
 
-    const {aToJoin, bToJoin} = await proposeMultipleChannelsToEachother(params);
+    const {aToJoin, bToJoin} = await proposeMultipleChannelsToEachother(peerSetup, params);
 
     const joinB = await peerEngines.b.joinChannels(bToJoin);
     const joinA = await peerEngines.a.joinChannels(aToJoin);
@@ -835,7 +870,7 @@ describe('Funding multiple channels concurrently (two sides)', () => {
     const messagesAwillSendToB = [joinA.outbox];
     const messagesBwillSendToA = [joinB.outbox];
 
-    await exchangeMessagesBetweenAandB(messagesBwillSendToA, messagesAwillSendToB);
+    await exchangeMessagesBetweenAandB(peerSetup, messagesBwillSendToA, messagesAwillSendToB);
 
     await interParticipantChannelResultsAreEqual(peerEngines.a, peerEngines.b);
     const {channelResults} = await peerEngines.a.getChannels();

--- a/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
@@ -1,7 +1,7 @@
 import {CreateChannelParams} from '@statechannels/client-api-schema';
 import Knex from 'knex';
 
-import {getPeersSetup, peersTeardown, PeerSetup} from '../../jest/with-peers-setup-teardown';
+import {getPeersSetup, teardownPeerSetup, PeerSetup} from '../../jest/with-peers-setup-teardown';
 import {WalletObjective, ObjectiveModel} from '../models/objective';
 import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
 import {bob} from '../engine/__test__/fixtures/participants';
@@ -13,7 +13,7 @@ beforeAll(async () => {
   peerSetup = await getPeersSetup(true);
 });
 afterAll(async () => {
-  await peersTeardown(peerSetup);
+  await teardownPeerSetup(peerSetup);
 });
 test('Objectives can be synced if a message is lost', async () => {
   const createChannelParams: CreateChannelParams = createChannelArgs();

--- a/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/sync-objectives.test.ts
@@ -1,20 +1,24 @@
 import {CreateChannelParams} from '@statechannels/client-api-schema';
 import Knex from 'knex';
 
-import {peerEngines, getPeersSetup, peersTeardown} from '../../jest/with-peers-setup-teardown';
+import {getPeersSetup, peersTeardown, PeerSetup} from '../../jest/with-peers-setup-teardown';
 import {WalletObjective, ObjectiveModel} from '../models/objective';
 import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
 import {bob} from '../engine/__test__/fixtures/participants';
 import {getChannelResultFor, getPayloadFor} from '../__test__/test-helpers';
 
 jest.setTimeout(10_000);
-
-beforeAll(getPeersSetup(true));
-afterAll(peersTeardown);
-
+let peerSetup: PeerSetup;
+beforeAll(async () => {
+  peerSetup = await getPeersSetup(true);
+});
+afterAll(async () => {
+  await peersTeardown(peerSetup);
+});
 test('Objectives can be synced if a message is lost', async () => {
   const createChannelParams: CreateChannelParams = createChannelArgs();
 
+  const {peerEngines} = peerSetup;
   // We mimic not receiving a message containing objectives
   const messageToLose = await peerEngines.a.createChannel(createChannelParams);
 
@@ -40,7 +44,7 @@ test('Objectives can be synced if a message is lost', async () => {
 
 test('handles the objective being synced even if no message is lost', async () => {
   const createChannelParams: CreateChannelParams = createChannelArgs();
-
+  const {peerEngines} = peerSetup;
   const messageResponse = await peerEngines.a.createChannel(createChannelParams);
 
   const channelId = messageResponse.channelResult.channelId;
@@ -79,7 +83,7 @@ test('handles the objective being synced even if no message is lost', async () =
 
 test('Can successfully push the sync objective message multiple times', async () => {
   const createChannelParams: CreateChannelParams = createChannelArgs();
-
+  const {peerEngines} = peerSetup;
   // We mimic not receiving a message containing objectives
   const messageToLose = await peerEngines.a.createChannel(createChannelParams);
 

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -2,7 +2,7 @@ import {ChannelResult, CreateChannelParams} from '@statechannels/client-api-sche
 import _ from 'lodash';
 
 import {Engine} from '..';
-import {participantA, participantB} from '../../jest/with-peers-setup-teardown';
+import {PeerSetup} from '../../jest/with-peers-setup-teardown';
 import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
 
 export async function expectLatestStateToMatch(
@@ -14,9 +14,9 @@ export async function expectLatestStateToMatch(
   expect(latest.channelResult).toMatchObject(partial);
 }
 
-export function getWithPeersCreateChannelsArgs(): CreateChannelParams {
+export function getWithPeersCreateChannelsArgs(peerSetup: PeerSetup): CreateChannelParams {
   return createChannelArgs({
-    participants: [participantA, participantB],
+    participants: [peerSetup.participantA, peerSetup.participantB],
     fundingStrategy: 'Fake',
   });
 }

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -1,4 +1,4 @@
-import {getPeersSetup, PeerSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
+import {getPeersSetup, PeerSetup, teardownPeerSetup} from '../../../jest/with-peers-setup-teardown';
 import {LatencyOptions} from '../../message-service/test-message-service';
 import {WalletObjective} from '../../models/objective';
 import {Wallet} from '../../wallet/wallet';
@@ -11,7 +11,7 @@ beforeAll(async () => {
   peerSetup = await getPeersSetup();
 });
 afterAll(async () => {
-  await peersTeardown(peerSetup);
+  await teardownPeerSetup(peerSetup);
 });
 
 describe('EnsureObjectives', () => {

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -1,5 +1,10 @@
 import {Wallet} from '../../wallet';
-import {getPeersSetup, PeerSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
+import {
+  crashAndRestart,
+  getPeersSetup,
+  PeerSetup,
+  peersTeardown,
+} from '../../../jest/with-peers-setup-teardown';
 import {ObjectiveModel, WalletObjective} from '../../models/objective';
 import {getWithPeersCreateChannelsArgs} from '../utils';
 
@@ -48,8 +53,7 @@ describe('jumpstartObjectives', () => {
 
     await expect(createResponse).toBeObjectiveDoneType('EnsureObjectiveFailed');
 
-    // TODO: Enable this once https://github.com/statechannels/statechannels/issues/3476 is fixed
-    // await crashAndRestart('A');
+    peerSetup = await crashAndRestart(peerSetup, 'A');
 
     wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -1,5 +1,5 @@
 import {Wallet} from '../../wallet';
-import {getPeersSetup, PeerSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
+import {getPeersSetup, PeerSetup, teardownPeerSetup} from '../../../jest/with-peers-setup-teardown';
 import {ObjectiveModel, WalletObjective} from '../../models/objective';
 import {getWithPeersCreateChannelsArgs} from '../utils';
 
@@ -8,7 +8,7 @@ beforeAll(async () => {
   peerSetup = await getPeersSetup();
 });
 afterAll(async () => {
-  await peersTeardown(peerSetup);
+  await teardownPeerSetup(peerSetup);
 });
 jest.setTimeout(60_000);
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -1,10 +1,5 @@
 import {Wallet} from '../../wallet';
-import {
-  crashAndRestart,
-  getPeersSetup,
-  PeerSetup,
-  peersTeardown,
-} from '../../../jest/with-peers-setup-teardown';
+import {getPeersSetup, PeerSetup, peersTeardown} from '../../../jest/with-peers-setup-teardown';
 import {ObjectiveModel, WalletObjective} from '../../models/objective';
 import {getWithPeersCreateChannelsArgs} from '../utils';
 
@@ -35,9 +30,9 @@ describe('jumpstartObjectives', () => {
     expect(await wallet.jumpStartObjectives()).toHaveLength(0);
   });
 
-  it('can jumpstart objectives successfully after a restart', async () => {
+  it('can jumpstart objectives successfully after they fail to send', async () => {
     const {peerEngines, messageService} = peerSetup;
-    let wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
+    const wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
 
     // This ensures that the channel will be joined so the objective can progress
     peerEngines.b.on('objectiveStarted', async (o: WalletObjective) => {
@@ -52,14 +47,6 @@ describe('jumpstartObjectives', () => {
     );
 
     await expect(createResponse).toBeObjectiveDoneType('EnsureObjectiveFailed');
-
-    const restartedPeerSetup = await crashAndRestart(peerSetup, 'A');
-
-    wallet = await Wallet.create(
-      restartedPeerSetup.peerEngines.a,
-      restartedPeerSetup.messageService,
-      {numberOfAttempts: 1}
-    );
 
     const jumpstartResponse = await wallet.jumpStartObjectives();
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -53,9 +53,13 @@ describe('jumpstartObjectives', () => {
 
     await expect(createResponse).toBeObjectiveDoneType('EnsureObjectiveFailed');
 
-    peerSetup = await crashAndRestart(peerSetup, 'A');
+    const restartedPeerSetup = await crashAndRestart(peerSetup, 'A');
 
-    wallet = await Wallet.create(peerEngines.a, messageService, {numberOfAttempts: 1});
+    wallet = await Wallet.create(
+      restartedPeerSetup.peerEngines.a,
+      restartedPeerSetup.messageService,
+      {numberOfAttempts: 1}
+    );
 
     const jumpstartResponse = await wallet.jumpStartObjectives();
 

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -53,9 +53,8 @@ export class TestMessageService implements MessageServiceInterface {
 
   static async create(
     incomingMessageHandler: MessageHandler,
-
     logger?: Logger
-  ): Promise<MessageServiceInterface> {
+  ): Promise<TestMessageService> {
     const service = new TestMessageService(incomingMessageHandler, logger);
     return service;
   }


### PR DESCRIPTION
# Description
Refactor `with-peers` setup and teardown methods to no longer rely on global objects.

Instead, the setup and teardown methods return their own `PeerSetup` object cotaining the `engines` and `messagingService`.

This is done to prevent issues like #3486 where one test has a reference to a `engine` or `messageService` that gets unassigned by another test.

The `crashAndRestart` function has also been refactored and the tests that rely on it have been re-enabled.


## How Has This Been Tested? 
I am relying on the existing `with-Peers` test to provide testing.


---
## Checklist:

### Code quality
- [ ] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
