### PR TITLE
Fix EnsureObjective

### DIFF
--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -179,13 +179,6 @@ export const teardownPeerSetup = async (peerSetup: PeerSetup): Promise<void> => 
     await Promise.all([peerEngines.a.destroy(), peerEngines.b.destroy()]);
     await Promise.all([DBAdmin.dropDatabase(aEngineConfig), DBAdmin.dropDatabase(bEngineConfig)]);
   } catch (error) {
-    if (error.message === 'aborted') {
-      // When we destroy the engines there still may open knex connections due to our use of delay in the TestMessageService
-      // These throw an abort error that can make the test output messy
-      // We just swallow the error here to avoid it
-      logger.trace({error}, 'Ignoring knex aborted error');
-      return;
-    }
     logger.error(error, 'peersTeardown failed');
     throw error;
   }

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -49,6 +49,17 @@ describe('EnsureObjectives', () => {
       );
 
       await expect(response).toBeObjectiveDoneType('Success');
+
+      const {channelResults: aChannels} = await peerEngines.a.getChannels();
+      const {channelResults: bChannels} = await peerEngines.b.getChannels();
+
+      for (const a of aChannels) {
+        expect(a.status).toEqual('running');
+      }
+
+      for (const b of bChannels) {
+        expect(b.status).toEqual('running');
+      }
     }
   );
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -50,15 +50,10 @@ describe('EnsureObjectives', () => {
 
       await expect(response).toBeObjectiveDoneType('Success');
 
+      // Ensure that all of A's channels are running
       const {channelResults: aChannels} = await peerEngines.a.getChannels();
-      const {channelResults: bChannels} = await peerEngines.b.getChannels();
-
       for (const a of aChannels) {
         expect(a.status).toEqual('running');
-      }
-
-      for (const b of bChannels) {
-        expect(b.status).toEqual('running');
       }
     }
   );

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -48,8 +48,8 @@ describe('jumpstartObjectives', () => {
 
     await expect(createResponse).toBeObjectiveDoneType('EnsureObjectiveFailed');
 
+    messageService.setLatencyOptions({dropRate: 0});
     const jumpstartResponse = await wallet.jumpStartObjectives();
-
     await expect(jumpstartResponse).toBeObjectiveDoneType('Success');
   });
 

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -111,7 +111,7 @@ export class Wallet {
       let isComplete = false;
 
       const onObjectiveSucceeded = (o: WalletObjective) => {
-        if (o.objectiveId === o.objectiveId) {
+        if (objective.objectiveId === o.objectiveId) {
           isComplete = true;
           this._engine.removeListener('objectiveSucceeded', onObjectiveSucceeded);
         }


### PR DESCRIPTION
Fixes #3483. Fixes #3510.

# Description
This is a collection of fixes that are required to get `EnsureObjective` working properly.

1. A [fix](d8d86b6) for the objectiveId check on `objectiveSuceeded` that would always return true.
2. A [fix](6adf909) to the custom matcher so it prints out error results properly.
3. A small [enhancement](067b88c) to the ensure objective tests that checks the channel results.
4.  Some other minor fixes.

With these changes, we no longer see the `knex` errors from #3483 as we are actually waiting to get back an actual result from the `wallet`. Previously objective succeeded would be fired even if the objective had not suceeded.


## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
