### PR TITLE
[browser-wallet] Guarantee type safety for rich objective feeds

### DIFF
--- a/packages/browser-wallet/src/channel-wallet.ts
+++ b/packages/browser-wallet/src/channel-wallet.ts
@@ -72,7 +72,7 @@ export class ChannelWallet {
       this.messagingService.sendMessageNotification(m);
     });
 
-    store.crankRichObjectivesFeed.subscribe(_.bind(this.crankRichObjective, this));
+    store.crankRichObjectiveFeed.subscribe(_.bind(this.crankRichObjective, this));
 
     // Whenever an OpenChannel objective is received
     // we alert the user that there is a new channel

--- a/packages/browser-wallet/src/store/store.ts
+++ b/packages/browser-wallet/src/store/store.ts
@@ -74,7 +74,7 @@ export class Store {
   public richObjectives: Dictionary<RichObjective> = {};
 
   public richObjectiveFeed = new Subject<RichObjective>();
-  public crankRichObjectivesFeed = new Subject<RichObjectiveEvent>();
+  public crankRichObjectiveFeed = new Subject<RichObjectiveEvent>();
 
   /**
    *  END of wallet 2.0
@@ -575,7 +575,7 @@ export class Store {
       // TODO: account for the case a message containing states for many channels
       const channelId = calculateChannelId(signedStates[0]);
       if (this.richObjectives[channelId]) {
-        this.crankRichObjectivesFeed.next({
+        this.crankRichObjectiveFeed.next({
           type: 'StatesReceived',
           states: signedStates,
           channelId
@@ -636,7 +636,7 @@ export class Store {
 
   private registerChannelWithChain(channelId): void {
     this.chain.chainUpdatedFeed(channelId).subscribe(chainInfo =>
-      this.crankRichObjectivesFeed.next({
+      this.crankRichObjectiveFeed.next({
         type: 'FundingUpdated',
         amount: chainInfo.amount,
         finalized: true,


### PR DESCRIPTION
The browser wallet store defines feeds. The feeds are event emitters wrapped in an observable. This pattern does NOT provide type safety. The store can emit an event where the event name does not match the event data type.

With rxjs subjects, we guarantee type safety as well as reduce a level of indirection. Only rich objective feeds have been refactored. Legacy feeds from wallet
v1 remain as is.