### PR TITLE
require non-zero holdings in _transfer

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -235,6 +235,8 @@ contract AssetHolder is IAssetHolder {
         );
         uint256 initialHoldings = holdings[fromChannelId];
 
+        require(initialHoldings > 0, 'no holdings for this channel');
+
         (
             Outcome.AllocationItem[] memory newAllocation,
             bool safeToDelete,

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -16,8 +16,8 @@ export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
       NitroAdjudicator: 2421626, // Singleton
-      ETHAssetHolder: 1632711, // Singleton (could be more in principle)
-      ERC20AssetHolder: 1654810, // Per Token (could be more in principle)
+      ETHAssetHolder: 1651445, // Singleton (could be more in principle)
+      ERC20AssetHolder: 1673544, // Per Token (could be more in principle)
     },
   },
   directlyFundAChannelWithETHFirst: {


### PR DESCRIPTION
* Currently `concludePushOutcomeAndTransferAll` will happily succeed if the channel is not funded at all. While this is not necessarily *wrong*, it is pretty unexpected.