### PR TITLE
[browser-wallet] Introduce RichObjective and RichObjectiveEvent types

### DIFF
--- a/packages/browser-wallet/src/channel-wallet-types.ts
+++ b/packages/browser-wallet/src/channel-wallet-types.ts
@@ -1,8 +1,13 @@
-import {DirectFunder, SharedObjective, SignedState} from '@statechannels/wallet-core';
+import {
+  RichObjective,
+  RichObjectiveEvent,
+  SharedObjective,
+  SignedState
+} from '@statechannels/wallet-core';
 import {Interpreter} from 'xstate';
 
 export type AnyInterpreter = Interpreter<any, any, any>;
-export type TriggerObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => void;
+export type TriggerObjectiveEvent = (event: RichObjectiveEvent) => void;
 /**
  * The channel wallet is not able to update UI. The channel wallet is supplied a callback to invoke
  * when UI should be updated.
@@ -10,10 +15,7 @@ export type TriggerObjectiveEvent = (event: DirectFunder.OpenChannelEvent) => vo
  * UI needs a way to communicate objective events to the channel wallet. UI invokes triggerObjectiveEvent
  * when UI triggers an objective event
  */
-export type UpdateUI = (update: {
-  service?: AnyInterpreter;
-  objective?: DirectFunder.OpenChannelObjective;
-}) => void;
+export type UpdateUI = (update: {service?: AnyInterpreter; objective?: RichObjective}) => void;
 
 export interface Workflow {
   id: string;

--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -250,7 +250,7 @@ export class ChannelWallet {
     // TODO: this should invoke a store method
     const richObjective = this.store.richObjectives[event.channelId];
     if (!richObjective) {
-      throw new Error(`Unable to map event ${JSON.stringify(event)} to an objectie`);
+      throw new Error(`Unable to map event ${JSON.stringify(event)} to an objective`);
     }
     const channelId = richObjective.channelId;
     const result = DirectFunder.openChannelCranker(

--- a/packages/browser-wallet/src/index.ts
+++ b/packages/browser-wallet/src/index.ts
@@ -81,7 +81,7 @@ function setTriggerObjectiveEvent(callback: TriggerObjectiveEvent): void {
 
 function renderUI(update: {service?: AnyInterpreter; objective?: RichObjective}) {
   if (!triggerObjectiveEvent) {
-    throw new Error('onObjectiveEventCallback must be defined');
+    throw new Error('triggerObjectiveEvent must be defined');
   }
 
   if (document.getElementById('root')) {

--- a/packages/browser-wallet/src/index.ts
+++ b/packages/browser-wallet/src/index.ts
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import {isStateChannelsRequest, WalletReady} from '@statechannels/client-api-schema';
 import {AnyInterpreter} from 'xstate';
 import React from 'react';
-import {DirectFunder} from '@statechannels/wallet-core';
+import {RichObjective} from '@statechannels/wallet-core';
 import _ from 'lodash';
 
 import {TriggerObjectiveEvent} from './channel-wallet-types';
@@ -79,12 +79,9 @@ function setTriggerObjectiveEvent(callback: TriggerObjectiveEvent): void {
   ReactDOM.render(App({wallet: channelWallet}), document.getElementById('root'));
 })();
 
-function renderUI(update: {
-  service?: AnyInterpreter;
-  objective?: DirectFunder.OpenChannelObjective;
-}) {
+function renderUI(update: {service?: AnyInterpreter; objective?: RichObjective}) {
   if (!triggerObjectiveEvent) {
-    throw new Error('triggerObjectiveEventCallback must be defined');
+    throw new Error('onObjectiveEventCallback must be defined');
   }
 
   if (document.getElementById('root')) {

--- a/packages/browser-wallet/src/store/store.ts
+++ b/packages/browser-wallet/src/store/store.ts
@@ -22,7 +22,9 @@ import {
   BN,
   Uint256,
   makeAddress,
-  DirectFunder
+  DirectFunder,
+  RichObjective,
+  RichObjectiveEvent
 } from '@statechannels/wallet-core';
 import {Dictionary} from 'lodash';
 
@@ -40,10 +42,10 @@ import {Errors, DBBackend, ObjectStores} from '.';
 interface InternalEvents {
   channelUpdated: [ChannelStoreEntry];
   newObjective: [Objective];
-  newRichObjective: DirectFunder.OpenChannelObjective;
+  newRichObjective: RichObjective;
   addToOutbox: [Payload];
   lockUpdated: [ChannelLock];
-  crankRichObjectives: DirectFunder.OpenChannelEvent;
+  crankRichObjectives: RichObjectiveEvent;
 }
 export type ChannelLock = {
   channelId: string;
@@ -71,7 +73,7 @@ export class Store {
    *      - Store this information in permanent storage instead of memory.
    *      - Create getters and setters.
    */
-  public richObjectives: Dictionary<DirectFunder.OpenChannelObjective> = {};
+  public richObjectives: Dictionary<RichObjective> = {};
 
   /**
    *  END of wallet 2.0
@@ -150,11 +152,8 @@ export class Store {
     return merge(newObjectives, currentObjectives);
   }
 
-  get richObjectiveFeed(): Observable<DirectFunder.OpenChannelObjective> {
-    const newObjectives = fromEvent<DirectFunder.OpenChannelObjective>(
-      this._eventEmitter,
-      'newRichObjective'
-    );
+  get richObjectiveFeed(): Observable<RichObjective> {
+    const newObjectives = fromEvent<RichObjective>(this._eventEmitter, 'newRichObjective');
     const currentObjectives = of(Object.values(this.richObjectives)).pipe(concatAll());
 
     return merge(newObjectives, currentObjectives);
@@ -164,7 +163,7 @@ export class Store {
     return fromEvent(this._eventEmitter, 'addToOutbox');
   }
 
-  get crankRichObjectivesFeed(): Observable<DirectFunder.OpenChannelEvent> {
+  get crankRichObjectivesFeed(): Observable<RichObjectiveEvent> {
     return fromEvent(this._eventEmitter, 'crankRichObjectives');
   }
 

--- a/packages/browser-wallet/src/store/store.ts
+++ b/packages/browser-wallet/src/store/store.ts
@@ -584,11 +584,13 @@ export class Store {
     if (signedStates?.length) {
       // TODO: account for the case a message containing states for many channels
       const channelId = calculateChannelId(signedStates[0]);
-      this._eventEmitter.emit('crankRichObjectives', {
-        type: 'StatesReceived',
-        states: signedStates,
-        channelId
-      });
+      if (this.richObjectives[channelId]) {
+        this._eventEmitter.emit('crankRichObjectives', {
+          type: 'StatesReceived',
+          states: signedStates,
+          channelId
+        });
+      }
     }
   }
 

--- a/packages/browser-wallet/src/store/store.ts
+++ b/packages/browser-wallet/src/store/store.ts
@@ -581,10 +581,13 @@ export class Store {
         objectives.map(_.bind(this.createAndStoreRichObjectiveFromObjective, this))
       );
 
-    if (signedStates) {
+    if (signedStates?.length) {
+      // TODO: account for the case a message containing states for many channels
+      const channelId = calculateChannelId(signedStates[0]);
       this._eventEmitter.emit('crankRichObjectives', {
         type: 'StatesReceived',
-        states: signedStates
+        states: signedStates,
+        channelId
       });
     }
   }
@@ -644,7 +647,8 @@ export class Store {
       this._eventEmitter.emit('crankRichObjectives', {
         type: 'FundingUpdated',
         amount: chainInfo.amount,
-        finalized: true
+        finalized: true,
+        channelId
       })
     );
   }

--- a/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
+++ b/packages/browser-wallet/src/ui/objective/confirm-create-channel-workflow.tsx
@@ -4,7 +4,11 @@ import {Button, Flex, Text as RimbleText} from 'rimble-ui';
 
 import {ObjectiveContext} from './objective-context';
 
-export const ConfirmCreateChannel = () => {
+interface Props {
+  channelId: string;
+}
+
+export const ConfirmCreateChannel = ({channelId}: Props) => {
   const triggerObjectiveEvent = useContext(ObjectiveContext);
 
   return (
@@ -12,11 +16,13 @@ export const ConfirmCreateChannel = () => {
       <RimbleText fontSize={2} pb={2}>
         Do you wish to create a channel?
       </RimbleText>
-      <Button id="yes" onClick={() => triggerObjectiveEvent({type: 'Approval'})}>
+      <Button id="yes" onClick={() => triggerObjectiveEvent({type: 'Approval', channelId})}>
         Yes
       </Button>
       {/** TODO: add objective rejection */}
-      <Button.Text onClick={() => triggerObjectiveEvent({type: 'Approval'})}>No</Button.Text>
+      <Button.Text onClick={() => triggerObjectiveEvent({type: 'Approval', channelId})}>
+        No
+      </Button.Text>
     </Flex>
   );
 };

--- a/packages/browser-wallet/src/ui/objective/objective-context.tsx
+++ b/packages/browser-wallet/src/ui/objective/objective-context.tsx
@@ -1,6 +1,6 @@
-import {DirectFunder} from '@statechannels/wallet-core';
+import {RichObjectiveEvent} from '@statechannels/wallet-core';
 import React from 'react';
 
 export const ObjectiveContext = React.createContext<
-  (triggerObjectiveEvent: DirectFunder.OpenChannelEvent) => void
+  (triggerObjectiveEvent: RichObjectiveEvent) => void
 >(() => {});

--- a/packages/browser-wallet/src/ui/objective/objective.tsx
+++ b/packages/browser-wallet/src/ui/objective/objective.tsx
@@ -21,7 +21,9 @@ export const Objective = (props: Props) => {
       }}
       className="application-workflow-prompt"
     >
-      {objective.status === 'DirectFunder.approval' && <ConfirmCreateChannel />}
+      {objective.status === 'DirectFunder.approval' && (
+        <ConfirmCreateChannel channelId={objective.channelId} />
+      )}
       {/** TODO: map status to UI for the user */}
       {objective.status !== 'DirectFunder.approval' && (
         <RimbleText fontSize={2} pb={2}>

--- a/packages/browser-wallet/src/ui/wallet.tsx
+++ b/packages/browser-wallet/src/ui/wallet.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Interpreter} from 'xstate';
 import {useService} from '@xstate/react';
-import {DirectFunder} from '@statechannels/wallet-core';
+import {RichObjective, RichObjectiveEvent} from '@statechannels/wallet-core';
 
 import {WindowContext} from './window-context';
 import './wallet.scss';
@@ -16,8 +16,8 @@ import {ObjectiveContext} from './objective/objective-context';
 interface Props {
   workflow?: Interpreter<any, any, any>;
   // TODO: generalize to all rich objectives
-  objective?: DirectFunder.OpenChannelObjective;
-  triggerObjectiveEvent(event: DirectFunder.OpenChannelEvent): void;
+  objective?: RichObjective;
+  triggerObjectiveEvent(event: RichObjectiveEvent): void;
 }
 
 export const Wallet = (props: Props) => {

--- a/packages/browser-wallet/src/ui/wallet.tsx
+++ b/packages/browser-wallet/src/ui/wallet.tsx
@@ -15,7 +15,6 @@ import {ObjectiveContext} from './objective/objective-context';
 
 interface Props {
   workflow?: Interpreter<any, any, any>;
-  // TODO: generalize to all rich objectives
   objective?: RichObjective;
   triggerObjectiveEvent(event: RichObjectiveEvent): void;
 }

--- a/packages/wallet-core/src/index.ts
+++ b/packages/wallet-core/src/index.ts
@@ -9,7 +9,7 @@ export * from './serde/app-messages/serialize';
 export * from './serde/wire-format/deserialize';
 export * from './serde/wire-format/serialize';
 
-export {DirectFunder} from './protocols';
+export * from './protocols';
 
 // Test utilities
 export * from './tests/fixture';

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -5,16 +5,19 @@ import {BN} from '../bignumber';
 import {calculateChannelId, hashState, signState} from '../state-utils';
 import {Address, SignatureEntry, SignedState, State, Uint256} from '../types';
 
+import {BaseObjective, BaseObjectiveEvent} from './objective';
+
 // TODO: This ought to be configurable
 export const MAX_WAITING_TIME = 5_000;
 
-export type OpenChannelEvent = {now?: number} & (
-  | {type: 'Crank'} // Allows you to crank it every now and then to see if it's timed out.
-  | {type: 'StatesReceived'; states: SignedState[]}
-  | {type: 'FundingUpdated'; amount: Uint256; finalized: boolean}
-  | {type: 'DepositSubmitted'; tx: string; attempt: number; submittedAt: number}
-  | {type: 'Approval'}
-);
+export type OpenChannelEvent = BaseObjectiveEvent &
+  (
+    | {type: 'Crank'} // Allows you to crank it every now and then to see if it's timed out.
+    | {type: 'StatesReceived'; states: SignedState[]}
+    | {type: 'FundingUpdated'; amount: Uint256; finalized: boolean}
+    | {type: 'DepositSubmitted'; tx: string; attempt: number; submittedAt: number}
+    | {type: 'Approval'}
+  );
 
 export type SignedStateHash = {hash: string; signatures: SignatureEntry[]};
 
@@ -31,7 +34,7 @@ const enum Steps {
   postFundSetup = 'postFundSetup'
 }
 
-export type OpenChannelObjective = {
+export type OpenChannelObjective = BaseObjective & {
   status: WaitingFor | 'success' | 'error';
   approved: boolean;
   channelId: string;
@@ -66,6 +69,7 @@ export function initialize(
     'signatures' in openingState ? mergeSignatures([], openingState.signatures) : [];
 
   return {
+    type: 'OpenChannel',
     approved,
     channelId: calculateChannelId(openingState),
     myIndex,

--- a/packages/wallet-core/src/protocols/index.ts
+++ b/packages/wallet-core/src/protocols/index.ts
@@ -1,1 +1,6 @@
-export * as DirectFunder from './direct-funder';
+import * as DirectFunder from './direct-funder';
+
+type Objective = DirectFunder.OpenChannelObjective;
+type ObjectiveEvent = DirectFunder.OpenChannelEvent;
+
+export {DirectFunder, Objective as RichObjective, ObjectiveEvent as RichObjectiveEvent};

--- a/packages/wallet-core/src/protocols/objective.ts
+++ b/packages/wallet-core/src/protocols/objective.ts
@@ -1,0 +1,3 @@
+export type BaseObjective = {type: 'OpenChannel'};
+// Every objective will have one channel as the target channel
+export type BaseObjectiveEvent = {channelId: string; now?: number};


### PR DESCRIPTION
🥞 stacked on https://github.com/statechannels/statechannels/pull/3509

Browser wallet is the only consumer of rich objectives at the moment. Browser wallet hardcoded the following assumptions:
- Only one rich objective is expected in the store. As a result, the browser wallet assumes that an objective event is intended for the stored objective.
- Only the DirectFunder open channel objective is considered.

This PR introduces the `RichObjective` and `RichObjectiveEvent` abstractions to help the browser wallet remove the above assumptions. At the moment, a RichObjective is always DirectFunder.OpenChannelObjective and a RichObjectiveEvent is always a DirectFunder.OpenChannelEvent