### PR TITLE
[browser-wallet] Add UI for Open Channel Objective

### DIFF
--- a/packages/browser-wallet/src/channel-wallet-types.ts
+++ b/packages/browser-wallet/src/channel-wallet-types.ts
@@ -8,7 +8,7 @@ export type TriggerObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => vo
  * when UI should be updated.
  *
  * UI needs a way to communicate objective events to the channel wallet. UI invokes triggerObjectiveEvent
- * when UI triggers an objetive event
+ * when UI triggers an objective event
  */
 export type UpdateUI = (update: {
   service?: AnyInterpreter;

--- a/packages/browser-wallet/src/channel-wallet-types.ts
+++ b/packages/browser-wallet/src/channel-wallet-types.ts
@@ -3,9 +3,19 @@ import {Interpreter} from 'xstate';
 
 export type AnyInterpreter = Interpreter<any, any, any>;
 export type OnObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => void;
-export type OnWorkflowStart = (service: AnyInterpreter, onObjectiveEvent: OnObjectiveEvent) => void;
-export type OnObjectiveUpdate = (
-  objective: DirectFunder.OpenChannelObjective,
+/**
+ * The channel wallet is not able to update UI. The channel wallet is supplied a callback to invoke
+ * when UI should be updated.
+ *
+ * UI needs a way to communicate objective events to the channel wallet. UI invokes onObjectiveEvent
+ * when UI triggers an objetive event
+ */
+export type UpdateUI = (
+  update: {
+    service?: AnyInterpreter;
+    objective?: DirectFunder.OpenChannelObjective;
+  },
+
   onObjectiveEvent: OnObjectiveEvent
 ) => void;
 

--- a/packages/browser-wallet/src/channel-wallet-types.ts
+++ b/packages/browser-wallet/src/channel-wallet-types.ts
@@ -4,7 +4,7 @@ import {Interpreter} from 'xstate';
 export type AnyInterpreter = Interpreter<any, any, any>;
 export type OnObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => void;
 export type OnWorkflowStart = (service: AnyInterpreter, onObjectiveEvent: OnObjectiveEvent) => void;
-export type OnObjectiveStart = (
+export type OnObjectiveUpdate = (
   objective: DirectFunder.OpenChannelObjective,
   onObjectiveEvent: OnObjectiveEvent
 ) => void;

--- a/packages/browser-wallet/src/channel-wallet-types.ts
+++ b/packages/browser-wallet/src/channel-wallet-types.ts
@@ -2,12 +2,12 @@ import {DirectFunder, SharedObjective, SignedState} from '@statechannels/wallet-
 import {Interpreter} from 'xstate';
 
 export type AnyInterpreter = Interpreter<any, any, any>;
-export type OnObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => void;
+export type TriggerObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => void;
 /**
  * The channel wallet is not able to update UI. The channel wallet is supplied a callback to invoke
  * when UI should be updated.
  *
- * UI needs a way to communicate objective events to the channel wallet. UI invokes onObjectiveEvent
+ * UI needs a way to communicate objective events to the channel wallet. UI invokes triggerObjectiveEvent
  * when UI triggers an objetive event
  */
 export type UpdateUI = (update: {

--- a/packages/browser-wallet/src/channel-wallet-types.ts
+++ b/packages/browser-wallet/src/channel-wallet-types.ts
@@ -10,14 +10,10 @@ export type OnObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => void;
  * UI needs a way to communicate objective events to the channel wallet. UI invokes onObjectiveEvent
  * when UI triggers an objetive event
  */
-export type UpdateUI = (
-  update: {
-    service?: AnyInterpreter;
-    objective?: DirectFunder.OpenChannelObjective;
-  },
-
-  onObjectiveEvent: OnObjectiveEvent
-) => void;
+export type UpdateUI = (update: {
+  service?: AnyInterpreter;
+  objective?: DirectFunder.OpenChannelObjective;
+}) => void;
 
 export interface Workflow {
   id: string;

--- a/packages/browser-wallet/src/channel-wallet-types.ts
+++ b/packages/browser-wallet/src/channel-wallet-types.ts
@@ -1,0 +1,21 @@
+import {DirectFunder, SharedObjective, SignedState} from '@statechannels/wallet-core';
+import {Interpreter} from 'xstate';
+
+export type AnyInterpreter = Interpreter<any, any, any>;
+export type OnObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => void;
+export type OnWorkflowStart = (service: AnyInterpreter, onObjectiveEvent: OnObjectiveEvent) => void;
+export type OnObjectiveStart = (
+  objective: DirectFunder.OpenChannelObjective,
+  onObjectiveEvent: OnObjectiveEvent
+) => void;
+
+export interface Workflow {
+  id: string;
+  service: AnyInterpreter;
+  domain: string; // TODO: Is this useful?
+}
+
+export type Message = {
+  objectives: SharedObjective[];
+  signedStates: SignedState[];
+};

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -37,6 +37,8 @@ export class ChannelWallet {
    *
    * @param chainAddress Ethereum address for the wallet
    * @param updateUI Callback that will be invoked when the channel wallet wants to update UI
+   * @param setTriggerObjectiveEvent The invoker of the create API might wish to send objective events to the wallet. The wallet
+   *  calls setTriggerObjectiveEvent to hand back the invoker the callback to use for objective events.
    * @returns
    */
   static async create(

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -16,7 +16,7 @@ import {
 } from '@statechannels/wallet-core';
 import _ from 'lodash';
 
-import {OnObjectiveEvent, UpdateUI, Workflow} from './channel-wallet-types';
+import {TriggerObjectiveEvent, UpdateUI, Workflow} from './channel-wallet-types';
 import {serializeChannelEntry} from './utils/wallet-core-v0.8.0';
 import {AppRequestEvent} from './event-types';
 import {Store} from './store';
@@ -42,7 +42,7 @@ export class ChannelWallet {
   static async create(
     chainAddress?: Address,
     updateUI?: UpdateUI,
-    setOnObjectiveEvent?: (callback: OnObjectiveEvent) => void
+    setTriggerObjectiveEvent?: (callback: TriggerObjectiveEvent) => void
   ): Promise<ChannelWallet> {
     const chain = new ChainWatcher(chainAddress);
     const store = new Store(chain);
@@ -51,7 +51,7 @@ export class ChannelWallet {
       store,
       new MessagingService(store),
       updateUI,
-      setOnObjectiveEvent
+      setTriggerObjectiveEvent
     );
     return wallet;
   }
@@ -60,9 +60,9 @@ export class ChannelWallet {
     private store: Store,
     private messagingService: MessagingServiceInterface,
     protected updateUI?: UpdateUI,
-    setOnObjectiveEvent?: (callback: OnObjectiveEvent) => void
+    setTriggerObjectiveEvent?: (callback: TriggerObjectiveEvent) => void
   ) {
-    setOnObjectiveEvent?.(_.bind(this.crankRichObjectives, this));
+    setTriggerObjectiveEvent?.(_.bind(this.crankRichObjectives, this));
     this.workflows = [];
 
     // Whenever the store wants to send something call sendMessage

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -97,7 +97,7 @@ export class ChannelWallet {
     });
 
     this.store.richObjectiveFeed.subscribe(objective =>
-      this.onObjectiveStart?.(objective, this.onObjectiveEvent)
+      this.onObjectiveStart?.(objective, _.bind(this.onObjectiveEvent, this))
     );
     this.messagingService.requestFeed.subscribe(x => this.handleRequest(x));
   }

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -48,7 +48,6 @@ export class ChannelWallet {
     private store: Store,
     private messagingService: MessagingServiceInterface,
     protected onWorkflowStart?: OnWorkflowStart,
-    // TODO: wire up this method
     protected onObjectiveStart?: OnObjectiveStart
   ) {
     this.workflows = [];

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -273,6 +273,7 @@ export class ChannelWallet {
             throw new Error('Not expected to reach here');
         }
       }
+      this.onObjectiveStart?.(richObjective[channelId], _.bind(this.crankRichObjectives, this));
     }
   }
 

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -96,7 +96,7 @@ export class ChannelWallet {
     });
 
     this.store.richObjectiveFeed.subscribe(objective =>
-      this.onObjectiveStart?.(objective, _.bind(this.onObjectiveEvent, this))
+      this.onObjectiveStart?.(objective, _.bind(this.crankRichObjectives, this))
     );
     this.messagingService.requestFeed.subscribe(x => this.handleRequest(x));
   }
@@ -203,7 +203,7 @@ export class ChannelWallet {
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))
       .start();
 
-    this.onWorkflowStart?.(service, this.onObjectiveEvent);
+    this.onWorkflowStart?.(service, _.bind(this.crankRichObjectives, this));
 
     const workflow = {id: workflowId, service, domain: 'TODO'};
     this.workflows.push(workflow);
@@ -274,10 +274,6 @@ export class ChannelWallet {
         }
       }
     }
-  }
-
-  public onObjectiveEvent(event: DirectFunder.OpenChannelEvent): void {
-    this.crankRichObjectives(event);
   }
 
   public async approveRichObjective(channelId: string): Promise<void> {

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -96,6 +96,9 @@ export class ChannelWallet {
       }
     });
 
