### PR TITLE
Add a toConsumeGas jest matcher

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -4,36 +4,31 @@ import {erc20AssetHolder, ethAssetHolder, nitroAdjudicator, token} from './vanil
 
 describe('Consumes the expected gas', () => {
   it(`when deploying the NitroAdjudicator >>>>>  ${gasRequiredTo.deployInfrastructureContracts.vanillaNitro.NitroAdjudicator} gas`, async () => {
-    const {gasUsed} = await nitroAdjudicator.deployTransaction.wait();
-    expect(gasUsed.toNumber()).toEqual(
+    await expect(await nitroAdjudicator.deployTransaction).toConsumeGas(
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.NitroAdjudicator
     );
   });
   it(`when deploying the ETHAssetHolder >>>>>  ${gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ETHAssetHolder} gas`, async () => {
-    const {gasUsed} = await ethAssetHolder.deployTransaction.wait();
-    expect(gasUsed.toNumber()).toEqual(
+    await expect(await ethAssetHolder.deployTransaction).toConsumeGas(
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ETHAssetHolder
     );
   });
   it(`when deploying the ERC20AssetHolder >>>>>  ${gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ERC20AssetHolder} gas`, async () => {
-    const {gasUsed} = await erc20AssetHolder.deployTransaction.wait();
-    expect(gasUsed.toNumber()).toEqual(
+    await expect(await erc20AssetHolder.deployTransaction).toConsumeGas(
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ERC20AssetHolder
     );
   });
   it(`when directly funding a channel with ETH (first deposit) >>>>>  ${gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro} gas`, async () => {
-    const tx = ethAssetHolder.deposit(channelId, 0, 5, {value: 5});
-    const {gasUsed} = await (await tx).wait();
-    expect(gasUsed.toNumber()).toEqual(gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro);
+    await expect(await ethAssetHolder.deposit(channelId, 0, 5, {value: 5})).toConsumeGas(
+      gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro
+    );
   });
   it(`when directly funding a channel with ETH (second deposit) >>>>> ${gasRequiredTo.directlyFundAChannelWithETHSecond.vanillaNitro} gas`, async () => {
     // begin setup
     const setupTX = ethAssetHolder.deposit(channelId, 0, 5, {value: 5});
     await (await setupTX).wait();
     // end setup
-    const tx = ethAssetHolder.deposit(channelId, 5, 5, {value: 5});
-    const {gasUsed} = await (await tx).wait();
-    expect(gasUsed.toNumber()).toEqual(
+    await expect(await ethAssetHolder.deposit(channelId, 5, 5, {value: 5})).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithETHSecond.vanillaNitro
     );
   });
@@ -41,15 +36,10 @@ describe('Consumes the expected gas', () => {
     // begin setup
     await (await token.transfer(erc20AssetHolder.address, 1)).wait(); // The asset holder already has some tokens (for other channels)
     // end setup
-    const {gasUsed: gasUsedToApprove} = await (
-      await token.increaseAllowance(erc20AssetHolder.address, 100)
-    ).wait();
-    expect(gasUsedToApprove.toNumber()).toEqual(
+    await expect(await token.increaseAllowance(erc20AssetHolder.address, 100)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20First.vanillaNitro.approve
     );
-    const tx = erc20AssetHolder.deposit(channelId, 0, 5);
-    const {gasUsed} = await (await tx).wait();
-    expect(gasUsed.toNumber()).toEqual(
+    await expect(await erc20AssetHolder.deposit(channelId, 0, 5)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20First.vanillaNitro.deposit
     );
   });
@@ -59,15 +49,10 @@ describe('Consumes the expected gas', () => {
     await (await erc20AssetHolder.deposit(channelId, 0, 5)).wait(); // The asset holder already has some tokens *for this channel*
     await (await token.decreaseAllowance(erc20AssetHolder.address, 95)).wait(); // reset allowance to zero
     // end setup
-    const {gasUsed: gasUsedToApprove} = await (
-      await token.increaseAllowance(erc20AssetHolder.address, 100)
-    ).wait();
-    expect(gasUsedToApprove.toNumber()).toEqual(
+    await expect(await token.increaseAllowance(erc20AssetHolder.address, 100)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20Second.vanillaNitro.approve
     );
-    const tx = erc20AssetHolder.deposit(channelId, 5, 5);
-    const {gasUsed} = await (await tx).wait();
-    expect(gasUsed.toNumber()).toEqual(
+    await expect(await erc20AssetHolder.deposit(channelId, 5, 5)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20Second.vanillaNitro.deposit
     );
   });

--- a/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
+++ b/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
@@ -5,6 +5,17 @@ import nitroAdjudicatorArtifact from '../artifacts/contracts/NitroAdjudicator.so
 import ethAssetHolderArtifact from '../artifacts/contracts/ETHAssetHolder.sol/ETHAssetHolder.json';
 import erc20AssetHolderArtifact from '../artifacts/contracts/ERC20AssetHolder.sol/ERC20AssetHolder.json';
 import tokenArtifact from '../artifacts/contracts/Token.sol/Token.json';
+import {BigNumber, BigNumberish} from '@ethersproject/bignumber';
+import {Transaction} from 'ethers';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toConsumeGas(benchmark: number): R;
+    }
+  }
+}
 
 export let ethAssetHolder: Contract;
 export let erc20AssetHolder: Contract;
@@ -48,4 +59,26 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await ganacheServer.close();
+});
+
+expect.extend({
+  async toConsumeGas(
+    received: any, // TransactionResponse
+    benchmark: number
+  ) {
+    const {gasUsed} = await received.wait();
+    const pass = (gasUsed as BigNumber).eq(benchmark); // This could get replaced with a looser check with upper/lower bounds
+    if (pass) {
+      return {
+        message: () => `expected to NOT consume ${benchmark} gas, but did`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () =>
+          `expected to consume ${benchmark} gas, but actually consumed ${(gasUsed as BigNumber).toNumber()} gas. Consider updating the appropriate number in gas.ts!`,
+        pass: false,
+      };
+    }
+  },
 });


### PR DESCRIPTION
The current gas benchmark test file:
1. is quite repetitive with converting to/from BigNumbers and awaiting transactions to be mined
2. doesn't give you a hint about what to do in the case of a test failure (you should fix the expectation, and not the test, in many cases)
3. won't be that easy to change to a "fuzzy" check which doesn't require strict equality

A custom matcher can:
*  DRY out the code, and provide a single place to fuzzify the expectation if we want to later on
* provide a custom message, including context-specific hints

## Changes [Optional] 
1.  adds a custom matcher, following [the documentation for jest.](https://jestjs.io/docs/expect#async-matchers)
2. uses that matcher in the benchmark test file

## How Has This Been Tested? [Optional] 
Existing test continue to pass.  A manual mutation confirms the new message pops up as expected.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
