### PR TITLE
Bump cache and add missing path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ save_dep: &save_dep
       - packages/wallet-core/node_modules
       - packages/wire-format/node_modules
       - packages/browser-wallet/node_modules
+      - packages/interop-tests/node_modules
 
 restore_dep: &restore_dep
   restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ postgres: &postgres
 
 save_dep: &save_dep
   save_cache:
-    key: v13-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v14-dependency-cache-{{ checksum "yarn.lock" }}
     paths:
       - node_modules
       - packages/client-api-schema/node_modules
@@ -41,7 +41,7 @@ save_dep: &save_dep
 
 restore_dep: &restore_dep
   restore_cache:
-    key: v13-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v14-dependency-cache-{{ checksum "yarn.lock" }}
 
 # END MACROS
 


### PR DESCRIPTION
Should result in cache hits on circle (during `yarn install`) which haven't been happening in a while...


Rerunning circle on this branch brought the `prepare` step down from 5m46 to 2m45 (!)

![Screenshot 2021-06-14 at 10 47 28](https://user-images.githubusercontent.com/1833419/121873095-eecaea80-ccfd-11eb-92f4-87eaca0fb6bc.png)
