### PR TITLE
Add a diff indicator (+/- X) to error message of toConsumeGas

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
+++ b/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
@@ -94,9 +94,11 @@ expect.extend({
         pass: true,
       };
     } else {
+      const diff: BigNumber = (gasUsed as BigNumber).sub(benchmark);
+      const diffStr: string = diff.gt(0) ? '+' + diff.toString() : diff.toString();
       return {
         message: () =>
-          `expected to consume ${benchmark} gas, but actually consumed ${(gasUsed as BigNumber).toNumber()} gas. Consider updating the appropriate number in gas.ts!`,
+          `expected to consume ${benchmark} gas, but actually consumed ${(gasUsed as BigNumber).toNumber()} gas (${diffStr}). Consider updating the appropriate number in gas.ts!`,
         pass: false,
       };
     }


### PR DESCRIPTION
This is a quick addition to the `toConsumeGas` error matcher that saves us the trouble of reading large numbers and trying to compare them.

## How Has This Been Tested? [Optional] 

I've tested the behaviour of this locally. It:
- prints with expected formatting
- has the correct sign

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
