### PR TITLE
add test for create2ing the channel

### DIFF
--- a/packages/nitro-protocol/contracts/ninja-nitro/AdjudicatorFactory.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/AdjudicatorFactory.sol
@@ -42,7 +42,6 @@ contract AdjudicatorFactory {
     /// @dev Allows us to create new channel contract and get it all set up in one transaction
     function createChannel(bytes32 channelId) public returns (address payable channel) {
         channel = payable(_deployChannelProxy(channelId));
-        emit ChannelCreation(channel);
     }
 
     /// @dev Allows us to create new channel contract, payout all of the funds, and destroy the contract

--- a/packages/nitro-protocol/contracts/ninja-nitro/AdjudicatorFactory.sol
+++ b/packages/nitro-protocol/contracts/ninja-nitro/AdjudicatorFactory.sol
@@ -40,8 +40,8 @@ contract AdjudicatorFactory {
     }
 
     /// @dev Allows us to create new channel contract and get it all set up in one transaction
-    function createChannel(bytes32 channelId) public returns (address payable channel) {
-        channel = payable(_deployChannelProxy(channelId));
+    function createChannel(bytes32 channelId) public {
+        _deployChannelProxy(channelId);
     }
 
     /// @dev Allows us to create new channel contract, payout all of the funds, and destroy the contract
@@ -76,7 +76,7 @@ contract AdjudicatorFactory {
 
     /// @dev Allows us to create new channel contact using CREATE2
     function _deployChannelProxy(bytes32 channelId) internal returns (address) {
-        bytes32 salt = channelId;
-        return Create2.deploy(0, salt, getProxyCreationCode());
+        // the channelId is used as the create2 salt
+        return Create2.deploy(0, channelId, getProxyCreationCode());
     }
 }

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/createChannel.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/createChannel.test.ts
@@ -25,10 +25,10 @@ const channelNonce = getRandomNonce('deployAndPayout');
 /**
  * We expect the gas cost of this call to be roughly as follows:
  * 21K base fee
- * 32K CREATE2 base fee
- * 200 gas per byte of contract code  = 200 x 90 + 18000
- * a little bit more to hash the contract init code
- * so roughly 71000
+ * 32K CREATE2 base fee (G_create)
+ * G_codedeposit = 200 gas per byte of contract code  = 200 x 45 = 9K
+ * G_sha3word = 6 x words_of_init_code = 12
+ * so roughly 62000
  */
 describe('deployAndPayout', () => {
   it('create2s the channel', async () => {
@@ -50,7 +50,7 @@ describe('deployAndPayout', () => {
     // e.g. 0x363d3d373d3d3d363d73655341aabd39a5ee0939796df610ad685a984c535af43d82803e903d91602b57fd5bf3
     //      ......................address-of-master-copy-goes-in-thisspace..............................
     // See https://eips.ethereum.org/EIPS/eip-1167
-    expect(byteCode).toHaveLength(92); // 90 bytes plus the 0x prefix
+    expect(byteCode).toHaveLength(92); // 90 hexits (45 bytes) plus the 0x prefix
     expect(receipt.gasUsed).toBeTruthy();
   });
 });

--- a/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/createChannel.test.ts
+++ b/packages/nitro-protocol/test/contracts/ninja-nitro/AdjudicatorFactory/createChannel.test.ts
@@ -1,0 +1,56 @@
+import {Contract} from 'ethers';
+
+import AdjudicatorFactoryArtifact from '../../../../artifacts/contracts/ninja-nitro/AdjudicatorFactory.sol/AdjudicatorFactory.json';
+import {Channel, getChannelId} from '../../../../src/contract/channel';
+import {
+  getRandomNonce,
+  getTestProvider,
+  setupContracts,
+  writeGasConsumption,
+} from '../../../test-helpers';
+
+const provider = getTestProvider();
+let AdjudicatorFactory: Contract;
+const chainId = process.env.CHAIN_NETWORK_ID;
+const participants: string[] = [];
+beforeAll(async () => {
+  AdjudicatorFactory = await setupContracts(
+    provider,
+    AdjudicatorFactoryArtifact,
+    process.env.ADJUDICATOR_FACTORY_ADDRESS
+  );
+});
+
+const channelNonce = getRandomNonce('deployAndPayout');
+/**
+ * We expect the gas cost of this call to be roughly as follows:
+ * 21K base fee
+ * 32K CREATE2 base fee
+ * 200 gas per byte of contract code  = 200 x 90 + 18000
+ * a little bit more to hash the contract init code
+ * so roughly 71000
+ */
+describe('deployAndPayout', () => {
+  it('create2s the channel', async () => {
+    const channel: Channel = {chainId, participants, channelNonce};
+    const channelId = getChannelId(channel);
+    const tx = AdjudicatorFactory.createChannel(channelId, {gasLimit: 3000000});
+
+    const receipt = await (await tx).wait();
+
+    console.log('gas used: ' + receipt.gasUsed);
+
+    await writeGasConsumption(
+      'ChannelFactory.createChannel.gas.md',
+      'createChannel',
+      receipt.gasUsed
+    );
+    const channelAddress = await AdjudicatorFactory.getChannelAddress(channelId);
+    const byteCode = await provider.getCode(channelAddress);
+    // e.g. 0x363d3d373d3d3d363d73655341aabd39a5ee0939796df610ad685a984c535af43d82803e903d91602b57fd5bf3
+    //      ......................address-of-master-copy-goes-in-thisspace..............................
+    // See https://eips.ethereum.org/EIPS/eip-1167
+    expect(byteCode).toHaveLength(92); // 90 bytes plus the 0x prefix
+    expect(receipt.gasUsed).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Record a reference of what deploying our proxies would be.

Pen and paper suggests 62K , the test suggests 64.7K, implying about 2.7K for constructing the proxy creation code (via [`abi.encodePacked`](https://ethereum.stackexchange.com/questions/729/how-to-concatenate-strings-in-solidity)). 

## Changes 
1. Code path stripped down to minimize unnecessary gas expenditure (no event emitted, for example)
2. test added
---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
