### PR TITLE
Add a Objective Monitor

### DIFF
--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -35,7 +35,6 @@ export function waitForObjectiveEvent(
         handledObjectiveIds.add(o.objectiveId);
 
         if (handledObjectiveIds.size === _.uniq(objectiveIds).length) {
-          engine.removeListener(objectiveEventType);
           resolve();
         }
       }

--- a/packages/server-wallet/src/__test-with-peers__/wallet/close-channels.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/close-channels.test.ts
@@ -31,8 +31,8 @@ describe('CloseChannels', () => {
 
     // Delay and drop
     {dropRate: 0.1, meanDelay: 15, closer: 'A'},
-    // TODO: This test case can fail due to https://github.com/statechannels/statechannels/issues/3530
-    //{dropRate: 0.1, meanDelay: 15, closer: 'B'},
+
+    {dropRate: 0.1, meanDelay: 15, closer: 'B'},
   ];
   test.each(testCases)(
     'can successfully create and close channel with the latency options: %o',

--- a/packages/server-wallet/src/wallet/objective-monitor.ts
+++ b/packages/server-wallet/src/wallet/objective-monitor.ts
@@ -24,6 +24,7 @@ export class ObjectiveMonitor extends EventEmitter<ObjectiveMonitorEvents> {
   public constructor(engineEmitter: EngineEmitter, logger?: Logger) {
     super();
 
+    // Listen for new objectives and make sure we're monitoring them
     engineEmitter.on('objectiveStarted', async (o: WalletObjective) => {
       const {objectiveId} = o;
       if (!this.isMonitored(objectiveId)) {
@@ -33,6 +34,7 @@ export class ObjectiveMonitor extends EventEmitter<ObjectiveMonitorEvents> {
       }
     });
 
+    // Listen for objective completed and mark objectives as complete
     engineEmitter.on('objectiveSucceeded', o => {
       const {objectiveId} = o;
       if (this.isMonitored(objectiveId)) {
@@ -43,15 +45,31 @@ export class ObjectiveMonitor extends EventEmitter<ObjectiveMonitorEvents> {
       }
     });
   }
+
+  /**
+   * Returns whether an objective has been completed or not
+   * @param objectiveId The id of the objective to check
+   * @returns True if the objective status is failed or succeeded, false otherwise
+   */
   public isComplete(objectiveId: string): boolean {
     const result = this._objectives.get(objectiveId);
     return result === 'succeeded' || result === 'failed';
   }
 
+  /**
+   * Returns whether the ObjectiveMonitor is monitoring a specified objective
+   * @param objectiveId The id of the objective to check
+   * @returns true if the objective is monitored by the Objective Manager, false otherwise
+   */
   public isMonitored(objectiveId: string): boolean {
     return this._objectives.has(objectiveId);
   }
 
+  /**
+   * Mark an objective as complete
+   * @param objectiveId The id of the objective to update.
+   * @param status Either a succeeded or failed status. Defaults to succeeded.
+   */
   public markAsComplete(objectiveId: string, status: 'succeeded' | 'failed' = 'succeeded'): void {
     if (!this._objectives.has(objectiveId)) {
       throw new Error('Cannot update the handling status if the objective is not being monitored');
@@ -60,6 +78,10 @@ export class ObjectiveMonitor extends EventEmitter<ObjectiveMonitorEvents> {
     }
   }
 
+  /**
+   * Lets the Objective Monitor know that we should watch the objectives for any change of status
+   * @param objectives A collection of objectives
+   */
   public monitorObjectives(objectives: WalletObjective[]): void {
     for (const objective of objectives) {
       this._objectives.set(objective.objectiveId, objective.status);

--- a/packages/server-wallet/src/wallet/objective-monitor.ts
+++ b/packages/server-wallet/src/wallet/objective-monitor.ts
@@ -1,0 +1,72 @@
+import EventEmitter from 'eventemitter3';
+import {Logger} from 'pino';
+
+import {EngineEvent} from '..';
+import {ObjectiveStatus, WalletObjective} from '../models/objective';
+
+type EngineEmitter = EventEmitter<
+  {
+    [key in EngineEvent['type']]: EngineEvent['value'];
+  }
+>;
+
+type ObjectiveMonitorEvents = {
+  newObjective: WalletObjective;
+};
+
+/**
+ * The ObjectiveMonitor is responsible for monitoring objectives and letting us easily check the status of an objective
+ *
+ */
+export class ObjectiveMonitor extends EventEmitter<ObjectiveMonitorEvents> {
+  private _objectives = new Map<string, ObjectiveStatus>();
+
+  public constructor(engineEmitter: EngineEmitter, logger?: Logger) {
+    super();
+
+    engineEmitter.on('objectiveStarted', async (o: WalletObjective) => {
+      const {objectiveId} = o;
+      if (!this.isMonitored(objectiveId)) {
+        logger?.trace({objectiveId}, 'Monitoring objective');
+        this.monitorObjectives([o]);
+        this.emit('newObjective', o);
+      }
+    });
+
+    engineEmitter.on('objectiveSucceeded', o => {
+      const {objectiveId} = o;
+      if (this.isMonitored(objectiveId)) {
+        if (!this.isComplete(objectiveId)) {
+          this.markAsComplete(objectiveId);
+          logger?.trace({objectiveId}, 'Objective succeeded');
+        }
+      }
+    });
+  }
+  public isComplete(objectiveId: string): boolean {
+    const result = this._objectives.get(objectiveId);
+    return result === 'succeeded' || result === 'failed';
+  }
+
+  public isMonitored(objectiveId: string): boolean {
+    return this._objectives.has(objectiveId);
+  }
+
+  public markAsComplete(objectiveId: string, status: 'succeeded' | 'failed' = 'succeeded'): void {
+    if (!this._objectives.has(objectiveId)) {
+      throw new Error('Cannot update the handling status if the objective is not being monitored');
+    } else {
+      this._objectives.set(objectiveId, status);
+    }
+  }
+
+  public monitorObjectives(objectives: WalletObjective[]): void {
+    for (const objective of objectives) {
+      this._objectives.set(objective.objectiveId, objective.status);
+    }
+  }
+
+  public destroy(): void {
+    this.removeAllListeners();
+  }
+}

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -37,6 +37,15 @@ export class Wallet {
     private _retryOptions: RetryOptions
   ) {
     this._objectiveMonitor = new ObjectiveMonitor(_engine, _engine.logger);
+
+    // The CloseChannel objective gets auto approved so there will be no call to approveObjectives.
+    // This means we have to call ensureObjective when we detect a new CloseChannel objective.
+    this._objectiveMonitor.on('newObjective', async o => {
+      if (o.type === 'CloseChannel') {
+        this._engine.logger.trace({objectiveId: o.objectiveId}, 'Ensuring CloseChannel');
+        await this.ensureObjective(o, []);
+      }
+    });
   }
 
   /**

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -200,7 +200,14 @@ export class Wallet {
         );
         await this._messageService.send(messagesForObjective);
       }
-      return {numberOfAttempts: this._retryOptions.numberOfAttempts, type: 'EnsureObjectiveFailed'};
+      if (this._objectiveMonitor.isComplete(objective.objectiveId)) {
+        return {channelId: objective.data.targetChannelId, type: 'Success'};
+      } else {
+        return {
+          numberOfAttempts: this._retryOptions.numberOfAttempts,
+          type: 'EnsureObjectiveFailed',
+        };
+      }
     } catch (error) {
       return {
         type: 'InternalError' as const,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -137,6 +137,7 @@ export class Wallet {
    */
   public async jumpStartObjectives(): Promise<ObjectiveResult[]> {
     const objectives = await this._engine.getApprovedObjectives();
+    this._objectiveMonitor.monitorObjectives(objectives);
     const objectiveIds = objectives.map(o => o.objectiveId);
     // Instead of getting messages per objective we just get them all at once
     // This will prevent us from querying the database for each objective


### PR DESCRIPTION
# Description
Fixes #3530 

Introduces a simple ObjectiveMonitor that can be used to check if an objective is new or is complete. The `ObjectiveMonitor` is mostly used to work around the current behaviour of the `engine`. 

Since the `ObjectiveMonitor` is an in-memory cache it implies some constraints on concurrency (ie: two wallets using the same database).   When the `engine` API gets [cleaned up
](https://www.notion.so/statechannels/Remove-events-from-Engine-and-improve-Engine-API-c156edc960c34c8196e8c758d23c3939) the `ObjectiveMonitor` should be retired.

This `ObjectiveMonitor` is used to call `EnsureObjective` on `CloseChannel` objectives started by other participants, thus resolving #3540.

The `ObjectiveMonitor` is essentially an in-memory list of objectives we're watching and their status. This lets the `wallet` easily check:
- If an objective has been completed
- If there is a new objective to handle


The `wallet` can now check the `ObjectiveManager` to determine if the objective is complete or a new objective instead of listening for an ObjectiveCompleted event.

The `ObjectiveMonitor` is also an EventEmitter that emits one kind of event: `NewObjective`. This event is fired every time an objective is added to the monitor for the first time. We use this event to call `ensureObjective` on `CloseChannel` objectives to resolve #3530. 

Once the `wallet` is updated to take in a `MessageServiceFactory` for #3531 we can probably remove the `NewObjective` event and just rely on calling `monitorObjectives` after calling `pushMessage`.

## How Has This Been Tested? 

Currently, I'm relying on the existing `wallet` tests to inherently test the new functionality. The ObjectiveMonitor is pretty simple so I felt that it didn't justify a new test suite.


---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
