### PR TITLE
[nitro-protocol] Remove writeGasConsumption helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,6 @@ commands:
           path: /home/circleci/<< parameters.file >>.txt
           destination: << parameters.file >>
 
-  upload_gas_report:
-    description: 'Upload gas report '
-    parameters:
-      package:
-        type: string
-    steps:
-      - store_artifacts:
-          path: /home/circleci/project/packages/<< parameters.package >>/gas-artifacts
-
   upload_artifacts:
     description: 'Upload generic artifacts'
     steps:
@@ -161,8 +152,6 @@ jobs:
           no_output_timeout: 30m
       - upload_logs:
           file: test-stats
-      - upload_gas_report:
-          package: nitro-protocol
       - notify_slack
 
   server-wallet-e2e-test:

--- a/packages/nitro-protocol/deployment/deploy-test-contracts.ts
+++ b/packages/nitro-protocol/deployment/deploy-test-contracts.ts
@@ -3,7 +3,6 @@
 import {GanacheDeployer, ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
 import {Wallet} from 'ethers';
 
-import {writeGasConsumption} from '../test/test-helpers';
 import countingAppArtifact from '../artifacts/contracts/CountingApp.sol/CountingApp.json';
 import erc20AssetHolderArtifact from '../artifacts/contracts/test/TestErc20AssetHolder.sol/TestErc20AssetHolder.json';
 import ethAssetHolderArtifact from '../artifacts/contracts/ETHAssetHolder.sol/ETHAssetHolder.json';
@@ -22,7 +21,6 @@ export async function deploy(): Promise<Record<string, string>> {
   const nitroAdjudicatorDeploymentGas = await deployer.etherlimeDeployer.estimateGas(
     nitroAdjudicatorArtifact as any
   );
-  writeGasConsumption('NitroAdjudicator.gas.md', 'deployment', nitroAdjudicatorDeploymentGas);
   console.log(
     `\nDeploying NitroAdjudicator... (cost estimated to be ${nitroAdjudicatorDeploymentGas})\n`
   );

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claim.test.ts
@@ -13,7 +13,6 @@ import {
   randomExternalDestination,
   replaceAddressesAndBigNumberify,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 
 const provider = getTestProvider();
@@ -146,7 +145,6 @@ describe('claim', () => {
 
         // Extract logs
         const {events: eventsFromTx, gasUsed} = await (await tx).wait();
-        await writeGasConsumption('claim.gas.md', name, gasUsed);
 
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!
         expect(eventsFromTx).toMatchObject(expectedEvents);

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -13,7 +13,6 @@ import {
   randomExternalDestination,
   replaceAddressesAndBigNumberify,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 
 jest.setTimeout(10_000);
@@ -143,8 +142,7 @@ describe('claimAll (by passing [] as indices to claim)', () => {
         ];
 
         // Extract logs
-        const {events: eventsFromTx, gasUsed} = await (await tx).wait();
-        await writeGasConsumption('claimAll.gas.md', name, gasUsed);
+        const {events: eventsFromTx} = await (await tx).wait();
 
         // Check that each expectedEvent is contained as a subset of the properies of each *corresponding* event: i.e. the order matters!
         expect(eventsFromTx).toMatchObject(expectedEvents);

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transfer.test.ts
@@ -10,7 +10,6 @@ import {
   randomExternalDestination,
   replaceAddressesAndBigNumberify,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 import {encodeAllocation} from '../../../src/contract/outcome';
 
@@ -105,7 +104,6 @@ describe('transfer', () => {
 
         const {events: eventsFromTx, gasUsed} = await (await tx).wait();
         // NOTE: _transferAsset is a NOOP in TESTAssetHolder, so gas costs will be much lower than for a real Asset Holder
-        await writeGasConsumption('transfer.gas.md', name, gasUsed);
         expect(eventsFromTx).toMatchObject(expectedEvents);
         // Check new holdings
         Object.keys(heldAfter).forEach(async key =>

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -10,7 +10,6 @@ import {
   randomExternalDestination,
   replaceAddressesAndBigNumberify,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 import {encodeAllocation} from '../../../src/contract/outcome';
 
@@ -93,8 +92,7 @@ describe('transferAll (using transfer and empty indices array)', () => {
       if (reason) {
         await expectRevert(() => tx, reason);
       } else {
-        const {events: eventsFromLogs, gasUsed} = await (await tx).wait();
-        await writeGasConsumption('transferAll.gas.md', name, gasUsed);
+        const {events: eventsFromLogs} = await (await tx).wait();
         const expectedEvents = [
           {
             event: 'AllocationUpdated',

--- a/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ERC20AssetHolder/deposit.test.ts
@@ -6,12 +6,7 @@ const {AddressZero} = ethers.constants;
 import ERC20AssetHolderArtifact from '../../../artifacts/contracts//test/TestErc20AssetHolder.sol/TestErc20AssetHolder.json';
 import TokenArtifact from '../../../artifacts/contracts/Token.sol/Token.json';
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {
-  getRandomNonce,
-  getTestProvider,
-  setupContract,
-  writeGasConsumption,
-} from '../../test-helpers';
+import {getRandomNonce, getTestProvider, setupContract} from '../../test-helpers';
 
 const provider = getTestProvider();
 const signer0 = provider.getSigner(0); // Convention matches setupContract function
@@ -68,17 +63,7 @@ describe('deposit', () => {
     await expect(balance.gte(held.add(amount))).toBe(true);
 
     // Increase allowance
-    const {gasUsed: increaseAllowanceGasUsed} = await (
-      await Token.increaseAllowance(ERC20AssetHolder.address, held.add(amount))
-    ).wait(); // Approve enough for setup and main test
-
-    if (!reasonString) {
-      await writeGasConsumption(
-        'erc20-deposit.gas.md',
-        'Token.increaseAllowance',
-        increaseAllowanceGasUsed
-      );
-    }
+    await (await Token.increaseAllowance(ERC20AssetHolder.address, held.add(amount))).wait(); // Approve enough for setup and main test
 
     // Check allowance updated
     const allowance = BigNumber.from(
@@ -101,7 +86,6 @@ describe('deposit', () => {
       await expectRevert(() => tx, reasonString);
     } else {
       const {gasUsed, events} = await (await tx).wait();
-      await writeGasConsumption('erc20-deposit.gas.md', description, gasUsed);
 
       const depositedEvent = getDepositedEvent(events);
       expect(depositedEvent).toMatchObject({

--- a/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
+++ b/packages/nitro-protocol/test/contracts/ETHAssetHolder/deposit.test.ts
@@ -4,12 +4,7 @@ const {parseUnits} = ethers.utils;
 
 import ETHAssetHolderArtifact from '../../../artifacts/contracts/ETHAssetHolder.sol/ETHAssetHolder.json';
 import {Channel, getChannelId} from '../../../src/contract/channel';
-import {
-  getRandomNonce,
-  getTestProvider,
-  setupContract,
-  writeGasConsumption,
-} from '../../test-helpers';
+import {getRandomNonce, getTestProvider, setupContract} from '../../test-helpers';
 
 const provider = getTestProvider();
 let ETHAssetHolder: Contract;
@@ -49,7 +44,7 @@ describe('deposit', () => {
     ${description3} | ${'3'} | ${'2'}       | ${'2'} | ${'2'}   | ${'4'}          | ${undefined}
   `(
     '$description',
-    async ({description, held, expectedHeld, amount, msgValue, reasonString, heldAfterString}) => {
+    async ({held, expectedHeld, amount, msgValue, reasonString, heldAfterString}) => {
       held = parseUnits(held, 'wei');
       expectedHeld = parseUnits(expectedHeld, 'wei');
       amount = parseUnits(amount, 'wei');
@@ -81,8 +76,7 @@ describe('deposit', () => {
       if (reasonString) {
         await expectRevert(() => tx, reasonString);
       } else {
-        const {gasUsed, events} = await (await tx).wait();
-        await writeGasConsumption('deposit.gas.md', description, gasUsed);
+        const {events} = await (await tx).wait();
         const event = getDepositedEvent(events);
         expect(event).toMatchObject({
           destination,

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -29,7 +29,6 @@ import {
   nonParticipant,
   ongoingChallengeFingerprint,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 import {createChallengeTransaction, NITRO_MAX_GAS} from '../../../src/transactions';
 import {hashChallengeMessage} from '../../../src/contract/challenge';
@@ -210,7 +209,6 @@ describe('challenge', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const receipt = await (await tx).wait();
-        await writeGasConsumption('challenge.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
 
         // Catch ChallengeRegistered event

--- a/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/conclude.test.ts
@@ -20,7 +20,6 @@ import {
   getTestProvider,
   ongoingChallengeFingerprint,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 import {signState, signStates} from '../../../src';
 
@@ -130,7 +129,6 @@ describe('conclude', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const receipt = await (await tx).wait();
-        await writeGasConsumption('./conclude.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
         const finalizesAt = (await provider.getBlock(receipt.blockNumber)).timestamp;
         expect(event.args).toMatchObject({channelId, finalizesAt});

--- a/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
@@ -17,7 +17,6 @@ import {
   getRandomNonce,
   getTestProvider,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 import {sign} from '../../../src/signatures';
 
@@ -73,7 +72,6 @@ describe('respond', () => {
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({
-      description,
       isFinalAB,
       turnNumRecord,
       appDatas,
@@ -132,7 +130,6 @@ describe('respond', () => {
         await expectRevert(() => tx, reasonString);
       } else {
         const receipt = await (await tx).wait();
-        await writeGasConsumption('respond.gas.md', description, receipt.gasUsed);
         const event = receipt.events.pop();
 
         expect(event.args).toMatchObject({

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludePushOutcomeAndTransferAll.test.ts
@@ -23,7 +23,6 @@ import {
   randomExternalDestination,
   replaceAddressesAndBigNumberify,
   setupContract,
-  writeGasConsumption,
 } from '../../test-helpers';
 import {signStates} from '../../../src';
 import {NITRO_MAX_GAS} from '../../../src/transactions';
@@ -232,12 +231,6 @@ describe('concludePushOutcomeAndTransferAll', () => {
         const receipt = await (await tx).wait();
 
         expect(BigNumber.from(receipt.gasUsed).lt(BigNumber.from(NITRO_MAX_GAS))).toBe(true);
-
-        await writeGasConsumption(
-          './concludePushOutcomeAndTransferAll.gas.md',
-          description,
-          receipt.gasUsed
-        );
 
         // Compute expected ChannelDataHash
         const blockTimestamp = (await provider.getBlock(receipt.blockNumber)).timestamp;

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -334,23 +334,6 @@ export function compileEventsFromLogs(logs: any[], contractsArray: Contract[]): 
   return events;
 }
 
-export async function writeGasConsumption(
-  filename: string,
-  description: string,
-  gas: BigNumberish
-): Promise<void> {
-  const dir = './gas-artifacts';
-
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
-  }
-
-  const path = dir + '/' + filename;
-  await fs.appendFile(path, description + ':\n' + gas.toString() + ' gas\n\n', err => {
-    if (err) throw err;
-  });
-}
-
 export function getRandomNonce(seed: string): number {
   return Number.parseInt(ethers.utils.id(seed).slice(2, 11), 16);
 }


### PR DESCRIPTION
[See this pitch.](https://www.notion.so/statechannels/Improved-gas-benchmarking-in-nitro-protocol-d14938f9671a48588e6974462e9ffb00)

We now have an entirely new and improved method of recording gas consumption  (see #3544). 

This PR removes the legacy code we were using to measure gas usage. It should
* reduce test duration 
* discourage use of the legacy method and therefore encourage use of the new method
* stop cluttering dev's laptops with data that is never cleaned up 🗑️ 