### PR TITLE
Properly await knex.destroy in DB-Admin

### DIFF
--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -67,7 +67,7 @@ export class DBAdmin {
   static async migrateDatabase(config: IncomingEngineConfig): Promise<void> {
     const knex = getKnexFromConfig(config);
     await DBAdmin.migrateDatabaseFromKnex(knex);
-    knex.destroy();
+    await knex.destroy();
   }
 
   /**
@@ -93,7 +93,7 @@ export class DBAdmin {
   ): Promise<void> {
     const knex = getKnexFromConfig(config);
     await DBAdmin.truncateDataBaseFromKnex(knex, tables);
-    knex.destroy();
+    await knex.destroy();
   }
 
   /**


### PR DESCRIPTION
Properly awaits `knex.destroy` in the `db-admin`. This may be causing issues with `knex` failing to acquire a connection in some tests.