### PR TITLE
[interop-test] Add a more reliable postfund check

### DIFF
--- a/packages/interop-tests/package.json
+++ b/packages/interop-tests/package.json
@@ -7,6 +7,7 @@
     "@statechannels/browser-wallet": "0.7.0",
     "@statechannels/devtools": "0.5.6",
     "@statechannels/server-wallet": "1.24.0",
+    "@statechannels/wire-format": "0.9.1",
     "ethers": "5.0.12",
     "identity-obj-proxy": "^3.0.0",
     "jest": "26.6.3",

--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -141,7 +141,7 @@ function generatePushMessage(messageParams: Message): PushMessageRequest {
 }
 
 // In theory, we should be able to check the channelResult. In practice, the channelResult seems to have an incorrect turn number
-function constainsPostfundState(singleChannelOutput: SingleChannelOutput): boolean {
+function containsPostfundState(singleChannelOutput: SingleChannelOutput): boolean {
   if (!singleChannelOutput.outbox.length) return false;
 
   const signedStates = deserializeMessage(singleChannelOutput.outbox[0].params as WireMessage)
@@ -196,7 +196,7 @@ it('server wallet creates channel + cooperates with browser wallet to fund chann
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const postFundA = await fromEvent<SingleChannelOutput>(serverWallet as any, 'channelUpdated')
-    .pipe(first(constainsPostfundState))
+    .pipe(first(containsPostfundState))
     .toPromise();
 
   serverWallet.on('channelUpdated', e => console.log(JSON.stringify(e)));
@@ -257,7 +257,7 @@ it('browser wallet creates channel + cooperates with server wallet to fund chann
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const postFundA = await fromEvent<SingleChannelOutput>(serverWallet as any, 'channelUpdated')
-    .pipe(first(constainsPostfundState))
+    .pipe(first(containsPostfundState))
     .toPromise();
 
   await browserWallet.pushMessage(serverMessageToBrowserMessage(postFundA), 'dummyDomain');


### PR DESCRIPTION
This PR refactors the brittle logic in the interop test to filter server wallet notifications for a notification that contains the postfund state.

Fixes https://github.com/statechannels/statechannels/issues/3495