### PR TITLE
make interop-tests private

### DIFF
--- a/packages/interop-tests/package.json
+++ b/packages/interop-tests/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@statechannels/browser-wallet": "0.7.0",
     "@statechannels/devtools": "0.5.6",


### PR DESCRIPTION
We should also unpublish https://www.npmjs.com/package/interop-tests if we can. 