### PR TITLE
benchmark sad path for exiting a virtually-funded channel

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -290,6 +290,9 @@ describe('Consumes the expected gas for sad-path exits', () => {
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.pushOutcomeAndTransferAllX);
     // pushOutcomeAndTransferAllX  ⬛ -----------------------------> 👩
+
+    // meta-test here to confirm the total recorded in gas.ts is up to date
+    // with the recorded costs of each step
     expect(
       (Object.values(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro) as number[]).reduce(
         (a, b) => a + b

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -270,7 +270,6 @@ describe('Consumes the expected gas for sad-path exits', () => {
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.pushOutcomeJ);
     // pushOutcomeJ                ⬛ --------> (G) -> (J) -> (X) -> 👩
-    console.log(G.guaranteeOrAllocation, J.guaranteeOrAllocation);
     await expect(
       await ethAssetHolder.claim(
         G.channelId,

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -185,6 +185,9 @@ describe('Consumes the expected gas for sad-path exits', () => {
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.pushOutcomeAndTransferAllX);
     // pushOutcomeAndTransferAllX  ⬛ ---------------> 👩
+
+    // meta-test here to confirm the total recorded in gas.ts is up to date
+    // with the recorded costs of each step
     expect(
       gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.challengeL +
         gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.pushOutcomeAndTransferAllL +

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -3,12 +3,14 @@ import {Wallet} from '@ethersproject/wallet';
 import {constants, ContractReceipt} from 'ethers';
 
 import {
+  Allocation,
   Bytes32,
   Channel,
   convertAddressToBytes32,
   encodeOutcome,
   getChannelId,
   getFixedPart,
+  Guarantee,
   hashAppPart,
   signChallengeMessage,
   SignedState,
@@ -27,6 +29,9 @@ export const Alice = new Wallet(
   '0x277fb9e0ad81dc836c60294e385b10dfcc0a9586eeb0b1d31da92e384a0d2efa'
 );
 export const Bob = new Wallet('0xc8774aa98410b3e3281ff1ec40ea2637d2b9280328c4d1ff00d06cd95dd42cbd');
+export const Ingrid = new Wallet(
+  '0x558789345da13a7ac1d6d6ac9275ba66836eb4a088efc1920db0f5d092d6ee71'
+);
 export const participants = [Alice.address, Bob.address];
 
 export const channel: Channel = {chainId, channelNonce, participants};
@@ -34,6 +39,7 @@ export const channelId = getChannelId(channel);
 
 export const someOtherChannelId = getChannelId({...channel, channelNonce: 1337});
 
+// X
 export function someState(assetHolderAddress: string): State {
   return {
     challengeDuration: 600,
@@ -54,7 +60,10 @@ export function someState(assetHolderAddress: string): State {
   };
 }
 
-export function someLedgerState(assetHolderAddress: string): State {
+// L
+export const ledgerChannel: Channel = {chainId, channelNonce: channelNonce + 10000, participants};
+export const ledgerChannelId = getChannelId(ledgerChannel);
+export function someLedgerStateFundingX(assetHolderAddress: string): State {
   return {
     challengeDuration: 600,
     appDefinition: constants.AddressZero,
@@ -70,6 +79,86 @@ export function someLedgerState(assetHolderAddress: string): State {
     appData: '0x',
   };
 }
+export function someLedgerStateFundingG(assetHolderAddress: string): State {
+  return {
+    challengeDuration: 600,
+    appDefinition: constants.AddressZero,
+    channel: ledgerChannel,
+    turnNum: 6,
+    isFinal: false,
+    outcome: [
+      {
+        assetHolderAddress,
+        allocationItems: [{destination: guarantorChannelId, amount: '0xa'}],
+      },
+    ],
+    appData: '0x',
+  };
+}
+
+// J
+export const jointChannel: Channel = {
+  chainId,
+  channelNonce: channelNonce, // note different participant set so nonce re-use is OK
+  participants: [...participants, Ingrid.address],
+};
+export const jointChannelId = getChannelId(jointChannel);
+export const jointChannelAllocation: Allocation = [
+  {destination: channelId, amount: '0xa'},
+  {destination: convertAddressToBytes32(Ingrid.address), amount: '0xa'},
+];
+
+export function someJointChannelState(assetHolderAddress: string): State {
+  return {
+    challengeDuration: 600,
+    appDefinition: constants.AddressZero,
+    channel: jointChannel,
+    turnNum: 6,
+    isFinal: false,
+    outcome: [
+      {
+        assetHolderAddress,
+        allocationItems: jointChannelAllocation,
+      },
+    ],
+    appData: '0x',
+  };
+}
+
+// G
+export const guarantee: Guarantee = {
+  targetChannelId: jointChannelId,
+  destinations: [
+    convertAddressToBytes32(Alice.address),
+    convertAddressToBytes32(Ingrid.address),
+    channelId,
+  ],
+};
+
+export const guarantorChannel: Channel = {
+  chainId,
+  channelNonce: channelNonce + 10001,
+  participants,
+};
+export const guarantorChannelId = getChannelId(guarantorChannel);
+export function someGuarantorState(assetHolderAddress: string): State {
+  return {
+    challengeDuration: 600,
+    appDefinition: constants.AddressZero,
+    channel: guarantorChannel,
+    turnNum: 6,
+    isFinal: false,
+    outcome: [
+      {
+        assetHolderAddress,
+        guarantee,
+      },
+    ],
+    appData: '0x',
+  };
+}
+
+// Utils
 
 export function finalState(assetHolderAddress: string): State {
   return {
@@ -85,8 +174,8 @@ export function counterSignedSupportProof( // for challenging and outcome pushin
   fixedPart: FixedPart;
   variableParts: VariablePart[];
   isFinalCount: number;
-  whoSignedWhat: [0, 0];
-  signatures: [Signature, Signature];
+  whoSignedWhat: [0, 0] | [0, 0, 0];
+  signatures: [Signature, Signature] | [Signature, Signature, Signature];
   challengeSignature: Signature;
   outcomeBytes: string;
   stateHash: string;
@@ -97,11 +186,15 @@ export function counterSignedSupportProof( // for challenging and outcome pushin
     fixedPart: getFixedPart(state),
     variableParts: [getVariablePart(state)],
     isFinalCount: 0,
-    whoSignedWhat: [0, 0],
-    signatures: [
-      signState(state, Alice.privateKey).signature,
-      signState(state, Bob.privateKey).signature,
-    ],
+    whoSignedWhat: state.channel.participants.length == 2 ? [0, 0] : [0, 0, 0],
+    signatures:
+      state.channel.participants.length == 2
+        ? [signState(state, Alice.privateKey).signature, signState(state, Bob.privateKey).signature]
+        : [
+            signState(state, Alice.privateKey).signature,
+            signState(state, Bob.privateKey).signature,
+            signState(state, Ingrid.privateKey).signature,
+          ],
     challengeSignature: signChallengeMessage([{state} as SignedState], Alice.privateKey),
     outcomeBytes: encodeOutcome(state.outcome),
     stateHash: hashState(state),
@@ -117,8 +210,8 @@ export function finalizationProof( // for concluding
   appPartHash: Bytes32;
   outcomeBytes: Bytes;
   numStates: 1;
-  whoSignedWhat: [0, 0];
-  sigs: [Signature, Signature];
+  whoSignedWhat: [0, 0] | [0, 0, 0];
+  sigs: [Signature, Signature] | [Signature, Signature, Signature];
 } {
   return {
     largestTurnNum: state.turnNum,
@@ -126,11 +219,15 @@ export function finalizationProof( // for concluding
     appPartHash: hashAppPart(state),
     outcomeBytes: encodeOutcome(state.outcome),
     numStates: 1,
-    whoSignedWhat: [0, 0],
-    sigs: [
-      signState(state, Alice.privateKey).signature,
-      signState(state, Bob.privateKey).signature,
-    ],
+    whoSignedWhat: state.channel.participants.length == 2 ? [0, 0] : [0, 0, 0],
+    sigs:
+      state.channel.participants.length == 2
+        ? [signState(state, Alice.privateKey).signature, signState(state, Bob.privateKey).signature]
+        : [
+            signState(state, Alice.privateKey).signature,
+            signState(state, Bob.privateKey).signature,
+            signState(state, Ingrid.privateKey).signature,
+          ],
   };
 }
 
@@ -144,6 +241,3 @@ export async function waitForChallengesToTimeOut(finalizesAtArray: number[]): Pr
   await provider.send('evm_setNextBlockTimestamp', [finalizesAt + 1]);
   await provider.send('evm_mine', []);
 }
-
-export const ledgerChannel: Channel = {chainId, channelNonce: channelNonce + 10000, participants};
-export const ledgerChannelId = getChannelId(ledgerChannel);

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -7,7 +7,6 @@ import {
   Bytes32,
   Channel,
   convertAddressToBytes32,
-  encodeGuarantee,
   encodeOutcome,
   getChannelId,
   getFixedPart,
@@ -138,7 +137,7 @@ class TestChannel {
   }
 
   async challengeTx(assetHolderAddress: string) {
-    const proof = this.counterSignedSupportProof(this.someState(assetHolderAddress)); // TODO use a nontrivial app with a state transition
+    const proof = this.counterSignedSupportProof(this.someState(assetHolderAddress));
     return await nitroAdjudicator.challenge(
       proof.fixedPart,
       proof.largestTurnNum,

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -182,11 +182,13 @@ export const J = new TestChannel(
     {destination: convertAddressToBytes32(Ingrid.address), amount: '0xa'},
   ]
 );
+
+/** Guarantor channel between Alice and Ingid, targeting joint channel J */
 export const G = new TestChannel(6, [Alice, Ingrid], {
   targetChannelId: J.channelId,
   destinations: [
     convertAddressToBytes32(Alice.address),
-    convertAddressToBytes32(Bob.address),
+    convertAddressToBytes32(Ingrid.address),
     X.channelId,
   ],
 });

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -150,7 +150,7 @@ class TestChannel {
   }
 }
 
-// An application channel
+/** An application channel between Alice and Bob */
 export const X = new TestChannel(
   2,
   [Alice, Bob],
@@ -159,6 +159,8 @@ export const X = new TestChannel(
     {destination: convertAddressToBytes32(Bob.address), amount: '0x5'},
   ]
 );
+
+/** Another application channel between Alice and Bob */
 export const Y = new TestChannel(
   3,
   [Alice, Bob],
@@ -168,10 +170,10 @@ export const Y = new TestChannel(
   ]
 );
 
-// Ledger funding
+/** Ledger channel between Alice and Bob, providing funds to channel X */
 export const LforX = new TestChannel(4, [Alice, Bob], [{destination: X.channelId, amount: '0xa'}]);
 
-// Virtual funding
+/** Joint channel between Alice, Bob, and Ingrid, funding application channel X */
 export const J = new TestChannel(
   5,
   [Alice, Bob, Ingrid],
@@ -202,10 +204,9 @@ export async function waitForChallengesToTimeOut(finalizesAtArray: number[]): Pr
 }
 
 /**
- * Constructs a support proof from the supplied state; calls challenge, asserts the expected gas and returns the proof and finalizesAt
- * @param state
- * @param expectedGas
- * @returns
+ * Constructs a support proof for the supplied channel, calls challenge,
+ * and asserts the expected gas
+ * @returns The proof and finalizesAt
  */
 export async function challengeChannelAndExpectGas(
   channel: TestChannel,

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -89,10 +89,10 @@ export const gasRequiredTo: GasRequiredTo = {
       // pushOutcomeAndTransferAllL  ⬛ --------> (X) -> 👩
       // pushOutcomeAndTransferAllX  ⬛ ---------------> 👩
       challengeX: 93404,
-      challengeL: 92122,
+      challengeL: 92338,
       pushOutcomeAndTransferAllL: 58640,
       pushOutcomeAndTransferAllX: 107742,
-      total: 351908,
+      total: 352124,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -104,16 +104,16 @@ export const gasRequiredTo: GasRequiredTo = {
       // pushOutcomeJ                ⬛ --------> (G) -> (J) -> (X) -> 👩
       // claimG                      ⬛ ----------------------> (X) -> 👩
       // pushOutcomeAndTransferAllX  ⬛ -----------------------------> 👩
-      challengeL: 92110,
-      challengeG: 94417,
-      challengeJ: 94417,
+      challengeL: 92350,
+      challengeG: 94645,
+      challengeJ: 101748,
       challengeX: 93404,
-      pushOutcomeAndTransferAllL: 58640,
-      pushOutcomeG: 61410,
+      pushOutcomeAndTransferAllL: 58652,
+      pushOutcomeG: 61422,
       pushOutcomeJ: 60558,
-      claimG: 58432,
+      claimG: 58856,
       pushOutcomeAndTransferAllX: 107742,
-      total: 721130,
+      total: 729377,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -14,15 +14,17 @@ type Path =
   | 'ETHexit'
   | 'ERC20exit'
   | 'ETHexitSad'
+  | 'ETHexitSadLedgerFunded'
+  | 'ETHexitSadVirtualFunded'
   | 'ETHexitSadLedgerFunded';
 
 // The channel being benchmarked is a 2 party null app funded with 5 wei / tokens each.
 // KEY
 // ---
-// ⬛ -> funding on chain
+// ⬛ -> funding on chain (from Alice)
 //  C    channel not yet on chain
 // (C)   channel finalized on chain
-// 🧑‍🤝‍🧑    external destinations
+// 👩    Alice's external destination (e.g. her EOA)
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
@@ -71,9 +73,9 @@ export const gasRequiredTo: GasRequiredTo = {
   },
   ETHexitSad: {
     // Scenario: counterparty goes offline
-    // initially                 ⬛ ->  X  -> 🧑‍🤝‍🧑
-    // challenge + timeout       ⬛ -> (X) -> 🧑‍🤝‍🧑
-    // pushOutcomeAndTransferAll ⬛ -> 🧑‍🤝‍🧑
+    // initially                 ⬛ ->  X  -> 👩
+    // challenge + timeout       ⬛ -> (X) -> 👩
+    // pushOutcomeAndTransferAll ⬛ --------> 👩
     vanillaNitro: {
       challenge: 93404,
       pushOutcomeAndTransferAll: 107742,
@@ -81,18 +83,41 @@ export const gasRequiredTo: GasRequiredTo = {
     },
   },
   ETHexitSadLedgerFunded: {
-    // Scenario: counterparty goes offline
     vanillaNitro: {
-      // initially                   ⬛ ->  L  ->  X  -> 🧑‍🤝‍🧑
-      // challenge X and timeout     ⬛ ->  L  -> (X) -> 🧑‍🤝‍🧑
-      // challenge L and timeout     ⬛ -> (L) -> (X) -> 🧑‍🤝‍🧑
-      // pushOutcomeAndTransferAllL  ⬛ -> (X) -> 🧑‍🤝‍🧑
-      // pushOutcomeAndTransferAllX  ⬛ -> 🧑‍🤝‍🧑
+      // initially                   ⬛ ->  L  ->  X  -> 👩
+      // challenge X and timeout     ⬛ ->  L  -> (X) -> 👩
+      // challenge L and timeout     ⬛ -> (L) -> (X) -> 👩
+      // pushOutcomeAndTransferAllL  ⬛ --------> (X) -> 👩
+      // pushOutcomeAndTransferAllX  ⬛ ---------------> 👩
       challengeX: 93404,
       challengeL: 92122,
       pushOutcomeAndTransferAllL: 58640,
       pushOutcomeAndTransferAllX: 107742,
       total: 351908,
+    },
+  },
+  ETHexitSadVirtualFunded: {
+    vanillaNitro: {
+      // initially                   ⬛ ->  L  ->  G  ->  J  ->  X  -> 👩
+      // challenge L and timeout     ⬛ -> (L) ->  G  ->  J  ->  X  -> 👩
+      // challenge G and timeout     ⬛ -> (L) -> (G) ->  J  ->  X  -> 👩
+      // challenge J and timeout     ⬛ -> (L) -> (G) -> (J) ->  X  -> 👩
+      // challenge X and timeout     ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
+      // pushOutcomeAndTransferAllL  ⬛ --------> (G) -> (J) -> (X) -> 👩
+      // pushOutcomeG                ⬛ --------> (G) -> (J) -> (X) -> 👩
+      // pushOutcomeJ                ⬛ --------> (G) -> (J) -> (X) -> 👩
+      // claimG                      ⬛ ----------------------> (X) -> 👩
+      // pushOutcomeAndTransferAllX  ⬛ -----------------------------> 👩
+      challengeL: 92110,
+      challengeG: 94417,
+      challengeJ: 94417,
+      challengeX: 93404,
+      pushOutcomeAndTransferAllL: 58640,
+      pushOutcomeG: 61410,
+      pushOutcomeJ: 60558,
+      claimG: 58432,
+      pushOutcomeAndTransferAllX: 107742,
+      total: 721130,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -85,8 +85,7 @@ export const gasRequiredTo: GasRequiredTo = {
   ETHexitSadLedgerFunded: {
     vanillaNitro: {
       // initially                   ⬛ ->  L  ->  X  -> 👩
-      // challenge X and timeout     ⬛ ->  L  -> (X) -> 👩
-      // challenge L and timeout     ⬛ -> (L) -> (X) -> 👩
+      // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
       // pushOutcomeAndTransferAllL  ⬛ --------> (X) -> 👩
       // pushOutcomeAndTransferAllX  ⬛ ---------------> 👩
       challengeX: 93404,
@@ -99,10 +98,7 @@ export const gasRequiredTo: GasRequiredTo = {
   ETHexitSadVirtualFunded: {
     vanillaNitro: {
       // initially                   ⬛ ->  L  ->  G  ->  J  ->  X  -> 👩
-      // challenge L and timeout     ⬛ -> (L) ->  G  ->  J  ->  X  -> 👩
-      // challenge G and timeout     ⬛ -> (L) -> (G) ->  J  ->  X  -> 👩
-      // challenge J and timeout     ⬛ -> (L) -> (G) -> (J) ->  X  -> 👩
-      // challenge X and timeout     ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
+      // challenge L,G,J,X + timeout ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
       // pushOutcomeAndTransferAllL  ⬛ --------> (G) -> (J) -> (X) -> 👩
       // pushOutcomeG                ⬛ --------> (G) -> (J) -> (X) -> 👩
       // pushOutcomeJ                ⬛ --------> (G) -> (J) -> (X) -> 👩

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -105,15 +105,15 @@ export const gasRequiredTo: GasRequiredTo = {
       // claimG                      ⬛ ----------------------> (X) -> 👩
       // pushOutcomeAndTransferAllX  ⬛ -----------------------------> 👩
       challengeL: 92350,
-      challengeG: 94645,
+      challengeG: 94621,
       challengeJ: 101748,
       challengeX: 93404,
       pushOutcomeAndTransferAllL: 58652,
-      pushOutcomeG: 61422,
+      pushOutcomeG: 61410,
       pushOutcomeJ: 60558,
-      claimG: 58856,
+      claimG: 58432,
       pushOutcomeAndTransferAllX: 107742,
-      total: 729377,
+      total: 728917,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -72,7 +72,7 @@ export const gasRequiredTo: GasRequiredTo = {
     vanillaNitro: 139148,
   },
   ETHexitSad: {
-    // Scenario: counterparty goes offline
+    // Scenario: Counterparty Bob goes offline
     // initially                 ⬛ ->  X  -> 👩
     // challenge + timeout       ⬛ -> (X) -> 👩
     // pushOutcomeAndTransferAll ⬛ --------> 👩
@@ -83,6 +83,7 @@ export const gasRequiredTo: GasRequiredTo = {
     },
   },
   ETHexitSadLedgerFunded: {
+    // Scenario: Counterparty Bob goes offline
     vanillaNitro: {
       // initially                   ⬛ ->  L  ->  X  -> 👩
       // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
@@ -96,6 +97,7 @@ export const gasRequiredTo: GasRequiredTo = {
     },
   },
   ETHexitSadVirtualFunded: {
+    // Scenario: Intermediary Ingrid goes offline
     vanillaNitro: {
       // initially                   ⬛ ->  L  ->  G  ->  J  ->  X  -> 👩
       // challenge L,G,J,X + timeout ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩


### PR DESCRIPTION
Follows on from #3601.

* adds a benchmark for a virtually funded channel
* improves the inline diagrams a bit and replicates them in actual test script
* introduces a `TestChannel` class which helps DRY out the fixtures somewhat


When this PR is merged, we can consider this [associated pitch](https://www.notion.so/statechannels/Improved-gas-benchmarking-in-nitro-protocol-d14938f9671a48588e6974462e9ffb00) as completed. 