### PR TITLE
disable nightly builds

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,8 +1,8 @@
 name: Publish Packages (canary)
 
 on:
-  schedule:
-    - cron:  '0 7 * * *'
+  # schedule:
+  #   - cron:  '0 7 * * *'
   # enable users to manually trigger with workflow_dispatch
   workflow_dispatch: {}
 


### PR DESCRIPTION
The purpose of these nightly builds was to get the latest changes pulled into consuming projects at a high frequency to flag any breaking changes / regressions. 

I don't think that need exists for us right now, hence we can avoid spamming npm. 