### PR TITLE
increase timeout for concludePushOutcomeAndTransferAll

### DIFF
--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -28,6 +28,8 @@ import {
 import {signStates} from '../../../src';
 import {NITRO_MAX_GAS} from '../../../src/transactions';
 
+jest.setTimeout(15_000);
+
 const provider = getTestProvider();
 let NitroAdjudicator: Contract;
 let EthAssetHolder1: Contract;


### PR DESCRIPTION
I'm seeing this flickering a bit, citing timeout. Possibly as side effect of #3560 