+    this.store.richObjectiveFeed.subscribe(objective =>
+      this.onObjectiveStart?.(objective, this.onObjectiveEvent)
+    );
     this.messagingService.requestFeed.subscribe(x => this.handleRequest(x));
   }
 

--- a/packages/browser-wallet/src/index.ts
+++ b/packages/browser-wallet/src/index.ts
@@ -38,14 +38,7 @@ const log = logger.trace.bind(logger);
 
   await store.initialize([], CLEAR_STORAGE_ON_START);
   const messagingService = new MessagingService(store);
-  const channelWallet = new ChannelWallet(
-    store,
-    messagingService,
-    (service: AnyInterpreter, onObjectiveEvent: OnObjectiveEvent) =>
-      renderUI(onObjectiveEvent, service),
-    (objective: DirectFunder.OpenChannelObjective, onObjectiveEvent: OnObjectiveEvent) =>
-      renderUI(onObjectiveEvent, undefined, objective)
-  );
+  const channelWallet = new ChannelWallet(store, messagingService, renderUI);
 
   if (NODE_ENV === 'production') {
     Sentry.configureScope(async scope => {
@@ -77,13 +70,19 @@ const log = logger.trace.bind(logger);
 })();
 
 function renderUI(
-  onObjectiveEvent: OnObjectiveEvent,
-  machine?: AnyInterpreter,
-  objective?: DirectFunder.OpenChannelObjective
+  update: {
+    service?: AnyInterpreter;
+    objective?: DirectFunder.OpenChannelObjective;
+  },
+  onObjectiveEvent: OnObjectiveEvent
 ) {
   if (document.getElementById('root')) {
     ReactDOM.render(
-      React.createElement(WalletUI, {workflow: machine, objective, onObjectiveEvent}),
+      React.createElement(WalletUI, {
+        workflow: update.service,
+        objective: update.objective,
+        onObjectiveEvent
+      }),
       document.getElementById('root')
     );
   }

--- a/packages/browser-wallet/src/index.ts
+++ b/packages/browser-wallet/src/index.ts
@@ -7,7 +7,7 @@ import React from 'react';
 import {DirectFunder} from '@statechannels/wallet-core';
 import _ from 'lodash';
 
-import {OnObjectiveEvent} from './channel-wallet-types';
+import {TriggerObjectiveEvent} from './channel-wallet-types';
 import {Backend} from './store/dexie-backend';
 import {Store} from './store';
 import {MemoryBackend} from './store/memory-backend';
@@ -27,9 +27,9 @@ if (NODE_ENV === 'production') {
 }
 
 const log = logger.trace.bind(logger);
-let onObjectiveEvent: OnObjectiveEvent | undefined = undefined;
-function setOnObjectiveEvent(callback: OnObjectiveEvent): void {
-  onObjectiveEvent = callback;
+let triggerObjectiveEvent: TriggerObjectiveEvent | undefined = undefined;
+function setTriggerObjectiveEvent(callback: TriggerObjectiveEvent): void {
+  triggerObjectiveEvent = callback;
 }
 
 (async function () {
@@ -43,7 +43,12 @@ function setOnObjectiveEvent(callback: OnObjectiveEvent): void {
   await store.initialize([], CLEAR_STORAGE_ON_START);
   const messagingService = new MessagingService(store);
 
-  const channelWallet = new ChannelWallet(store, messagingService, renderUI, setOnObjectiveEvent);
+  const channelWallet = new ChannelWallet(
+    store,
+    messagingService,
+    renderUI,
+    setTriggerObjectiveEvent
+  );
 
   if (NODE_ENV === 'production') {
     Sentry.configureScope(async scope => {
@@ -78,8 +83,8 @@ function renderUI(update: {
   service?: AnyInterpreter;
   objective?: DirectFunder.OpenChannelObjective;
 }) {
-  if (!onObjectiveEvent) {
-    throw new Error('onObjectiveEventCallback must be defined');
+  if (!triggerObjectiveEvent) {
+    throw new Error('triggerObjectiveEventCallback must be defined');
   }
 
   if (document.getElementById('root')) {
@@ -87,7 +92,7 @@ function renderUI(update: {
       React.createElement(WalletUI, {
         workflow: update.service,
         objective: update.objective,
-        onObjectiveEvent
+        triggerObjectiveEvent
       }),
       document.getElementById('root')
     );

--- a/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
+++ b/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
@@ -15,6 +15,7 @@ export const ConfirmCreateChannel = () => {
       <Button id="yes" onClick={onObjectiveEvent({type: 'Approval'})}>
         Yes
       </Button>
+      {/** TODO: add objective rejection */}
       <Button.Text onClick={onObjectiveEvent({type: 'Approval'})}>No</Button.Text>
     </Flex>
   );

--- a/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
+++ b/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
@@ -12,11 +12,11 @@ export const ConfirmCreateChannel = () => {
       <RimbleText fontSize={2} pb={2}>
         Do you wish to create a channel?
       </RimbleText>
-      <Button id="yes" onClick={onObjectiveEvent({type: 'Approval'})}>
+      <Button id="yes" onClick={() => onObjectiveEvent({type: 'Approval'})}>
         Yes
       </Button>
       {/** TODO: add objective rejection */}
-      <Button.Text onClick={onObjectiveEvent({type: 'Approval'})}>No</Button.Text>
+      <Button.Text onClick={() => onObjectiveEvent({type: 'Approval'})}>No</Button.Text>
     </Flex>
   );
 };

--- a/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
+++ b/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
@@ -1,0 +1,21 @@
+import React, {useContext} from 'react';
+import '../wallet.scss';
+import {Button, Flex, Text as RimbleText} from 'rimble-ui';
+
+import {ObjectiveContext} from './objective-context';
+
+export const ConfirmCreateChannel = () => {
+  const onObjectiveEvent = useContext(ObjectiveContext);
+
+  return (
+    <Flex alignItems="left" flexDirection="column">
+      <RimbleText fontSize={2} pb={2}>
+        Do you wish to create a channel?
+      </RimbleText>
+      <Button id="yes" onClick={onObjectiveEvent({type: 'Approval'})}>
+        Yes
+      </Button>
+      <Button.Text onClick={onObjectiveEvent({type: 'Approval'})}>No</Button.Text>
+    </Flex>
+  );
+};

--- a/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
+++ b/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
@@ -5,18 +5,18 @@ import {Button, Flex, Text as RimbleText} from 'rimble-ui';
 import {ObjectiveContext} from './objective-context';
 
 export const ConfirmCreateChannel = () => {
-  const onObjectiveEvent = useContext(ObjectiveContext);
+  const triggerObjectiveEvent = useContext(ObjectiveContext);
 
   return (
     <Flex alignItems="left" flexDirection="column">
       <RimbleText fontSize={2} pb={2}>
         Do you wish to create a channel?
       </RimbleText>
-      <Button id="yes" onClick={() => onObjectiveEvent({type: 'Approval'})}>
+      <Button id="yes" onClick={() => triggerObjectiveEvent({type: 'Approval'})}>
         Yes
       </Button>
       {/** TODO: add objective rejection */}
-      <Button.Text onClick={() => onObjectiveEvent({type: 'Approval'})}>No</Button.Text>
+      <Button.Text onClick={() => triggerObjectiveEvent({type: 'Approval'})}>No</Button.Text>
     </Flex>
   );
 };

--- a/packages/browser-wallet/src/ui/objective/objective-context.tsx
+++ b/packages/browser-wallet/src/ui/objective/objective-context.tsx
@@ -2,5 +2,5 @@ import {DirectFunder} from '@statechannels/wallet-core';
 import React from 'react';
 
 export const ObjectiveContext = React.createContext<
-  (onObjectiveEvent: DirectFunder.OpenChannelEvent) => void
+  (triggerObjectiveEvent: DirectFunder.OpenChannelEvent) => void
 >(() => {});

--- a/packages/browser-wallet/src/ui/objective/objective-context.tsx
+++ b/packages/browser-wallet/src/ui/objective/objective-context.tsx
@@ -1,0 +1,6 @@
+import {DirectFunder} from '@statechannels/wallet-core';
+import React from 'react';
+
+export const ObjectiveContext = React.createContext<
+  (onObjectiveEvent: DirectFunder.OpenChannelEvent) => void
+>(() => {});

--- a/packages/browser-wallet/src/ui/objective/objective.tsx
+++ b/packages/browser-wallet/src/ui/objective/objective.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import '../wallet.scss';
+import {DirectFunder} from '@statechannels/wallet-core';
+
+import {ConfirmCreateChannel} from './confirm-create-channel-workflow';
+
+interface Props {
+  // TODO: generalize to all objectives
+  objective: DirectFunder.OpenChannelObjective;
+}
+
+export const Objective = (props: Props) => {
+  const {objective} = props;
+
+  if (!objective.approved) {
+    return (
+      <div
+        style={{
+          paddingTop: '50px',
+          textAlign: 'center'
+        }}
+        className="application-workflow-prompt"
+      >
+        <ConfirmCreateChannel />
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        paddingTop: '50px',
+        textAlign: 'center'
+      }}
+      className="application-workflow-prompt"
+    ></div>
+  );
+};

--- a/packages/browser-wallet/src/ui/objective/objective.tsx
+++ b/packages/browser-wallet/src/ui/objective/objective.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import '../wallet.scss';
 import {DirectFunder} from '@statechannels/wallet-core';
+import {Text as RimbleText} from 'rimble-ui';
 
 import {ConfirmCreateChannel} from './confirm-create-channel-workflow';
 
@@ -12,19 +13,6 @@ interface Props {
 export const Objective = (props: Props) => {
   const {objective} = props;
 
-  if (!objective.approved) {
-    return (
-      <div
-        style={{
-          paddingTop: '50px',
-          textAlign: 'center'
-        }}
-        className="application-workflow-prompt"
-      >
-        <ConfirmCreateChannel />
-      </div>
-    );
-  }
   return (
     <div
       style={{
@@ -32,6 +20,14 @@ export const Objective = (props: Props) => {
         textAlign: 'center'
       }}
       className="application-workflow-prompt"
-    ></div>
+    >
+      {objective.status === 'DirectFunder.approval' && <ConfirmCreateChannel />}
+      {/** TODO: map status to UI for the user */}
+      {objective.status !== 'DirectFunder.approval' && (
+        <RimbleText fontSize={2} pb={2}>
+          {objective.status}
+        </RimbleText>
+      )}
+    </div>
   );
 };

--- a/packages/browser-wallet/src/ui/stories/application-workflow.stories.tsx
+++ b/packages/browser-wallet/src/ui/stories/application-workflow.stories.tsx
@@ -3,7 +3,7 @@ import {interpret} from 'xstate';
 import React from 'react';
 
 import {MessagingServiceInterface, MessagingService} from '../../messaging';
-import {ApplicationWorkflow} from '../application-workflow';
+import {ApplicationWorkflow} from '../workflows/application-workflow';
 import {Store} from '../../store';
 import {Application} from '../../workflows';
 

--- a/packages/browser-wallet/src/ui/stories/approve-budget-and-fund-workflow.stories.tsx
+++ b/packages/browser-wallet/src/ui/stories/approve-budget-and-fund-workflow.stories.tsx
@@ -14,7 +14,7 @@ import {utils} from 'ethers';
 import {logger} from '../../logger';
 import {Store} from '../../store';
 import {MessagingServiceInterface, MessagingService} from '../../messaging';
-import {ApproveBudgetAndFund} from '../approve-budget-and-fund-workflow';
+import {ApproveBudgetAndFund} from '../workflows/approve-budget-and-fund-workflow';
 import {machine as approveBudgetAndFundWorkflow} from '../../workflows/approve-budget-and-fund';
 
 import {renderComponentInFrontOfApp} from './helpers';

--- a/packages/browser-wallet/src/ui/stories/close-ledger-and-withdraw.stories.tsx
+++ b/packages/browser-wallet/src/ui/stories/close-ledger-and-withdraw.stories.tsx
@@ -5,7 +5,7 @@ import {Participant, DomainBudget, ethBudget, BN, makeAddress} from '@statechann
 import {utils} from 'ethers';
 
 import {MessagingService, MessagingServiceInterface} from '../../messaging';
-import {CloseLedgerAndWithdraw} from '../close-ledger-and-withdraw';
+import {CloseLedgerAndWithdraw} from '../workflows/close-ledger-and-withdraw';
 import {Store} from '../../store';
 import {logger} from '../../logger';
 import {

--- a/packages/browser-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/browser-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {workflow, config, WorkflowContext} from '../../workflows/confirm';
 import {logger} from '../../logger';
 import {Store} from '../../store';
-import {ConfirmCreateChannel} from '../confirm-create-channel-workflow';
+import {ConfirmCreateChannel} from '../workflows/confirm-create-channel-workflow';
 
 import {renderComponentInFrontOfApp} from './helpers';
 

--- a/packages/browser-wallet/src/ui/stories/enable-ethereum.stories.tsx
+++ b/packages/browser-wallet/src/ui/stories/enable-ethereum.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import {MessagingServiceInterface, MessagingService} from '../../messaging';
 import {ethereumEnableWorkflow} from '../../workflows/ethereum-enable';
-import {EnableEthereum} from '../enable-ethereum-workflow';
+import {EnableEthereum} from '../workflows/enable-ethereum-workflow';
 import {Store} from '../../store';
 import {WindowContext} from '../window-context';
 import {logger} from '../../logger';

--- a/packages/browser-wallet/src/ui/stories/open-channel-objective.stories.tsx
+++ b/packages/browser-wallet/src/ui/stories/open-channel-objective.stories.tsx
@@ -81,8 +81,11 @@ const openingState: State = {
  * End of copy/paste from wallet-core direct-funder.test.ts
  */
 
-const objective = DirectFunder.initialize(openingState, 0);
-storiesOf('Objectives / OpenChannel', module).add(
-  'Create Channel',
-  renderComponentInFrontOfApp(<Objective objective={objective} />)
-);
+Object.keys(DirectFunder.WaitingFor).map(waitingForKey => {
+  const objective = DirectFunder.initialize(openingState, 0);
+  objective.status = DirectFunder.WaitingFor[waitingForKey];
+  storiesOf('Objectives', module).add(
+    waitingForKey,
+    renderComponentInFrontOfApp(<Objective objective={objective} />)
+  );
+});

--- a/packages/browser-wallet/src/ui/stories/open-channel-objective.stories.tsx
+++ b/packages/browser-wallet/src/ui/stories/open-channel-objective.stories.tsx
@@ -1,0 +1,88 @@
+import {
+  Address,
+  BN,
+  DirectFunder,
+  makeAddress,
+  makeDestination,
+  SimpleAllocation,
+  State
+} from '@statechannels/wallet-core';
+import {storiesOf} from '@storybook/react';
+import {ethers} from 'ethers';
+import React from 'react';
+
+import {Objective} from '../objective/objective';
+
+import {renderComponentInFrontOfApp} from './helpers';
+
+/**
+ * Copy/paste from wallet-core direct-funder.test.ts
+ * Should wallet-core export these sample test objectives?
+ */
+
+const addressZero = ethers.constants.AddressZero as Address;
+export const participants = {
+  A: {
+    privateKey: '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318',
+    signingAddress: makeAddress('0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'),
+    participantId: 'alice',
+    destination: makeDestination(
+      '0x00000000000000000000000000000000000000000000000000000000000aaaa1'
+    )
+  },
+  B: {
+    privateKey: '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727',
+    signingAddress: makeAddress('0x2222E21c8019b14dA16235319D34b5Dd83E644A9'),
+    participantId: 'bob',
+    destination: makeDestination(
+      '0x00000000000000000000000000000000000000000000000000000000000bbbb2'
+    )
+  },
+  H: {
+    privateKey: '0xc9a5f30ceaf2a0ccbb30d50aa9de3f273aa6e76f89e26090c42775e9647f5b6a',
+    signingAddress: makeAddress('0x33335846dd121B14B4C313Cb6b766F09e75890dF'),
+    participantId: 'hub',
+    destination: makeDestination(
+      '0x00000000000000000000000000000000000000000000000000000000000ffff3'
+    )
+  }
+};
+
+const deposits = {
+  part: BN.from(2),
+  A: BN.from(3),
+  B: BN.from(5),
+  total: BN.from(8)
+};
+
+const assetHolderAddress = makeAddress(addressZero); // must be even length
+const outcome: SimpleAllocation = {
+  type: 'SimpleAllocation',
+  allocationItems: [
+    {destination: participants.A.destination, amount: deposits.A},
+    {destination: participants.B.destination, amount: deposits.B}
+  ],
+  assetHolderAddress
+};
+
+const openingState: State = {
+  participants: [participants.A, participants.B],
+  chainId: '0x01',
+  challengeDuration: 86400, // one day
+  channelNonce: 0,
+  appDefinition: ethers.constants.AddressZero as Address,
+  appData: makeAddress(ethers.constants.AddressZero), // must be even length
+  turnNum: 0,
+  outcome,
+  isFinal: false
+};
+
+/**
+ * End of copy/paste from wallet-core direct-funder.test.ts
+ */
+
+const objective = DirectFunder.initialize(openingState, 0);
+storiesOf('Objectives / OpenChannel', module).add(
+  'Create Channel',
+  renderComponentInFrontOfApp(<Objective objective={objective} />)
+);

--- a/packages/browser-wallet/src/ui/wallet.tsx
+++ b/packages/browser-wallet/src/ui/wallet.tsx
@@ -14,10 +14,10 @@ import {Objective} from './objective/objective';
 import {ObjectiveContext} from './objective/objective-context';
 
 interface Props {
-  onObjectiveEvent(event: DirectFunder.OpenChannelEvent): void;
   workflow?: Interpreter<any, any, any>;
   // TODO: generalize to all rich objectives
   objective?: DirectFunder.OpenChannelObjective;
+  onObjectiveEvent(event: DirectFunder.OpenChannelEvent): void;
 }
 
 export const Wallet = (props: Props) => {

--- a/packages/browser-wallet/src/ui/wallet.tsx
+++ b/packages/browser-wallet/src/ui/wallet.tsx
@@ -41,14 +41,16 @@ export const Wallet = (props: Props) => {
         </Layout>
       </WindowContext.Provider>
     );
+  } else if (props.objective) {
+    return (
+      <ObjectiveContext.Provider value={props.onObjectiveEvent}>
+        <Layout>
+          <Objective objective={props.objective} />
+        </Layout>
+        ;
+      </ObjectiveContext.Provider>
+    );
+  } else {
+    throw new Error('A wallet renders an objective or a workflow. Neither has been supplied.');
   }
-  if (props.objective) {
-    <ObjectiveContext.Provider value={props.onObjectiveEvent}>
-      <Layout>
-        <Objective objective={props.objective} />
-      </Layout>
-      ;
-    </ObjectiveContext.Provider>;
-  }
-  throw new Error('A wallet renders an objective or a workflow. Neither has been supplied.');
 };

--- a/packages/browser-wallet/src/ui/wallet.tsx
+++ b/packages/browser-wallet/src/ui/wallet.tsx
@@ -17,7 +17,7 @@ interface Props {
   workflow?: Interpreter<any, any, any>;
   // TODO: generalize to all rich objectives
   objective?: DirectFunder.OpenChannelObjective;
-  onObjectiveEvent(event: DirectFunder.OpenChannelEvent): void;
+  triggerObjectiveEvent(event: DirectFunder.OpenChannelEvent): void;
 }
 
 export const Wallet = (props: Props) => {
@@ -43,7 +43,7 @@ export const Wallet = (props: Props) => {
     );
   } else if (props.objective) {
     return (
-      <ObjectiveContext.Provider value={props.onObjectiveEvent}>
+      <ObjectiveContext.Provider value={props.triggerObjectiveEvent}>
         <Layout>
           <Objective objective={props.objective} />
         </Layout>

--- a/packages/browser-wallet/src/ui/wallet.tsx
+++ b/packages/browser-wallet/src/ui/wallet.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Interpreter} from 'xstate';
 import {useService} from '@xstate/react';
+import {DirectFunder} from '@statechannels/wallet-core';
 
 import {WindowContext} from './window-context';
 import './wallet.scss';
@@ -9,27 +10,45 @@ import {EnableEthereum} from './workflows/enable-ethereum-workflow';
 import {Layout} from './layout';
 import {ApproveBudgetAndFund} from './workflows/approve-budget-and-fund-workflow';
 import {CloseLedgerAndWithdraw} from './workflows/close-ledger-and-withdraw';
+import {Objective} from './objective/objective';
+import {ObjectiveContext} from './objective/objective-context';
 
 interface Props {
-  workflow: Interpreter<any, any, any>;
+  onObjectiveEvent(event: DirectFunder.OpenChannelEvent): void;
+  workflow?: Interpreter<any, any, any>;
+  // TODO: generalize to all rich objectives
+  objective?: DirectFunder.OpenChannelObjective;
 }
 
 export const Wallet = (props: Props) => {
-  const [current, send] = useService(props.workflow);
-  return (
-    <WindowContext.Provider value={window}>
+  if (props.workflow) {
+    const [current, send] = useService(props.workflow);
+    return (
+      <WindowContext.Provider value={window}>
+        <Layout>
+          {props.workflow.id === 'application-workflow' && (
+            <ApplicationWorkflow current={current} />
+          )}
+          {props.workflow.id === 'enable-ethereum' && (
+            <EnableEthereum current={current} send={send} />
+          )}
+          {props.workflow.id === 'approve-budget-and-fund' && (
+            <ApproveBudgetAndFund service={props.workflow} />
+          )}
+          {props.workflow.id === 'close-and-withdraw' && (
+            <CloseLedgerAndWithdraw service={props.workflow} />
+          )}
+        </Layout>
+      </WindowContext.Provider>
+    );
+  }
+  if (props.objective) {
+    <ObjectiveContext.Provider value={props.onObjectiveEvent}>
       <Layout>
-        {props.workflow.id === 'application-workflow' && <ApplicationWorkflow current={current} />}
-        {props.workflow.id === 'enable-ethereum' && (
-          <EnableEthereum current={current} send={send} />
-        )}
-        {props.workflow.id === 'approve-budget-and-fund' && (
-          <ApproveBudgetAndFund service={props.workflow} />
-        )}
-        {props.workflow.id === 'close-and-withdraw' && (
-          <CloseLedgerAndWithdraw service={props.workflow} />
-        )}
+        <Objective objective={props.objective} />
       </Layout>
-    </WindowContext.Provider>
-  );
+      ;
+    </ObjectiveContext.Provider>;
+  }
+  throw new Error('A wallet renders an objective or a workflow. Neither has been supplied.');
 };

--- a/packages/browser-wallet/src/ui/wallet.tsx
+++ b/packages/browser-wallet/src/ui/wallet.tsx
@@ -4,11 +4,11 @@ import {useService} from '@xstate/react';
 
 import {WindowContext} from './window-context';
 import './wallet.scss';
-import {ApplicationWorkflow} from './application-workflow';
-import {EnableEthereum} from './enable-ethereum-workflow';
+import {ApplicationWorkflow} from './workflows/application-workflow';
+import {EnableEthereum} from './workflows/enable-ethereum-workflow';
 import {Layout} from './layout';
-import {ApproveBudgetAndFund} from './approve-budget-and-fund-workflow';
-import {CloseLedgerAndWithdraw} from './close-ledger-and-withdraw';
+import {ApproveBudgetAndFund} from './workflows/approve-budget-and-fund-workflow';
+import {CloseLedgerAndWithdraw} from './workflows/close-ledger-and-withdraw';
 
 interface Props {
   workflow: Interpreter<any, any, any>;

--- a/packages/browser-wallet/src/ui/workflows/application-workflow.tsx
+++ b/packages/browser-wallet/src/ui/workflows/application-workflow.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import './wallet.scss';
+import '../wallet.scss';
 import {Flex, Heading, Progress} from 'rimble-ui';
 
-import {Application} from '../workflows';
-
-import {ChannelId} from './channel-id';
+import {Application} from '../../workflows';
+import {ChannelId} from '../channel-id';
 import {
   isConfirmCreateChannel,
   getConfirmCreateChannelService,
@@ -13,9 +12,10 @@ import {
   isApplicationOpening,
   getApplicationStateValue,
   isApplicationChallenging
-} from './selectors';
-import {ChallengeChannel} from './challenge-channel-workflow';
+} from '../selectors';
+
 import {ConfirmCreateChannel} from './confirm-create-channel-workflow';
+import {ChallengeChannel} from './challenge-channel-workflow';
 
 interface Props {
   current: Application.WorkflowState;

--- a/packages/browser-wallet/src/ui/workflows/approve-budget-and-fund-workflow.tsx
+++ b/packages/browser-wallet/src/ui/workflows/approve-budget-and-fund-workflow.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import './wallet.scss';
+import '../wallet.scss';
 import {useService} from '@xstate/react';
 import {
   Button,
@@ -15,11 +15,10 @@ import {
 import {BN} from '@statechannels/wallet-core';
 import {utils} from 'ethers';
 
-import {ApproveBudgetAndFundService} from '../workflows/approve-budget-and-fund';
-import {track} from '../segment-analytics';
-import {ETH_ASSET_HOLDER_ADDRESS, TARGET_NETWORK, FAUCET_LINK} from '../config';
-
-import {getAmountsFromBudget} from './selectors';
+import {ApproveBudgetAndFundService} from '../../workflows/approve-budget-and-fund';
+import {track} from '../../segment-analytics';
+import {ETH_ASSET_HOLDER_ADDRESS, TARGET_NETWORK, FAUCET_LINK} from '../../config';
+import {getAmountsFromBudget} from '../selectors';
 interface Props {
   service: ApproveBudgetAndFundService;
 }

--- a/packages/browser-wallet/src/ui/workflows/challenge-channel-workflow.tsx
+++ b/packages/browser-wallet/src/ui/workflows/challenge-channel-workflow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Interpreter} from 'xstate';
 
-import './wallet.scss';
+import '../wallet.scss';
 
 interface Props {
   service: Interpreter<any>;

--- a/packages/browser-wallet/src/ui/workflows/close-ledger-and-withdraw.tsx
+++ b/packages/browser-wallet/src/ui/workflows/close-ledger-and-withdraw.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import './wallet.scss';
+import '../wallet.scss';
 import {useService} from '@xstate/react';
 import {utils} from 'ethers';
 import {Button, Heading, Flex, Text as RimbleText, Link, Loader} from 'rimble-ui';
 import {DomainBudget, BN} from '@statechannels/wallet-core';
 
-import {track} from '../segment-analytics';
-import {CloseLedgerAndWithdrawService} from '../workflows/close-ledger-and-withdraw';
-import {TARGET_NETWORK} from '../config';
-
-import {getAmountsFromBudget} from './selectors';
+import {track} from '../../segment-analytics';
+import {CloseLedgerAndWithdrawService} from '../../workflows/close-ledger-and-withdraw';
+import {TARGET_NETWORK} from '../../config';
+import {getAmountsFromBudget} from '../selectors';
 
 interface Props {
   service: CloseLedgerAndWithdrawService;

--- a/packages/browser-wallet/src/ui/workflows/confirm-create-channel-workflow.tsx
+++ b/packages/browser-wallet/src/ui/workflows/confirm-create-channel-workflow.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import './wallet.scss';
+import '../wallet.scss';
 import {Button, Flex, Text as RimbleText} from 'rimble-ui';
 import {useService} from '@xstate/react';
 import {Interpreter} from 'xstate';
 
-import {track} from '../segment-analytics';
+import {track} from '../../segment-analytics';
 
 interface Props {
   service: Interpreter<any>;

--- a/packages/browser-wallet/src/ui/workflows/enable-ethereum-workflow.tsx
+++ b/packages/browser-wallet/src/ui/workflows/enable-ethereum-workflow.tsx
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react';
 import {Sender} from 'xstate';
-import './wallet.scss';
+import '../wallet.scss';
 import {
   Button,
   Box,
@@ -16,11 +16,10 @@ import ConnectionBanner from '@rimble/connection-banner';
 // eslint-disable-next-line import/no-unresolved
 import RimbleUtils from '@rimble/utils';
 
-import {WorkflowState} from '../workflows/ethereum-enable';
-import {CHAIN_NETWORK_ID} from '../config';
-import {track} from '../segment-analytics';
-
-import {WindowContext} from './window-context';
+import {CHAIN_NETWORK_ID} from '../../config';
+import {track} from '../../segment-analytics';
+import {WorkflowState} from '../../workflows/ethereum-enable';
+import {WindowContext} from '../window-context';
 
 interface Props {
   current: WorkflowState;

--- a/packages/interop-tests/tsconfig.json
+++ b/packages/interop-tests/tsconfig.json
@@ -13,7 +13,7 @@
       "path": "../server-wallet"
     },
     {
-      "path": "../xstate-wallet"
+      "path": "../browser-wallet"
     }
   ],
   "include": ["src", "jest"],

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -70,7 +70,7 @@ export function initialize(
     channelId: calculateChannelId(openingState),
     myIndex,
     openingState: _.omit(openingState, 'signatures'),
-    status: WaitingFor.theirPreFundSetup,
+    status: approved ? WaitingFor.theirPreFundSetup : WaitingFor.approval,
     preFundSetup: {hash: hashState(setupState(openingState, Steps.preFundSetup)), signatures},
     funding: {amount: BN.from(0), finalized: true},
     fundingRequest: undefined,

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -1,7 +1,7 @@
 import {ethers} from 'ethers';
 import * as _ from 'lodash';
-import {DirectFunder} from 'protocols';
 
+import {DirectFunder} from '../protocols';
 import {unreachable} from '../utils';
 import {addHash, calculateChannelId} from '../state-utils';
 import {BN} from '../bignumber';

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -94,7 +94,7 @@ const initial: OpenChannelObjective = {
   approved: false,
   channelId,
   openingState,
-  status: WaitingFor.theirPreFundSetup,
+  status: WaitingFor.approval,
   myIndex: 0,
   preFundSetup: richPreFS.signedBy(),
   funding: {amount: BN.from(0), finalized: true},


### PR DESCRIPTION
Browser wallet UI can be:
- xstate machine based. This is the established UI methodology in the browser wallet.
- objective based. This is added in this PR.

For objective based UI, the following are the ways that the `ChannelWallet` communicates with the UI and the UI communicates with the `ChannelWallet`:
- On initialization, the `ChannelWallet` is supplied an `updateUI` function that the `ChannelWallet` must invoke whenever the `ChannelWallet` needs the UI to update.
- The UI is supplied a function that can be invoked with an Objective event argument. This function is wired up on `ChannelWallet` initialization.

This PR has been tested with:
- existing unit and interop tests.
- storybook to display new UI.
- manual calls to browser wallet APIs.

https://user-images.githubusercontent.com/1062379/115122417-1ce9b380-9f75-11eb-84bc-9510dd34082a.mov

Fixes https://github.com/statechannels/statechannels/issues/3497.

