### PR TITLE
Fix check on maximum number of participants

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -935,7 +935,9 @@ contract ForceMove is IForceMove {
             (numSigs == numParticipants) && (numWhoSignedWhats == numParticipants),
             'Bad |signatures|v|whoSignedWhat|'
         );
-        require(numParticipants < type(uint8).max, 'Too many participants!');
+        require(numParticipants <= type(uint8).max, 'Too many participants!'); // type(uint8).max = 2**8 - 1 = 255
+        // no more than 255 participants
+        // max index for participants is 254
         return true;
     }
 }

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -15,7 +15,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 2421626, // Singleton
+      NitroAdjudicator: 2421830, // Singleton
       ETHAssetHolder: 1634011, // Singleton (could be more in principle)
       ERC20AssetHolder: 1657410, // Per Token (could be more in principle)
     },


### PR DESCRIPTION
Our docs state that the maximum length of the participants array is 255, but our  runtime check is actually that the length of the participants array is less than 255. It should check that the length is less than or equal to 255.



This PR fixes the check.