### PR TITLE
chore: add no self compare lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'plugin:import/typescript'
   ],
   rules: {
+    'no-self-compare': 'error',
     'import/order': [
       1,
       {

--- a/packages/server-wallet/.eslintrc.js
+++ b/packages/server-wallet/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     'plugin:import/warnings',
   ],
   rules: {
+    'no-self-compare': 'error',
     // It's annoying having to deal with these jest rules
     'jest/no-disabled-tests': 'off',
     'jest/expect-expect': 'off',

--- a/packages/server-wallet/.eslintrc.js
+++ b/packages/server-wallet/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     'plugin:import/warnings',
   ],
   rules: {
-    'no-self-compare': 'error',
     // It's annoying having to deal with these jest rules
     'jest/no-disabled-tests': 'off',
     'jest/expect-expect': 'off',


### PR DESCRIPTION
Enables the no-self compare lint rule to prevent us from shooting ourselves in the feet.