### PR TITLE
More gas benchmarking

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -235,6 +235,8 @@ contract AssetHolder is IAssetHolder {
         );
         uint256 initialHoldings = holdings[fromChannelId];
 
+        require(initialHoldings > 0, 'no holdings for this channel');
+
         (
             Outcome.AllocationItem[] memory newAllocation,
             bool safeToDelete,

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -235,8 +235,6 @@ contract AssetHolder is IAssetHolder {
         );
         uint256 initialHoldings = holdings[fromChannelId];
 
-        require(initialHoldings > 0, 'no holdings for this channel');
-
         (
             Outcome.AllocationItem[] memory newAllocation,
             bool safeToDelete,

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -2,7 +2,7 @@ import {channelId} from './fixtures';
 import {gasRequiredTo} from './gas';
 import {erc20AssetHolder, ethAssetHolder, nitroAdjudicator, token} from './vanillaSetup';
 
-describe('Consumes the expected gas', () => {
+describe('Consumes the expected gas for deployments', () => {
   it(`when deploying the NitroAdjudicator >>>>>  ${gasRequiredTo.deployInfrastructureContracts.vanillaNitro.NitroAdjudicator} gas`, async () => {
     await expect(await nitroAdjudicator.deployTransaction).toConsumeGas(
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.NitroAdjudicator
@@ -18,6 +18,8 @@ describe('Consumes the expected gas', () => {
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ERC20AssetHolder
     );
   });
+});
+describe('Consumes the expected gas for deposits', () => {
   it(`when directly funding a channel with ETH (first deposit) >>>>>  ${gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro} gas`, async () => {
     await expect(await ethAssetHolder.deposit(channelId, 0, 5, {value: 5})).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -78,4 +78,22 @@ describe('Consumes the expected gas for happy-path exits', () => {
     const {gasUsed} = await (await tx).wait();
     expect(gasUsed.toNumber()).toEqual(gasRequiredTo.ETHexit.vanillaNitro);
   });
+  it(`when exiting a directly funded (with ERC20s) channel`, async () => {
+    // begin setup
+    await (await token.increaseAllowance(erc20AssetHolder.address, 100)).wait();
+    await (await erc20AssetHolder.deposit(channelId, 0, 10)).wait();
+    // end setup
+    const fP = finalizationProof(finalState(erc20AssetHolder.address));
+    const tx = nitroAdjudicator.concludePushOutcomeAndTransferAll(
+      fP.largestTurnNum,
+      fP.fixedPart,
+      fP.appPartHash,
+      fP.outcomeBytes,
+      fP.numStates,
+      fP.whoSignedWhat,
+      fP.sigs
+    );
+    const {gasUsed} = await (await tx).wait();
+    expect(gasUsed.toNumber()).toEqual(gasRequiredTo.ERC20exit.vanillaNitro);
+  });
 });

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -1,4 +1,4 @@
-import {channelId, finalizationProof, finalState} from './fixtures';
+import {channelId, finalizationProof, finalState, someOtherChannelId} from './fixtures';
 import {gasRequiredTo} from './gas';
 import {erc20AssetHolder, ethAssetHolder, nitroAdjudicator, token} from './vanillaSetup';
 
@@ -62,8 +62,8 @@ describe('Consumes the expected gas for deposits', () => {
 describe('Consumes the expected gas for happy-path exits', () => {
   it(`when exiting a directly funded (with ETH) channel`, async () => {
     // begin setup
-    const setupTX = ethAssetHolder.deposit(channelId, 0, 10, {value: 10});
-    await (await setupTX).wait();
+    await (await ethAssetHolder.deposit(someOtherChannelId, 0, 10, {value: 10})).wait(); // other channels are funded by this asset holder
+    await (await ethAssetHolder.deposit(channelId, 0, 10, {value: 10})).wait();
     // end setup
     const fP = finalizationProof(finalState(ethAssetHolder.address));
     await expect(
@@ -81,6 +81,7 @@ describe('Consumes the expected gas for happy-path exits', () => {
   it(`when exiting a directly funded (with ERC20s) channel`, async () => {
     // begin setup
     await (await token.increaseAllowance(erc20AssetHolder.address, 100)).wait();
+    await (await erc20AssetHolder.deposit(someOtherChannelId, 0, 10)).wait(); // other channels are funded by this asset holder
     await (await erc20AssetHolder.deposit(channelId, 0, 10)).wait();
     // end setup
     const fP = finalizationProof(finalState(erc20AssetHolder.address));

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -66,17 +66,17 @@ describe('Consumes the expected gas for happy-path exits', () => {
     await (await setupTX).wait();
     // end setup
     const fP = finalizationProof(finalState(ethAssetHolder.address));
-    const tx = nitroAdjudicator.concludePushOutcomeAndTransferAll(
-      fP.largestTurnNum,
-      fP.fixedPart,
-      fP.appPartHash,
-      fP.outcomeBytes,
-      fP.numStates,
-      fP.whoSignedWhat,
-      fP.sigs
-    );
-    const {gasUsed} = await (await tx).wait();
-    expect(gasUsed.toNumber()).toEqual(gasRequiredTo.ETHexit.vanillaNitro);
+    await expect(
+      await nitroAdjudicator.concludePushOutcomeAndTransferAll(
+        fP.largestTurnNum,
+        fP.fixedPart,
+        fP.appPartHash,
+        fP.outcomeBytes,
+        fP.numStates,
+        fP.whoSignedWhat,
+        fP.sigs
+      )
+    ).toConsumeGas(gasRequiredTo.ETHexit.vanillaNitro);
   });
   it(`when exiting a directly funded (with ERC20s) channel`, async () => {
     // begin setup
@@ -84,16 +84,16 @@ describe('Consumes the expected gas for happy-path exits', () => {
     await (await erc20AssetHolder.deposit(channelId, 0, 10)).wait();
     // end setup
     const fP = finalizationProof(finalState(erc20AssetHolder.address));
-    const tx = nitroAdjudicator.concludePushOutcomeAndTransferAll(
-      fP.largestTurnNum,
-      fP.fixedPart,
-      fP.appPartHash,
-      fP.outcomeBytes,
-      fP.numStates,
-      fP.whoSignedWhat,
-      fP.sigs
-    );
-    const {gasUsed} = await (await tx).wait();
-    expect(gasUsed.toNumber()).toEqual(gasRequiredTo.ERC20exit.vanillaNitro);
+    await expect(
+      await nitroAdjudicator.concludePushOutcomeAndTransferAll(
+        fP.largestTurnNum,
+        fP.fixedPart,
+        fP.appPartHash,
+        fP.outcomeBytes,
+        fP.numStates,
+        fP.whoSignedWhat,
+        fP.sigs
+      )
+    ).toConsumeGas(gasRequiredTo.ERC20exit.vanillaNitro);
   });
 });

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -60,9 +60,11 @@ describe('Consumes the expected gas for deposits', () => {
   });
 });
 describe('Consumes the expected gas for happy-path exits', () => {
-  it(`when exiting a directly funded with ETH channel`, async () => {
-    // we completely liquidate the channel (paying out both parties)
-    // This is the first the adjudicator learns about the channel
+  it(`when exiting a directly funded (with ETH) channel`, async () => {
+    // begin setup
+    const setupTX = ethAssetHolder.deposit(channelId, 0, 10, {value: 10});
+    await (await setupTX).wait();
+    // end setup
     const fP = finalizationProof(finalState(ethAssetHolder.address));
     const tx = nitroAdjudicator.concludePushOutcomeAndTransferAll(
       fP.largestTurnNum,

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -27,6 +27,8 @@ export const participants = [Alice.address, Bob.address];
 const channel: Channel = {chainId, channelNonce, participants};
 export const channelId = getChannelId(channel);
 
+export const someOtherChannelId = getChannelId({...channel, channelNonce: 1337});
+
 export function finalState(assetHolderAddress: string): State {
   return {
     challengeDuration: 600,

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -1,8 +1,21 @@
+import {Signature} from '@ethersproject/bytes';
 import {Wallet} from '@ethersproject/wallet';
 
-import {Channel, getChannelId} from '../src';
+import {
+  Bytes32,
+  Channel,
+  convertAddressToBytes32,
+  encodeOutcome,
+  getChannelId,
+  getFixedPart,
+  hashAppPart,
+  signState,
+  State,
+} from '../src';
+import {FixedPart} from '../src/contract/state';
+import {Bytes} from '../src/contract/types';
 
-export const chainId = '0x1';
+export const chainId = '0x7a69'; // 31337 in hex (hardhat network default)
 export const channelNonce = 2;
 
 export const Alice = new Wallet(
@@ -13,3 +26,48 @@ export const participants = [Alice.address, Bob.address];
 
 const channel: Channel = {chainId, channelNonce, participants};
 export const channelId = getChannelId(channel);
+
+export function finalState(assetHolderAddress: string): State {
+  return {
+    challengeDuration: 600,
+    appDefinition: '0x8504FcA6e1e73947850D66D032435AC931892116',
+    channel,
+    turnNum: 6,
+    isFinal: true,
+    outcome: [
+      {
+        assetHolderAddress,
+        allocationItems: [
+          {destination: convertAddressToBytes32(Alice.address), amount: '0x5'},
+          {destination: convertAddressToBytes32(Bob.address), amount: '0x5'},
+        ],
+      },
+    ],
+    appData: '0x', // TODO choose a more representative example
+  };
+}
+
+export function finalizationProof(
+  state: State
+): {
+  largestTurnNum: number;
+  fixedPart: FixedPart;
+  appPartHash: Bytes32;
+  outcomeBytes: Bytes;
+  numStates: 1;
+  whoSignedWhat: [0, 0];
+  sigs: [Signature, Signature];
+} {
+  return {
+    largestTurnNum: state.turnNum,
+    fixedPart: getFixedPart(state),
+    appPartHash: hashAppPart(state),
+    outcomeBytes: encodeOutcome(state.outcome),
+    numStates: 1,
+    whoSignedWhat: [0, 0],
+    sigs: [
+      signState(state, Alice.privateKey).signature,
+      signState(state, Bob.privateKey).signature,
+    ],
+  };
+}

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -17,7 +17,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 2421626, // Singleton
+      NitroAdjudicator: 2421830, // Singleton
       ETHAssetHolder: 1652745, // Singleton (could be more in principle)
       ERC20AssetHolder: 1676144, // Per Token (could be more in principle)
     },
@@ -54,11 +54,11 @@ export const gasRequiredTo: GasRequiredTo = {
   },
   ETHexit: {
     // e completely liquidate the channel (paying out both parties)
-    vanillaNitro: 146807,
+    vanillaNitro: 146810,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
     // This is cheaper than the ETHexit because storage slots are zero-ed out.
-    vanillaNitro: 124162,
+    vanillaNitro: 124165,
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -18,8 +18,8 @@ export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
       NitroAdjudicator: 2421830, // Singleton
-      ETHAssetHolder: 1652745, // Singleton (could be more in principle)
-      ERC20AssetHolder: 1676144, // Per Token (could be more in principle)
+      ETHAssetHolder: 1634011, // Singleton (could be more in principle)
+      ERC20AssetHolder: 1657410, // Per Token (could be more in principle)
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -54,11 +54,11 @@ export const gasRequiredTo: GasRequiredTo = {
   },
   ETHexit: {
     // e completely liquidate the channel (paying out both parties)
-    vanillaNitro: 146810,
+    vanillaNitro: 146793,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
     // This is cheaper than the ETHexit because storage slots are zero-ed out.
-    vanillaNitro: 124165,
+    vanillaNitro: 124148,
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -53,12 +53,11 @@ export const gasRequiredTo: GasRequiredTo = {
     },
   },
   ETHexit: {
-    // e completely liquidate the channel (paying out both parties)
+    // We completely liquidate the channel (paying out both parties)
     vanillaNitro: 146793,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
-    // This is cheaper than the ETHexit because storage slots are zero-ed out.
     vanillaNitro: 139148,
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -11,7 +11,8 @@ type Path =
   | 'directlyFundAChannelWithETHSecond'
   | 'directlyFundAChannelWithERC20First'
   | 'directlyFundAChannelWithERC20Second'
-  | 'ETHexit';
+  | 'ETHexit'
+  | 'ERC20exit';
 
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
@@ -52,7 +53,12 @@ export const gasRequiredTo: GasRequiredTo = {
     },
   },
   ETHexit: {
-    // we completely liquidate the channel (paying out both parties)
+    // e completely liquidate the channel (paying out both parties)
     vanillaNitro: 146807,
+  },
+  ERC20exit: {
+    // We completely liquidate the channel (paying out both parties)
+    // This is cheaper than the ETHexit because storage slots are zero-ed out.
+    vanillaNitro: 124162,
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -10,7 +10,8 @@ type Path =
   | 'directlyFundAChannelWithETHFirst'
   | 'directlyFundAChannelWithETHSecond'
   | 'directlyFundAChannelWithERC20First'
-  | 'directlyFundAChannelWithERC20Second';
+  | 'directlyFundAChannelWithERC20Second'
+  | 'ETHexit';
 
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
@@ -21,11 +22,11 @@ export const gasRequiredTo: GasRequiredTo = {
     },
   },
   directlyFundAChannelWithETHFirst: {
-    vanillaNitro: 47596,
+    vanillaNitro: 47608,
   },
   directlyFundAChannelWithETHSecond: {
     // meaning the second participant in the channel
-    vanillaNitro: 30508,
+    vanillaNitro: 30520,
   },
   directlyFundAChannelWithERC20First: {
     // The depositor begins with zero tokens approved for the AssetHolder
@@ -37,7 +38,7 @@ export const gasRequiredTo: GasRequiredTo = {
       // ^^^^^
       // In principle this only needs to be done once per account
       // (the cost may be amortized over several deposits into this AssetHolder)
-      deposit: 72842,
+      deposit: 72854,
     },
   },
   directlyFundAChannelWithERC20Second: {
@@ -47,7 +48,10 @@ export const gasRequiredTo: GasRequiredTo = {
       // ^^^^^
       // In principle this only needs to be done once per account
       // (the cost may be amortized over several deposits into this AssetHolder)
-      deposit: 55754,
+      deposit: 55766,
     },
+  },
+  ETHexit: {
+    vanillaNitro: 110791,
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -16,9 +16,9 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 2421830, // Singleton
-      ETHAssetHolder: 1634011, // Singleton (could be more in principle)
-      ERC20AssetHolder: 1657410, // Per Token (could be more in principle)
+      NitroAdjudicator: 2421626, // Singleton
+      ETHAssetHolder: 1652745, // Singleton (could be more in principle)
+      ERC20AssetHolder: 1676144, // Per Token (could be more in principle)
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -52,6 +52,7 @@ export const gasRequiredTo: GasRequiredTo = {
     },
   },
   ETHexit: {
-    vanillaNitro: 110791,
+    // we completely liquidate the channel (paying out both parties)
+    vanillaNitro: 146807,
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -59,6 +59,6 @@ export const gasRequiredTo: GasRequiredTo = {
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
     // This is cheaper than the ETHexit because storage slots are zero-ed out.
-    vanillaNitro: 124148,
+    vanillaNitro: 139148,
   },
 };


### PR DESCRIPTION
adds a case for a happy exit with ETH, and one for ERC20 tokens. Follow on work from #3544.

Non-essential Changes:
~Includes #3571~   