### PR TITLE
Update ApproveObjectives to return correct status on objectives

### DIFF
--- a/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
@@ -12,21 +12,13 @@ beforeAll(async () => {
 afterAll(async () => {
   await teardownPeerSetup(peerSetup);
 });
-
+const DEFAULT__RETRY_OPTIONS = {numberOfAttempts: 100, initialDelay: 50, multiple: 1};
 test('approving a completed objective returns immediately', async () => {
   const {peerEngines, messageService} = peerSetup;
   messageService.setLatencyOptions({dropRate: 0});
 
-  const wallet = await Wallet.create(peerEngines.a, messageService, {
-    numberOfAttempts: 100,
-    initialDelay: 50,
-    multiple: 1,
-  });
-  const walletB = await Wallet.create(peerEngines.b, messageService, {
-    numberOfAttempts: 100,
-    initialDelay: 50,
-    multiple: 1,
-  });
+  const wallet = await Wallet.create(peerEngines.a, messageService, DEFAULT__RETRY_OPTIONS);
+  const walletB = await Wallet.create(peerEngines.b, messageService, DEFAULT__RETRY_OPTIONS);
 
   const createResult = await wallet.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
 
@@ -45,16 +37,8 @@ test('can approve the objective multiple times', async () => {
   const {peerEngines, messageService} = peerSetup;
   messageService.setLatencyOptions({dropRate: 0});
 
-  const wallet = await Wallet.create(peerEngines.a, messageService, {
-    numberOfAttempts: 100,
-    initialDelay: 50,
-    multiple: 1,
-  });
-  const walletB = await Wallet.create(peerEngines.b, messageService, {
-    numberOfAttempts: 100,
-    initialDelay: 50,
-    multiple: 1,
-  });
+  const wallet = await Wallet.create(peerEngines.a, messageService, DEFAULT__RETRY_OPTIONS);
+  const walletB = await Wallet.create(peerEngines.b, messageService, DEFAULT__RETRY_OPTIONS);
 
   const result = await wallet.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
   await new Promise<void>(resolve => peerEngines.b.on('objectiveStarted', () => resolve()));

--- a/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import {Wallet} from '../..';
 import {getPeersSetup, PeerSetup, teardownPeerSetup} from '../../../jest/with-peers-setup-teardown';
-import {getWithPeersCreateChannelsArgs} from '../utils';
+import {getWithPeersCreateChannelsArgs, waitForObjectiveStarted} from '../utils';
 jest.setTimeout(60_000);
 let peerSetup: PeerSetup;
 
@@ -29,8 +29,9 @@ test('approving a completed objective returns immediately', async () => {
   });
 
   const createResult = await wallet.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
-  await new Promise<void>(resolve => peerEngines.b.on('objectiveStarted', () => resolve()));
+
   const {objectiveId} = createResult[0];
+  await waitForObjectiveStarted([objectiveId], peerEngines.b);
 
   const approveResult = await walletB.approveObjectives([objectiveId]);
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
@@ -1,0 +1,45 @@
+import _ from 'lodash';
+
+import {Wallet} from '../..';
+import {getPeersSetup, PeerSetup, teardownPeerSetup} from '../../../jest/with-peers-setup-teardown';
+import {getWithPeersCreateChannelsArgs} from '../utils';
+jest.setTimeout(60_000);
+let peerSetup: PeerSetup;
+
+beforeAll(async () => {
+  peerSetup = await getPeersSetup();
+});
+afterAll(async () => {
+  await teardownPeerSetup(peerSetup);
+});
+test('can approve the objective multiple times', async () => {
+  const {peerEngines, messageService} = peerSetup;
+  messageService.setLatencyOptions({dropRate: 0});
+
+  const wallet = await Wallet.create(peerEngines.a, messageService, {
+    numberOfAttempts: 100,
+    initialDelay: 50,
+    multiple: 1,
+  });
+  const walletB = await Wallet.create(peerEngines.b, messageService, {
+    numberOfAttempts: 100,
+    initialDelay: 50,
+    multiple: 1,
+  });
+
+  const result = await wallet.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
+  await new Promise<void>(resolve => peerEngines.b.on('objectiveStarted', () => resolve()));
+  const {objectiveId} = result[0];
+
+  const approveCalls = 50;
+  const approvePromises = _.range(approveCalls).map(() => walletB.approveObjectives([objectiveId]));
+
+  const results = _.flatten(await Promise.all(approvePromises));
+
+  // We expect an objective result from each call which points to the same objective
+  expect(results).toHaveLength(approveCalls);
+  for (const result of results) {
+    expect(result.objectiveId).toEqual(objectiveId);
+  }
+  await expect(results).toBeObjectiveDoneType('Success');
+});

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -1,9 +1,8 @@
 import {getPeersSetup, PeerSetup, teardownPeerSetup} from '../../../jest/with-peers-setup-teardown';
 import {LatencyOptions} from '../../message-service/test-message-service';
 import {WalletObjective} from '../../models/objective';
-import {ObjectiveResult} from '../../wallet';
 import {Wallet} from '../../wallet/wallet';
-import {getWithPeersCreateChannelsArgs} from '../utils';
+import {getWithPeersCreateChannelsArgs, waitForObjectiveStarted} from '../utils';
 
 jest.setTimeout(60_000);
 let peerSetup: PeerSetup;
@@ -46,17 +45,13 @@ describe('EnsureObjectives', () => {
         multiple: 1,
       });
 
-      const bResponse: ObjectiveResult[] = [];
-      const listener = async (o: WalletObjective) => {
-        const result = await walletB.approveObjectives([o.objectiveId]);
-        bResponse.push(...result);
-      };
-      peerEngines.b.on('objectiveStarted', listener);
-
       const response = await wallet.createChannels(
         Array(10).fill(getWithPeersCreateChannelsArgs(peerSetup))
       );
 
+      const objectiveIds = response.map(o => o.objectiveId);
+      await waitForObjectiveStarted(objectiveIds, peerEngines.b);
+      const bResponse = await walletB.approveObjectives(objectiveIds);
       await expect(response).toBeObjectiveDoneType('Success');
       await expect(bResponse).toBeObjectiveDoneType('Success');
       // Ensure that all of A's channels are running
@@ -70,7 +65,6 @@ describe('EnsureObjectives', () => {
       for (const b of bChannels) {
         expect(b.status).toEqual('running');
       }
-      peerEngines.b.removeListener('objectiveStarted', listener);
     }
   );
 

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -88,7 +88,7 @@ describe('EnsureObjectives', () => {
 
     const result = await wallet.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
 
-    expect(result).toBeObjectiveDoneType('EnsureObjectiveFailed');
+    await expect(result).toBeObjectiveDoneType('EnsureObjectiveFailed');
     peerEngines.b.removeListener('objectiveStarted', listener);
   });
 });

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -362,7 +362,7 @@ export class Store {
     return LedgerRequest.ledgersWithNewRequestsIds(tx || this.knex);
   }
 
-  async approveObjective(objectiveId: string, tx?: Transaction): Promise<void> {
+  async approveObjective(objectiveId: string, tx?: Transaction): Promise<WalletObjective> {
     const objective = await ObjectiveModel.approve(objectiveId, tx || this.knex);
 
     if (objective.type === 'OpenChannel') {
@@ -384,6 +384,7 @@ export class Store {
         .where({channelId})
         .patch({fundingStrategy, fundingLedgerChannelId});
     }
+    return objective;
   }
 
   async markObjectiveStatus<O extends WalletObjective>(


### PR DESCRIPTION
**STACKED ON #3485** 


# Description
Makes sure the Objective is returned with the correct status in `ApproveObjective`.

There are a few changes here to make sure we return the correct status:
- We now lock on the objectiveId when we fetch the objective.
- We refetch the objectives after `takeActions` is called.


## How Has This Been Tested? 

A new test suite has been added to test `ApproveObjective`. Also the previous failures in #3485 were resolved with these changes.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#b304e56734a74dfbb341b8b4b27b1c0c)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/Team-working-agreements-2a95c926bb5642e5a5c42e4b74a9dd24#d534e68e7edc46fe8a4cda61b2258c4e) on zenhub for the linked issue
