### PR TITLE
Fix pushMessage updating approved objective statuses to pending

### DIFF
--- a/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
@@ -306,7 +306,11 @@ export class TestChannel {
     turnNums.push(turnNum);
 
     // insert the OpenChannel objective
-    const objective = await ObjectiveModel.insert(this.openChannelObjective, true, store.knex);
+    const objective = await ObjectiveModel.insert(
+      this.openChannelObjective,
+      store.knex,
+      'approved'
+    );
 
     // make it a ledger here
     if (this.isLedger) {

--- a/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
@@ -64,7 +64,7 @@ describe('directly funded app', () => {
           role: 'app',
         },
       },
-      false,
+
       w.knex
     );
 
@@ -78,7 +78,7 @@ describe('directly funded app', () => {
           role: 'app',
         },
       },
-      false,
+
       w.knex
     );
 
@@ -132,7 +132,7 @@ describe('directly funded app', () => {
           role: 'app',
         },
       },
-      false,
+
       w.knex
     );
 
@@ -171,7 +171,7 @@ describe('directly funded app', () => {
           role: 'app',
         },
       },
-      false,
+
       w.knex
     );
 
@@ -251,7 +251,7 @@ describe('ledger funded app scenarios', () => {
           role: 'app',
         },
       },
-      false,
+
       w.knex
     );
 

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -27,7 +27,7 @@ import {MultiThreadedEngine, Engine} from '../..';
 const dropNonVariables = (s: SignedState): any =>
   _.pick(s, 'appData', 'outcome', 'isFinal', 'turnNum', 'stateHash', 'signatures');
 
-jest.setTimeout(120_000);
+jest.setTimeout(20_000);
 
 let engine: Engine;
 let multiThreadedEngine: MultiThreadedEngine;

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -14,7 +14,7 @@ import {addHash} from '../../../state-utils';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import {alice as aliceP, bob as bobP, charlie as charlieP} from '../fixtures/participants';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {stateSignedBy} from '../fixtures/states';
+import {stateSignedBy, stateWithHashSignedBy} from '../fixtures/states';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
 import {ObjectiveModel} from '../../../models/objective';
@@ -57,7 +57,10 @@ const five = 5;
 const six = 6;
 
 it('does not set the status of an objective if it already exists', async () => {
-  const {channelId} = await Channel.query(engine.knex).insert(channel());
+  // TODO: We pass in a signed state to avoid https://github.com/statechannels/statechannels/issues/3525
+  const channelToInsert = channel({vars: [stateWithHashSignedBy([alice()])()]});
+
+  const {channelId} = await Channel.query(engine.knex).insert(channelToInsert);
 
   const objective: OpenChannel = {
     type: 'OpenChannel',

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -27,7 +27,7 @@ import {MultiThreadedEngine, Engine} from '../..';
 const dropNonVariables = (s: SignedState): any =>
   _.pick(s, 'appData', 'outcome', 'isFinal', 'turnNum', 'stateHash', 'signatures');
 
-jest.setTimeout(20_000);
+jest.setTimeout(120_000);
 
 let engine: Engine;
 let multiThreadedEngine: MultiThreadedEngine;
@@ -69,7 +69,7 @@ it('does not set the status of an objective if it already exists', async () => {
     },
   };
 
-  const inserted = await ObjectiveModel.insert(objective, true, engine.knex);
+  const inserted = await ObjectiveModel.insert(objective, engine.knex, 'approved');
   //Sanity check: We expect the objective to be approved since we used the preApproved flag
   expect(inserted.status).toBe('approved');
 
@@ -78,9 +78,7 @@ it('does not set the status of an objective if it already exists', async () => {
     signedStates: [],
     objectives: [objective],
   });
-
   const latest = await ObjectiveModel.forId(objectiveId(objective), engine.knex);
-
   // The status should still be approved after we receive the message in a payload
   expect(latest.status).toBe('approved');
 });
@@ -324,8 +322,9 @@ describe('when the application protocol returns an action', () => {
           role: 'app',
         },
       },
-      true,
-      engine.knex
+
+      engine.knex,
+      'approved'
     );
 
     expect(c.latestSignedByMe?.turnNum).toEqual(0);

