### PR TITLE
deploy nitro contracts to arbitrum testnet

### DIFF
--- a/packages/nitro-protocol/addresses.json
+++ b/packages/nitro-protocol/addresses.json
@@ -4,11 +4,11 @@
       "name": "mainnet",
       "chainId": "1",
       "contracts": {
-        "NitroAdjudicator": {
-          "address": "0x7917b6f2C5deC4021Ed5D0ff3e5bb27A69B2eaCf"
-        },
         "ETHAssetHolder": {
           "address": "0x8504FcA6e1e73947850D66D032435AC931892116"
+        },
+        "NitroAdjudicator": {
+          "address": "0x7917b6f2C5deC4021Ed5D0ff3e5bb27A69B2eaCf"
         }
       }
     }
@@ -23,6 +23,20 @@
         },
         "NitroAdjudicator": {
           "address": "0x7917b6f2C5deC4021Ed5D0ff3e5bb27A69B2eaCf"
+        }
+      }
+    }
+  },
+  "212984383488152": {
+    "arbitrum_testnet_v4": {
+      "name": "arbitrum_testnet_v4",
+      "chainId": "212984383488152",
+      "contracts": {
+        "NitroAdjudicator": {
+          "address": "0x35d4c6CE4BB623b9B9C05E3DCfA688D80b616858"
+        },
+        "ETHAssetHolder": {
+          "address": "0xFf6C92ceA1eFB9542498dC74cb591F8CF431d202"
         }
       }
     }

--- a/packages/nitro-protocol/hardhat.config.ts
+++ b/packages/nitro-protocol/hardhat.config.ts
@@ -2,6 +2,7 @@ import 'hardhat-watcher';
 import 'hardhat-deploy';
 import '@nomiclabs/hardhat-etherscan';
 import {HardhatUserConfig} from 'hardhat/config';
+import {getPrivateKeyWithEth} from '@statechannels/devtools';
 
 const infuraToken = process.env.INFURA_TOKEN;
 const rinkebyDeployerPK = process.env.RINKEBY_DEPLOYER_PK;
@@ -57,6 +58,11 @@ const config: HardhatUserConfig = {
       url: infuraToken ? 'https://mainnet.infura.io/v3/' + infuraToken : '',
       accounts: mainnetDeployerPK ? [mainnetDeployerPK] : undefined,
       chainId: 1,
+    },
+    arbitrum_testnet_v4: {
+      url: 'https://kovan4.arbitrum.io/rpc',
+      accounts: [getPrivateKeyWithEth()], // just use a dummy account from devtools
+      chainId: 212984383488152,
     },
   },
   etherscan: {

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -82,6 +82,7 @@
     "contract:compile:watch": "yarn hardhat watch compilation",
     "contract:deploy-rinkeby": "yarn hardhat deploy --network rinkeby --export-all addresses.json && node ./scripts/postdeploy.js",
     "contract:deploy-mainnet": "yarn hardhat deploy --network mainnet --export-all addresses.json && node ./scripts/postdeploy.js",
+    "contract:deploy-arbitrum-testnet": "yarn hardhat deploy --network arbitrum_testnet_v4 --export-all addresses.json && node ./scripts/postdeploy.js",
     "docgen": "solidoc",
     "generate-api": "yarn docgen",
     "lint:check": "eslint \"*/**/*.ts\" --cache && yarn solhint:check",


### PR DESCRIPTION
This is mostly just exploration of how easy it might be to deploy our stuff to arbitrum.

Answer: very easy.


See this transaction for example https://explorer.arbitrum.io/#/tx/0xc97de88cecc8b162a994577768cb07cf36496809f05cc2d00a1ead396748f96f 

I don't believe it is straightforward for us to run our test suite against something other than a local ganache instance... so I didn't do that yet. 


