### PR TITLE
Remove Objective Events from the engine

### DIFF
--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -22,7 +22,7 @@ import {fromEvent} from 'rxjs';
 import {first} from 'rxjs/operators';
 import {ContractArtifacts} from '@statechannels/nitro-protocol';
 import _ from 'lodash';
-import {WalletObjective} from '@statechannels/server-wallet/src/models/objective';
+
 import {
   CreateChannelParams,
   isJsonRpcNotification,
@@ -67,7 +67,6 @@ let serverAddress: Address;
 let serverDestination: Destination;
 let browserAddress: Address;
 let browserDestination: Destination;
-let objectiveSuccededPromise: Promise<void>;
 
 beforeAll(() => {
   provider = new providers.JsonRpcProvider(rpcEndpoint);
@@ -97,12 +96,6 @@ beforeEach(async () => {
     if (isJsonRpcNotification(message)) {
       serverWallet.pushMessage((message.params as Message).data);
     }
-  });
-
-  objectiveSuccededPromise = new Promise<void>(r => {
-    serverWallet.on('objectiveSucceeded', (o: WalletObjective) => {
-      if (o.type === 'OpenChannel' && o.status === 'succeeded') r();
-    });
   });
 });
 
@@ -201,8 +194,6 @@ it('server wallet creates channel + cooperates with browser wallet to fund chann
 
   serverWallet.on('channelUpdated', e => console.log(JSON.stringify(e)));
   await browserWallet.pushMessage(serverMessageToBrowserMessage(await postFundA), 'dummyDomain');
-
-  await objectiveSuccededPromise;
 });
 
 it('browser wallet creates channel + cooperates with server wallet to fund channel', async () => {
@@ -261,6 +252,4 @@ it('browser wallet creates channel + cooperates with server wallet to fund chann
     .toPromise();
 
   await browserWallet.pushMessage(serverMessageToBrowserMessage(postFundA), 'dummyDomain');
-
-  await objectiveSuccededPromise;
 });

--- a/packages/server-wallet/e2e-test/challenge.test.ts
+++ b/packages/server-wallet/e2e-test/challenge.test.ts
@@ -7,7 +7,7 @@ import {stateVars} from '../src/engine/__test__/fixtures/state-vars';
 import {alice as aliceP, bob as bobP} from '../src/engine/__test__/fixtures/participants';
 import {alice} from '../src/engine/__test__/fixtures/signing-wallets';
 import {channel, withSupportedState} from '../src/models/__test__/fixtures/channel';
-import {defaultTestNetworkConfiguration, EngineConfig, EngineEvent} from '../src';
+import {defaultTestNetworkConfiguration, EngineConfig} from '../src';
 import {Channel} from '../src/models/channel';
 import {DBAdmin} from '../src/db-admin/db-admin';
 import {AdjudicatorStatusModel} from '../src/models/adjudicator-status';
@@ -71,10 +71,6 @@ test('the engine handles the basic challenging v0 behavior', async () => {
   // We expect the channel to be in an open status
   expect(await getChannelMode(channelId)).toEqual('Open');
 
-  const events: EngineEvent[] = [];
-  const names = ['objectiveStarted', 'objectiveSucceeded'] as const;
-  names.map(event => payerClient.engine.on(event, e => events.push({...e, event})));
-
   // Call challenge and mine blocks
   await payerClient.challenge(channelId);
 
@@ -87,9 +83,6 @@ test('the engine handles the basic challenging v0 behavior', async () => {
 
   But for now, the objectives succeeds straight away.
   */
-  expect(events).toHaveLength(2);
-  expect(events).toContainObject({event: 'objectiveStarted', type: 'SubmitChallenge'});
-  expect(events).toContainObject({event: 'objectiveSucceeded', type: 'SubmitChallenge'});
 
   await payerClient.mineBlocks(5);
 
@@ -102,10 +95,6 @@ test('the engine handles the basic challenging v0 behavior', async () => {
 
   // We expect the channel to be marked as finalized
   expect(await getChannelMode(channelId)).toEqual('Finalized');
-
-  expect(events).toHaveLength(4);
-  expect(events).toContainObject({event: 'objectiveStarted', type: 'DefundChannel'});
-  expect(events).toContainObject({event: 'objectiveSucceeded', type: 'DefundChannel'});
 
   // We expect the balances to be updated based on the outcome
   const finalPayerBalance = await getBalance(payerClient.provider, payer);

--- a/packages/server-wallet/e2e-test/e2e.test.ts
+++ b/packages/server-wallet/e2e-test/e2e.test.ts
@@ -88,7 +88,7 @@ describe.each([0, 2])('e2e with %i worker threads', workerThreadAmount => {
   });
 
   it('can create a channel, send signed state via http', async () => {
-    const {channelResult: channel, events} = await payerClient.createPayerChannel(receiver);
+    const {channelResult: channel} = await payerClient.createPayerChannel(receiver);
 
     expect(channel.participants).toStrictEqual([payer, receiver]);
     expect(channel.status).toBe('running');
@@ -97,18 +97,6 @@ describe.each([0, 2])('e2e with %i worker threads', workerThreadAmount => {
     expect(
       (await ChannelPayer.forId(channel.channelId, ChannelPayer.knex())).protocolState
     ).toMatchObject({supported: {turnNum: 3}});
-
-    expect(events).toHaveLength(2);
-    expect(events).toContainObject({
-      event: 'objectiveStarted',
-      type: 'OpenChannel',
-      status: 'approved',
-    });
-    expect(events).toContainObject({
-      event: 'objectiveSucceeded',
-      type: 'OpenChannel',
-      status: 'succeeded',
-    });
   });
 });
 

--- a/packages/server-wallet/e2e-test/payer/client.ts
+++ b/packages/server-wallet/e2e-test/payer/client.ts
@@ -90,7 +90,7 @@ export default class PayerClient {
 
   public async createPayerChannel(receiver: Participant): Promise<TestChannelResult> {
     const events: EngineEvent[] = [];
-    const names = ['channelUpdated', 'objectiveStarted', 'objectiveSucceeded'] as const;
+    const names = ['channelUpdated'] as const;
     names.map(event => this.engine.on(event, e => events.push({...e, event})));
 
     const {

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -142,11 +142,9 @@ export abstract class Engine extends SingleThreadedEngine implements EngineInter
 export type EngineConfig = RequiredEngineConfig & OptionalEngineConfig;
 
 // Warning: (ae-forgotten-export) The symbol "ChannelUpdatedEvent" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ObjectiveStarted" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ObjectiveSucceeded" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type EngineEvent = ChannelUpdatedEvent | ObjectiveStarted | ObjectiveSucceeded;
+export type EngineEvent = ChannelUpdatedEvent;
 
 // @public (undocumented)
 export interface EngineInterface {
@@ -260,6 +258,11 @@ export type ObjectiveDoneResult = ObjectiveSuccess | ObjectiveError;
 
 // @public (undocumented)
 export type ObjectiveError = EnsureObjectiveFailed | InternalError;
+
+// @public (undocumented)
+export type ObjectiveProposed = {
+    ObjectiveProposed: WalletObjective;
+};
 
 // @public
 export type ObjectiveResult = {
@@ -443,7 +446,7 @@ export function validateEngineConfig(config: Record<string, any>): {
 };
 
 // @public (undocumented)
-export class Wallet {
+export class Wallet extends EventEmitter<ObjectiveProposed> {
     approveObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]>;
     closeChannels(channelIds: string[]): Promise<ObjectiveResult[]>;
     // Warning: (ae-forgotten-export) The symbol "MessageServiceFactory" needs to be exported by the entry point index.d.ts
@@ -462,7 +465,7 @@ export class Wallet {
 // Warnings were encountered during analysis:
 //
 // src/engine/types.ts:24:3 - (ae-forgotten-export) The symbol "WireMessage" needs to be exported by the entry point index.d.ts
-// src/engine/types.ts:77:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
+// src/engine/types.ts:68:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
 // src/wallet/types.ts:53:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -1,9 +1,8 @@
 import {ChannelResult, CreateChannelParams} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
-import {Engine} from '..';
+import {Engine, Wallet} from '..';
 import {PeerSetup} from '../../jest/with-peers-setup-teardown';
-import {EngineEvent} from '../engine';
 import {createChannelArgs} from '../engine/__test__/fixtures/create-channel';
 import {WalletObjective} from '../models/objective';
 
@@ -23,11 +22,7 @@ export function getWithPeersCreateChannelsArgs(peerSetup: PeerSetup): CreateChan
   });
 }
 
-export function waitForObjectiveEvent(
-  objectiveIds: string[],
-  objectiveEventType: EngineEvent['type'],
-  engine: Engine
-): Promise<void> {
+export function waitForObjectiveProposals(objectiveIds: string[], wallet: Wallet): Promise<void> {
   const handledObjectiveIds = new Set<string>();
   return new Promise<void>(resolve => {
     const listener = (o: WalletObjective) => {
@@ -39,6 +34,6 @@ export function waitForObjectiveEvent(
         }
       }
     };
-    engine.on(objectiveEventType, listener);
+    wallet.on('ObjectiveProposed', listener);
   });
 }

--- a/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/approve-objective.test.ts
@@ -6,7 +6,7 @@ import {
   PeerSetupWithWallets,
 } from '../../../jest/with-peers-setup-teardown';
 import {TestMessageService} from '../../message-service/test-message-service';
-import {getWithPeersCreateChannelsArgs, waitForObjectiveEvent} from '../utils';
+import {getWithPeersCreateChannelsArgs, waitForObjectiveProposals} from '../utils';
 jest.setTimeout(60_000);
 let peerSetup: PeerSetupWithWallets;
 
@@ -18,7 +18,7 @@ afterAll(async () => {
 });
 
 test('approving a completed objective returns immediately', async () => {
-  const {peerEngines, peerWallets} = peerSetup;
+  const {peerWallets} = peerSetup;
   TestMessageService.setLatencyOptions(peerWallets, {dropRate: 0});
 
   const createResult = await peerWallets.a.createChannels([
@@ -26,7 +26,7 @@ test('approving a completed objective returns immediately', async () => {
   ]);
 
   const {objectiveId} = createResult[0];
-  await waitForObjectiveEvent([objectiveId], 'objectiveStarted', peerEngines.b);
+  await waitForObjectiveProposals([objectiveId], peerWallets.b);
 
   const approveResult = await peerWallets.b.approveObjectives([objectiveId]);
 
@@ -38,11 +38,11 @@ test('approving a completed objective returns immediately', async () => {
 });
 
 test('can approve the objective multiple times', async () => {
-  const {peerEngines, peerWallets} = peerSetup;
+  const {peerWallets} = peerSetup;
 
   const result = await peerWallets.a.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
   const {objectiveId} = result[0];
-  await waitForObjectiveEvent([objectiveId], 'objectiveStarted', peerEngines.b);
+  await waitForObjectiveProposals([objectiveId], peerWallets.b);
 
   TestMessageService.freeze(peerWallets);
   const firstResult = await peerWallets.b.approveObjectives([objectiveId]);

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -4,8 +4,7 @@ import {
   PeerSetupWithWallets,
 } from '../../../jest/with-peers-setup-teardown';
 import {LatencyOptions, TestMessageService} from '../../message-service/test-message-service';
-import {WalletObjective} from '../../models/objective';
-import {getWithPeersCreateChannelsArgs, waitForObjectiveEvent} from '../utils';
+import {getWithPeersCreateChannelsArgs, waitForObjectiveProposals} from '../utils';
 
 jest.setTimeout(60_000);
 let peerSetup: PeerSetupWithWallets;
@@ -43,7 +42,7 @@ describe('EnsureObjectives', () => {
       );
 
       const objectiveIds = response.map(o => o.objectiveId);
-      await waitForObjectiveEvent(objectiveIds, 'objectiveStarted', peerEngines.b);
+      await waitForObjectiveProposals(objectiveIds, peerWallets.b);
       const bResponse = await peerWallets.b.approveObjectives(objectiveIds);
       await expect(response).toBeObjectiveDoneType('Success');
       await expect(bResponse).toBeObjectiveDoneType('Success');
@@ -65,16 +64,11 @@ describe('EnsureObjectives', () => {
   // TODO: Determine why this is failing
   //  This is a nice sanity check to ensure that messages do get dropped
   test.skip('fails when all messages are dropped', async () => {
-    const {peerEngines, peerWallets} = peerSetup;
+    const {peerWallets} = peerSetup;
     TestMessageService.setLatencyOptions(peerWallets, {dropRate: 1});
-    const listener = async (o: WalletObjective) => {
-      await peerWallets.b.approveObjectives([o.objectiveId]);
-    };
-    peerEngines.b.on('objectiveStarted', listener);
 
     const result = await peerWallets.a.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
 
     await expect(result).toBeObjectiveDoneType('EnsureObjectiveFailed');
-    peerEngines.b.removeListener('objectiveStarted', listener);
   });
 });

--- a/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/ensure-objectives.test.ts
@@ -61,12 +61,11 @@ describe('EnsureObjectives', () => {
     }
   );
 
-  // TODO: Determine why this is failing
   //  This is a nice sanity check to ensure that messages do get dropped
-  test.skip('fails when all messages are dropped', async () => {
+  test('fails when all messages are dropped', async () => {
     const {peerWallets} = peerSetup;
     TestMessageService.setLatencyOptions(peerWallets, {dropRate: 1});
-
+    peerWallets.b.on('ObjectiveProposed', o => peerWallets.b.approveObjectives([o.objectiveId]));
     const result = await peerWallets.a.createChannels([getWithPeersCreateChannelsArgs(peerSetup)]);
 
     await expect(result).toBeObjectiveDoneType('EnsureObjectiveFailed');

--- a/packages/server-wallet/src/engine/__test__/challenge.test.ts
+++ b/packages/server-wallet/src/engine/__test__/challenge.test.ts
@@ -36,8 +36,7 @@ it('throws an error when challenging with a non ledger channel', async () => {
 });
 it('submits a challenge when no challenge exists for a channel', async () => {
   const spy = jest.spyOn(w.chainService, 'challenge');
-  const callback = jest.fn();
-  w.once('objectiveStarted', callback);
+
   const c = channel({
     channelNonce: 1,
     // Set a random address so this will be a "ledger" channel
@@ -56,7 +55,6 @@ it('submits a challenge when no challenge exists for a channel', async () => {
 
   await w.challenge(channelId);
   expect(spy).toHaveBeenCalledWith(c.initialSupport, alice().privateKey);
-  expect(callback).toHaveBeenCalledWith(expect.objectContaining({type: 'SubmitChallenge'}));
 });
 
 it('stores the challenge state on the challenge created event', async () => {

--- a/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
@@ -22,12 +22,11 @@ afterEach(async () => {
 describe('happy path', () => {
   beforeEach(async () => seedAlicesSigningWallet(w.knex));
 
-  it('creates a channel, emits an ObjectiveStarted event, and allows an objective to be queried through the API', async () => {
+  it('creates a channel, and allows an objective to be queried through the API', async () => {
     expect(await Channel.query(w.knex).resultSize()).toEqual(0);
 
     const appData = '0xaf00';
-    const callback = jest.fn();
-    w.once('objectiveStarted', callback);
+
     const createResult = await w.createChannels(createChannelArgs({appData}), 1);
     const channelId = '0x4460dab6d4438f3bf1719720fcced4054a38baf60f315e49995eead80cfa498f';
     expect(createResult).toMatchObject({channelResults: [{channelId}]});
@@ -61,7 +60,7 @@ describe('happy path', () => {
       ],
       channelResults: [{channelId: expect.any(String), turnNum: 0, appData}],
     });
-    expect(callback).toHaveBeenCalledWith(expect.objectContaining({type: 'OpenChannel'}));
+
     expect(createResult.channelResults[0].channelId).toEqual(channelId);
     expect(await Channel.query(w.knex).resultSize()).toEqual(1);
 

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -350,42 +350,6 @@ describe('when the application protocol returns an action', () => {
     });
   });
 
-  it.each(['with', 'without'] as const)(
-    'emits objectiveStarted when a engine %s worker threads receives a new objective',
-    async withOrWithout => {
-      const _engine: Engine = withOrWithout === 'with' ? engine : multiThreadedEngine;
-      const turnNum = 6;
-      const state = stateSignedBy()({outcome: simpleEthAllocation([]), turnNum});
-
-      const c = channel({vars: [addHash(state)]});
-      await Channel.query(_engine.knex).insert(c);
-
-      const {channelId} = c;
-      const finalState = {...state, isFinal: true, turnNum: turnNum + 1};
-
-      const callback = jest.fn();
-      _engine.once('objectiveStarted', callback);
-
-      const result = await _engine.pushMessage({
-        walletVersion: WALLET_VERSION,
-        signedStates: [serializeState(stateSignedBy([bob()])(finalState))],
-        objectives: [
-          {
-            type: 'CloseChannel',
-            participants: [],
-            data: {
-              targetChannelId: channelId,
-              fundingStrategy: 'Direct',
-              txSubmitterOrder: [1, 0],
-            },
-          },
-        ],
-      });
-      expect(result.newObjectives).toHaveLength(1);
-      expect(callback).toHaveBeenCalledWith(expect.objectContaining({type: 'CloseChannel'}));
-    }
-  );
-
   it('forms a conclusion proof when the peer wishes to close the channel', async () => {
     const turnNum = 6;
     const state = stateSignedBy()({outcome: simpleEthAllocation([]), turnNum});

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -1006,8 +1006,10 @@ export class SingleThreadedEngine
         tx,
         'approved'
       );
+
       // TODO: The response is currently not returned or sent anywhere
-      response.queueCreatedObjective(objective, 0, []);
+      const channel = await this.store.getChannel(arg.channelId, tx);
+      response.queueCreatedObjective(objective, channel?.myIndex || 0, channel?.participants || []);
     });
 
     await this.takeActions([arg.channelId], response);

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -360,7 +360,7 @@ export class SingleThreadedEngine
         tx,
         'approved'
       );
-      this.emit('objectiveStarted', objective);
+      response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
 
       response.queueChannel(channel);
     });
@@ -497,7 +497,6 @@ export class SingleThreadedEngine
       fundingLedgerChannelId
     );
 
-    this.emit('objectiveStarted', objective);
     response.queueState(signedState, channel.myIndex, channel.channelId, objective.objectiveId);
     response.queueCreatedObjective(objective, channel.myIndex, channel.participants);
     response.queueChannelState(channel);
@@ -937,9 +936,6 @@ export class SingleThreadedEngine
         channelIds = [...channelIds, ...touchedChannels];
       }
     }
-
-    response.createdObjectives.map(o => this.emit('objectiveStarted', o));
-    response.succeededObjectives.map(o => this.emit('objectiveSucceeded', o));
   }
 
   /**
@@ -1010,7 +1006,8 @@ export class SingleThreadedEngine
         tx,
         'approved'
       );
-      this.emit('objectiveStarted', objective);
+      // TODO: The response is currently not returned or sent anywhere
+      response.queueCreatedObjective(objective, 0, []);
     });
 
     await this.takeActions([arg.channelId], response);

--- a/packages/server-wallet/src/engine/multi-threaded-engine/worker.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/worker.ts
@@ -34,7 +34,7 @@ async function startWorker() {
   logger.debug(`Worker %o starting`, threadId);
   const engine = await SingleThreadedEngine.create(engineConfig);
 
-  const events = ['channelUpdated', 'objectiveStarted', 'objectiveSucceeded'] as const;
+  const events = ['channelUpdated'] as const;
   events.forEach(name => engine.on(name, relayEngineEvents(name)));
 
   parentPort?.on('message', async (message: any) => {

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -428,6 +428,11 @@ export class Store {
     return await ObjectiveModel.forId(objectiveId, tx);
   }
 
+  async isObjectiveComplete(objectiveId: string): Promise<boolean> {
+    const {status} = await ObjectiveModel.forId(objectiveId, this.knex);
+    return status === 'failed' || status === 'succeeded';
+  }
+
   /**
    * Gets and locks the objective with the supplied id
    * @param objectiveId

--- a/packages/server-wallet/src/engine/types.ts
+++ b/packages/server-wallet/src/engine/types.ts
@@ -35,16 +35,7 @@ type ChannelUpdatedEvent = {
   value: SingleChannelOutput;
 };
 
-type ObjectiveStarted = {
-  type: 'objectiveStarted';
-  value: WalletObjective;
-};
-type ObjectiveSucceeded = {
-  type: 'objectiveSucceeded';
-  value: WalletObjective;
-};
-
-export type EngineEvent = ChannelUpdatedEvent | ObjectiveStarted | ObjectiveSucceeded;
+export type EngineEvent = ChannelUpdatedEvent;
 
 export interface EngineInterface {
   // App utilities

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import {ObjectiveStatus} from '../models/objective';
+import {ObjectiveStatus, WalletObjective} from '../models/objective';
 
 export type RetryOptions = {
   /**
@@ -58,4 +58,8 @@ export type ObjectiveResult = {
 
   // The channelId for the objective
   channelId: string;
+};
+
+export type ObjectiveProposed = {
+  ObjectiveProposed: WalletObjective;
 };

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -1,5 +1,6 @@
 import {CreateChannelParams, Message} from '@statechannels/client-api-schema';
 import _ from 'lodash';
+import EventEmitter from 'eventemitter3';
 
 import {
   MessageHandler,
@@ -10,13 +11,19 @@ import {getMessages} from '../message-service/utils';
 import {WalletObjective} from '../models/objective';
 import {Engine, SyncObjectiveResult} from '../engine';
 
-import {RetryOptions, ObjectiveResult, ObjectiveError, ObjectiveSuccess} from './types';
+import {
+  RetryOptions,
+  ObjectiveResult,
+  ObjectiveError,
+  ObjectiveSuccess,
+  ObjectiveProposed,
+} from './types';
 
 export const delay = async (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms));
 
 const DEFAULTS: RetryOptions = {numberOfAttempts: 10, multiple: 2, initialDelay: 50};
-export class Wallet {
+export class Wallet extends EventEmitter<ObjectiveProposed> {
   /**
    * Constructs a channel manager that will ensure objectives get accomplished by resending messages if needed.
    * @param engine The engine to use.
@@ -39,9 +46,13 @@ export class Wallet {
     private _engine: Engine,
     private _retryOptions: RetryOptions
   ) {
+    super();
     const handler: MessageHandler = async message => {
-      const {outbox} = await this._engine.pushMessage(message.data);
-
+      const {outbox, newObjectives} = await this._engine.pushMessage(message.data);
+      // Receiving messages from other participants may have resulted in new proposed objectives
+      for (const o of newObjectives) {
+        this.emit('ObjectiveProposed', o);
+      }
       await this.messageService.send(getMessages(outbox));
     };
 
@@ -175,15 +186,6 @@ export class Wallet {
         );
         return {type: 'Success', channelId: objective.data.targetChannelId};
       }
-      let isComplete = false;
-
-      const onObjectiveSucceeded = (o: WalletObjective) => {
-        if (objective.objectiveId === o.objectiveId) {
-          isComplete = true;
-        }
-      };
-
-      this._engine.on('objectiveSucceeded', onObjectiveSucceeded);
 
       // Now that we're listening for objective success we can now send messages
       // that might trigger progress on the objective
@@ -194,8 +196,11 @@ export class Wallet {
        * Consult https://github.com/statechannels/statechannels/issues/3518 for background on this retry logic
        */
       const {multiple, initialDelay, numberOfAttempts} = this._retryOptions;
+      const {objectiveId} = objective;
       for (let i = 0; i < numberOfAttempts; i++) {
-        if (isComplete) return {channelId: objective.data.targetChannelId, type: 'Success'};
+        if (await this._engine.store.isObjectiveComplete(objectiveId)) {
+          return {channelId: objective.data.targetChannelId, type: 'Success'};
+        }
         const delayAmount = initialDelay * Math.pow(multiple, i);
 
         await delay(delayAmount);
@@ -209,7 +214,10 @@ export class Wallet {
 
         await this._messageService.send(messagesForObjective);
       }
-      if (isComplete) return {channelId: objective.data.targetChannelId, type: 'Success'};
+
+      if (await this._engine.store.isObjectiveComplete(objectiveId)) {
+        return {channelId: objective.data.targetChannelId, type: 'Success'};
+      }
       return {numberOfAttempts: this._retryOptions.numberOfAttempts, type: 'EnsureObjectiveFailed'};
     } catch (error) {
       this._engine.logger.error({err: error}, 'Uncaught error in EnsureObjective');


### PR DESCRIPTION
# Description
Removes Objective events from the engine.

This simplifies dealing with the `engine`. Instead of listening for objective events, objectives are returned from the engine api.

The `wallet` is also now an `EventEmitter` with one event `ObjectiveProposed`.  This event fires when the `wallet` receives a new proposed objective from a participant.  `wallet.approveObjectives` can then be used to approve the objective.

Currently there is still a `channel-updated` event. I think this can be deprecated as well but I would like to tackle this in a separate PR.

The wallet now queries the DB when executing `ensureObjective`. This is a pragmatic choice, simplifying the logic to determine when wallet API functions should resolve. Ideally, these API calls should resolve as soon as the objective succeeds -- see #3554 for one possible approach. (Note that API calls did NOT resolve as quickly as possible prior to this change either.)

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [ ] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [ ] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
