### PR TITLE
fix some eslint settings and warnings

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
+++ b/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
@@ -5,13 +5,12 @@ import {ContractFactory, Contract} from '@ethersproject/contracts';
 import {providers} from 'ethers';
 import waitOn from 'wait-on';
 import kill from 'tree-kill';
+import {BigNumber} from '@ethersproject/bignumber';
 
 import nitroAdjudicatorArtifact from '../artifacts/contracts/NitroAdjudicator.sol/NitroAdjudicator.json';
 import ethAssetHolderArtifact from '../artifacts/contracts/ETHAssetHolder.sol/ETHAssetHolder.json';
 import erc20AssetHolderArtifact from '../artifacts/contracts/ERC20AssetHolder.sol/ERC20AssetHolder.json';
 import tokenArtifact from '../artifacts/contracts/Token.sol/Token.json';
-import {BigNumber, BigNumberish} from '@ethersproject/bignumber';
-import {Transaction} from 'ethers';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -32,7 +31,7 @@ const hardHatNetworkEndpoint = 'http://localhost:9546'; // the port should be un
 
 jest.setTimeout(15_000); // give hardhat network a chance to get going
 if (existsSync(logFile)) truncateSync(logFile);
-const hardhatProcess = exec('npx hardhat node --no-deploy --port 9546', (error, stdout, stderr) => {
+const hardhatProcess = exec('npx hardhat node --no-deploy --port 9546', (error, stdout) => {
   promises.appendFile(logFile, stdout);
 });
 const hardhatProcessExited = new Promise(resolve => hardhatProcess.on('exit', resolve));

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -88,7 +88,7 @@
     "contract:deploy-arbitrum-testnet": "yarn hardhat deploy --network arbitrum_testnet_v4 --export-all addresses.json && node ./scripts/postdeploy.js",
     "docgen": "solidoc",
     "generate-api": "yarn docgen",
-    "lint:check": "eslint \"*/**/*.ts\" --cache && yarn solhint:check",
+    "lint:check": "eslint \"*/**/*.ts\" --cache  --max-warnings=0 && yarn solhint:check",
     "lint:write": "eslint \"*/**/*.ts\" --fix && yarn prettier:write",
     "precommit": "lint-staged --quiet",
     "prepare": "yarn contract:compile && yarn build:typescript",


### PR DESCRIPTION
At the top level of the monorepo, we thread the `--max-warnings=0` flag down to the `yarn lint:check` script.

This usually forces us to tidy up lint warnings (unused variables, etc). However, if `yarn lint:check = eslint && something else`, the flag never gets to the eslint bit where it is needed. 

I think we probably ought to be writing the flag into each package. Here's a step in that direction with nitro-protocol. 