### PR TITLE
Engine-Response returns messages by objective id

### DIFF
--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -141,7 +141,7 @@ function generatePushMessage(messageParams: Message): PushMessageRequest {
 }
 
 // In theory, we should be able to check the channelResult. In practice, the channelResult seems to have an incorrect turn number
-function constainsPostfundState(singleChannelOutput: SingleChannelOutput): boolean {
+function containsPostfundState(singleChannelOutput: SingleChannelOutput): boolean {
   if (!singleChannelOutput.outbox.length) return false;
 
   const signedStates = deserializeMessage(singleChannelOutput.outbox[0].params as WireMessage)
@@ -196,7 +196,7 @@ it('server wallet creates channel + cooperates with browser wallet to fund chann
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const postFundA = await fromEvent<SingleChannelOutput>(serverWallet as any, 'channelUpdated')
-    .pipe(first(constainsPostfundState))
+    .pipe(first(containsPostfundState))
     .toPromise();
 
   serverWallet.on('channelUpdated', e => console.log(JSON.stringify(e)));
@@ -257,7 +257,7 @@ it('browser wallet creates channel + cooperates with server wallet to fund chann
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const postFundA = await fromEvent<SingleChannelOutput>(serverWallet as any, 'channelUpdated')
-    .pipe(first(constainsPostfundState))
+    .pipe(first(containsPostfundState))
     .toPromise();
 
   await browserWallet.pushMessage(serverMessageToBrowserMessage(postFundA), 'dummyDomain');

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -28,6 +28,8 @@ import Knex from 'knex';
 import { Level } from 'pino';
 import { Logger } from 'pino';
 import { Payload as Message } from '@statechannels/wallet-core';
+import { Message as Message_2 } from '@statechannels/wire-format';
+import { Message as Message_3 } from '@statechannels/client-api-schema';
 import { MessageQueuedNotification } from '@statechannels/client-api-schema';
 import { Model } from 'objection';
 import { ModelOptions } from 'objection';
@@ -179,6 +181,12 @@ export interface EngineInterface {
 }
 
 // @public (undocumented)
+export type EnsureObjectiveFailed = {
+    type: 'EnsureObjectiveFailed';
+    numberOfAttempts: number;
+};
+
+// @public (undocumented)
 export function extractDBConfigFromEngineConfig(engineConfig: EngineConfig): Config;
 
 // Warning: (ae-forgotten-export) The symbol "DatabaseConnectionConfigObject" needs to be exported by the entry point index.d.ts
@@ -196,6 +204,12 @@ export function hasNewObjective(response: SingleChannelOutput): response is Sing
 
 // @public
 export type IncomingEngineConfig = RequiredEngineConfig & Partial<OptionalEngineConfig>;
+
+// @public
+export type InternalError = {
+    type: 'InternalError';
+    error: Error;
+};
 
 // @public
 export type LoggingConfiguration = {
@@ -238,6 +252,26 @@ export class MultiThreadedEngine extends SingleThreadedEngine {
 // @public
 export type NetworkConfiguration = {
     chainNetworkID: number;
+};
+
+// @public (undocumented)
+export type ObjectiveDoneResult = ObjectiveSuccess | ObjectiveError;
+
+// @public (undocumented)
+export type ObjectiveError = EnsureObjectiveFailed | InternalError;
+
+// @public
+export type ObjectiveResult = {
+    done: Promise<ObjectiveDoneResult>;
+    currentStatus: ObjectiveStatus;
+    objectiveId: string;
+    channelId: string;
+};
+
+// @public (undocumented)
+export type ObjectiveSuccess = {
+    channelId: string;
+    type: 'Success';
 };
 
 // @public
@@ -298,6 +332,13 @@ export type RequiredDatabaseConfiguration = {
 export type RequiredEngineConfig = {
     databaseConfiguration: RequiredDatabaseConfiguration;
     networkConfiguration: NetworkConfiguration;
+};
+
+// @public (undocumented)
+export type RetryOptions = {
+    numberOfAttempts: number;
+    initialDelay: number;
+    multiple: number;
 };
 
 // @public (undocumented)
@@ -377,9 +418,15 @@ export class SingleThreadedEngine extends EventEmitter<EventEmitterType> impleme
     store: Store;
     syncChannel({ channelId }: SyncChannelParams): Promise<SingleChannelOutput>;
     syncChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
-    syncObjectives(objectiveIds: string[]): Promise<MultipleChannelOutput>;
+    syncObjectives(objectiveIds: string[]): Promise<SyncObjectiveResult>;
     updateChannel({ channelId, allocations, appData, }: UpdateChannelParams): Promise<SingleChannelOutput>;
 }
+
+// @public (undocumented)
+export type SyncObjectiveResult = {
+    messagesByObjective: Record<string, WireMessage[]>;
+    outbox: Outgoing[];
+};
 
 // @public (undocumented)
 export function validateEngineConfig(config: Record<string, any>): {
@@ -388,10 +435,22 @@ export function validateEngineConfig(config: Record<string, any>): {
     errors: ValidationErrorItem[];
 };
 
+// @public (undocumented)
+export class Wallet {
+    // Warning: (ae-forgotten-export) The symbol "MessageServiceInterface" needs to be exported by the entry point index.d.ts
+    static create(engine: Engine, messageService: MessageServiceInterface, retryOptions?: Partial<RetryOptions>): Promise<Wallet>;
+    createChannels(channelParameters: CreateChannelParams[]): Promise<ObjectiveResult[]>;
+    // (undocumented)
+    destroy(): Promise<void>;
+    jumpStartObjectives(): Promise<ObjectiveResult[]>;
+    }
+
 
 // Warnings were encountered during analysis:
 //
-// src/engine/types.ts:72:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
+// src/engine/types.ts:27:3 - (ae-forgotten-export) The symbol "WireMessage" needs to be exported by the entry point index.d.ts
+// src/engine/types.ts:76:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
+// src/wallet/types.ts:53:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
@@ -47,8 +47,7 @@ describe('SyncObjective', () => {
     // We only expect 1 outbox
     expect(result.outbox).toHaveLength(1);
 
-    // We expect the message to contain the objective as well as the sync channel payload
-    expect(result.outbox[0]).toMatchObject({
+    const expectedPayload = {
       method: 'MessageQueued',
       params: {
         sender: 'alice',
@@ -62,6 +61,14 @@ describe('SyncObjective', () => {
           objectives: [{type: 'OpenChannel', data: {targetChannelId: channelId}}],
         },
       },
-    });
+    };
+    // We expect the message to contain the objective as well as the sync channel payload
+    expect(result.outbox[0]).toMatchObject(expectedPayload);
+
+    // We expect the message to be correctly indexed by objective id
+    const objectiveIds = Object.keys(result.messagesByObjective);
+    expect(objectiveIds).toHaveLength(1);
+    const messagesByObjective = result.messagesByObjective[objectiveIds[0]];
+    expect(messagesByObjective).toMatchObject([expectedPayload.params]);
   });
 });

--- a/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
@@ -29,8 +29,6 @@ describe('SyncObjective', () => {
 
   it('handles being called with no objective ids', async () => {
     const syncResults = await engine.syncObjectives([]);
-    expect(syncResults.channelResults).toHaveLength(0);
-    expect(syncResults.newObjectives).toHaveLength(0);
     expect(syncResults.outbox).toHaveLength(0);
   });
 
@@ -44,20 +42,13 @@ describe('SyncObjective', () => {
 
     const {channelId} = targetChannel;
 
-    const {newObjectives, outbox, channelResults} = await engine.syncObjectives([
-      objective.objectiveId,
-    ]);
-
-    // There should be no new objectives
-    expect(newObjectives).toHaveLength(0);
-    // We should get the channel result for any channels we need to sync
-    expect(channelResults).toEqual([targetChannel.channelResult]);
+    const result = await engine.syncObjectives([objective.objectiveId]);
 
     // We only expect 1 outbox
-    expect(outbox).toHaveLength(1);
+    expect(result.outbox).toHaveLength(1);
 
     // We expect the message to contain the objective as well as the sync channel payload
-    expect(outbox[0]).toMatchObject({
+    expect(result.outbox[0]).toMatchObject({
       method: 'MessageQueued',
       params: {
         sender: 'alice',

--- a/packages/server-wallet/src/engine/engine-response.ts
+++ b/packages/server-wallet/src/engine/engine-response.ts
@@ -204,6 +204,10 @@ export class EngineResponse {
     }));
   }
 
+  public get messagesByObjective(): Map<string, WireMessage[]> {
+    return this.queuedMessages;
+  }
+
   public get channelResults(): ChannelResult[] {
     return Object.values(this._channelResults);
   }

--- a/packages/server-wallet/src/engine/engine-response.ts
+++ b/packages/server-wallet/src/engine/engine-response.ts
@@ -83,6 +83,12 @@ export class EngineResponse {
     });
   }
 
+  /**
+   * Adds a message to the current collection of messages.
+   * If no objective id is provided a placeholder of NO_OBJECTIVE_ID is used.
+   * @param message The message to add.
+   * @param objectiveId The optional objective id to associate the message with.
+   */
   private addMessage(message: WireMessage, objectiveId?: string): void {
     const id = objectiveId ?? 'NO_OBJECTIVE_ID';
     const previousValue = this.queuedMessages[id] ?? [];

--- a/packages/server-wallet/src/engine/engine-response.ts
+++ b/packages/server-wallet/src/engine/engine-response.ts
@@ -83,7 +83,7 @@ export class EngineResponse {
     });
   }
 
-  addMessage(message: WireMessage, objectiveId?: string): void {
+  private addMessage(message: WireMessage, objectiveId?: string): void {
     const id = objectiveId ?? 'NO_OBJECTIVE_ID';
     const previousValue = this.queuedMessages[id] ?? [];
     const mergedMessages = mergeMessages(previousValue.concat(message));

--- a/packages/server-wallet/src/engine/engine-response.ts
+++ b/packages/server-wallet/src/engine/engine-response.ts
@@ -86,7 +86,9 @@ export class EngineResponse {
   addMessage(message: WireMessage, objectiveId?: string): void {
     const id = objectiveId ?? 'NO_OBJECTIVE_ID';
     const previousValue = this.queuedMessages[id] ?? [];
-    this.queuedMessages[id] = previousValue.concat(message);
+    const mergedMessages = mergeMessages(previousValue.concat(message));
+
+    this.queuedMessages[id] = mergedMessages;
   }
 
   /**
@@ -268,6 +270,11 @@ export class EngineResponse {
 // Utilities
 // -----------
 
+export function mergeMessages(messages: WireMessage[]): WireMessage[] {
+  return mergeOutgoing(messages.map(m => ({method: 'MessageQueued' as const, params: m}))).map(
+    o => o.params as WireMessage
+  );
+}
 // Merges any messages to the same recipient into one message
 // This makes message delivery less painful with the request/response model
 export function mergeOutgoing(outgoing: Notice[]): Notice[] {

--- a/packages/server-wallet/src/engine/engine-response.ts
+++ b/packages/server-wallet/src/engine/engine-response.ts
@@ -143,7 +143,12 @@ export class EngineResponse {
   /**
    * Add a GetChannelRequest to outbox for given channelId
    */
-  queueChannelRequest(channelId: string, myIndex: number, participants: Participant[]): void {
+  queueChannelRequest(
+    channelId: string,
+    myIndex: number,
+    participants: Participant[],
+    objectiveId?: string
+  ): void {
     const myParticipantId = participants[myIndex].participantId;
 
     participants.forEach((p, i) => {
@@ -158,7 +163,8 @@ export class EngineResponse {
             p.participantId,
             myParticipantId,
             channelId
-          )
+          ),
+          objectiveId
         );
       }
     });

--- a/packages/server-wallet/src/engine/engine-response.ts
+++ b/packages/server-wallet/src/engine/engine-response.ts
@@ -62,7 +62,7 @@ export class EngineResponse {
   /**
    * Queues state for sending to opponent
    */
-  queueState(state: SignedState, myIndex: number, objectiveId?: string, channelId?: string): void {
+  queueState(state: SignedState, myIndex: number, channelId: string, objectiveId?: string): void {
     const myParticipantId = state.participants[myIndex].participantId;
     state.participants.forEach((p, i) => {
       if (i !== myIndex) {

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -340,7 +340,7 @@ export class SingleThreadedEngine
 
     const {myIndex, participants} = channelState;
 
-    states.forEach(s => response.queueState(s, myIndex, objectiveId, channelId));
+    states.forEach(s => response.queueState(s, myIndex, channelId, objectiveId));
     response.queueChannelRequest(channelId, myIndex, participants, objectiveId);
     response.queueChannelState(channelState);
   }
@@ -512,7 +512,7 @@ export class SingleThreadedEngine
     );
 
     this.emit('objectiveStarted', objective);
-    response.queueState(signedState, channel.myIndex, objective.objectiveId, channel.channelId);
+    response.queueState(signedState, channel.myIndex, channel.channelId, objective.objectiveId);
     response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
     response.queueChannelState(channel);
 

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -288,7 +288,7 @@ export class SingleThreadedEngine
    * @param objectiveIds The ids of the objectives that should be sent to the counterparties
    * @returns A promise that resolves to an object containing the messages.
    */
-  public async syncObjectives(objectiveIds: string[]): Promise<MultipleChannelOutput> {
+  public async syncObjectives(objectiveIds: string[]): Promise<Map<string, Message[]>> {
     const response = EngineResponse.initialize();
     const objectives = await this.store.getObjectivesByIds(objectiveIds);
 
@@ -315,7 +315,7 @@ export class SingleThreadedEngine
       response.queueSendObjective(o, channel.myIndex, participants);
     }
 
-    return response.multipleChannelOutput();
+    return response.messagesByObjective;
   }
 
   /**

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -341,8 +341,7 @@ export class SingleThreadedEngine
     const {myIndex, participants} = channelState;
 
     states.forEach(s => response.queueState(s, myIndex, objectiveId, channelId));
-
-    response.queueChannelRequest(channelId, myIndex, participants);
+    response.queueChannelRequest(channelId, myIndex, participants, objectiveId);
     response.queueChannelState(channelState);
   }
 

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -309,7 +309,7 @@ export class SingleThreadedEngine
       // This could be refactored if performance is an issue
       const channel = await this.store.getChannelState(o.data.targetChannelId);
       // This will make sure any relevant channel information is synced
-      await this._syncChannel(channel.channelId, response);
+      await this._syncChannel(channel.channelId, response, o.objectiveId);
 
       const {participants} = channel;
       response.queueSendObjective(o, channel.myIndex, participants);
@@ -330,12 +330,16 @@ export class SingleThreadedEngine
     return response.singleChannelOutput();
   }
 
-  private async _syncChannel(channelId: string, response: EngineResponse): Promise<void> {
+  private async _syncChannel(
+    channelId: string,
+    response: EngineResponse,
+    objectiveId?: string
+  ): Promise<void> {
     const {states, channelState} = await this.store.getStates(channelId);
 
     const {myIndex, participants} = channelState;
 
-    states.forEach(s => response.queueState(s, myIndex, channelId));
+    states.forEach(s => response.queueState(s, myIndex, objectiveId, channelId));
 
     response.queueChannelRequest(channelId, myIndex, participants);
     response.queueChannelState(channelState);
@@ -508,7 +512,7 @@ export class SingleThreadedEngine
     );
 
     this.emit('objectiveStarted', objective);
-    response.queueState(signedState, channel.myIndex, channel.channelId);
+    response.queueState(signedState, channel.myIndex, objective.objectiveId, channel.channelId);
     response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
     response.queueChannelState(channel);
 

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -66,6 +66,7 @@ import {
   EngineInterface,
   EngineEvent,
   hasNewObjective,
+  SyncObjectiveResult,
 } from './types';
 import {EngineResponse} from './engine-response';
 
@@ -288,7 +289,7 @@ export class SingleThreadedEngine
    * @param objectiveIds The ids of the objectives that should be sent to the counterparties
    * @returns A promise that resolves to an object containing the messages.
    */
-  public async syncObjectives(objectiveIds: string[]): Promise<Map<string, Message[]>> {
+  public async syncObjectives(objectiveIds: string[]): Promise<SyncObjectiveResult> {
     const response = EngineResponse.initialize();
     const objectives = await this.store.getObjectivesByIds(objectiveIds);
 
@@ -315,7 +316,7 @@ export class SingleThreadedEngine
       response.queueSendObjective(o, channel.myIndex, participants);
     }
 
-    return response.messagesByObjective;
+    return response.syncObjectiveResult;
   }
 
   /**

--- a/packages/server-wallet/src/engine/types.ts
+++ b/packages/server-wallet/src/engine/types.ts
@@ -10,7 +10,7 @@ import {
 
 import {WalletObjective} from '../models/objective';
 import {Outgoing} from '../protocols/actions';
-import {Bytes32} from '../type-aliases';
+import {Bytes32, WireMessage} from '../type-aliases';
 
 export type SingleChannelOutput = {
   outbox: Outgoing[];
@@ -23,6 +23,10 @@ export type MultipleChannelOutput = {
   newObjectives: WalletObjective[];
 };
 
+export type SyncObjectiveResult = {
+  messagesByObjective: Record<string, WireMessage[]>;
+  outbox: Outgoing[];
+};
 export type Output = SingleChannelOutput | MultipleChannelOutput;
 
 type ChannelUpdatedEvent = {

--- a/packages/server-wallet/src/index.ts
+++ b/packages/server-wallet/src/index.ts
@@ -1,6 +1,7 @@
 export {Payload as Message} from '@statechannels/wallet-core';
 
 export * from './engine';
+export * from './wallet';
 export {Outgoing} from './protocols/actions';
 
 export {DBAdmin} from './db-admin/db-admin';

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -66,7 +66,7 @@ export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
         this.timingMetrics
       );
 
-      if (!(await this.areAllFinalStatesSigned(channel, tx, response))) {
+      if (!(await this.areAllFinalStatesSigned(objective.objectiveId, channel, tx, response))) {
         response.queueChannel(channel);
         return WaitingFor.theirFinalState;
       }
@@ -85,6 +85,7 @@ export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
   }
 
   private async areAllFinalStatesSigned(
+    objectiveId: string,
     channel: Channel,
     tx: Transaction,
     response: EngineResponse
@@ -102,16 +103,17 @@ export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
     if (channel.myTurn) {
       // I am the first to sign a final state
       if (!supported.isFinal) {
-        await this.signState(channel, supported.turnNum + 1, tx, response);
+        await this.signState(objectiveId, channel, supported.turnNum + 1, tx, response);
         return false;
       }
-      await this.signState(channel, supported.turnNum, tx, response);
+      await this.signState(objectiveId, channel, supported.turnNum, tx, response);
       return channel.hasConclusionProof;
     }
     return false;
   }
 
   private async signState(
+    objectiveId: string,
     channel: Channel,
     turnNum: number,
     tx: Transaction,
@@ -124,7 +126,7 @@ export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
 
     const vars: StateVariables = {...channel.supported, turnNum, isFinal: true};
     const signedState = await this.store.signState(channel, vars, tx);
-    response.queueState(signedState, myIndex, channelId);
+    response.queueState(signedState, myIndex, channelId, objectiveId);
   }
 
   private async completeObjective(

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -126,7 +126,7 @@ export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
 
     const vars: StateVariables = {...channel.supported, turnNum, isFinal: true};
     const signedState = await this.store.signState(channel, vars, tx);
-    response.queueState(signedState, myIndex, objectiveId, channelId);
+    response.queueState(signedState, myIndex, channelId, objectiveId);
   }
 
   private async completeObjective(

--- a/packages/server-wallet/src/protocols/channel-closer.ts
+++ b/packages/server-wallet/src/protocols/channel-closer.ts
@@ -126,7 +126,7 @@ export class ChannelCloser implements Cranker<WalletObjective<CloseChannel>> {
 
     const vars: StateVariables = {...channel.supported, turnNum, isFinal: true};
     const signedState = await this.store.signState(channel, vars, tx);
-    response.queueState(signedState, myIndex, channelId, objectiveId);
+    response.queueState(signedState, myIndex, objectiveId, channelId);
   }
 
   private async completeObjective(

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -117,7 +117,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
     // TODO: should probably have more checking around the form of channel.latest
     const prefund = {...channel.latest, turnNum: 0};
     const signedState = await this.store.signState(channel, prefund, tx);
-    response.queueState(signedState, channel.myIndex, objectiveId, channel.channelId);
+    response.queueState(signedState, channel.myIndex, channel.channelId, objectiveId);
     response.queueChannel(channel);
   }
 
@@ -130,7 +130,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
     // TODO: should probably have more checking around the form of channel.latest
     const postfund = {...channel.latest, turnNum: channel.nParticipants * 2 - 1};
     const signedState = await this.store.signState(channel, postfund, tx);
-    response.queueState(signedState, channel.myIndex, objectiveId, channel.channelId);
+    response.queueState(signedState, channel.myIndex, channel.channelId, objectiveId);
     response.queueChannel(channel);
   }
 }

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -117,7 +117,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
     // TODO: should probably have more checking around the form of channel.latest
     const prefund = {...channel.latest, turnNum: 0};
     const signedState = await this.store.signState(channel, prefund, tx);
-    response.queueState(signedState, channel.myIndex, channel.channelId, objectiveId);
+    response.queueState(signedState, channel.myIndex, objectiveId, channel.channelId);
     response.queueChannel(channel);
   }
 
@@ -130,7 +130,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
     // TODO: should probably have more checking around the form of channel.latest
     const postfund = {...channel.latest, turnNum: channel.nParticipants * 2 - 1};
     const signedState = await this.store.signState(channel, postfund, tx);
-    response.queueState(signedState, channel.myIndex, channel.channelId, objectiveId);
+    response.queueState(signedState, channel.myIndex, objectiveId, channel.channelId);
     response.queueChannel(channel);
   }
 }

--- a/packages/server-wallet/src/protocols/channel-opener.ts
+++ b/packages/server-wallet/src/protocols/channel-opener.ts
@@ -50,7 +50,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
 
     // if we haven't signed the pre-fund, sign it
     if (!channel.prefundSigned) {
-      await this.signPrefundSetup(channel, response, tx);
+      await this.signPrefundSetup(objective.objectiveId, channel, response, tx);
     }
 
     // if we don't have a complete preFundSetup, we are still waitingFor theirPreFundState and cannot progress
@@ -65,7 +65,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
 
     // if the channel is funded and I haven't signed the post-fund, sign it
     if (funded && !channel.postfundSigned) {
-      await this.signPostfundSetup(channel, response, tx);
+      await this.signPostfundSetup(objective.objectiveId, channel, response, tx);
     }
 
     // If we are still waitingFor theirPostFundState, we cannot complete
@@ -109,6 +109,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
   }
 
   private async signPrefundSetup(
+    objectiveId: string,
     channel: Channel,
     response: EngineResponse,
     tx: Transaction
@@ -116,11 +117,12 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
     // TODO: should probably have more checking around the form of channel.latest
     const prefund = {...channel.latest, turnNum: 0};
     const signedState = await this.store.signState(channel, prefund, tx);
-    response.queueState(signedState, channel.myIndex, channel.channelId);
+    response.queueState(signedState, channel.myIndex, channel.channelId, objectiveId);
     response.queueChannel(channel);
   }
 
   private async signPostfundSetup(
+    objectiveId: string,
     channel: Channel,
     response: EngineResponse,
     tx: Transaction
@@ -128,7 +130,7 @@ export class ChannelOpener implements Cranker<WalletObjective<OpenChannel>> {
     // TODO: should probably have more checking around the form of channel.latest
     const postfund = {...channel.latest, turnNum: channel.nParticipants * 2 - 1};
     const signedState = await this.store.signState(channel, postfund, tx);
-    response.queueState(signedState, channel.myIndex, channel.channelId);
+    response.queueState(signedState, channel.myIndex, channel.channelId, objectiveId);
     response.queueChannel(channel);
   }
 }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -83,7 +83,7 @@ export class Wallet {
     const syncMessages = await this._engine.syncObjectives(objectiveIds);
     return Promise.all(
       objectives.map(async o => {
-        const messagesForObjective = syncMessages.get(o.objectiveId) ?? [];
+        const messagesForObjective = syncMessages.messagesByObjective[o.objectiveId];
         return {
           objectiveId: o.objectiveId,
           currentStatus: o.status,
@@ -129,8 +129,8 @@ export class Wallet {
         await delay(delayAmount);
 
         const syncResult = await this._engine.syncObjectives([objective.objectiveId]);
-        const messages = _.flatten(Array.from(syncResult.values()));
-        await this._messageService.send(messages);
+
+        await this._messageService.send(getMessages(syncResult.outbox));
       }
       if (isComplete) return {channelId: objective.data.targetChannelId, type: 'Success'};
       return {numberOfAttempts: this._retryOptions.numberOfAttempts, type: 'EnsureObjectiveFailed'};

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -130,7 +130,8 @@ export class Wallet {
 
         const syncResult = await this._engine.syncObjectives([objective.objectiveId]);
 
-        await this._messageService.send(getMessages(syncResult.outbox));
+        const messagesForObjective = syncResult.messagesByObjective[objective.objectiveId];
+        await this._messageService.send(messagesForObjective);
       }
       if (isComplete) return {channelId: objective.data.targetChannelId, type: 'Success'};
       return {numberOfAttempts: this._retryOptions.numberOfAttempts, type: 'EnsureObjectiveFailed'};


### PR DESCRIPTION
# Description
Update Engine-Response to return messages by objective id.

By indexing messages by objective id it allows the `wallet` to get messages specifically per an objective.

This is helpful in `ensureObjective` as we can only send the messages for the objective instead of all the messages.

Instead of forcing all existing code to specify an `ObjectiveId` when adding a message to `EngineResponse` it is optional. If no `ObjectiveId` is specified the message is added to the collection under the key of `NO_OBJECTIVE_ID`.

For backwards compatibility, there is an `outbox` property on `SyncChannelResult` that contains all messages (including those added with no objective Id). This allows most existing code to continue to work without any changes.

---
## Checklist:

### Code quality
- [ ] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
