### PR TITLE
Benchmark sad defunding of a ledger-funded channel

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -21,11 +21,13 @@ describe('Consumes the expected gas for deployments', () => {
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.NitroAdjudicator
     );
   });
+
   it(`when deploying the ETHAssetHolder`, async () => {
     await expect(await ethAssetHolder.deployTransaction).toConsumeGas(
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ETHAssetHolder
     );
   });
+
   it(`when deploying the ERC20AssetHolder`, async () => {
     await expect(await erc20AssetHolder.deployTransaction).toConsumeGas(
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ERC20AssetHolder
@@ -38,6 +40,7 @@ describe('Consumes the expected gas for deposits', () => {
       gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro
     );
   });
+
   it(`when directly funding a channel with ETH (second deposit)`, async () => {
     // begin setup
     const setupTX = ethAssetHolder.deposit(channelId, 0, 5, {value: 5});
@@ -47,6 +50,7 @@ describe('Consumes the expected gas for deposits', () => {
       gasRequiredTo.directlyFundAChannelWithETHSecond.vanillaNitro
     );
   });
+
   it(`when directly funding a channel with an ERC20 (first deposit)`, async () => {
     // begin setup
     await (await token.transfer(erc20AssetHolder.address, 1)).wait(); // The asset holder already has some tokens (for other channels)
@@ -58,6 +62,7 @@ describe('Consumes the expected gas for deposits', () => {
       gasRequiredTo.directlyFundAChannelWithERC20First.vanillaNitro.deposit
     );
   });
+
   it(`when directly funding a channel with an ERC20 (second deposit)`, async () => {
     // begin setup
     await (await token.increaseAllowance(erc20AssetHolder.address, 100)).wait();
@@ -91,6 +96,7 @@ describe('Consumes the expected gas for happy-path exits', () => {
       )
     ).toConsumeGas(gasRequiredTo.ETHexit.vanillaNitro);
   });
+
   it(`when exiting a directly funded (with ERC20s) channel`, async () => {
     // begin setup
     await (await token.increaseAllowance(erc20AssetHolder.address, 100)).wait();
@@ -148,6 +154,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
         gasRequiredTo.ETHexitSad.vanillaNitro.pushOutcomeAndTransferAll
     ).toEqual(gasRequiredTo.ETHexitSad.vanillaNitro.total);
   });
+
   it(`when exiting a ledger funded (with ETH) channel`, async () => {
     // begin setup
     await (await ethAssetHolder.deposit(ledgerChannelId, 0, 10, {value: 10})).wait();

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -13,7 +13,10 @@ type Path =
   | 'directlyFundAChannelWithERC20Second'
   | 'ETHexit'
   | 'ERC20exit'
-  | 'ETHexitSad';
+  | 'ETHexitSad'
+  | 'ETHexitSadLedgerFunded';
+
+// The channel being benchmarked is a 2 party null app funded with 5 wei / tokens each.
 
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
@@ -62,10 +65,22 @@ export const gasRequiredTo: GasRequiredTo = {
     vanillaNitro: 139148,
   },
   ETHexitSad: {
+    // Scenario: counterparty goes offline
     vanillaNitro: {
       challenge: 93404,
       pushOutcomeAndTransferAll: 107742,
       total: 201146, // An alternative would be to 1. pushOutcome then 2. transfer(indices)
+      // ...but we assume that costs more gas overall
+    },
+  },
+  ETHexitSadLedgerFunded: {
+    // Scenario: counterparty goes offline
+    vanillaNitro: {
+      challengeX: 93404,
+      challengeL: 92122,
+      pushOutcomeAndTransferAllL: 58640,
+      pushOutcomeAndTransferAllX: 107742,
+      total: 351908, // An alternative would be to 1. pushOutcome then 2. transfer(indices)
       // ...but we assume that costs more gas overall
     },
   },

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -17,7 +17,12 @@ type Path =
   | 'ETHexitSadLedgerFunded';
 
 // The channel being benchmarked is a 2 party null app funded with 5 wei / tokens each.
-
+// KEY
+// ---
+// ⬛ -> funding on chain
+//  C    channel not yet on chain
+// (C)   channel finalized on chain
+// 🧑‍🤝‍🧑    external destinations
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
@@ -66,22 +71,28 @@ export const gasRequiredTo: GasRequiredTo = {
   },
   ETHexitSad: {
     // Scenario: counterparty goes offline
+    // initially                 ⬛ ->  X  -> 🧑‍🤝‍🧑
+    // challenge + timeout       ⬛ -> (X) -> 🧑‍🤝‍🧑
+    // pushOutcomeAndTransferAll ⬛ -> 🧑‍🤝‍🧑
     vanillaNitro: {
       challenge: 93404,
       pushOutcomeAndTransferAll: 107742,
-      total: 201146, // An alternative would be to 1. pushOutcome then 2. transfer(indices)
-      // ...but we assume that costs more gas overall
+      total: 201146,
     },
   },
   ETHexitSadLedgerFunded: {
     // Scenario: counterparty goes offline
     vanillaNitro: {
+      // initially                   ⬛ ->  L  ->  X  -> 🧑‍🤝‍🧑
+      // challenge X and timeout     ⬛ ->  L  -> (X) -> 🧑‍🤝‍🧑
+      // challenge L and timeout     ⬛ -> (L) -> (X) -> 🧑‍🤝‍🧑
+      // pushOutcomeAndTransferAllL  ⬛ -> (X) -> 🧑‍🤝‍🧑
+      // pushOutcomeAndTransferAllX  ⬛ -> 🧑‍🤝‍🧑
       challengeX: 93404,
       challengeL: 92122,
       pushOutcomeAndTransferAllL: 58640,
       pushOutcomeAndTransferAllX: 107742,
-      total: 351908, // An alternative would be to 1. pushOutcome then 2. transfer(indices)
-      // ...but we assume that costs more gas overall
+      total: 351908,
     },
   },
 };


### PR DESCRIPTION
Follows the established benchmarking patterns. introduces a ledger channel funding the channel in question. Both are challenged and the money is pushed down from L to X and then out. (The scenario being that the counter-party goes offline). 