### PR TITLE
Add "Update Channel" to wallet API

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -405,6 +405,23 @@ export type SyncOptions = {
     staleThreshold: number;
 };
 
+// @public
+export type UpdateChannelError = {
+    type: 'InternalError';
+    channelId: string;
+    error: Error;
+};
+
+// @public (undocumented)
+export type UpdateChannelResult = UpdateChannelSuccess | UpdateChannelError;
+
+// @public
+export type UpdateChannelSuccess = {
+    type: 'Success';
+    channelId: string;
+    result: ChannelResult;
+};
+
 // @public (undocumented)
 export function validateEngineConfig(config: Record<string, any>): {
     valid: boolean;
@@ -428,8 +445,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
     // (undocumented)
     get messageService(): MessageServiceInterface;
     registerAppDefinition(appDefinition: string): Promise<void>;
-    // (undocumented)
-    updateChannel(channelId: string, allocations: Allocation[], appData: string): Promise<ChannelResult>;
+    updateChannel(channelId: string, allocations: Allocation[], appData: string): Promise<UpdateChannelResult>;
 }
 
 // @public (undocumented)
@@ -447,7 +463,7 @@ export interface WalletEvents {
 //
 // src/engine/types.ts:28:3 - (ae-forgotten-export) The symbol "ChainRequest" needs to be exported by the entry point index.d.ts
 // src/engine/types.ts:66:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
-// src/wallet/types.ts:60:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
+// src/wallet/types.ts:61:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Address } from '@statechannels/wallet-core';
+import { Allocation } from '@statechannels/client-api-schema';
 import { AllocationItem } from '@statechannels/wallet-core';
 import { AllocationItem as AllocationItem_2 } from '@statechannels/nitro-protocol';
 import { AssetOutcome } from '@statechannels/nitro-protocol';
@@ -427,7 +428,9 @@ export class Wallet extends EventEmitter<WalletEvents> {
     // (undocumented)
     get messageService(): MessageServiceInterface;
     registerAppDefinition(appDefinition: string): Promise<void>;
-    }
+    // (undocumented)
+    updateChannel(channelId: string, allocations: Allocation[], appData: string): Promise<ChannelResult>;
+}
 
 // @public (undocumented)
 export interface WalletEvents {

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -199,8 +199,11 @@ test.each(testCases)(
     );
 
     expect(updated).toMatchObject({
-      turnNum: 4,
-      allocations: [createAllocation(1, 4)],
+      type: 'Success',
+      result: {
+        turnNum: 4,
+        allocations: [createAllocation(1, 4)],
+      },
     });
 
     const closeResponse =

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -4,7 +4,7 @@ import {CreateChannelParams, Participant, Allocation} from '@statechannels/clien
 import {TEST_ACCOUNTS} from '@statechannels/devtools';
 import {ContractArtifacts} from '@statechannels/nitro-protocol';
 import {BN, makeAddress, makeDestination} from '@statechannels/wallet-core';
-import {BigNumber, BigNumberish, constants, Contract, ethers, providers} from 'ethers';
+import {BigNumber, BigNumberish, Contract, providers, utils} from 'ethers';
 import _ from 'lodash';
 import {hexZeroPad} from '@ethersproject/bytes';
 
@@ -17,6 +17,7 @@ import {SyncOptions, Wallet} from '../wallet';
 import {ONE_DAY} from '../__test__/test-helpers';
 import {waitForObjectiveProposals} from '../__test-with-peers__/utils';
 import {ARTIFACTS_DIR} from '../../jest/chain-setup';
+import {COUNTING_APP_DEFINITION} from '../models/__test__/fixtures/app-bytecode';
 
 jest.setTimeout(60_000);
 
@@ -171,8 +172,8 @@ test.each(testCases)(
     const channelParams: CreateChannelParams = {
       participants: [participantA, participantB],
       allocations: [createAllocation(3, 2)],
-      appDefinition: ethers.constants.AddressZero,
-      appData: constants.HashZero,
+      appDefinition: COUNTING_APP_DEFINITION,
+      appData: utils.defaultAbiCoder.encode(['uint256'], [1]),
       fundingStrategy: 'Direct',
       challengeDuration: ONE_DAY,
     };
@@ -191,7 +192,11 @@ test.each(testCases)(
     expect(BN.sub(assetHolderBalanceUpdated, assetHolderBalanceInit)).toEqual(BN.add(2, 3));
 
     const {channelId} = response[0];
-    const updated = await a.updateChannel(channelId, [createAllocation(1, 4)], constants.HashZero);
+    const updated = await a.updateChannel(
+      channelId,
+      [createAllocation(1, 4)],
+      utils.defaultAbiCoder.encode(['uint256'], [2])
+    );
 
     expect(updated).toMatchObject({
       turnNum: 4,

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -1,3 +1,4 @@
+import {ChannelResult} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {ObjectiveStatus, WalletObjective} from '../models/objective';
@@ -66,6 +67,22 @@ export type ObjectiveResult = {
   // The channelId for the objective
   channelId: string;
 };
+
+/**
+ * This is returned when an unhandled error occurs when trying to update a channel
+ */
+export type UpdateChannelError = {type: 'InternalError'; channelId: string; error: Error};
+
+/**
+ * This is returned when a channel is sucessfully updated
+ */
+export type UpdateChannelSuccess = {
+  type: 'Success';
+  channelId: string;
+  result: ChannelResult;
+};
+
+export type UpdateChannelResult = UpdateChannelSuccess | UpdateChannelError;
 
 export interface WalletEvents {
   ObjectiveCompleted: (o: WalletObjective) => void;

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -208,6 +208,14 @@ export class Wallet extends EventEmitter<WalletEvents> {
     );
   }
 
+  /**
+   * Updates a channel with the given allocations and app data.
+   * @param channelId The id of the channel to update.
+   * @param allocations The updated allocations for the channel.
+   * @param appData The updated appData for the channel.
+   * @returns A promise that resolves to either a sucess result (which includes the updated channel) or
+   * an error type that contains more information about the error.
+   */
   public async updateChannel(
     channelId: string,
     allocations: Allocation[],

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -6,7 +6,7 @@ import {
 } from '@statechannels/client-api-schema';
 import _ from 'lodash';
 import EventEmitter from 'eventemitter3';
-import {makeAddress, makeDestination} from '@statechannels/wallet-core';
+import {calculateObjectiveId, makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {utils} from 'ethers';
 import {setIntervalAsync, clearIntervalAsync} from 'set-interval-async/dynamic';
 
@@ -256,7 +256,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
   public async closeChannels(channelIds: string[]): Promise<ObjectiveResult[]> {
     return Promise.all(
       channelIds.map(async channelId => {
-        const objectiveId = ['CloseChannel', channelId].join('-');
+        const objectiveId = calculateObjectiveId('CloseChannel', channelId);
         const done = this.createObjectiveDoneResult(objectiveId);
         const closeResult = await this._engine.closeChannel({channelId});
         const {newObjective, channelResult} = closeResult;

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -1,4 +1,9 @@
-import {ChannelResult, CreateChannelParams, Uint256} from '@statechannels/client-api-schema';
+import {
+  Allocation,
+  ChannelResult,
+  CreateChannelParams,
+  Uint256,
+} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 import EventEmitter from 'eventemitter3';
 import {makeAddress, makeDestination} from '@statechannels/wallet-core';
@@ -196,6 +201,16 @@ export class Wallet extends EventEmitter<WalletEvents> {
         }
       })
     );
+  }
+
+  public async updateChannel(
+    channelId: string,
+    allocations: Allocation[],
+    appData: string
+  ): Promise<ChannelResult> {
+    const result = await this._engine.updateChannel({channelId, allocations, appData});
+    await this.handleEngineOutput(result);
+    return result.channelResult;
   }
 
   private async syncObjectives() {

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -189,6 +189,10 @@ export const isCloseLedger = guard<CloseLedger>('CloseLedger');
 export const isSubmitChallenge = guard<SubmitChallenge>('SubmitChallenge');
 export const isDefundChannel = guard<DefundChannel>('DefundChannel');
 
+export function calculateObjectiveId(objectiveType: Objective['type'], channelId: string): string {
+  return `${objectiveType}-${channelId}`;
+}
+
 export function objectiveId(objective: Objective): string {
   switch (objective.type) {
     case 'OpenChannel':
@@ -196,12 +200,12 @@ export function objectiveId(objective: Objective): string {
     case 'VirtuallyFund':
     case 'SubmitChallenge':
     case 'DefundChannel':
-      return [objective.type, objective.data.targetChannelId].join('-');
+      return calculateObjectiveId(objective.type, objective.data.targetChannelId);
     case 'FundGuarantor':
-      return [objective.type, objective.data.guarantorId].join('-');
+      return calculateObjectiveId(objective.type, objective.data.guarantorId);
     case 'FundLedger':
     case 'CloseLedger':
-      return [objective.type, objective.data.ledgerId].join('-');
+      return calculateObjectiveId(objective.type, objective.data.ledgerId);
   }
 }
 


### PR DESCRIPTION
Fixes #3504 

Adds an update channel method to the `wallet`. The directly funded channel test has been updated to call `updateChannel`.

Due to #3600 validate transition fails when there is no `bytecode` provided.  The directly funded test has been updated to use the `COUNTING_APP` to get around this. This also means once #3576 is resolved we'll be validating the transition with the evm.