### PR TITLE
[browser-wallet] refactor: collapse approve objective into crank objective function

### DIFF
--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -286,17 +286,14 @@ export class ChannelWallet {
         }
       }
       this.updateUI?.({objective: richObjectives[channelId]});
+
+      // TODO: we might want to first crank the objective, gather all states that need to be sent, and then send
+      // both the objective and the new states
+      if (event.type === 'Approval') this.sendObjective(richObjectives[channelId]);
     }
   }
 
-  public async approveRichObjective(channelId: string): Promise<void> {
-    const richObjective = this.store.richObjectives[channelId];
-    if (!richObjective) {
-      throw new Error(`Rich objective must exist for channelId ${channelId}`);
-    }
-
-    await this.crankRichObjectives({type: 'Approval'});
-
+  private async sendObjective(richObjective: DirectFunder.OpenChannelObjective) {
     // TODO: need a better way to figure out when to broadcast an objective
     //        since we don't know here if we are the creator of the objective or received the objective from elsewhere
     const amCreator = richObjective.myIndex === 0;
@@ -305,16 +302,19 @@ export class ChannelWallet {
       const objectiveToSend: OpenChannel = {
         type: 'OpenChannel',
         participants: richObjective.openingState.participants,
-        data: {targetChannelId: channelId, fundingStrategy: 'Direct'}
+        data: {targetChannelId: richObjective.channelId, fundingStrategy: 'Direct'}
       };
 
-      // TODO: we might want to first crank the objective, gather all states that need to be sent, and then send
-      // both the objective and the new states
       await this.messagingService.sendMessageNotification({
         walletVersion: WALLET_VERSION,
         objectives: [objectiveToSend]
       });
     }
+  }
+
+  public async approveRichObjective(_channelId: string): Promise<void> {
+    // TODO: it seems that an objective event should have an objective id or a channel id associated with the event
+    this.crankRichObjectives({type: 'Approval'});
   }
 
   public getRichObjectives() {


### PR DESCRIPTION
🥞 stacked on https://github.com/statechannels/statechannels/pull/3505.

As of https://github.com/statechannels/statechannels/pull/3505, `crankRichObjectives` is a generic handler for any objective event. `approveRichObjectives` function contains custom logic for just the Approve event.  The custom logic sends the objective to other participants.

This approve event logic will not get triggered for events arriving directly to `crankRichObjectives`.

