### PR TITLE
PR3: Direct funding test using chain and two wallets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ jobs:
           file: test-stats
       - upload_gas_report:
           package: nitro-protocol
+      - upload_artifacts 
       - notify_slack
 
   server-wallet-e2e-test:

--- a/packages/server-wallet/jest/chain-setup.ts
+++ b/packages/server-wallet/jest/chain-setup.ts
@@ -1,10 +1,18 @@
 /* eslint-disable no-process-env */
+import * as fs from 'fs';
+
 import {ETHERLIME_ACCOUNTS, GanacheServer} from '@statechannels/devtools';
 import {utils} from 'ethers';
 
 import {deploy} from '../deployment/deploy';
-
+export const ARTIFACTS_DIR = '../../artifacts';
 export default async function setup(): Promise<void> {
+  try {
+    fs.mkdirSync(ARTIFACTS_DIR);
+  } catch (err) {
+    if (err.message !== "EEXIST: file already exists, mkdir '../../artifacts'") throw err;
+  }
+
   if (process.env.CHAIN_NETWORK_ID) {
     console.log(
       `CHAIN_NETWORK_ID defined as ${process.env.CHAIN_NETWORK_ID}. Assuming chain env vars are set by caller`

--- a/packages/server-wallet/jest/jest.chain.config.js
+++ b/packages/server-wallet/jest/jest.chain.config.js
@@ -1,6 +1,6 @@
 const config = require('./jest.config');
 config.testMatch = ['<rootDir>/src/**/__chain-test__/?(*.)test.ts?(x)'];
-config.setupFilesAfterEnv = [];
+config.setupFilesAfterEnv = ['./jest/custom-matchers.ts'];
 config.globalSetup = '<rootDir>/jest/chain-setup.ts';
 config.globalTeardown = '<rootDir>/jest/test-teardown.ts';
 module.exports = config;

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -15,6 +15,7 @@ import {TestMessageService} from '../message-service/test-message-service';
 import {SyncOptions, Wallet} from '../wallet';
 import {ONE_DAY} from '../__test__/test-helpers';
 import {waitForObjectiveProposals} from '../__test-with-peers__/utils';
+import {ARTIFACTS_DIR} from '../../jest/chain-setup';
 
 jest.setTimeout(30_000);
 
@@ -39,7 +40,7 @@ let a: Wallet;
 let b: Wallet;
 let aEngine: Engine;
 let bEngine: Engine;
-const ARTIFACTS_DIR = '../../artifacts';
+
 const bEngineConfig: EngineConfig = {
   ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_b'}),
   loggingConfiguration: {

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -1,16 +1,20 @@
+import path from 'path';
+
 import {CreateChannelParams, Participant, Allocation} from '@statechannels/client-api-schema';
 import {ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
 import {ContractArtifacts} from '@statechannels/nitro-protocol';
 import {BN, makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {BigNumber, constants, Contract, ethers, providers} from 'ethers';
 import _ from 'lodash';
-import {fromEvent} from 'rxjs';
-import {take} from 'rxjs/operators';
 
+import {ChainService} from '../chain-service';
 import {defaultTestConfig, overwriteConfigWithDatabaseConnection, EngineConfig} from '../config';
 import {DBAdmin} from '../db-admin/db-admin';
-import {Engine, SingleChannelOutput} from '../engine';
-import {getChannelResultFor, getPayloadFor, ONE_DAY} from '../__test__/test-helpers';
+import {Engine} from '../engine';
+import {TestMessageService} from '../message-service/test-message-service';
+import {SyncOptions, Wallet} from '../wallet';
+import {ONE_DAY} from '../__test__/test-helpers';
+import {waitForObjectiveProposals} from '../__test-with-peers__/utils';
 
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
@@ -18,6 +22,7 @@ const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!)
 if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const rpcEndpoint = process.env.RPC_ENDPOINT;
+const delay = async (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
 const config = {
   ...defaultTestConfig(),
@@ -29,11 +34,17 @@ const config = {
 };
 
 let provider: providers.JsonRpcProvider;
-let a: Engine;
-let b: Engine;
-
+let a: Wallet;
+let b: Wallet;
+let aEngine: Engine;
+let bEngine: Engine;
+const ARTIFACTS_DIR = '../../artifacts';
 const bEngineConfig: EngineConfig = {
   ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_b'}),
+  loggingConfiguration: {
+    logDestination: path.join(ARTIFACTS_DIR, 'direct-funding.log'),
+    logLevel: 'trace',
+  },
   chainServiceConfiguration: {
     attachChainService: true,
     provider: rpcEndpoint,
@@ -44,6 +55,10 @@ const bEngineConfig: EngineConfig = {
 };
 const aEngineConfig: EngineConfig = {
   ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_a'}),
+  loggingConfiguration: {
+    logDestination: path.join(ARTIFACTS_DIR, 'direct-funding.log'),
+    logLevel: 'trace',
+  },
   chainServiceConfiguration: {
     attachChainService: true,
     provider: rpcEndpoint,
@@ -86,9 +101,26 @@ beforeAll(async () => {
     })
   );
 
-  a = await Engine.create(aEngineConfig);
-  b = await Engine.create(bEngineConfig);
+  aEngine = await Engine.create(aEngineConfig);
+  bEngine = await Engine.create(bEngineConfig);
+  const aChainService = new ChainService({
+    ...aEngineConfig.chainServiceConfiguration,
+    logger: aEngine.logger,
+  });
+  const bChainService = new ChainService({
+    ...bEngineConfig.chainServiceConfiguration,
+    logger: bEngine.logger,
+  });
 
+  const syncOptions: SyncOptions = {
+    pollInterval: 50,
+    timeOutThreshold: 30_000,
+    staleThreshold: 1_000,
+  };
+  a = await Wallet.create(aEngine, aChainService, TestMessageService.create, syncOptions);
+  b = await Wallet.create(bEngine, bChainService, TestMessageService.create, syncOptions);
+
+  TestMessageService.linkMessageServices(a.messageService, b.messageService, aEngine.logger);
   const assetHolder = new Contract(
     ethAssetHolderAddress,
     ContractArtifacts.EthAssetHolderArtifact.abi,
@@ -100,19 +132,18 @@ beforeAll(async () => {
 afterAll(async () => {
   await Promise.all([a.destroy(), b.destroy()]);
   await Promise.all([DBAdmin.dropDatabase(aEngineConfig), DBAdmin.dropDatabase(bEngineConfig)]);
-
   provider.polling = false;
+  provider.removeAllListeners();
 });
 
-// TODO: This should be re-enabled once the chain service has been decoupled from the engine
-it.skip('Create a directly funded channel between two engines ', async () => {
+it('Create a directly funded channel between two wallets ', async () => {
   const participantA: Participant = {
-    signingAddress: await a.getSigningAddress(),
+    signingAddress: await aEngine.getSigningAddress(),
     participantId: 'a',
     destination: makeDestination(aAddress),
   };
   const participantB: Participant = {
-    signingAddress: await b.getSigningAddress(),
+    signingAddress: await bEngine.getSigningAddress(),
     participantId: 'b',
     destination: makeDestination(bAddress),
   };
@@ -139,143 +170,27 @@ it.skip('Create a directly funded channel between two engines ', async () => {
     fundingStrategy: 'Direct',
     challengeDuration: ONE_DAY,
   };
-
-  // the type assertion is due to
-  // https://github.com/devanshj/rxjs-from-emitter/blob/master/docs/solving-some-from-event-flaws.md#the-way-fromevent-checks-if-the-first-argument-passed-is-an-emitter-or-not-is-incorrect
-  const postFundAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
-    .pipe(take(2))
-    .toPromise();
-
-  const postFundBPromise = fromEvent<SingleChannelOutput>(b as any, 'channelUpdated')
-    .pipe(take(2))
-    .toPromise();
-
-  const channelClosedAPromise = fromEvent<SingleChannelOutput>(a as any, 'channelUpdated')
-    .pipe(take(4))
-    .toPromise();
-
-  //        A <> B
-  // PreFund0
-  const preFundA = await a.createChannel(channelParams);
-
-  const channelId = preFundA.channelResult.channelId;
-
   const aBalanceInit = await getBalance(aAddress);
   const bBalanceInit = await getBalance(bAddress);
 
-  expect(preFundA.channelResult).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
-  });
+  const response = await a.createChannels([channelParams]);
+  await waitForObjectiveProposals([response[0].objectiveId], b);
+  const bResponse = await b.approveObjectives([response[0].objectiveId]);
 
-  const resultB0 = await b.pushMessage(getPayloadFor(participantB.participantId, preFundA.outbox));
+  await expect(response).toBeObjectiveDoneType('Success');
+  await expect(bResponse).toBeObjectiveDoneType('Success');
 
-  expect(getChannelResultFor(channelId, resultB0.channelResults)).toMatchObject({
-    status: 'proposed',
-    turnNum: 0,
-  });
+  const assetHolderBalance = await getBalance(ethAssetHolderAddress);
+  expect(assetHolderBalance.toHexString()).toBe('0x01');
 
-  const prefundB = await b.joinChannel({channelId});
-  expect(getChannelResultFor(channelId, [prefundB.channelResult])).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
-  });
-
-  const resultA0 = await a.pushMessage(getPayloadFor(participantA.participantId, prefundB.outbox));
-
-  expect(getChannelResultFor(channelId, resultA0.channelResults)).toMatchObject({
-    status: 'opening',
-    turnNum: 0,
-  });
-
-  const postFundA = await postFundAPromise;
-  const postFundB = await postFundBPromise;
-
-  expect(postFundA.channelResult).toMatchObject({
-    channelId,
-    status: 'opening',
-    turnNum: 0,
-  });
-
-  expect(postFundB.channelResult).toMatchObject({
-    channelId,
-    status: 'opening',
-    turnNum: 0,
-  });
-
-  await b.pushMessage(getPayloadFor(participantB.participantId, postFundA.outbox));
-
-  const resultA1 = await a.pushMessage(getPayloadFor(participantA.participantId, postFundB.outbox));
-  expect(getChannelResultFor(channelId, resultA1.channelResults)).toMatchObject({
-    status: 'running',
-    turnNum: 3,
-  });
-
-  const resultB1 = await b.pushMessage(getPayloadFor(participantB.participantId, postFundA.outbox));
-  expect(getChannelResultFor(channelId, resultB1.channelResults)).toMatchObject({
-    status: 'running',
-    turnNum: 3,
-    // TODO: the fundingStatus is incorrect as the funding table is not joined with channels table
-    //  when processing the pushMessage above
-    // fundingStatus: 'Funded',
-  });
-
-  const closeA = await a.closeChannel({channelId});
-  expect(closeA.channelResult).toMatchObject({
-    status: 'closing',
-    turnNum: 4,
-    // TODO: the fundingStatus is incorrect as the funding table is not joined with channels table
-    //  when processing the pushMessage above
-    // fundingStatus: 'Funded',
-  });
-
-  const closeB = await b.pushMessage(getPayloadFor(participantB.participantId, closeA.outbox));
-  expect(getChannelResultFor(channelId, closeB.channelResults)).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-    fundingStatus: 'Defunded',
-  });
-
-  const close2A = await a.pushMessage(getPayloadFor(participantA.participantId, closeB.outbox));
-  expect(getChannelResultFor(channelId, close2A.channelResults)).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-    fundingStatus: 'Funded',
-  });
-
-  // Mine a few blocks, but not enough for the chain service to update holdings
-  // Then wait 500ms so that, if the chain service incorrectly updated holdings,
-  // then the updated holdings would have been processed by the engine.
-  await mineBlocks(3);
-  await new Promise(r => setTimeout(r, 500));
-  expect((await a.getState({channelId})).channelResult).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-    fundingStatus: 'Funded',
-  });
-
-  await mineBlocks(2);
-
-  const channelClosedA = await channelClosedAPromise;
-
-  expect(channelClosedA.channelResult).toMatchObject({
-    status: 'closed',
-    turnNum: 4,
-    fundingStatus: 'Defunded',
-  });
+  const {channelId} = response[0];
+  const closeResponse = await b.closeChannels([channelId]);
+  await expect(closeResponse).toBeObjectiveDoneType('Success');
 
   const aBalanceFinal = await getBalance(aAddress);
   const bBalanceFinal = await getBalance(bAddress);
 
   expect(BN.sub(aBalanceFinal, aBalanceInit)).toEqual(aFunding);
   expect(BN.sub(bBalanceFinal, bBalanceInit)).toEqual(bFunding);
-
-  // TODO: remove this
-  // The reason for the wait:
-  // - B CloseChannel objective succeeds BEFORE AssetTransferred event arrives
-  // - B has no funds in the channel, so B does not wait for an AssetTransferred event to complete the CloseObjective
-  // - AssetTransferred event arrives to B after the test finishes running
-  // - We see "Error: Unable to acquire a connection"
-  // - The error does NOT fail the test
-  await new Promise(r => setTimeout(r, 500));
-}, 50_000);
+  await delay(1000);
+}, 5_000_000);

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -116,9 +116,9 @@ beforeAll(async () => {
     });
 
     const syncOptions: SyncOptions = {
-      pollInterval: 50,
-      timeOutThreshold: 30_000,
-      staleThreshold: 1_000,
+      pollInterval: 1_000,
+      timeOutThreshold: 60_000,
+      staleThreshold: 10_000,
     };
     a = await Wallet.create(aEngine, aChainService, TestMessageService.create, syncOptions);
     b = await Wallet.create(bEngine, bChainService, TestMessageService.create, syncOptions);

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -200,4 +200,8 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   expect(BN.sub(aBalanceFinal, aBalanceInit)).toEqual(aFunding);
   expect(BN.sub(bBalanceFinal, bBalanceInit)).toEqual(bFunding);
+
+  // TODO: This is slightly hacky but it's a workaround for chain event listeners promises
+  // that are still executing when destroy is called.
+  await new Promise(resolve => setTimeout(resolve, 2_000));
 });

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -179,6 +179,7 @@ it('Create a directly funded channel between two wallets ', async () => {
   };
   const aBalanceInit = await getBalance(aAddress);
   const bBalanceInit = await getBalance(bAddress);
+  const assetHolderBalanceInit = await getBalance(ethAssetHolderAddress);
 
   const response = await a.createChannels([channelParams]);
   await waitForObjectiveProposals([response[0].objectiveId], b);
@@ -187,8 +188,8 @@ it('Create a directly funded channel between two wallets ', async () => {
   await expect(response).toBeObjectiveDoneType('Success');
   await expect(bResponse).toBeObjectiveDoneType('Success');
 
-  const assetHolderBalance = await getBalance(ethAssetHolderAddress);
-  expect(assetHolderBalance.toHexString()).toBe('0x01');
+  const assetHolderBalanceUpdated = await getBalance(ethAssetHolderAddress);
+  expect(BN.sub(assetHolderBalanceUpdated, assetHolderBalanceInit)).toEqual('0x01');
 
   const {channelId} = response[0];
   const closeResponse = await b.closeChannels([channelId]);

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -16,13 +16,14 @@ import {SyncOptions, Wallet} from '../wallet';
 import {ONE_DAY} from '../__test__/test-helpers';
 import {waitForObjectiveProposals} from '../__test-with-peers__/utils';
 
+jest.setTimeout(30_000);
+
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const rpcEndpoint = process.env.RPC_ENDPOINT;
-const delay = async (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
 const config = {
   ...defaultTestConfig(),
@@ -192,5 +193,4 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   expect(BN.sub(aBalanceFinal, aBalanceInit)).toEqual(aFunding);
   expect(BN.sub(bBalanceFinal, bBalanceInit)).toEqual(bFunding);
-  await delay(1000);
-}, 5_000_000);
+});

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -90,6 +90,7 @@ const mineBlocksForEvent = () => mineBlocks();
 
 function mineOnEvent(contract: Contract) {
   contract.on('Deposited', mineBlocksForEvent);
+  contract.on('AllocationUpdated', mineBlocksForEvent);
 }
 
 beforeAll(async () => {

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -73,8 +73,8 @@ const aEngineConfig: EngineConfig = {
 const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';
 const bAddress = '0x632d0b05c78A83cEd439D3bd6C710c4814D3a6db';
 
-const aFunding = BN.from(1);
-const bFunding = BN.from(0);
+const aFunding = BN.from(3);
+const bFunding = BN.from(2);
 
 async function getBalance(address: string): Promise<BigNumber> {
   return await provider.getBalance(address);
@@ -184,7 +184,9 @@ it('Create a directly funded channel between two wallets ', async () => {
   await expect(bResponse).toBeObjectiveDoneType('Success');
 
   const assetHolderBalanceUpdated = await getBalance(ethAssetHolderAddress);
-  expect(BN.sub(assetHolderBalanceUpdated, assetHolderBalanceInit)).toEqual('0x01');
+  expect(BN.sub(assetHolderBalanceUpdated, assetHolderBalanceInit)).toEqual(
+    BN.add(aFunding, bFunding)
+  );
 
   const {channelId} = response[0];
   const closeResponse = await b.closeChannels([channelId]);
@@ -195,8 +197,4 @@ it('Create a directly funded channel between two wallets ', async () => {
 
   expect(BN.sub(aBalanceFinal, aBalanceInit)).toEqual(aFunding);
   expect(BN.sub(bBalanceFinal, bBalanceInit)).toEqual(bFunding);
-
-  // TODO: This is slightly hacky but it's a workaround for chain event listeners promises
-  // that are still executing when destroy is called.
-  await new Promise(resolve => setTimeout(resolve, 2_000));
 });

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -17,7 +17,7 @@ import {ONE_DAY} from '../__test__/test-helpers';
 import {waitForObjectiveProposals} from '../__test-with-peers__/utils';
 import {ARTIFACTS_DIR} from '../../jest/chain-setup';
 
-jest.setTimeout(30_000);
+jest.setTimeout(60_000);
 
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -93,47 +93,42 @@ function mineOnEvent(contract: Contract) {
 }
 
 beforeAll(async () => {
-  try {
-    provider = new providers.JsonRpcProvider(rpcEndpoint);
+  provider = new providers.JsonRpcProvider(rpcEndpoint);
 
-    await Promise.all(
-      [aEngineConfig, bEngineConfig].map(async config => {
-        await DBAdmin.dropDatabase(config);
-        await DBAdmin.createDatabase(config);
-        await DBAdmin.migrateDatabase(config);
-      })
-    );
+  await Promise.all(
+    [aEngineConfig, bEngineConfig].map(async config => {
+      await DBAdmin.dropDatabase(config);
+      await DBAdmin.createDatabase(config);
+      await DBAdmin.migrateDatabase(config);
+    })
+  );
 
-    aEngine = await Engine.create(aEngineConfig);
-    bEngine = await Engine.create(bEngineConfig);
-    const aChainService = new ChainService({
-      ...aEngineConfig.chainServiceConfiguration,
-      logger: aEngine.logger,
-    });
-    const bChainService = new ChainService({
-      ...bEngineConfig.chainServiceConfiguration,
-      logger: bEngine.logger,
-    });
+  aEngine = await Engine.create(aEngineConfig);
+  bEngine = await Engine.create(bEngineConfig);
+  const aChainService = new ChainService({
+    ...aEngineConfig.chainServiceConfiguration,
+    logger: aEngine.logger,
+  });
+  const bChainService = new ChainService({
+    ...bEngineConfig.chainServiceConfiguration,
+    logger: bEngine.logger,
+  });
 
-    const syncOptions: SyncOptions = {
-      pollInterval: 1_000,
-      timeOutThreshold: 60_000,
-      staleThreshold: 10_000,
-    };
-    a = await Wallet.create(aEngine, aChainService, TestMessageService.create, syncOptions);
-    b = await Wallet.create(bEngine, bChainService, TestMessageService.create, syncOptions);
+  const syncOptions: SyncOptions = {
+    pollInterval: 1_000,
+    timeOutThreshold: 60_000,
+    staleThreshold: 10_000,
+  };
+  a = await Wallet.create(aEngine, aChainService, TestMessageService.create, syncOptions);
+  b = await Wallet.create(bEngine, bChainService, TestMessageService.create, syncOptions);
 
-    TestMessageService.linkMessageServices(a.messageService, b.messageService, aEngine.logger);
-    const assetHolder = new Contract(
-      ethAssetHolderAddress,
-      ContractArtifacts.EthAssetHolderArtifact.abi,
-      provider
-    );
-    mineOnEvent(assetHolder);
-  } catch (error) {
-    console.error('beforeAll failed');
-    console.error(error);
-  }
+  TestMessageService.linkMessageServices(a.messageService, b.messageService, aEngine.logger);
+  const assetHolder = new Contract(
+    ethAssetHolderAddress,
+    ContractArtifacts.EthAssetHolderArtifact.abi,
+    provider
+  );
+  mineOnEvent(assetHolder);
 });
 
 afterAll(async () => {

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -137,6 +137,8 @@ export class ChainService implements ChainServiceInterface {
     chainRequests: ChainRequest[]
   ): Promise<providers.TransactionResponse[]> {
     const responses: providers.TransactionResponse[] = [];
+
+    this.logger.trace({chainRequests}, 'Handling chain requests');
     for (const chainRequest of chainRequests) {
       let response;
       switch (chainRequest.type) {
@@ -176,9 +178,13 @@ export class ChainService implements ChainServiceInterface {
 
   // Only used for unit tests
   destructor(): void {
+    this.logger.trace('Starting destroy');
     this.provider.polling = false;
     this.provider.removeAllListeners();
+
     this.addressToContract.forEach(contract => contract.removeAllListeners());
+
+    this.logger.trace('Completed destroy');
   }
 
   private addContractMapping(
@@ -538,6 +544,10 @@ export class ChainService implements ChainServiceInterface {
   private listenForContractEvents(assetHolderContract: Contract): void {
     // Listen to all contract events
     assetHolderContract.on({}, async (ethersEvent: Event) => {
+      this.logger.trace(
+        {address: assetHolderContract.address, event: ethersEvent},
+        'AssetHolder event being handled'
+      );
       await this.waitForConfirmations(ethersEvent);
       this.onAssetHolderEvent(assetHolderContract, ethersEvent);
     });

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -179,6 +179,7 @@ export class ChainService implements ChainServiceInterface {
   // Only used for unit tests
   destructor(): void {
     this.logger.trace('Starting destroy');
+    this.channelToEventTrackers.clear();
     this.provider.polling = false;
     this.provider.removeAllListeners();
 
@@ -461,6 +462,9 @@ export class ChainService implements ChainServiceInterface {
     channelId: string,
     eventTracker: EventTracker
   ): Promise<void> {
+    // If the destructor has been called we want to abort right away
+    // We use this.provider.polling since we know the destructor sets that to false
+    if (!this.provider.polling) return;
     const currentBlock = await this.provider.getBlockNumber();
     const confirmedBlock = currentBlock - this.blockConfirmations;
     const currentHolding = BN.from(await contract.holdings(channelId));

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -224,7 +224,8 @@ export class Wallet extends EventEmitter<WalletEvents> {
       channelIds.map(async channelId => {
         const closeResult = await this._engine.closeChannel({channelId});
         const {newObjective, channelResult} = closeResult;
-
+        // create the promise before we send anything out
+        const done = this.createObjectiveDoneResult(newObjective);
         // TODO: We just refetch to get the latest status
         // Long term we should make sure the engine returns the latest objectives
         const latest = await this._engine.getObjective(newObjective.objectiveId);
@@ -234,7 +235,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
           channelId: channelResult.channelId,
           currentStatus: latest.status,
           objectiveId: newObjective.objectiveId,
-          done: this.createObjectiveDoneResult(newObjective),
+          done,
         };
       })
     );

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -150,9 +150,8 @@ export class Wallet extends EventEmitter<WalletEvents> {
     // TODO: ApproveObjective should probably just return a MultipleChannelOuput
     const completedObjectives = objectives.filter(o => o.status === 'succeeded');
     completedObjectives.forEach(o => this.emit('ObjectiveCompleted', o));
-    const transactions = await this._chainService.handleChainRequests(chainRequests);
+    await this._chainService.handleChainRequests(chainRequests);
     await this.messageService.send(messages);
-    await Promise.all(transactions.map(tr => tr.wait()));
 
     return Promise.all(results);
   }


### PR DESCRIPTION
**based on top of #3564 and #3555** 

Adds a very basic test that ensures direct funding works between two wallets using a chain service running against a real ganache.

Currently, the test creates and then closes a channel. It ensures that the wallet promises resolve successfully and that the funds on ganache get updated correctly.