--- a/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
@@ -38,7 +38,7 @@ describe('SyncObjective', () => {
       .insert(channel({vars: [stateWithHashSignedBy([alice()])()]}))
       .withGraphFetched('signingWallet')
       .withGraphFetched('funding');
-    const objective = await ObjectiveModel.insert(openChannelObjective(), false, testKnex);
+    const objective = await ObjectiveModel.insert(openChannelObjective(), testKnex);
 
     const {channelId} = targetChannel;
 

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -371,8 +371,9 @@ export class SingleThreadedEngine
           participants: [],
           data: {targetChannelId: channelId},
         },
-        true, // preApprove
-        tx
+
+        tx,
+        'approved'
       );
       this.emit('objectiveStarted', objective);
 
@@ -972,8 +973,9 @@ export class SingleThreadedEngine
           participants: [],
           data: {targetChannelId: arg.channelId},
         },
-        true, // preApproved
-        tx
+
+        tx,
+        'approved'
       );
       this.emit('objectiveStarted', objective);
     });

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -322,8 +322,8 @@ export class Store {
       const storedObjectives: WalletObjective[] = [];
       for (const o of deserializedObjectives) {
         if (isSupportedObjective(o)) {
-          const preApprove = o.type === 'CloseChannel'; // Close channel objectives do not need co-operative approval
-          storedObjectives.push(await ObjectiveModel.insert(o, preApprove, tx));
+          const status = o.type === 'CloseChannel' ? 'approved' : undefined; // Close channel objectives do not need co-operative approval
+          storedObjectives.push(await ObjectiveModel.insert(o, tx, status));
         } else this.logger.warn('Unsupported objective received');
       }
 
@@ -625,8 +625,9 @@ export class Store {
 
       const objective = await ObjectiveModel.insert(
         o,
-        true, // preApproved
+
         tx,
+        'approved',
         OpenChannelWaitingFor.theirPreFundSetup
       );
       return {channel: await this.getChannelState(channelId, tx), firstSignedState, objective};

--- a/packages/server-wallet/src/models/__test__/objectives.test.ts
+++ b/packages/server-wallet/src/models/__test__/objectives.test.ts
@@ -28,8 +28,9 @@ describe('Objective > insert', () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
     const inserted = await ObjectiveModel.insert(
       objective,
-      false,
+
       knex,
+      undefined,
       ChannelOpenerWaitingFor.theirPreFundSetup
     );
 
@@ -39,7 +40,7 @@ describe('Objective > insert', () => {
   it('fails to insert / associate an objective when it references a channel that does not exist', async () => {
     // For some reason this does not catch the error :/
     await expect(
-      ObjectiveModel.insert(objective, false, knex, ChannelOpenerWaitingFor.theirPreFundSetup)
+      ObjectiveModel.insert(objective, knex, undefined, ChannelOpenerWaitingFor.theirPreFundSetup)
     ).rejects.toThrow();
 
     expect(await ObjectiveModel.query(knex).select()).toMatchObject([]);
@@ -50,7 +51,12 @@ describe('Objective > insert', () => {
   it('inserts and associates an objective with all channels that it references (channels exist)', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
-    await ObjectiveModel.insert(objective, false, knex, ChannelOpenerWaitingFor.theirPreFundSetup);
+    await ObjectiveModel.insert(
+      objective,
+      knex,
+      undefined,
+      ChannelOpenerWaitingFor.theirPreFundSetup
+    );
 
     expect(await ObjectiveModel.query(knex).select()).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},
@@ -66,8 +72,9 @@ describe('Objective > insert', () => {
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
     const {createdAt} = await ObjectiveModel.insert(
       objective,
-      false,
+
       knex,
+      undefined,
       ChannelOpenerWaitingFor.theirPreFundSetup
     );
     const after = Date.now() + 1000; // scroll forward 1000 ms to allow for finite precision / rounding
@@ -80,8 +87,9 @@ describe('Objective > insert', () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
     const {objectiveId} = await ObjectiveModel.insert(
       objective,
-      false,
+
       knex,
+      undefined,
       ChannelOpenerWaitingFor.theirPreFundSetup
     );
     const before = Date.now() - 1000; // scroll back 1000 ms to allow for finite precision / rounding
@@ -100,7 +108,12 @@ describe('Objective > insert', () => {
 describe('Objective > forId', () => {
   it('returns an objective with Date types for timestamps', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
-    await ObjectiveModel.insert(objective, false, knex, ChannelOpenerWaitingFor.theirPreFundSetup);
+    await ObjectiveModel.insert(
+      objective,
+      knex,
+      undefined,
+      ChannelOpenerWaitingFor.theirPreFundSetup
+    );
 
     const fetchedObjective = await ObjectiveModel.forId(`OpenChannel-${c.channelId}`, knex);
     expect(fetchedObjective.createdAt instanceof Date).toBe(true);
@@ -112,7 +125,12 @@ describe('Objective > forChannelIds', () => {
   it('retrieves objectives associated with a given channelId', async () => {
     await Channel.query(knex).withGraphFetched('signingWallet').insert(c);
 
-    await ObjectiveModel.insert(objective, false, knex, ChannelOpenerWaitingFor.theirPreFundSetup);
+    await ObjectiveModel.insert(
+      objective,
+      knex,
+      undefined,
+      ChannelOpenerWaitingFor.theirPreFundSetup
+    );
 
     expect(await ObjectiveModel.forChannelIds([c.channelId], knex)).toMatchObject([
       {objectiveId: `OpenChannel-${c.channelId}`},

--- a/packages/server-wallet/src/models/objective.ts
+++ b/packages/server-wallet/src/models/objective.ts
@@ -150,7 +150,7 @@ export class ObjectiveModel extends Model {
   static async insert<O extends SupportedObjective = SupportedObjective>(
     objectiveToBeStored: O,
     tx: TransactionOrKnex,
-    status?: ObjectiveStatus,
+    approvalStatus?: 'approved' | 'pending',
     waitingFor?: WaitingFor // TODO this should be correlated to O
   ): Promise<WalletObjective<O>> {
     const id: string = objectiveId(objectiveToBeStored);
@@ -159,7 +159,7 @@ export class ObjectiveModel extends Model {
       const query = ObjectiveModel.query(trx)
         .insert({
           objectiveId: id,
-          status: status ?? 'pending',
+          status: approvalStatus ?? 'pending',
           type: objectiveToBeStored.type,
           data: objectiveToBeStored.data,
           createdAt: new Date(),
@@ -191,8 +191,11 @@ export class ObjectiveModel extends Model {
         .returning('*')
         .first();
 
-      const model = await query.onConflict('objectiveId').merge({status: status ?? 'pending'});
-
+      const shouldOverride = !!approvalStatus || !!waitingFor;
+      // This allows for for the insert method to override the existing status or waitingFor if desired
+      const model = shouldOverride
+        ? await query.onConflict('objectiveId').merge({status: approvalStatus, waitingFor})
+        : await query.onConflict('objectiveId').ignore();
       // this avoids a UniqueViolationError being thrown
       // and turns the query into an upsert. We are either:
       // - re-approving the objective.

--- a/packages/server-wallet/src/objectives/close-channel.ts
+++ b/packages/server-wallet/src/objectives/close-channel.ts
@@ -23,8 +23,9 @@ export class CloseChannelObjective {
               txSubmitterOrder: [1, 0],
             },
           },
-          true,
-          tx
+
+          tx,
+          'approved'
         );
         // add new objective to the response
         response.queueCreatedObjective(walletObjective, channel.myIndex, channel.participants);

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -51,9 +51,7 @@ describe(`challenge-submitter`, () => {
       data: {targetChannelId: c.channelId},
     };
 
-    const walletObjective = await knex.transaction(async tx =>
-      ObjectiveModel.insert(obj, false, tx)
-    );
+    const walletObjective = await knex.transaction(async tx => ObjectiveModel.insert(obj, tx));
 
     await await crankAndAssert(walletObjective, {callsChallenge: false, completesObj: false});
   });
@@ -71,7 +69,7 @@ describe(`challenge-submitter`, () => {
       data: {targetChannelId: c.channelId},
     };
 
-    const objective = await knex.transaction(tx => ObjectiveModel.insert(obj, false, tx));
+    const objective = await knex.transaction(tx => ObjectiveModel.insert(obj, tx));
 
     await await crankAndAssert(objective, {callsChallenge: false, completesObj: false});
   });
@@ -90,7 +88,7 @@ describe(`challenge-submitter`, () => {
       data: {targetChannelId: c.channelId},
     };
 
-    const objective = await knex.transaction(tx => ObjectiveModel.insert(obj, false, tx));
+    const objective = await knex.transaction(tx => ObjectiveModel.insert(obj, tx));
     await await crankAndAssert(objective, {
       callsChallenge: true,
       completesObj: true,

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -104,8 +104,8 @@ const setup = async (
   const objective = await store.transaction(async tx => {
     const o = await ObjectiveModel.insert(
       testChan.closeChannelObjective([participant, 1 - participant]),
-      true, // preApproved
-      tx
+      tx,
+      'approved'
     );
     return o;
   });

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -66,7 +66,7 @@ beforeEach(async () => {
       participants: [],
       data: {targetChannelId: testChan.channelId},
     },
-    false,
+
     knex
   );
 
@@ -76,7 +76,7 @@ beforeEach(async () => {
       participants: [],
       data: {targetChannelId: testChan2.channelId},
     },
-    false,
+
     knex
   );
 

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -40,8 +40,8 @@ async function ensureCloseObjective(
   // add the closeChannel objective and approve
   return ObjectiveModel.insert(
     channel.closeChannelObjective([participantIndex, 1 - participantIndex]),
-    true,
-    tx
+    tx,
+    'approved'
   );
 }
 
@@ -49,8 +49,8 @@ async function ensureDefundObjective(
   channel: TestChannel,
   tx: Transaction
 ): Promise<WalletObjective<DefundChannel>> {
-  // add a preapproved defundChannel objective and approve
-  return ObjectiveModel.insert(channel.defundChannelObjective(), true, tx);
+  // add a approved defundChannel objective and approve
+  return ObjectiveModel.insert(channel.defundChannelObjective(), tx, 'approved');
 }
 
 function testShouldSubmitCollaborativeTx(channel: Channel, order: number[], outcome: boolean) {


### PR DESCRIPTION
# Description
Stops `PushMessage` from updating the status of approved objectives to pending.
Fixes #3523.

Before this PR the `pushMessage` on method on the `store` would call `ObjectiveModel.insert` on each objective it received in a message.

For every objective type besides `CloseChannel` `pushMessage` would call `ObjectiveModel.insert` with `preApprove` set to `false`.

This means that `ObjectiveModel.Insert` would update the status of approved objectives to pending.

The change in this PR is to switch from a `preApprove` boolean flag to an optional status argument: `approvalStatus?:'approved'|'pending'`. This allows us to only override the status if we intend to. Otherwise, it is left untouched.

It does seems like a code smell that we have a method called `insert` that's a partial `upsert` but I didn't want to increase the scope of this too much.

## How Has This Been Tested?
A test for the specific scenario was added in 4f9ae21

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
