### PR TITLE
Wallet constructs own engine

### DIFF
--- a/packages/interop-tests/src/__test__/interop.test.ts
+++ b/packages/interop-tests/src/__test__/interop.test.ts
@@ -1,7 +1,6 @@
 import {
   DBAdmin,
   defaultTestWalletConfig,
-  SyncOptions,
   Wallet as ServerWallet
 } from '@statechannels/server-wallet';
 import {TEST_ACCOUNTS} from '@statechannels/devtools';
@@ -47,7 +46,11 @@ const serverConfig = defaultTestWalletConfig({
     attachChainService: true,
     provider: rpcEndpoint,
     pk: TEST_ACCOUNTS[0].privateKey
-  }
+  },
+  // Currently the browser wallet crashes if it receives the same objective again
+  // To avoid this we prevent the wallet from retrying objectives by using
+  // a really large poll value (one hour)
+  syncConfiguration: {pollInterval: 3_600_000}
 });
 
 let provider: providers.JsonRpcProvider;
@@ -76,11 +79,7 @@ beforeAll(async () => {
   );
 
   const factory = BrowserServerMessageService.createFactory(browserWallet);
-  // Currently the browser wallet crashes if it receives the same objective again
-  // To avoid this we prevent the wallet from retrying objectives by using
-  // a really large poll value (one hour)
-  const syncOptions: Partial<SyncOptions> = {pollInterval: 3_600_000};
-  serverWallet = await ServerWallet.create(serverConfig, factory, syncOptions);
+  serverWallet = await ServerWallet.create(serverConfig, factory);
 
   serverAddress = await serverWallet.getSigningAddress();
   serverDestination = makeDestination(serverAddress);

--- a/packages/server-wallet/jest/knex-setup-teardown.ts
+++ b/packages/server-wallet/jest/knex-setup-teardown.ts
@@ -8,8 +8,8 @@ import {DBAdmin} from '../src/db-admin/db-admin';
 configureEnvVariables();
 
 import {
-  extractDBConfigFromEngineConfig,
-  defaultTestConfig,
+  extractDBConfigFromWalletConfig,
+  defaultTestWalletConfig,
   DatabaseConfiguration,
 } from '../src/config';
 
@@ -22,7 +22,9 @@ const constructedKnexs: Knex[] = [];
  * returns a knex instance which is automatically destroyed after all jest tests have run
  */
 export const constructKnex = (databaseConfiguration: Partial<DatabaseConfiguration>): Knex => {
-  const knex = Knex(extractDBConfigFromEngineConfig(defaultTestConfig({databaseConfiguration})));
+  const knex = Knex(
+    extractDBConfigFromWalletConfig(defaultTestWalletConfig({databaseConfiguration}))
+  );
   constructedKnexs.push(knex);
 
   return knex;

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -6,7 +6,7 @@ import {makeDestination} from '@statechannels/wallet-core';
 import {Logger} from 'pino';
 import {utils} from 'ethers';
 
-import {Engine, extractDBConfigFromWalletConfig, IncomingEngineConfigV2} from '../src/engine';
+import {Engine, extractDBConfigFromWalletConfig, EngineConfig} from '../src/engine';
 import {
   DBAdmin,
   defaultTestWalletConfig,
@@ -67,12 +67,12 @@ const baseEngineConfig = {
   chainNetworkID: utils.hexlify(baseConfig.networkConfiguration.chainNetworkID),
   workerThreadAmount: 0,
 };
-export const aRealEngineConfig: IncomingEngineConfigV2 = {
+export const aRealEngineConfig: EngineConfig = {
   ...baseEngineConfig,
   dbConfig: {connection: extractDBConfigFromWalletConfig(aWalletConfig)},
 };
 
-export const bRealEngineConfig: IncomingEngineConfigV2 = {
+export const bRealEngineConfig: EngineConfig = {
   ...baseEngineConfig,
   dbConfig: {connection: extractDBConfigFromWalletConfig(bWalletConfig)},
 };

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -67,12 +67,12 @@ const baseEngineConfig = {
   chainNetworkID: utils.hexlify(baseConfig.networkConfiguration.chainNetworkID),
   workerThreadAmount: 0,
 };
-export const aRealEngineConfig: EngineConfig = {
+export const aEngineConfig: EngineConfig = {
   ...baseEngineConfig,
   dbConfig: extractDBConfigFromWalletConfig(aWalletConfig),
 };
 
-export const bRealEngineConfig: EngineConfig = {
+export const bEngineConfig: EngineConfig = {
   ...baseEngineConfig,
   dbConfig: extractDBConfigFromWalletConfig(bWalletConfig),
 };
@@ -131,8 +131,8 @@ export async function setupPeerEngines(withWalletSeeding = false): Promise<PeerS
     ]);
 
     const peerEngines = {
-      a: await Engine.create(aRealEngineConfig, createLogger(aWalletConfig)),
-      b: await Engine.create(bRealEngineConfig, createLogger(bWalletConfig)),
+      a: await Engine.create(aEngineConfig, createLogger(aWalletConfig)),
+      b: await Engine.create(bEngineConfig, createLogger(bWalletConfig)),
     };
 
     if (withWalletSeeding) {

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -13,7 +13,7 @@ import {
   defaultTestWalletConfig,
   overwriteConfigWithDatabaseConnection,
 } from '../src/engine';
-import {DBAdmin, SyncOptions, Wallet} from '../src';
+import {DBAdmin, Wallet} from '../src';
 import {
   seedAlicesSigningWallet,
   seedBobsSigningWallet,
@@ -31,11 +31,6 @@ export interface TestPeerWallets {
   a: Wallet;
   b: Wallet;
 }
-const DEFAULT_SYNC_OPTIONS: SyncOptions = {
-  pollInterval: 50,
-  staleThreshold: 1_000,
-  timeOutThreshold: 45_000,
-};
 
 const aDatabase = 'server_wallet_test_a';
 const bDatabase = 'server_wallet_test_b';
@@ -51,6 +46,7 @@ const baseConfig = defaultTestWalletConfig({
     logLevel: 'trace',
     logDestination: path.join(ARTIFACTS_DIR, 'with-peers.log'),
   },
+  syncConfiguration: {pollInterval: 50, staleThreshold: 1_000, timeOutThreshold: 45_000},
 });
 export const aWalletConfig = overwriteConfigWithDatabaseConnection(baseConfig, {
   database: aDatabase,
@@ -103,8 +99,8 @@ export async function setupPeerWallets(withWalletsSeeding = false): Promise<Peer
   const peerSetup = await setupPeerEngines(withWalletsSeeding);
 
   const peerWallets = {
-    a: await Wallet.create(aWalletConfig, TestMessageService.create, DEFAULT_SYNC_OPTIONS),
-    b: await Wallet.create(bWalletConfig, TestMessageService.create, DEFAULT_SYNC_OPTIONS),
+    a: await Wallet.create(aWalletConfig, TestMessageService.create),
+    b: await Wallet.create(bWalletConfig, TestMessageService.create),
   };
   TestMessageService.linkMessageServices(
     peerWallets.a.messageService,

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -6,7 +6,7 @@ import {makeDestination} from '@statechannels/wallet-core';
 import {Logger} from 'pino';
 import {utils} from 'ethers';
 
-import {Engine, extractDBConfigFromWalletConfig} from '../src/engine';
+import {Engine, extractDBConfigFromWalletConfig, IncomingEngineConfigV2} from '../src/engine';
 import {
   DBAdmin,
   defaultTestWalletConfig,
@@ -21,7 +21,6 @@ import {
 import {TestMessageService} from '../src/message-service/test-message-service';
 import {createLogger} from '../src/logger';
 import {LegacyTestMessageHandler} from '../src/message-service/legacy-test-message-service';
-import {IncomingEngineConfigV2} from '../src/engine/engine';
 
 interface TestPeerEngines {
   a: Engine;

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -6,14 +6,14 @@ import {makeDestination} from '@statechannels/wallet-core';
 import {Logger} from 'pino';
 import {utils} from 'ethers';
 
-import {Engine, extractDBConfigFromWalletConfig, EngineConfig} from '../src/engine';
 import {
-  DBAdmin,
+  Engine,
+  extractDBConfigFromWalletConfig,
+  EngineConfig,
   defaultTestWalletConfig,
   overwriteConfigWithDatabaseConnection,
-  SyncOptions,
-  Wallet,
-} from '../src';
+} from '../src/engine';
+import {DBAdmin, SyncOptions, Wallet} from '../src';
 import {
   seedAlicesSigningWallet,
   seedBobsSigningWallet,
@@ -69,12 +69,12 @@ const baseEngineConfig = {
 };
 export const aRealEngineConfig: EngineConfig = {
   ...baseEngineConfig,
-  dbConfig: {connection: extractDBConfigFromWalletConfig(aWalletConfig)},
+  dbConfig: extractDBConfigFromWalletConfig(aWalletConfig),
 };
 
 export const bRealEngineConfig: EngineConfig = {
   ...baseEngineConfig,
-  dbConfig: {connection: extractDBConfigFromWalletConfig(bWalletConfig)},
+  dbConfig: extractDBConfigFromWalletConfig(bWalletConfig),
 };
 
 const logger: Logger = createLogger(baseConfig);

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -7,8 +7,6 @@
 import { Address } from '@statechannels/wallet-core';
 import { Allocation } from '@statechannels/client-api-schema';
 import { AllocationItem } from '@statechannels/wallet-core';
-import { AllocationItem as AllocationItem_2 } from '@statechannels/nitro-protocol';
-import { AssetOutcome } from '@statechannels/nitro-protocol';
 import { ChannelConstants } from '@statechannels/wallet-core';
 import { ChannelId } from '@statechannels/client-api-schema';
 import { ChannelResult } from '@statechannels/client-api-schema';
@@ -35,12 +33,12 @@ import { Model } from 'objection';
 import { ModelOptions } from 'objection';
 import { OpenChannel } from '@statechannels/wallet-core';
 import { Outcome } from '@statechannels/wallet-core';
+import P from 'pino';
 import { Participant } from '@statechannels/wallet-core';
 import { Participant as Participant_2 } from '@statechannels/client-api-schema';
 import { Payload } from '@statechannels/wire-format';
 import { Pojo } from 'objection';
 import { PrivateKey } from '@statechannels/wallet-core';
-import { providers } from 'ethers';
 import { QueryContext } from 'objection';
 import { SignatureEntry } from '@statechannels/wallet-core';
 import { SignedState } from '@statechannels/wallet-core';
@@ -80,13 +78,13 @@ export type DatabasePoolConfiguration = {
 
 // @public
 export class DBAdmin {
-    static createDatabase(config: IncomingEngineConfig): Promise<void>;
+    static createDatabase(config: IncomingWalletConfig): Promise<void>;
     static createDatabaseFromKnex(knex: Knex): Promise<void>;
-    static dropDatabase(config: IncomingEngineConfig): Promise<void>;
+    static dropDatabase(config: IncomingWalletConfig): Promise<void>;
     static dropDatabaseFromKnex(knex: Knex): Promise<void>;
-    static migrateDatabase(config: IncomingEngineConfig): Promise<void>;
+    static migrateDatabase(config: IncomingWalletConfig): Promise<void>;
     static migrateDatabaseFromKnex(knex: Knex): Promise<void>;
-    static truncateDatabase(config: IncomingEngineConfig, tables?: string[]): Promise<void>;
+    static truncateDatabase(config: IncomingWalletConfig, tables?: string[]): Promise<void>;
     static truncateDataBaseFromKnex(knex: Knex, tables?: string[]): Promise<void>;
 }
 
@@ -105,7 +103,7 @@ export const DEFAULT_DB_USER = "postgres";
 export const defaultChainServiceConfiguration: ChainServiceConfiguration;
 
 // @public
-export const defaultConfig: OptionalEngineConfig;
+export const defaultConfig: OptionalWalletConfig;
 
 // @public (undocumented)
 export const defaultDatabaseConfiguration: OptionalDatabaseConfiguration & {
@@ -124,22 +122,34 @@ export const defaultMetricsConfiguration: {
     timingMetrics: boolean;
 };
 
-// Warning: (ae-forgotten-export) The symbol "HasDatabaseConnectionConfigObject" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export const defaultTestConfig: (partialConfig?: DeepPartial<EngineConfig & HasDatabaseConnectionConfigObject>) => EngineConfig & HasDatabaseConnectionConfigObject;
+export const defaultSyncConfiguration: SyncConfiguration;
+
+// @public (undocumented)
+export function defaultTestEngineConfig(partialConfig?: Partial<EngineConfig>): EngineConfig;
 
 // @public (undocumented)
 export const defaultTestNetworkConfiguration: NetworkConfiguration;
 
+// Warning: (ae-forgotten-export) The symbol "HasDatabaseConnectionConfigObject" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export function defaultTestWalletConfig(partialConfig?: DeepPartial<WalletConfig & HasDatabaseConnectionConfigObject>): WalletConfig & HasDatabaseConnectionConfigObject;
+
 // @public
 export abstract class Engine extends SingleThreadedEngine implements EngineInterface {
     // (undocumented)
-    static create(engineConfig: IncomingEngineConfig): Promise<SingleThreadedEngine | MultiThreadedEngine>;
+    static create(engineConfig: EngineConfig, logger: P.Logger): Promise<SingleThreadedEngine | MultiThreadedEngine>;
 }
 
-// @public
-export type EngineConfig = RequiredEngineConfig & OptionalEngineConfig;
+// @public (undocumented)
+export type EngineConfig = {
+    skipEvmValidation: boolean;
+    metrics: MetricsConfiguration;
+    dbConfig: Config;
+    chainNetworkID: string;
+    workerThreadAmount: number;
+};
 
 // @public (undocumented)
 export interface EngineInterface {
@@ -172,12 +182,12 @@ export interface EngineInterface {
 }
 
 // @public (undocumented)
-export function extractDBConfigFromEngineConfig(engineConfig: EngineConfig): Config;
+export function extractDBConfigFromWalletConfig(walletConfig: WalletConfig): Config;
 
 // Warning: (ae-forgotten-export) The symbol "DatabaseConnectionConfigObject" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function getDatabaseConnectionConfig(config: EngineConfig): DatabaseConnectionConfigObject & {
+export function getDatabaseConnectionConfig(config: WalletConfig): DatabaseConnectionConfigObject & {
     host: string;
     port: number;
 };
@@ -188,7 +198,7 @@ export function hasNewObjective(response: SingleChannelOutput): response is Sing
 };
 
 // @public
-export type IncomingEngineConfig = RequiredEngineConfig & Partial<OptionalEngineConfig>;
+export type IncomingWalletConfig = RequiredWalletConfig & Partial<OptionalWalletConfig>;
 
 // @public
 export type InternalError = {
@@ -224,9 +234,9 @@ export type MultipleChannelOutput = {
 
 // @public
 export class MultiThreadedEngine extends SingleThreadedEngine {
-    protected constructor(engineConfig: IncomingEngineConfig);
+    protected constructor(engineConfig: EngineConfig, logger: P.Logger);
     // (undocumented)
-    static create(engineConfig: IncomingEngineConfig): Promise<MultiThreadedEngine>;
+    static create(engineConfig: EngineConfig, logger: P.Logger): Promise<MultiThreadedEngine>;
     // (undocumented)
     destroy(): Promise<void>;
     // (undocumented)
@@ -284,7 +294,7 @@ export type OptionalDatabaseConfiguration = {
 };
 
 // @public
-export interface OptionalEngineConfig {
+export interface OptionalWalletConfig {
     // (undocumented)
     chainServiceConfiguration: ChainServiceConfiguration;
     // (undocumented)
@@ -295,6 +305,8 @@ export interface OptionalEngineConfig {
     metricsConfiguration: MetricsConfiguration;
     // (undocumented)
     skipEvmValidation: boolean;
+    // (undocumented)
+    syncConfiguration: SyncConfiguration;
     // (undocumented)
     workerThreadAmount: number;
 }
@@ -310,7 +322,7 @@ export type Output = SingleChannelOutput | MultipleChannelOutput;
 // Warning: (ae-forgotten-export) The symbol "PartialConfigObject" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function overwriteConfigWithDatabaseConnection(config: EngineConfig, databaseConnectionConfig: PartialConfigObject | string): EngineConfig;
+export function overwriteConfigWithDatabaseConnection(config: WalletConfig, databaseConnectionConfig: PartialConfigObject | string): WalletConfig;
 
 // @public
 export type RequiredConnectionConfiguration = {
@@ -326,7 +338,7 @@ export type RequiredDatabaseConfiguration = {
 };
 
 // @public
-export type RequiredEngineConfig = {
+export type RequiredWalletConfig = {
     databaseConfiguration: RequiredDatabaseConfiguration;
     networkConfiguration: NetworkConfiguration;
 };
@@ -341,7 +353,7 @@ export type SingleChannelOutput = {
 
 // @public
 export class SingleThreadedEngine implements EngineInterface {
-    protected constructor(engineConfig: IncomingEngineConfig);
+    protected constructor(config: EngineConfig, logger: Logger);
     addSigningKey(privateKey: PrivateKey): Promise<void>;
     // (undocumented)
     approveObjectives(objectiveIds: string[]): Promise<{
@@ -349,6 +361,8 @@ export class SingleThreadedEngine implements EngineInterface {
         messages: Message_2[];
         chainRequests: ChainRequest[];
     }>;
+    // (undocumented)
+    chainNetworkId: string;
     challenge(channelId: string): Promise<SingleChannelOutput>;
     closeChannel({ channelId, }: CloseChannelParams): Promise<SingleChannelOutput & {
         newObjective: WalletObjective;
@@ -356,15 +370,13 @@ export class SingleThreadedEngine implements EngineInterface {
     closeChannels(channelIds: Bytes32[]): Promise<MultipleChannelOutput>;
     crank(channelIds: string[]): Promise<MultipleChannelOutput>;
     // (undocumented)
-    static create(engineConfig: IncomingEngineConfig): Promise<SingleThreadedEngine>;
+    static create(engineConfig: EngineConfig, logger: Logger): Promise<SingleThreadedEngine>;
     createChannel(args: CreateChannelParams): Promise<SingleChannelOutput & {
         newObjective: WalletObjective;
     }>;
     createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
     createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
     destroy(): Promise<void>;
-    // (undocumented)
-    readonly engineConfig: EngineConfig;
     getApprovedObjectives(): Promise<WalletObjective[]>;
     getChannels(): Promise<MultipleChannelOutput>;
     getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
@@ -380,7 +392,7 @@ export class SingleThreadedEngine implements EngineInterface {
     // (undocumented)
     ledgerManager: LedgerManager;
     // (undocumented)
-    logger: Logger;
+    protected logger: Logger;
     // Warning: (ae-forgotten-export) The symbol "ObjectiveManager" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -399,7 +411,7 @@ export class SingleThreadedEngine implements EngineInterface {
 }
 
 // @public (undocumented)
-export type SyncOptions = {
+export type SyncConfiguration = {
     pollInterval: number;
     timeOutThreshold: number;
     staleThreshold: number;
@@ -425,7 +437,7 @@ export type UpdateChannelSuccess = {
 // @public (undocumented)
 export function validateEngineConfig(config: Record<string, any>): {
     valid: boolean;
-    value: EngineConfig | undefined;
+    value: WalletConfig | undefined;
     errors: ValidationErrorItem[];
 };
 
@@ -433,12 +445,15 @@ export function validateEngineConfig(config: Record<string, any>): {
 export class Wallet extends EventEmitter<WalletEvents> {
     approveObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]>;
     closeChannels(channelIds: string[]): Promise<ObjectiveResult[]>;
-    // Warning: (ae-forgotten-export) The symbol "ChainServiceInterface" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "MessageServiceFactory" needs to be exported by the entry point index.d.ts
-    static create(engine: Engine, chainService: ChainServiceInterface, messageServiceFactory: MessageServiceFactory, retryOptions?: Partial<SyncOptions>): Promise<Wallet>;
+    static create(incomingConfig: IncomingWalletConfig, messageServiceFactory: MessageServiceFactory): Promise<Wallet>;
     createChannels(channelParameters: CreateChannelParams[]): Promise<ObjectiveResult[]>;
     // (undocumented)
     destroy(): Promise<void>;
+    // (undocumented)
+    getChannels(): Promise<ChannelResult[]>;
+    // (undocumented)
+    getSigningAddress(): Promise<Address>;
     jumpStartObjectives(): Promise<ObjectiveResult[]>;
     // Warning: (ae-forgotten-export) The symbol "MessageServiceInterface" needs to be exported by the entry point index.d.ts
     //
@@ -447,6 +462,9 @@ export class Wallet extends EventEmitter<WalletEvents> {
     registerAppDefinition(appDefinition: string): Promise<void>;
     updateChannel(channelId: string, allocations: Allocation[], appData: string): Promise<UpdateChannelResult>;
 }
+
+// @public
+export type WalletConfig = RequiredWalletConfig & OptionalWalletConfig;
 
 // @public (undocumented)
 export interface WalletEvents {
@@ -461,9 +479,9 @@ export interface WalletEvents {
 
 // Warnings were encountered during analysis:
 //
-// src/engine/types.ts:28:3 - (ae-forgotten-export) The symbol "ChainRequest" needs to be exported by the entry point index.d.ts
-// src/engine/types.ts:66:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
-// src/wallet/types.ts:61:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
+// src/engine/types.ts:31:3 - (ae-forgotten-export) The symbol "ChainRequest" needs to be exported by the entry point index.d.ts
+// src/engine/types.ts:69:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
+// src/wallet/types.ts:44:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -14,7 +14,6 @@ import {
   WalletConfig,
 } from '../config';
 import {DBAdmin} from '../db-admin/db-admin';
-import {Engine} from '../engine';
 import {LatencyOptions, TestMessageService} from '../message-service/test-message-service';
 import {SyncOptions, Wallet} from '../wallet';
 import {ONE_DAY} from '../__test__/test-helpers';
@@ -44,8 +43,6 @@ const config = {
 let provider: providers.JsonRpcProvider;
 let a: Wallet;
 let b: Wallet;
-let aEngine: Engine;
-let bEngine: Engine;
 
 const bWalletConfig: WalletConfig = {
   ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_b'}),
@@ -150,14 +147,13 @@ test.each(testCases)(
   `can successfully fund and defund a channel between two wallets with options %o`,
   async options => {
     TestMessageService.setLatencyOptions({a, b}, options);
-
-    const participantA = {
-      signingAddress: await aEngine.getSigningAddress(),
+    const participantA: Participant = {
+      signingAddress: await a.getSigningAddress(),
       participantId: 'a',
       destination: makeDestination(aAddress),
     };
-    const participantB = {
-      signingAddress: await bEngine.getSigningAddress(),
+    const participantB: Participant = {
+      signingAddress: await b.getSigningAddress(),
       participantId: 'b',
       destination: makeDestination(bAddress),
     };

--- a/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/directly-funded-channel.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../config';
 import {DBAdmin} from '../db-admin/db-admin';
 import {LatencyOptions, TestMessageService} from '../message-service/test-message-service';
-import {SyncOptions, Wallet} from '../wallet';
+import {Wallet} from '../wallet';
 import {ONE_DAY} from '../__test__/test-helpers';
 import {waitForObjectiveProposals} from '../__test-with-peers__/utils';
 import {ARTIFACTS_DIR} from '../../jest/chain-setup';
@@ -57,6 +57,7 @@ const bWalletConfig: WalletConfig = {
     pk: process.env.CHAIN_SERVICE_PK ?? TEST_ACCOUNTS[1].privateKey,
     allowanceMode: 'MaxUint',
   },
+  syncConfiguration: {pollInterval: 1_000, timeOutThreshold: 60_000, staleThreshold: 10_000},
 };
 const aWalletConfig: WalletConfig = {
   ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_a'}),
@@ -71,6 +72,7 @@ const aWalletConfig: WalletConfig = {
     pk: process.env.CHAIN_SERVICE_PK2 ?? TEST_ACCOUNTS[2].privateKey,
     allowanceMode: 'MaxUint',
   },
+  syncConfiguration: {pollInterval: 1_000, timeOutThreshold: 60_000, staleThreshold: 10_000},
 };
 
 const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';
@@ -104,13 +106,8 @@ beforeAll(async () => {
     })
   );
 
-  const syncOptions: SyncOptions = {
-    pollInterval: 1_000,
-    timeOutThreshold: 60_000,
-    staleThreshold: 10_000,
-  };
-  a = await Wallet.create(aWalletConfig, TestMessageService.create, syncOptions);
-  b = await Wallet.create(bWalletConfig, TestMessageService.create, syncOptions);
+  a = await Wallet.create(aWalletConfig, TestMessageService.create);
+  b = await Wallet.create(bWalletConfig, TestMessageService.create);
   const logger = createLogger(defaultTestWalletConfig());
 
   TestMessageService.linkMessageServices(a.messageService, b.messageService, logger);

--- a/packages/server-wallet/src/__test-with-peers__/wallet/close-channels.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/close-channels.test.ts
@@ -39,7 +39,7 @@ describe('CloseChannels', () => {
   test.each(testCases)(
     'can successfully create and close channel with the latency options: %o',
     async options => {
-      const {peerEngines, peerWallets} = peerSetup;
+      const {peerWallets} = peerSetup;
       // Always reset the latency options back to no drop / delay
       // This prevents the next test from using delay/dropping when doing setup
       TestMessageService.setLatencyOptions(peerWallets, {dropRate: 0, meanDelay: undefined});
@@ -83,12 +83,12 @@ describe('CloseChannels', () => {
       await expect(secondCloseResponse).toBeObjectiveDoneType('Success');
 
       // Ensure that A has all closed channels
-      const {channelResults: aChannels} = await peerEngines.a.getChannels();
+      const aChannels = await peerWallets.a.getChannels();
       for (const a of aChannels) {
         expect(a.status).toEqual('closed');
       }
       // Ensure that B has all closed channels
-      const {channelResults: bChannels} = await peerEngines.b.getChannels();
+      const bChannels = await peerWallets.b.getChannels();
       for (const b of bChannels) {
         expect(b.status).toEqual('closed');
       }

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -28,7 +28,7 @@ import {computeNewAssetOutcome} from '@statechannels/nitro-protocol/lib/src/cont
 
 import {Bytes32} from '../type-aliases';
 import {createLogger} from '../logger';
-import {defaultTestConfig} from '../config';
+import {defaultTestWalletConfig} from '../config';
 
 import {
   AllowanceMode,
@@ -96,7 +96,7 @@ export class ChainService implements ChainServiceInterface {
     this.blockConfirmations = blockConfirmations ?? 5;
     this.logger = logger
       ? logger.child({module: 'ChainService'})
-      : createLogger(defaultTestConfig());
+      : createLogger(defaultTestWalletConfig());
 
     this.allowanceMode = allowanceMode || 'MaxUint';
     if (provider && (provider.includes('0.0.0.0') || provider.includes('localhost'))) {

--- a/packages/server-wallet/src/config/__test__/validation.test.ts
+++ b/packages/server-wallet/src/config/__test__/validation.test.ts
@@ -1,18 +1,18 @@
-import {defaultTestConfig} from '../defaults';
+import {defaultTestWalletConfig} from '../defaults';
 import {DatabaseConfiguration} from '../types';
 import {validateEngineConfig} from '../validation';
 
 describe('config validation', () => {
   describe('server wallet config', () => {
     it('validates the default test config', () => {
-      expect(validateEngineConfig(defaultTestConfig()).valid).toBe(true);
+      expect(validateEngineConfig(defaultTestWalletConfig()).valid).toBe(true);
     });
   });
 
   describe('chain service config', () => {
     it('rejects an invalid private key', () => {
       const {valid, errors} = validateEngineConfig(
-        defaultTestConfig({
+        defaultTestWalletConfig({
           chainServiceConfiguration: {
             pk: 'bla',
           },
@@ -26,7 +26,7 @@ describe('config validation', () => {
     });
     it('rejects an invalid rpc endpoint', () => {
       const chainServiceConfiguration = {provider: 'badurl'};
-      const result = validateEngineConfig(defaultTestConfig({chainServiceConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({chainServiceConfiguration}));
       expect(result.errors[0].message).toMatch(
         '"chainServiceConfiguration.provider" must be a valid uri'
       );
@@ -37,7 +37,7 @@ describe('config validation', () => {
       const result = validateEngineConfig(
         // eslint-disable-next-line
         // @ts-ignore
-        defaultTestConfig({chainServiceConfiguration})
+        defaultTestWalletConfig({chainServiceConfiguration})
       );
       expect(result.errors[0].message).toMatch(
         '"chainServiceConfiguration.allowanceMode" must be one of [MaxUint, PerDeposit]'
@@ -46,7 +46,7 @@ describe('config validation', () => {
     });
     it('rejects an invalid polling interval', () => {
       const chainServiceConfiguration = {pollingInterval: 0};
-      const result = validateEngineConfig(defaultTestConfig({chainServiceConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({chainServiceConfiguration}));
       expect(result.errors[0].message).toMatch(
         '"chainServiceConfiguration.pollingInterval" must be a positive number'
       );
@@ -57,7 +57,7 @@ describe('config validation', () => {
   describe('network config', () => {
     it('rejects an invalid chain id', () => {
       const networkConfiguration = {chainNetworkID: 0.5};
-      const result = validateEngineConfig(defaultTestConfig({networkConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({networkConfiguration}));
       expect(result.errors[0].message).toMatch(
         '"networkConfiguration.chainNetworkID" must be an integer'
       );
@@ -69,7 +69,7 @@ describe('config validation', () => {
       const metricsConfiguration = {
         timingMetrics: true,
       };
-      const result = validateEngineConfig(defaultTestConfig({metricsConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({metricsConfiguration}));
       expect(result.errors[0].message).toMatch(
         '"metricsConfiguration.metricsOutputFile" is required'
       );
@@ -84,7 +84,7 @@ describe('config validation', () => {
         pool: {max: 5},
         debug: false,
       };
-      const result = validateEngineConfig(defaultTestConfig({databaseConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({databaseConfiguration}));
       expect(result.valid).toBe(true);
     });
 
@@ -94,7 +94,7 @@ describe('config validation', () => {
         pool: {max: 5},
         debug: false,
       };
-      const result = validateEngineConfig(defaultTestConfig({databaseConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({databaseConfiguration}));
       expect(result.valid).toBe(true);
     });
 
@@ -104,7 +104,7 @@ describe('config validation', () => {
         pool: {max: 5},
         debug: false,
       };
-      const result = validateEngineConfig(defaultTestConfig({databaseConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({databaseConfiguration}));
       expect(result.valid).toBe(false);
       expect(result.errors[0].message).toMatch('Invalid connection string');
     });
@@ -115,7 +115,7 @@ describe('config validation', () => {
         pool: {max: 5},
         debug: false,
       };
-      const result = validateEngineConfig(defaultTestConfig({databaseConfiguration}));
+      const result = validateEngineConfig(defaultTestWalletConfig({databaseConfiguration}));
       expect(result.valid).toBe(false);
       expect(result.errors[0].message).toMatch(
         '"databaseConfiguration.connection.dbName" is not allowed'

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -9,11 +9,11 @@ import {
   LoggingConfiguration,
   NetworkConfiguration,
   OptionalDatabaseConfiguration,
-  OptionalEngineConfig,
-  EngineConfig,
+  OptionalWalletConfig,
+  WalletConfig,
 } from './types';
 
-import {extractDBConfigFromEngineConfig} from '.';
+import {extractDBConfigFromWalletConfig} from '.';
 
 export const defaultDatabaseConfiguration: OptionalDatabaseConfiguration & {
   connection: {host: string; port: number; user: string};
@@ -49,7 +49,7 @@ export const defaultChainServiceConfiguration: ChainServiceConfiguration = {
  * These are the default values that will be used by the server wallet
  * if not overidden in the provided config
  */
-export const defaultConfig: OptionalEngineConfig = {
+export const defaultConfig: OptionalWalletConfig = {
   databaseConfiguration: defaultDatabaseConfiguration,
   loggingConfiguration: defaultLoggingConfiguration,
   metricsConfiguration: defaultMetricsConfiguration,
@@ -77,14 +77,14 @@ export const defaultTestEngineConfig = (
     workerThreadAmount: 0,
     // eslint-disable-next-line no-process-env
     chainNetworkID: utils.hexlify(parseInt(process.env.CHAIN_NETWORK_ID ?? '0')),
-    dbConfig: extractDBConfigFromEngineConfig(defaultTestConfig()),
+    dbConfig: extractDBConfigFromWalletConfig(defaultTestWalletConfig()),
   };
   return _.assign({}, defaultEngineConfig, partialConfig);
 };
 
-export const defaultTestConfig = (
-  partialConfig: DeepPartial<EngineConfig & HasDatabaseConnectionConfigObject> = {}
-): EngineConfig & HasDatabaseConnectionConfigObject => {
+export const defaultTestWalletConfig = (
+  partialConfig: DeepPartial<WalletConfig & HasDatabaseConnectionConfigObject> = {}
+): WalletConfig & HasDatabaseConnectionConfigObject => {
   const fullDefaultConfig = {
     ...defaultConfig,
     networkConfiguration: defaultTestNetworkConfiguration,

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -1,7 +1,4 @@
-import {utils} from 'ethers';
 import _ from 'lodash';
-
-import {IncomingEngineConfigV2} from '../engine/engine';
 
 import {
   ChainServiceConfiguration,
@@ -12,8 +9,6 @@ import {
   OptionalWalletConfig,
   WalletConfig,
 } from './types';
-
-import {extractDBConfigFromWalletConfig} from '.';
 
 export const defaultDatabaseConfiguration: OptionalDatabaseConfiguration & {
   connection: {host: string; port: number; user: string};
@@ -67,19 +62,6 @@ type HasDatabaseConnectionConfigObject = {
 export const defaultTestNetworkConfiguration: NetworkConfiguration = {
   // eslint-disable-next-line no-process-env
   chainNetworkID: parseInt(process.env.CHAIN_NETWORK_ID ?? '0'),
-};
-export const defaultTestEngineConfig = (
-  partialConfig?: Partial<IncomingEngineConfigV2>
-): IncomingEngineConfigV2 => {
-  const defaultEngineConfig: IncomingEngineConfigV2 = {
-    skipEvmValidation: true,
-    metrics: {timingMetrics: false},
-    workerThreadAmount: 0,
-    // eslint-disable-next-line no-process-env
-    chainNetworkID: utils.hexlify(parseInt(process.env.CHAIN_NETWORK_ID ?? '0')),
-    dbConfig: extractDBConfigFromWalletConfig(defaultTestWalletConfig()),
-  };
-  return _.assign({}, defaultEngineConfig, partialConfig);
 };
 
 export const defaultTestWalletConfig = (

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -64,9 +64,9 @@ export const defaultTestNetworkConfiguration: NetworkConfiguration = {
   chainNetworkID: parseInt(process.env.CHAIN_NETWORK_ID ?? '0'),
 };
 
-export const defaultTestWalletConfig = (
+export function defaultTestWalletConfig(
   partialConfig: DeepPartial<WalletConfig & HasDatabaseConnectionConfigObject> = {}
-): WalletConfig & HasDatabaseConnectionConfigObject => {
+): WalletConfig & HasDatabaseConnectionConfigObject {
   const fullDefaultConfig = {
     ...defaultConfig,
     networkConfiguration: defaultTestNetworkConfiguration,
@@ -86,4 +86,4 @@ export const defaultTestWalletConfig = (
     },
   };
   return _.merge({}, fullDefaultConfig, partialConfig);
-};
+}

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -1,4 +1,7 @@
+import {utils} from 'ethers';
 import _ from 'lodash';
+
+import {IncomingEngineConfigV2} from '../engine/engine';
 
 import {
   ChainServiceConfiguration,
@@ -9,6 +12,8 @@ import {
   OptionalEngineConfig,
   EngineConfig,
 } from './types';
+
+import {extractDBConfigFromEngineConfig} from '.';
 
 export const defaultDatabaseConfiguration: OptionalDatabaseConfiguration & {
   connection: {host: string; port: number; user: string};
@@ -58,9 +63,23 @@ export const DEFAULT_DB_USER = 'postgres';
 type HasDatabaseConnectionConfigObject = {
   databaseConfiguration: {connection: {host: string; port: number; database: string}};
 };
+
 export const defaultTestNetworkConfiguration: NetworkConfiguration = {
   // eslint-disable-next-line no-process-env
   chainNetworkID: parseInt(process.env.CHAIN_NETWORK_ID ?? '0'),
+};
+export const defaultTestEngineConfig = (
+  partialConfig?: Partial<IncomingEngineConfigV2>
+): IncomingEngineConfigV2 => {
+  const defaultEngineConfig: IncomingEngineConfigV2 = {
+    skipEvmValidation: true,
+    metrics: {timingMetrics: false},
+    workerThreadAmount: 0,
+    // eslint-disable-next-line no-process-env
+    chainNetworkID: utils.hexlify(parseInt(process.env.CHAIN_NETWORK_ID ?? '0')),
+    dbConfig: extractDBConfigFromEngineConfig(defaultTestConfig()),
+  };
+  return _.assign({}, defaultEngineConfig, partialConfig);
 };
 
 export const defaultTestConfig = (

--- a/packages/server-wallet/src/config/defaults.ts
+++ b/packages/server-wallet/src/config/defaults.ts
@@ -7,6 +7,7 @@ import {
   NetworkConfiguration,
   OptionalDatabaseConfiguration,
   OptionalWalletConfig,
+  SyncConfiguration,
   WalletConfig,
 } from './types';
 
@@ -36,6 +37,12 @@ export const defaultChainServiceConfiguration: ChainServiceConfiguration = {
   attachChainService: false,
 };
 
+export const defaultSyncConfiguration: SyncConfiguration = {
+  pollInterval: 100,
+  timeOutThreshold: 60_000,
+  staleThreshold: 1_000,
+};
+
 /**
  * Server Wallet config
  */
@@ -51,6 +58,7 @@ export const defaultConfig: OptionalWalletConfig = {
   chainServiceConfiguration: defaultChainServiceConfiguration,
   skipEvmValidation: false,
   workerThreadAmount: 0,
+  syncConfiguration: defaultSyncConfiguration,
 };
 
 export const DEFAULT_DB_NAME = 'server_wallet_test';

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -3,7 +3,7 @@ import {Level} from 'pino';
 import {ChainServiceArgs} from '../chain-service';
 
 export type SyncConfiguration = {
-  // How often we check for stale or timed out objectives in milliseconds.
+  /** How often we check for stale or timed out objectives in milliseconds. */
   pollInterval: number;
 
   /**

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -2,6 +2,23 @@ import {Level} from 'pino';
 
 import {ChainServiceArgs} from '../chain-service';
 
+export type SyncConfiguration = {
+  // How often we check for stale or timed out objectives in milliseconds.
+  pollInterval: number;
+
+  /**
+   * The amount of time (in milliseconds) that we wait for until we consider an objective timed out.
+   * When an objective is timed out we give up trying to complete it and return an error.
+   */
+  timeOutThreshold: number;
+
+  /**
+   * The amount of time (in milliseconds) that we wait for until we consider an objective "stale"
+   * If an objective is stale we attempt to sync the objectives with the other participants.
+   */
+  staleThreshold: number;
+};
+
 /**
  * Either a connection string or a config object with the dbName specified
  */
@@ -76,6 +93,7 @@ export interface OptionalWalletConfig {
   chainServiceConfiguration: ChainServiceConfiguration;
   loggingConfiguration: LoggingConfiguration;
   metricsConfiguration: MetricsConfiguration;
+  syncConfiguration: SyncConfiguration;
 }
 
 /**

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -59,17 +59,17 @@ export type ChainServiceConfiguration = {
 } & Partial<Exclude<ChainServiceArgs, 'logger'>>;
 
 /**
- * The minimum required configuration to use the engine.
+ * The minimum required configuration to use the wallet.
  */
-export type RequiredEngineConfig = {
+export type RequiredWalletConfig = {
   databaseConfiguration: RequiredDatabaseConfiguration;
   networkConfiguration: NetworkConfiguration;
 };
 
 /**
- * Additional configuration options for the engine that are not required.
+ * Additional configuration options for the wallet that are not required.
  */
-export interface OptionalEngineConfig {
+export interface OptionalWalletConfig {
   databaseConfiguration: OptionalDatabaseConfiguration;
   workerThreadAmount: number;
   skipEvmValidation: boolean;
@@ -81,13 +81,13 @@ export interface OptionalEngineConfig {
 /**
  * This is a fully filled out config. All Required and Optional fields are defined.
  */
-export type EngineConfig = RequiredEngineConfig & OptionalEngineConfig;
+export type WalletConfig = RequiredWalletConfig & OptionalWalletConfig;
 
 /**
  * This is the config accepted by the engine create method.
  * It is the required config properties plus additional optional properties
  */
-export type IncomingEngineConfig = RequiredEngineConfig & Partial<OptionalEngineConfig>;
+export type IncomingWalletConfig = RequiredWalletConfig & Partial<OptionalWalletConfig>;
 
 /**
  * Various network configuration options

--- a/packages/server-wallet/src/config/utils.ts
+++ b/packages/server-wallet/src/config/utils.ts
@@ -3,10 +3,10 @@ import {knexSnakeCaseMappers} from 'objection';
 import {parse} from 'pg-connection-string';
 
 import {defaultDatabaseConfiguration} from './defaults';
-import {EngineConfig, DatabaseConnectionConfiguration} from './types';
+import {WalletConfig, DatabaseConnectionConfiguration} from './types';
 
-export function extractDBConfigFromEngineConfig(engineConfig: EngineConfig): Config {
-  const connectionConfig = getDatabaseConnectionConfig(engineConfig);
+export function extractDBConfigFromWalletConfig(walletConfig: WalletConfig): Config {
+  const connectionConfig = getDatabaseConnectionConfig(walletConfig);
 
   return {
     client: 'postgres',
@@ -16,7 +16,7 @@ export function extractDBConfigFromEngineConfig(engineConfig: EngineConfig): Con
       user: connectionConfig.user || '',
     },
     ...knexSnakeCaseMappers(),
-    pool: engineConfig.databaseConfiguration.pool || {},
+    pool: walletConfig.databaseConfiguration.pool || {},
   };
 }
 type DatabaseConnectionConfigObject = Required<Exclude<DatabaseConnectionConfiguration, string>>;
@@ -24,9 +24,9 @@ type DatabaseConnectionConfigObject = Required<Exclude<DatabaseConnectionConfigu
 type PartialConfigObject = Partial<DatabaseConnectionConfigObject> &
   Required<Pick<DatabaseConnectionConfigObject, 'database'>>;
 export function overwriteConfigWithDatabaseConnection(
-  config: EngineConfig,
+  config: WalletConfig,
   databaseConnectionConfig: PartialConfigObject | string
-): EngineConfig {
+): WalletConfig {
   return {
     ...config,
     databaseConfiguration: {
@@ -51,7 +51,7 @@ function isPartialDatabaseConfigObject(
 }
 
 export function getDatabaseConnectionConfig(
-  config: EngineConfig
+  config: WalletConfig
 ): DatabaseConnectionConfigObject & {host: string; port: number} {
   if (typeof config.databaseConfiguration.connection === 'string') {
     const {connection: defaultConnection} = defaultDatabaseConfiguration;

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -29,6 +29,12 @@ const databasePoolConfigurationSchema = joi.object({
   min: joi.number().integer().min(0).optional(),
 });
 
+const syncConfigurationSchema = joi.object({
+  pollInterval: joi.number().min(1).optional(),
+  timeOutThreshold: joi.number().min(1).optional(),
+  staleThreshold: joi.number().min(1).optional(),
+});
+
 const databaseConfigurationSchema = joi.object({
   connection: databaseConnectionConfigurationSchema.required(),
   debug: joi.boolean().optional(),
@@ -75,6 +81,7 @@ const engine = joi.object({
   skipEvmValidation: joi.boolean().optional(),
   loggingConfiguration: loggingConfigurationSchema.optional(),
   metricsConfiguration: metricsConfigurationSchema.optional(),
+  syncConfiguration: syncConfigurationSchema.optional(),
 });
 
 export function validateEngineConfig(

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -1,7 +1,7 @@
 import joi, {ValidationErrorItem} from 'joi';
 import {parse} from 'pg-connection-string';
 
-import {EngineConfig} from './types';
+import {WalletConfig} from './types';
 
 const validateConnectionString = (connection: string) => {
   const parsed = parse(connection);
@@ -79,11 +79,11 @@ const engine = joi.object({
 
 export function validateEngineConfig(
   config: Record<string, any>
-): {valid: boolean; value: EngineConfig | undefined; errors: ValidationErrorItem[]} {
+): {valid: boolean; value: WalletConfig | undefined; errors: ValidationErrorItem[]} {
   const results = engine.validate(config);
   return {
     valid: !results.error,
-    value: results.value ? (results.value as EngineConfig) : undefined,
+    value: results.value ? (results.value as WalletConfig) : undefined,
     errors: results.error?.details || [],
   };
 }

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -30,9 +30,9 @@ const databasePoolConfigurationSchema = joi.object({
 });
 
 const syncConfigurationSchema = joi.object({
-  pollInterval: joi.number().min(1).optional(),
-  timeOutThreshold: joi.number().min(1).optional(),
-  staleThreshold: joi.number().min(1).optional(),
+  pollInterval: joi.number().integer().min(1).optional(),
+  timeOutThreshold: joi.number().integer().min(1).optional(),
+  staleThreshold: joi.number().integer().min(1).optional(),
 });
 
 const databaseConfigurationSchema = joi.object({

--- a/packages/server-wallet/src/db-admin/db-admin.ts
+++ b/packages/server-wallet/src/db-admin/db-admin.ts
@@ -17,9 +17,9 @@ import {ChainServiceRequest} from '../models/chain-service-request';
 import {AdjudicatorStatusModel} from '../models/adjudicator-status';
 import {
   defaultConfig,
-  extractDBConfigFromEngineConfig,
+  extractDBConfigFromWalletConfig,
   getDatabaseConnectionConfig,
-  IncomingEngineConfig,
+  IncomingWalletConfig,
 } from '../config';
 
 type DBConnectionConfig = {database: string; user: string};
@@ -32,7 +32,7 @@ export class DBAdmin {
    * Creates a database based on the database specified in the wallet configuration
    * @param config The wallet configuration object with a database specified
    */
-  static async createDatabase(config: IncomingEngineConfig): Promise<void> {
+  static async createDatabase(config: IncomingWalletConfig): Promise<void> {
     await createDbIfDoesntExist(getDbConnectionConfigFromConfig(config));
   }
 
@@ -48,7 +48,7 @@ export class DBAdmin {
    * Drops the database based on the database specified in the wallet configuration
    * @param config The wallet configuration object containing the database configuration to use
    */
-  static async dropDatabase(config: IncomingEngineConfig): Promise<void> {
+  static async dropDatabase(config: IncomingWalletConfig): Promise<void> {
     await dropDbIfExists(getDbConnectionConfigFromConfig(config));
   }
 
@@ -64,7 +64,7 @@ export class DBAdmin {
    * Performs wallet database migrations against the database specified in the config
    * @param config The wallet configuration object containing the database configuration to use
    */
-  static async migrateDatabase(config: IncomingEngineConfig): Promise<void> {
+  static async migrateDatabase(config: IncomingWalletConfig): Promise<void> {
     const knex = getKnexFromConfig(config);
     await DBAdmin.migrateDatabaseFromKnex(knex);
     await knex.destroy();
@@ -88,7 +88,7 @@ export class DBAdmin {
    * @param tables A list of table names to truncate. Defaults to ALL tables
    */
   static async truncateDatabase(
-    config: IncomingEngineConfig,
+    config: IncomingWalletConfig,
     tables = defaultTables
   ): Promise<void> {
     const knex = getKnexFromConfig(config);
@@ -118,16 +118,16 @@ export class DBAdmin {
   }
 }
 
-function getKnexFromConfig(config: IncomingEngineConfig): Knex {
+function getKnexFromConfig(config: IncomingWalletConfig): Knex {
   const populatedConfig = _.assign({}, defaultConfig, config);
-  return Knex(extractDBConfigFromEngineConfig(populatedConfig));
+  return Knex(extractDBConfigFromWalletConfig(populatedConfig));
 }
 function getDbConnectionConfigFromKnex(knex: Knex): DBConnectionConfig {
   const {database, user} = knex.client.config.connection;
   return {database, user};
 }
 
-function getDbConnectionConfigFromConfig(config: IncomingEngineConfig): DBConnectionConfig {
+function getDbConnectionConfigFromConfig(config: IncomingWalletConfig): DBConnectionConfig {
   const populatedConfig = _.assign({}, defaultConfig, config);
   const {database, user} = getDatabaseConnectionConfig(populatedConfig);
   return {database, user};

--- a/packages/server-wallet/src/db-admin/knexfile.ts
+++ b/packages/server-wallet/src/db-admin/knexfile.ts
@@ -6,8 +6,8 @@ import {Config} from 'knex';
 import {
   defaultConfig,
   defaultDatabaseConfiguration,
-  extractDBConfigFromEngineConfig,
-  EngineConfig,
+  extractDBConfigFromWalletConfig,
+  WalletConfig,
 } from '../config';
 
 // Populate env vars as knexfile is used directly in yarn scripts
@@ -26,9 +26,9 @@ WARNING: @statechannels/devtools not detected.
 
 const BASE_PATH = path.join(__dirname, '..', 'db');
 const extensions = [path.extname(__filename)];
-export function createKnexConfig(engineConfig: EngineConfig): Config<any> {
+export function createKnexConfig(engineConfig: WalletConfig): Config<any> {
   return {
-    ...extractDBConfigFromEngineConfig(engineConfig),
+    ...extractDBConfigFromWalletConfig(engineConfig),
     debug: engineConfig.databaseConfiguration.debug,
     migrations: {
       directory: path.join(BASE_PATH, 'migrations'),

--- a/packages/server-wallet/src/engine/__test__/add-my-state.test.ts
+++ b/packages/server-wallet/src/engine/__test__/add-my-state.test.ts
@@ -1,6 +1,6 @@
 import {Store} from '../store';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {channel} from '../../models/__test__/fixtures/channel';
 
 import {stateWithHashSignedBy} from './fixtures/states';
@@ -11,8 +11,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/engine/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/engine/__test__/add-signed-state.test.ts
@@ -5,14 +5,14 @@ import {utils} from 'ethers';
 import {Store} from '../store';
 import {Channel} from '../../models/channel';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 let store: Store;
 
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 });
@@ -47,7 +47,7 @@ describe('addSignedState', () => {
       participants: [],
       channelNonce: 1,
       channelId,
-      chainId: utils.hexlify(defaultTestConfig().networkConfiguration.chainNetworkID),
+      chainId: utils.hexlify(defaultTestWalletConfig().networkConfiguration.chainNetworkID),
       challengeDuration: 9001,
       signatures: [BOB_SIGNATURE],
     };

--- a/packages/server-wallet/src/engine/__test__/fixtures/states.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/states.ts
@@ -14,7 +14,7 @@ import {utils} from 'ethers';
 
 import {SigningWallet} from '../../../models/signing-wallet';
 import {addHash} from '../../../state-utils';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 
 import {Fixture, fixture, overwriteOutcome} from './utils';
 import {alice, bob} from './participants';
@@ -31,7 +31,7 @@ const defaultState: State = {
   ]),
   participants: [alice(), bob()],
   channelNonce: 1,
-  chainId: utils.hexlify(defaultTestConfig().networkConfiguration.chainNetworkID),
+  chainId: utils.hexlify(defaultTestWalletConfig().networkConfiguration.chainNetworkID),
   challengeDuration: 9001,
 };
 

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
@@ -26,7 +26,7 @@ import {SignedState as WireState, Payload} from '@statechannels/wire-format';
 import {utils} from 'ethers';
 
 import {Channel} from '../../../models/channel';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {WalletObjective, ObjectiveModel} from '../../../models/objective';
 import {SigningWallet} from '../../../models/signing-wallet';
 import {WALLET_VERSION} from '../../../version';
@@ -189,7 +189,7 @@ export class TestChannel {
       appDefinition: makeAddress('0x000000000000000000000000000000000000adef'),
       participants: this.participants,
       channelNonce: this.channelNonce,
-      chainId: utils.hexlify(defaultTestConfig().networkConfiguration.chainNetworkID),
+      chainId: utils.hexlify(defaultTestWalletConfig().networkConfiguration.chainNetworkID),
       challengeDuration: 9001,
     };
   }

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-ledger-channel.ts
@@ -9,7 +9,7 @@ import {
 import {utils} from 'ethers';
 import {Payload} from '@statechannels/wire-format';
 
-import {defaultTestConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {
   LedgerRequest,
   LedgerRequestStatus,
@@ -60,7 +60,7 @@ export class TestLedgerChannel extends TestChannel {
       appDefinition: makeAddress('0x0000000000000000000000000000000000000000'),
       participants: this.participants,
       channelNonce: this.channelNonce,
-      chainId: utils.hexlify(defaultTestConfig().networkConfiguration.chainNetworkID),
+      chainId: utils.hexlify(defaultTestWalletConfig().networkConfiguration.chainNetworkID),
       challengeDuration: 9001,
     };
   }

--- a/packages/server-wallet/src/engine/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/close-channel.test.ts
@@ -1,10 +1,10 @@
 import {Channel} from '../../../models/channel';
-import {Engine} from '../..';
+import {defaultTestEngineConfig, Engine} from '../..';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {Bytes32} from '../../../type-aliases';
 import {createLogger} from '../../../logger';
 

--- a/packages/server-wallet/src/engine/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/close-channel.test.ts
@@ -4,13 +4,13 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
 import {Bytes32} from '../../../type-aliases';
 import {createLogger} from '../../../logger';
 
 let w: Engine;
 beforeAll(async () => {
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   w = await Engine.create(defaultTestEngineConfig(), logger);
   await seedAlicesSigningWallet(w.knex);
 });

--- a/packages/server-wallet/src/engine/__test__/integration/close-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/close-channel.test.ts
@@ -4,12 +4,14 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
 import {Bytes32} from '../../../type-aliases';
+import {createLogger} from '../../../logger';
 
 let w: Engine;
 beforeAll(async () => {
-  w = await Engine.create(defaultTestConfig());
+  const logger = createLogger(defaultTestConfig());
+  w = await Engine.create(defaultTestEngineConfig(), logger);
   await seedAlicesSigningWallet(w.knex);
 });
 

--- a/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
@@ -4,7 +4,7 @@ import {Channel} from '../../../models/channel';
 import {Engine} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {WalletObjective} from '../../../models/objective';
 import {WaitingFor} from '../../../protocols/channel-opener';
@@ -12,7 +12,7 @@ import {createLogger} from '../../../logger';
 
 let w: Engine;
 beforeEach(async () => {
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   w = await Engine.create(defaultTestEngineConfig(), logger);
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });

--- a/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
@@ -4,14 +4,16 @@ import {Channel} from '../../../models/channel';
 import {Engine} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {WalletObjective} from '../../../models/objective';
 import {WaitingFor} from '../../../protocols/channel-opener';
+import {createLogger} from '../../../logger';
 
 let w: Engine;
 beforeEach(async () => {
-  w = await Engine.create(defaultTestConfig());
+  const logger = createLogger(defaultTestConfig());
+  w = await Engine.create(defaultTestEngineConfig(), logger);
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 

--- a/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-channel.test.ts
@@ -1,10 +1,10 @@
 import {OpenChannel} from '@statechannels/wallet-core';
 
 import {Channel} from '../../../models/channel';
-import {Engine} from '../..';
+import {defaultTestEngineConfig, Engine} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {WalletObjective} from '../../../models/objective';
 import {WaitingFor} from '../../../protocols/channel-opener';

--- a/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
@@ -5,18 +5,18 @@ import {Channel} from '../../../models/channel';
 import {Engine} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {createLogger} from '../../../logger';
 
 let w: Engine;
 
 beforeAll(async () => {
-  await DBAdmin.migrateDatabase(defaultTestConfig());
+  await DBAdmin.migrateDatabase(defaultTestWalletConfig());
 });
 
 beforeEach(async () => {
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   w = await Engine.create(defaultTestEngineConfig(), logger);
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });

--- a/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
@@ -5,8 +5,9 @@ import {Channel} from '../../../models/channel';
 import {Engine} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
+import {createLogger} from '../../../logger';
 
 let w: Engine;
 
@@ -15,7 +16,8 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  w = await Engine.create(defaultTestConfig());
+  const logger = createLogger(defaultTestConfig());
+  w = await Engine.create(defaultTestEngineConfig(), logger);
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
 });
 

--- a/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
@@ -2,10 +2,10 @@ import {constants} from 'ethers';
 import {NULL_APP_DATA} from '@statechannels/wallet-core';
 
 import {Channel} from '../../../models/channel';
-import {Engine} from '../..';
+import {defaultTestEngineConfig, Engine} from '../..';
 import {createChannelArgs} from '../fixtures/create-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {createLogger} from '../../../logger';
 

--- a/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
@@ -15,7 +15,7 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {bob, alice} from '../fixtures/signing-wallets';
 import {bob as bobP} from '../fixtures/participants';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';
@@ -23,7 +23,7 @@ import {createLogger} from '../../../logger';
 
 let w: Engine;
 beforeEach(async () => {
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   w = await Engine.create(defaultTestEngineConfig(), logger);
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
   await seedBobsSigningWallet(w.knex);

--- a/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
@@ -15,14 +15,16 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {bob, alice} from '../fixtures/signing-wallets';
 import {bob as bobP} from '../fixtures/participants';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';
+import {createLogger} from '../../../logger';
 
 let w: Engine;
 beforeEach(async () => {
-  w = await Engine.create(defaultTestConfig());
+  const logger = createLogger(defaultTestConfig());
+  w = await Engine.create(defaultTestEngineConfig(), logger);
   await DBAdmin.truncateDataBaseFromKnex(w.knex);
   await seedBobsSigningWallet(w.knex);
 });

--- a/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
@@ -9,13 +9,13 @@ import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/confi
 import Objection from 'objection';
 
 import {Channel} from '../../../models/channel';
-import {Engine} from '../..';
+import {defaultTestEngineConfig, Engine} from '../..';
 import {seedBobsSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {bob, alice} from '../fixtures/signing-wallets';
 import {bob as bobP} from '../fixtures/participants';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {getChannelResultFor, getSignedStateFor} from '../../../__test__/test-helpers';
 import {ObjectiveModel} from '../../../models/objective';

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -18,11 +18,12 @@ import {stateSignedBy, stateWithHashSignedBy} from '../fixtures/states';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
 import {ObjectiveModel} from '../../../models/objective';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {WALLET_VERSION} from '../../../version';
 import {PushMessageError} from '../../../errors/engine-error';
 import {MultiThreadedEngine, Engine} from '../..';
+import {createLogger} from '../../../logger';
 
 const dropNonVariables = (s: SignedState): any =>
   _.pick(s, 'appData', 'outcome', 'isFinal', 'turnNum', 'stateHash', 'signatures');
@@ -33,11 +34,13 @@ let engine: Engine;
 let multiThreadedEngine: MultiThreadedEngine;
 
 beforeAll(async () => {
+  const logger = createLogger(defaultTestConfig());
   await DBAdmin.migrateDatabase(defaultTestConfig());
-  engine = await Engine.create(defaultTestConfig());
+  engine = await Engine.create(defaultTestEngineConfig(), logger);
 
   multiThreadedEngine = await MultiThreadedEngine.create(
-    defaultTestConfig({workerThreadAmount: 2})
+    defaultTestEngineConfig({workerThreadAmount: 2}),
+    logger
   );
 });
 

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -18,7 +18,7 @@ import {stateSignedBy, stateWithHashSignedBy} from '../fixtures/states';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
 import {ObjectiveModel} from '../../../models/objective';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {WALLET_VERSION} from '../../../version';
 import {PushMessageError} from '../../../errors/engine-error';
@@ -34,8 +34,8 @@ let engine: Engine;
 let multiThreadedEngine: MultiThreadedEngine;
 
 beforeAll(async () => {
-  const logger = createLogger(defaultTestConfig());
-  await DBAdmin.migrateDatabase(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
+  await DBAdmin.migrateDatabase(defaultTestWalletConfig());
   engine = await Engine.create(defaultTestEngineConfig(), logger);
 
   multiThreadedEngine = await MultiThreadedEngine.create(

--- a/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/push-message.test.ts
@@ -18,11 +18,11 @@ import {stateSignedBy, stateWithHashSignedBy} from '../fixtures/states';
 import {channel, withSupportedState} from '../../../models/__test__/fixtures/channel';
 import {stateVars} from '../fixtures/state-vars';
 import {ObjectiveModel} from '../../../models/objective';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {WALLET_VERSION} from '../../../version';
 import {PushMessageError} from '../../../errors/engine-error';
-import {MultiThreadedEngine, Engine} from '../..';
+import {MultiThreadedEngine, Engine, defaultTestEngineConfig} from '../..';
 import {createLogger} from '../../../logger';
 
 const dropNonVariables = (s: SignedState): any =>

--- a/packages/server-wallet/src/engine/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/sync-channel.test.ts
@@ -7,7 +7,7 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import * as participantFixtures from '../fixtures/participants';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {createLogger} from '../../../logger';
@@ -16,7 +16,7 @@ let w: Engine;
 beforeEach(async () => {
   await DBAdmin.truncateDataBaseFromKnex(knex);
 
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   w = await Engine.create(defaultTestEngineConfig(), logger);
 });
 

--- a/packages/server-wallet/src/engine/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/sync-channel.test.ts
@@ -7,15 +7,17 @@ import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import * as participantFixtures from '../fixtures/participants';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {channel} from '../../../models/__test__/fixtures/channel';
+import {createLogger} from '../../../logger';
 
 let w: Engine;
 beforeEach(async () => {
   await DBAdmin.truncateDataBaseFromKnex(knex);
 
-  w = await Engine.create(defaultTestConfig());
+  const logger = createLogger(defaultTestConfig());
+  w = await Engine.create(defaultTestEngineConfig(), logger);
 });
 
 afterEach(async () => {

--- a/packages/server-wallet/src/engine/__test__/integration/sync-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/sync-channel.test.ts
@@ -1,13 +1,13 @@
 import _ from 'lodash';
 
 import {Channel} from '../../../models/channel';
-import {Engine} from '../..';
+import {defaultTestEngineConfig, Engine} from '../..';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob, charlie} from '../fixtures/signing-wallets';
 import * as participantFixtures from '../fixtures/participants';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {DBAdmin} from '../../../db-admin/db-admin';
 import {channel} from '../../../models/__test__/fixtures/channel';
 import {createLogger} from '../../../logger';

--- a/packages/server-wallet/src/engine/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/update-channel.test.ts
@@ -7,11 +7,12 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig} from '../../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {AppBytecode} from '../../../models/app-bytecode';
 import {appBytecode, COUNTING_APP_DEFINITION} from '../../../models/__test__/fixtures/app-bytecode';
 import {DBAdmin} from '../../../db-admin/db-admin';
+import {createLogger} from '../../../logger';
 
 let w: Engine;
 
@@ -22,7 +23,8 @@ afterEach(async () => {
 const appData1 = utils.defaultAbiCoder.encode(['uint256'], [1]);
 const appData2 = utils.defaultAbiCoder.encode(['uint256'], [2]);
 beforeEach(async () => {
-  w = await Engine.create({...defaultTestConfig(), skipEvmValidation: false});
+  const logger = createLogger(defaultTestConfig());
+  w = await Engine.create(defaultTestEngineConfig({skipEvmValidation: false}), logger);
 
   await DBAdmin.truncateDataBaseFromKnex(knex);
   await seedAlicesSigningWallet(knex);

--- a/packages/server-wallet/src/engine/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/update-channel.test.ts
@@ -7,7 +7,7 @@ import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds'
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {AppBytecode} from '../../../models/app-bytecode';
 import {appBytecode, COUNTING_APP_DEFINITION} from '../../../models/__test__/fixtures/app-bytecode';
@@ -23,7 +23,7 @@ afterEach(async () => {
 const appData1 = utils.defaultAbiCoder.encode(['uint256'], [1]);
 const appData2 = utils.defaultAbiCoder.encode(['uint256'], [2]);
 beforeEach(async () => {
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   w = await Engine.create(defaultTestEngineConfig({skipEvmValidation: false}), logger);
 
   await DBAdmin.truncateDataBaseFromKnex(knex);

--- a/packages/server-wallet/src/engine/__test__/integration/update-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/update-channel.test.ts
@@ -1,13 +1,13 @@
 import {utils} from 'ethers';
 
 import {Channel} from '../../../models/channel';
-import {Engine} from '../..';
+import {defaultTestEngineConfig, Engine} from '../..';
 import {updateChannelArgs} from '../fixtures/update-channel';
 import {seedAlicesSigningWallet} from '../../../db/seeds/1_signing_wallet_seeds';
 import {stateWithHashSignedBy} from '../fixtures/states';
 import {alice, bob} from '../fixtures/signing-wallets';
 import {channel} from '../../../models/__test__/fixtures/channel';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../../config';
+import {defaultTestWalletConfig} from '../../../config';
 import {testKnex as knex} from '../../../../jest/knex-setup-teardown';
 import {AppBytecode} from '../../../models/app-bytecode';
 import {appBytecode, COUNTING_APP_DEFINITION} from '../../../models/__test__/fixtures/app-bytecode';

--- a/packages/server-wallet/src/engine/__test__/lock-app.test.ts
+++ b/packages/server-wallet/src/engine/__test__/lock-app.test.ts
@@ -6,7 +6,7 @@ import {withSupportedState} from '../../models/__test__/fixtures/channel';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 
 import {stateVars} from './fixtures/state-vars';
 
@@ -17,8 +17,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/engine/__test__/sign-state.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sign-state.test.ts
@@ -5,7 +5,7 @@ import {channel} from '../../models/__test__/fixtures/channel';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {Channel} from '../../models/channel';
 import {constructKnex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {signState} from '../../utilities/signatures';
 
 import {stateWithHashSignedBy} from './fixtures/states';
@@ -19,8 +19,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/engine/__test__/signing-address.test.ts
+++ b/packages/server-wallet/src/engine/__test__/signing-address.test.ts
@@ -3,7 +3,7 @@ import {ethers} from 'ethers';
 import {Store} from '../store';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {DBAdmin} from '../../db-admin/db-admin';
 
 import {alice} from './fixtures/participants';
@@ -13,8 +13,8 @@ let store: Store;
 beforeAll(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 });

--- a/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
@@ -2,8 +2,9 @@ import _ from 'lodash';
 
 import {Engine} from '..';
 import {testKnex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestConfig, defaultTestEngineConfig} from '../../config';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
+import {createLogger} from '../../logger';
 import {Channel} from '../../models/channel';
 import {ObjectiveModel} from '../../models/objective';
 import {channel} from '../../models/__test__/fixtures/channel';
@@ -16,7 +17,8 @@ let engine: Engine;
 
 beforeAll(async () => {
   await seedAlicesSigningWallet(testKnex);
-  engine = await Engine.create(defaultTestConfig());
+  const logger = createLogger(defaultTestConfig());
+  engine = await Engine.create(defaultTestEngineConfig(), logger);
 });
 
 afterAll(async () => {

--- a/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import {Engine} from '..';
 import {testKnex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig, defaultTestEngineConfig} from '../../config';
+import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../config';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {createLogger} from '../../logger';
 import {Channel} from '../../models/channel';
@@ -17,7 +17,7 @@ let engine: Engine;
 
 beforeAll(async () => {
   await seedAlicesSigningWallet(testKnex);
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   engine = await Engine.create(defaultTestEngineConfig(), logger);
 });
 

--- a/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
-import {Engine} from '..';
+import {defaultTestEngineConfig, Engine} from '..';
 import {testKnex} from '../../../jest/knex-setup-teardown';
-import {defaultTestWalletConfig, defaultTestEngineConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {seedAlicesSigningWallet} from '../../db/seeds/1_signing_wallet_seeds';
 import {createLogger} from '../../logger';
 import {Channel} from '../../models/channel';

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -20,7 +20,7 @@ import {
   NULL_APP_DATA,
 } from '@statechannels/wallet-core';
 import * as Either from 'fp-ts/lib/Either';
-import Knex, {Config} from 'knex';
+import Knex from 'knex';
 import _ from 'lodash';
 import {ethers, utils} from 'ethers';
 import {Logger} from 'pino';
@@ -32,7 +32,6 @@ import * as UpdateChannel from '../handlers/update-channel';
 import * as JoinChannel from '../handlers/join-channel';
 import {PushMessageError} from '../errors/engine-error';
 import {timerFactory, recordFunctionMetrics, setupMetrics} from '../metrics';
-import {MetricsConfiguration} from '../config';
 import {ChainRequest} from '../chain-service';
 import {WALLET_VERSION} from '../version';
 import {ObjectiveManager} from '../objectives';
@@ -47,6 +46,7 @@ import {
   MultipleChannelOutput,
   EngineInterface,
   hasNewObjective,
+  IncomingEngineConfigV2,
 } from './types';
 import {EngineResponse} from './engine-response';
 
@@ -59,14 +59,6 @@ export class ConfigValidationError extends Error {
     super('Engine configuration validation failed');
   }
 }
-
-export type IncomingEngineConfigV2 = {
-  skipEvmValidation: boolean;
-  metrics: MetricsConfiguration;
-  dbConfig: Config;
-  chainNetworkID: string;
-  workerThreadAmount: number;
-};
 
 /**
  * A single-threaded Nitro engine

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -46,7 +46,7 @@ import {
   MultipleChannelOutput,
   EngineInterface,
   hasNewObjective,
-  IncomingEngineConfigV2,
+  EngineConfig,
 } from './types';
 import {EngineResponse} from './engine-response';
 
@@ -71,7 +71,7 @@ export class SingleThreadedEngine implements EngineInterface {
   ledgerManager: LedgerManager;
 
   public static async create(
-    engineConfig: IncomingEngineConfigV2,
+    engineConfig: EngineConfig,
     logger: Logger
   ): Promise<SingleThreadedEngine> {
     return new SingleThreadedEngine(engineConfig, logger);
@@ -81,7 +81,7 @@ export class SingleThreadedEngine implements EngineInterface {
    * Protected method. Initialize engine via Engine.create(..)
    * @readonly
    */
-  protected constructor(private config: IncomingEngineConfigV2, protected logger: Logger) {
+  protected constructor(private config: EngineConfig, protected logger: Logger) {
     this.knex = Knex(config.dbConfig);
     this.chainNetworkId = utils.hexlify(this.config.chainNetworkID);
     this.store = new Store(

--- a/packages/server-wallet/src/engine/index.ts
+++ b/packages/server-wallet/src/engine/index.ts
@@ -1,8 +1,8 @@
-import {IncomingEngineConfig} from '../config';
+import P from 'pino';
 
 import {MultiThreadedEngine} from './multi-threaded-engine';
 import {EngineInterface} from './types';
-import {SingleThreadedEngine} from './engine';
+import {IncomingEngineConfigV2, SingleThreadedEngine} from './engine';
 
 /**
  * A single- or multi-threaded Nitro Engine
@@ -12,12 +12,13 @@ import {SingleThreadedEngine} from './engine';
  */
 export abstract class Engine extends SingleThreadedEngine implements EngineInterface {
   static async create(
-    engineConfig: IncomingEngineConfig
+    engineConfig: IncomingEngineConfigV2,
+    logger: P.Logger
   ): Promise<SingleThreadedEngine | MultiThreadedEngine> {
     if (engineConfig?.workerThreadAmount && engineConfig.workerThreadAmount > 0) {
-      return MultiThreadedEngine.create(engineConfig);
+      return MultiThreadedEngine.create(engineConfig, logger);
     } else {
-      return SingleThreadedEngine.create(engineConfig);
+      return SingleThreadedEngine.create(engineConfig, logger);
     }
   }
 }

--- a/packages/server-wallet/src/engine/index.ts
+++ b/packages/server-wallet/src/engine/index.ts
@@ -1,8 +1,12 @@
 import P from 'pino';
+import _ from 'lodash';
+import {utils} from 'ethers';
+
+import {extractDBConfigFromWalletConfig, defaultTestWalletConfig} from '..';
 
 import {MultiThreadedEngine} from './multi-threaded-engine';
-import {EngineInterface} from './types';
-import {IncomingEngineConfigV2, SingleThreadedEngine} from './engine';
+import {EngineInterface, IncomingEngineConfigV2} from './types';
+import {SingleThreadedEngine} from './engine';
 
 /**
  * A single- or multi-threaded Nitro Engine
@@ -26,3 +30,17 @@ export abstract class Engine extends SingleThreadedEngine implements EngineInter
 export * from '../config';
 export * from './types';
 export {SingleThreadedEngine, MultiThreadedEngine};
+
+export const defaultTestEngineConfig = (
+  partialConfig?: Partial<IncomingEngineConfigV2>
+): IncomingEngineConfigV2 => {
+  const defaultEngineConfig: IncomingEngineConfigV2 = {
+    skipEvmValidation: true,
+    metrics: {timingMetrics: false},
+    workerThreadAmount: 0,
+    // eslint-disable-next-line no-process-env
+    chainNetworkID: utils.hexlify(parseInt(process.env.CHAIN_NETWORK_ID ?? '0')),
+    dbConfig: extractDBConfigFromWalletConfig(defaultTestWalletConfig()),
+  };
+  return _.assign({}, defaultEngineConfig, partialConfig);
+};

--- a/packages/server-wallet/src/engine/index.ts
+++ b/packages/server-wallet/src/engine/index.ts
@@ -5,7 +5,7 @@ import {utils} from 'ethers';
 import {extractDBConfigFromWalletConfig, defaultTestWalletConfig} from '..';
 
 import {MultiThreadedEngine} from './multi-threaded-engine';
-import {EngineInterface, IncomingEngineConfigV2} from './types';
+import {EngineInterface, EngineConfig} from './types';
 import {SingleThreadedEngine} from './engine';
 
 /**
@@ -16,7 +16,7 @@ import {SingleThreadedEngine} from './engine';
  */
 export abstract class Engine extends SingleThreadedEngine implements EngineInterface {
   static async create(
-    engineConfig: IncomingEngineConfigV2,
+    engineConfig: EngineConfig,
     logger: P.Logger
   ): Promise<SingleThreadedEngine | MultiThreadedEngine> {
     if (engineConfig?.workerThreadAmount && engineConfig.workerThreadAmount > 0) {
@@ -31,10 +31,8 @@ export * from '../config';
 export * from './types';
 export {SingleThreadedEngine, MultiThreadedEngine};
 
-export const defaultTestEngineConfig = (
-  partialConfig?: Partial<IncomingEngineConfigV2>
-): IncomingEngineConfigV2 => {
-  const defaultEngineConfig: IncomingEngineConfigV2 = {
+export const defaultTestEngineConfig = (partialConfig?: Partial<EngineConfig>): EngineConfig => {
+  const defaultEngineConfig: EngineConfig = {
     skipEvmValidation: true,
     metrics: {timingMetrics: false},
     workerThreadAmount: 0,

--- a/packages/server-wallet/src/engine/index.ts
+++ b/packages/server-wallet/src/engine/index.ts
@@ -2,7 +2,7 @@ import P from 'pino';
 import _ from 'lodash';
 import {utils} from 'ethers';
 
-import {extractDBConfigFromWalletConfig, defaultTestWalletConfig} from '..';
+import {defaultTestWalletConfig, extractDBConfigFromWalletConfig} from '../config';
 
 import {MultiThreadedEngine} from './multi-threaded-engine';
 import {EngineInterface, EngineConfig} from './types';
@@ -31,7 +31,7 @@ export * from '../config';
 export * from './types';
 export {SingleThreadedEngine, MultiThreadedEngine};
 
-export const defaultTestEngineConfig = (partialConfig?: Partial<EngineConfig>): EngineConfig => {
+export function defaultTestEngineConfig(partialConfig?: Partial<EngineConfig>): EngineConfig {
   const defaultEngineConfig: EngineConfig = {
     skipEvmValidation: true,
     metrics: {timingMetrics: false},
@@ -41,4 +41,4 @@ export const defaultTestEngineConfig = (partialConfig?: Partial<EngineConfig>): 
     dbConfig: extractDBConfigFromWalletConfig(defaultTestWalletConfig()),
   };
   return _.assign({}, defaultEngineConfig, partialConfig);
-};
+}

--- a/packages/server-wallet/src/engine/multi-threaded-engine/index.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/index.ts
@@ -1,8 +1,8 @@
 import {UpdateChannelParams} from '@statechannels/client-api-schema';
 import P from 'pino';
 
-import {MultipleChannelOutput, SingleChannelOutput} from '../types';
-import {IncomingEngineConfigV2, SingleThreadedEngine} from '../engine';
+import {IncomingEngineConfigV2, MultipleChannelOutput, SingleChannelOutput} from '../types';
+import {SingleThreadedEngine} from '../engine';
 
 import {WorkerManager} from './manager';
 

--- a/packages/server-wallet/src/engine/multi-threaded-engine/index.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/index.ts
@@ -1,8 +1,8 @@
 import {UpdateChannelParams} from '@statechannels/client-api-schema';
+import P from 'pino';
 
-import {IncomingEngineConfig} from '../../config';
 import {MultipleChannelOutput, SingleChannelOutput} from '../types';
-import {SingleThreadedEngine} from '../engine';
+import {IncomingEngineConfigV2, SingleThreadedEngine} from '../engine';
 
 import {WorkerManager} from './manager';
 
@@ -12,13 +12,16 @@ import {WorkerManager} from './manager';
 export class MultiThreadedEngine extends SingleThreadedEngine {
   private workerManager: WorkerManager;
 
-  public static async create(engineConfig: IncomingEngineConfig): Promise<MultiThreadedEngine> {
-    return new this(engineConfig);
+  public static async create(
+    engineConfig: IncomingEngineConfigV2,
+    logger: P.Logger
+  ): Promise<MultiThreadedEngine> {
+    return new this(engineConfig, logger);
   }
 
-  protected constructor(engineConfig: IncomingEngineConfig) {
-    super(engineConfig);
-    this.workerManager = new WorkerManager(this.engineConfig);
+  protected constructor(private engineConfig: IncomingEngineConfigV2, logger: P.Logger) {
+    super(engineConfig, logger);
+    this.workerManager = new WorkerManager(this.engineConfig, this.logger);
   }
 
   async updateChannel(args: UpdateChannelParams): Promise<SingleChannelOutput> {

--- a/packages/server-wallet/src/engine/multi-threaded-engine/index.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/index.ts
@@ -1,7 +1,7 @@
 import {UpdateChannelParams} from '@statechannels/client-api-schema';
 import P from 'pino';
 
-import {IncomingEngineConfigV2, MultipleChannelOutput, SingleChannelOutput} from '../types';
+import {EngineConfig, MultipleChannelOutput, SingleChannelOutput} from '../types';
 import {SingleThreadedEngine} from '../engine';
 
 import {WorkerManager} from './manager';
@@ -13,13 +13,13 @@ export class MultiThreadedEngine extends SingleThreadedEngine {
   private workerManager: WorkerManager;
 
   public static async create(
-    engineConfig: IncomingEngineConfigV2,
+    engineConfig: EngineConfig,
     logger: P.Logger
   ): Promise<MultiThreadedEngine> {
     return new this(engineConfig, logger);
   }
 
-  protected constructor(private engineConfig: IncomingEngineConfigV2, logger: P.Logger) {
+  protected constructor(private engineConfig: EngineConfig, logger: P.Logger) {
     super(engineConfig, logger);
     this.workerManager = new WorkerManager(this.engineConfig, this.logger);
   }

--- a/packages/server-wallet/src/engine/multi-threaded-engine/manager.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/manager.ts
@@ -8,8 +8,7 @@ import {isLeft, isRight} from 'fp-ts/lib/These';
 import _ from 'lodash';
 import P, {Logger} from 'pino';
 
-import {MultipleChannelOutput, SingleChannelOutput} from '../types';
-import {IncomingEngineConfigV2} from '../engine';
+import {IncomingEngineConfigV2, MultipleChannelOutput, SingleChannelOutput} from '../types';
 
 import {StateChannelWorkerData} from './worker-data';
 

--- a/packages/server-wallet/src/engine/multi-threaded-engine/manager.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/manager.ts
@@ -8,7 +8,7 @@ import {isLeft, isRight} from 'fp-ts/lib/These';
 import _ from 'lodash';
 import P, {Logger} from 'pino';
 
-import {IncomingEngineConfigV2, MultipleChannelOutput, SingleChannelOutput} from '../types';
+import {EngineConfig, MultipleChannelOutput, SingleChannelOutput} from '../types';
 
 import {StateChannelWorkerData} from './worker-data';
 
@@ -24,7 +24,7 @@ export class WorkerManager {
    * @param engineConfig engine config to be passed to the worker engine
    * @param onNewWorker callback that is executed when a new worker is created
    */
-  constructor(engineConfig: IncomingEngineConfigV2, logger: P.Logger) {
+  constructor(engineConfig: EngineConfig, logger: P.Logger) {
     this.logger = logger.child({module: 'Worker-Manager'});
     this.threadAmount = engineConfig.workerThreadAmount;
     if (this.threadAmount === 0) {

--- a/packages/server-wallet/src/engine/multi-threaded-engine/manager.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/manager.ts
@@ -6,11 +6,10 @@ import {UpdateChannelParams} from '@statechannels/client-api-schema';
 import {Either} from 'fp-ts/lib/Either';
 import {isLeft, isRight} from 'fp-ts/lib/These';
 import _ from 'lodash';
-import {Logger} from 'pino';
+import P, {Logger} from 'pino';
 
-import {EngineConfig} from '../../config';
-import {createLogger} from '../../logger';
 import {MultipleChannelOutput, SingleChannelOutput} from '../types';
+import {IncomingEngineConfigV2} from '../engine';
 
 import {StateChannelWorkerData} from './worker-data';
 
@@ -26,8 +25,8 @@ export class WorkerManager {
    * @param engineConfig engine config to be passed to the worker engine
    * @param onNewWorker callback that is executed when a new worker is created
    */
-  constructor(engineConfig: EngineConfig) {
-    this.logger = createLogger(engineConfig).child({module: 'Worker-Manager'});
+  constructor(engineConfig: IncomingEngineConfigV2, logger: P.Logger) {
+    this.logger = logger.child({module: 'Worker-Manager'});
     this.threadAmount = engineConfig.workerThreadAmount;
     if (this.threadAmount === 0) {
       throw new Error('Invalid engineConfig: threadAmount should not be 0');
@@ -38,7 +37,7 @@ export class WorkerManager {
         this.logger.trace('Starting worker');
 
         const worker = new Worker(path.resolve(__dirname, './loader.js'), {
-          workerData: engineConfig,
+          workerData: {engineConfig, parentLogger: logger},
         });
 
         worker.on('error', err => {

--- a/packages/server-wallet/src/engine/multi-threaded-engine/worker.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/worker.ts
@@ -4,8 +4,7 @@ import {left, right} from 'fp-ts/lib/Either';
 import P from 'pino';
 
 import {timerFactory} from '../../metrics';
-import {SingleThreadedEngine} from '..';
-import {IncomingEngineConfigV2} from '../engine';
+import {IncomingEngineConfigV2, SingleThreadedEngine} from '..';
 
 import {isStateChannelWorkerData} from './worker-data';
 

--- a/packages/server-wallet/src/engine/multi-threaded-engine/worker.ts
+++ b/packages/server-wallet/src/engine/multi-threaded-engine/worker.ts
@@ -4,7 +4,7 @@ import {left, right} from 'fp-ts/lib/Either';
 import P from 'pino';
 
 import {timerFactory} from '../../metrics';
-import {IncomingEngineConfigV2, SingleThreadedEngine} from '..';
+import {EngineConfig, SingleThreadedEngine} from '..';
 
 import {isStateChannelWorkerData} from './worker-data';
 
@@ -12,7 +12,7 @@ startWorker();
 
 async function startWorker() {
   const {engineConfig, parentLogger} = workerData as {
-    engineConfig: IncomingEngineConfigV2;
+    engineConfig: EngineConfig;
     parentLogger: P.Logger;
   };
 

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -43,13 +43,13 @@ import {ObjectiveModel, WalletObjective, isSupportedObjective} from '../models/o
 import {AppBytecode} from '../models/app-bytecode';
 import {LedgerRequest} from '../models/ledger-request';
 import {shouldValidateTransition, validateTransition} from '../utilities/validate-transition';
-import {defaultTestConfig} from '../config';
+import {defaultTestWalletConfig} from '../config';
 import {createLogger} from '../logger';
 import {ChainServiceRequest} from '../models/chain-service-request';
 import {AdjudicatorStatusModel} from '../models/adjudicator-status';
 import {WaitingFor as OpenChannelWaitingFor} from '../protocols/channel-opener';
 
-const defaultLogger = createLogger(defaultTestConfig());
+const defaultLogger = createLogger(defaultTestWalletConfig());
 
 export type AppHandler<T> = (tx: Transaction, channelRecord: Channel) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;

--- a/packages/server-wallet/src/engine/types.ts
+++ b/packages/server-wallet/src/engine/types.ts
@@ -70,7 +70,7 @@ export function hasNewObjective(
   return !!response.newObjective;
 }
 
-export type IncomingEngineConfigV2 = {
+export type EngineConfig = {
   skipEvmValidation: boolean;
   metrics: MetricsConfiguration;
   dbConfig: Config;

--- a/packages/server-wallet/src/engine/types.ts
+++ b/packages/server-wallet/src/engine/types.ts
@@ -7,11 +7,14 @@ import {
   ChannelId,
   ChannelResult,
 } from '@statechannels/client-api-schema';
+import {Config} from 'knex';
 
 import {ChainRequest} from '../chain-service';
 import {WalletObjective} from '../models/objective';
 import {Outgoing} from '../protocols/actions';
 import {Bytes32} from '../type-aliases';
+
+import {MetricsConfiguration} from '.';
 
 export type SingleChannelOutput = {
   outbox: Outgoing[];
@@ -66,3 +69,11 @@ export function hasNewObjective(
 ): response is SingleChannelOutput & {newObjective: WalletObjective} {
   return !!response.newObjective;
 }
+
+export type IncomingEngineConfigV2 = {
+  skipEvmValidation: boolean;
+  metrics: MetricsConfiguration;
+  dbConfig: Config;
+  chainNetworkID: string;
+  workerThreadAmount: number;
+};

--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -2,7 +2,7 @@ import {BN} from '@statechannels/wallet-core';
 
 import {DBAdmin} from '../../db-admin/db-admin';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {Store} from '../../engine/store';
 import {EngineResponse} from '../../engine/engine-response';
 import {TestChannel} from '../../engine/__test__/fixtures/test-channel';
@@ -20,8 +20,8 @@ let response: EngineResponse;
 beforeEach(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
   await DBAdmin.truncateDataBaseFromKnex(knex);

--- a/packages/server-wallet/src/logger.ts
+++ b/packages/server-wallet/src/logger.ts
@@ -1,9 +1,9 @@
 import pino from 'pino';
 
-import {getDatabaseConnectionConfig, EngineConfig} from './config';
+import {getDatabaseConnectionConfig, WalletConfig} from './config';
 import {WALLET_VERSION} from './version';
 
-export function createLogger(config: EngineConfig): pino.Logger {
+export function createLogger(config: WalletConfig): pino.Logger {
   const destination =
     config.loggingConfiguration.logDestination &&
     config.loggingConfiguration.logDestination.toLocaleLowerCase() !== 'console'

--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -8,7 +8,7 @@ import {testKnex as knex} from '../../../jest/knex-setup-teardown';
 import {dropNonVariables} from '../../state-utils';
 import {Funding} from '../funding';
 import {TestChannel} from '../../engine/__test__/fixtures/test-channel';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {Store} from '../../engine/store';
 import {DBAdmin} from '../../db-admin/db-admin';
 
@@ -89,8 +89,8 @@ describe('Channel funding', () => {
 
     store = new Store(
       knex,
-      defaultTestConfig().metricsConfiguration.timingMetrics,
-      defaultTestConfig().skipEvmValidation,
+      defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+      defaultTestWalletConfig().skipEvmValidation,
       '0'
     );
   });

--- a/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/challenge-submitter.test.ts
@@ -3,7 +3,7 @@ import {SubmitChallenge} from '@statechannels/wallet-core';
 
 import {Store} from '../../engine/store';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {EngineResponse} from '../../engine/engine-response';
 import {createLogger} from '../../logger';
 import {WalletObjective, ObjectiveModel} from '../../models/objective';
@@ -17,15 +17,15 @@ import {alice, bob} from '../../engine/__test__/fixtures/signing-wallets';
 import {ChainServiceRequest} from '../../models/chain-service-request';
 import {DBAdmin} from '../../db-admin/db-admin';
 
-const logger = createLogger(defaultTestConfig());
+const logger = createLogger(defaultTestWalletConfig());
 const timingMetrics = false;
 
 let store: Store;
 beforeEach(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 

--- a/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/close-channel.test.ts
@@ -2,7 +2,7 @@ import {CloseChannel} from '@statechannels/wallet-core';
 
 import {DBAdmin} from '../../db-admin/db-admin';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {createLogger} from '../../logger';
 import {ChainServiceRequest, requestTimeout} from '../../models/chain-service-request';
 import {WalletObjective, ObjectiveModel} from '../../models/objective';
@@ -19,8 +19,8 @@ let store: Store;
 beforeEach(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
   await DBAdmin.truncateDataBaseFromKnex(knex);
@@ -126,7 +126,7 @@ const crankAndAssert = async (
   const withdraws = args.withdraws || false;
   const completesObj = args.completesObj || false;
 
-  const logger = createLogger(defaultTestConfig());
+  const logger = createLogger(defaultTestWalletConfig());
   const timingMetrics = false;
   const channelCloser = ChannelCloser.create(store, logger, timingMetrics);
   const response = EngineResponse.initialize();

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -1,6 +1,6 @@
 import {DefundChannel, makeAddress, State} from '@statechannels/wallet-core';
 
-import {defaultTestConfig} from '../..';
+import {defaultTestWalletConfig} from '../..';
 import {createLogger} from '../../logger';
 import {WalletObjective, ObjectiveModel} from '../../models/objective';
 import {Store} from '../../engine/store';
@@ -15,7 +15,7 @@ import {alice} from '../../engine/__test__/fixtures/signing-wallets';
 import {Funding} from '../../models/funding';
 import {TestChannel} from '../../engine/__test__/fixtures/test-channel';
 
-const logger = createLogger(defaultTestConfig());
+const logger = createLogger(defaultTestWalletConfig());
 const timingMetrics = false;
 
 let store: Store;
@@ -32,8 +32,8 @@ let objective2: WalletObjective<DefundChannel>;
 beforeEach(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -1,7 +1,7 @@
 import {CloseChannel, DefundChannel} from '@statechannels/wallet-core';
 import {Transaction} from 'objection';
 
-import {defaultTestConfig} from '../..';
+import {defaultTestWalletConfig} from '../..';
 import {testKnex} from '../../../jest/knex-setup-teardown';
 import {DBAdmin} from '../../db-admin/db-admin';
 import {createLogger} from '../../logger';
@@ -66,8 +66,8 @@ beforeEach(async () => {
 
   store = new Store(
     testKnex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
 });
@@ -140,7 +140,7 @@ describe('Direct channel defunding', () => {
 
     const response = new EngineResponse();
 
-    const logger = createLogger(defaultTestConfig());
+    const logger = createLogger(defaultTestWalletConfig());
 
     let channel = await Channel.forId(testChannel.channelId, testKnex);
     const defunder = new Defunder(store, logger);
@@ -206,7 +206,7 @@ describe('Direct channel defunding', () => {
 
     const response = new EngineResponse();
 
-    const logger = createLogger(defaultTestConfig());
+    const logger = createLogger(defaultTestWalletConfig());
 
     const channel = await Channel.forId(testChannel.channelId, testKnex);
     const defunder = new Defunder(store, logger);
@@ -263,7 +263,7 @@ describe('Ledger funded channel defunding', () => {
     });
 
     const engineResponse = new EngineResponse();
-    const logger = createLogger(defaultTestConfig());
+    const logger = createLogger(defaultTestWalletConfig());
     const defunder = new Defunder(store, logger);
 
     let channel = await Channel.forId(testLedgerFundedChannel.channelId, testKnex);

--- a/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/open-channel.test.ts
@@ -3,7 +3,7 @@ import {BN, OpenChannel} from '@statechannels/wallet-core';
 import {ChannelOpener} from '../channel-opener';
 import {Store} from '../../engine/store';
 import {testKnex as knex} from '../../../jest/knex-setup-teardown';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 import {EngineResponse} from '../../engine/engine-response';
 import {TestChannel} from '../../engine/__test__/fixtures/test-channel';
 import {createLogger} from '../../logger';
@@ -11,7 +11,7 @@ import {WalletObjective} from '../../models/objective';
 import {ChainServiceRequest, requestTimeout} from '../../models/chain-service-request';
 import {DBAdmin} from '../..';
 
-const logger = createLogger(defaultTestConfig());
+const logger = createLogger(defaultTestWalletConfig());
 const timingMetrics = false;
 const testChan = TestChannel.create({aBal: 5, bBal: 5});
 
@@ -20,15 +20,15 @@ let store: Store;
 beforeEach(async () => {
   store = new Store(
     knex,
-    defaultTestConfig().metricsConfiguration.timingMetrics,
-    defaultTestConfig().skipEvmValidation,
+    defaultTestWalletConfig().metricsConfiguration.timingMetrics,
+    defaultTestWalletConfig().skipEvmValidation,
     '0'
   );
-  await DBAdmin.truncateDatabase(defaultTestConfig());
+  await DBAdmin.truncateDatabase(defaultTestWalletConfig());
 });
 
 afterEach(async () => {
-  await DBAdmin.truncateDatabase(defaultTestConfig());
+  await DBAdmin.truncateDatabase(defaultTestWalletConfig());
 });
 
 describe(`pre-fund-setup phase`, () => {

--- a/packages/server-wallet/src/utilities/__test__/signatures.test.ts
+++ b/packages/server-wallet/src/utilities/__test__/signatures.test.ts
@@ -13,9 +13,9 @@ import {participant} from '../../engine/__test__/fixtures/participants';
 import {recoverAddress, signState as wasmSignState} from '../signatures';
 import {addHash} from '../../state-utils';
 import {createLogger} from '../../logger';
-import {defaultTestConfig} from '../../config';
+import {defaultTestWalletConfig} from '../../config';
 
-const logger = createLogger(defaultTestConfig());
+const logger = createLogger(defaultTestWalletConfig());
 it('sign vs wasmSign', async () => {
   const promises = _.range(5).map(async channelNonce => {
     const {address: ethAddress, privateKey} = Wallet.createRandom();

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -3,23 +3,6 @@ import _ from 'lodash';
 
 import {ObjectiveStatus, WalletObjective} from '../models/objective';
 
-export type SyncOptions = {
-  // How often we check for stale or timed out objectives in milliseconds.
-  pollInterval: number;
-
-  /**
-   * The amount of time (in milliseconds) that we wait for until we consider an objective timed out.
-   * When an objective is timed out we give up trying to complete it and return an error.
-   */
-  timeOutThreshold: number;
-
-  /**
-   * The amount of time (in milliseconds) that we wait for until we consider an objective "stale"
-   * If an objective is stale we attempt to sync the objectives with the other participants.
-   */
-  staleThreshold: number;
-};
-
 export type ObjectiveError = ObjectiveTimedOutError | InternalError;
 
 /**

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -6,7 +6,12 @@ import {
 } from '@statechannels/client-api-schema';
 import _ from 'lodash';
 import EventEmitter from 'eventemitter3';
-import {calculateObjectiveId, makeAddress, makeDestination} from '@statechannels/wallet-core';
+import {
+  calculateObjectiveId,
+  makeAddress,
+  makeDestination,
+  Address,
+} from '@statechannels/wallet-core';
 import {utils} from 'ethers';
 import {setIntervalAsync, clearIntervalAsync} from 'set-interval-async/dynamic';
 import P from 'pino';
@@ -450,6 +455,10 @@ export class Wallet extends EventEmitter<WalletEvents> {
         throw err;
       }
     };
+  }
+
+  public async getSigningAddress(): Promise<Address> {
+    return this._engine.getSigningAddress();
   }
 
   async destroy(): Promise<void> {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -54,9 +54,8 @@ import {ObjectiveResult, WalletEvents, ObjectiveDoneResult, UpdateChannelResult}
 export class Wallet extends EventEmitter<WalletEvents> {
   /**
    * Constructs a channel manager that will ensure objectives get accomplished by resending messages if needed.
-   * @param engine The engine to use.
-   * @param messageService  The message service to use.
-   * @param syncOptions How often and for how long the channel manager should retry objectives.
+   * @param incomingConfig The configuration object that specifies various options.
+   * @param messageServiceFactory  A function that returns a message service when passed in a handler.
    * @returns A channel manager.
    */
   public static async create(

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -22,7 +22,7 @@ import {
   Engine,
   extractDBConfigFromWalletConfig,
   hasNewObjective,
-  IncomingEngineConfigV2,
+  EngineConfig,
   IncomingWalletConfig,
   isMultipleChannelOutput,
   MultipleChannelOutput,
@@ -79,7 +79,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
       throw new ConfigValidationError(errors);
     }
     const {skipEvmValidation, metricsConfiguration} = populatedConfig;
-    const engineConfig: IncomingEngineConfigV2 = {
+    const engineConfig: EngineConfig = {
       skipEvmValidation,
       dbConfig: extractDBConfigFromWalletConfig(populatedConfig),
       metrics: metricsConfiguration,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -9,6 +9,7 @@ import EventEmitter from 'eventemitter3';
 import {calculateObjectiveId, makeAddress, makeDestination} from '@statechannels/wallet-core';
 import {utils} from 'ethers';
 import {setIntervalAsync, clearIntervalAsync} from 'set-interval-async/dynamic';
+import P from 'pino';
 
 import {
   MessageHandler,
@@ -17,21 +18,32 @@ import {
 } from '../message-service/types';
 import {getMessages} from '../message-service/utils';
 import {
+  defaultConfig,
   Engine,
+  extractDBConfigFromEngineConfig,
   hasNewObjective,
+  IncomingEngineConfig,
   isMultipleChannelOutput,
   MultipleChannelOutput,
   SingleChannelOutput,
+  validateEngineConfig,
 } from '../engine';
 import {
   AssetOutcomeUpdatedArg,
   ChainEventSubscriberInterface,
+  ChainService,
   ChainServiceInterface,
   ChallengeRegisteredArg,
   ChannelFinalizedArg,
   HoldingUpdatedArg,
 } from '../chain-service';
 import * as ChannelState from '../protocols/state';
+import {createLogger} from '../logger';
+import {
+  ConfigValidationError,
+  IncomingEngineConfigV2,
+  SingleThreadedEngine,
+} from '../engine/engine';
 
 import {
   SyncOptions,
@@ -47,19 +59,46 @@ export class Wallet extends EventEmitter<WalletEvents> {
    * Constructs a channel manager that will ensure objectives get accomplished by resending messages if needed.
    * @param engine The engine to use.
    * @param messageService  The message service to use.
-   * @param retryOptions How often and for how long the channel manager should retry objectives.
+   * @param syncOptions How often and for how long the channel manager should retry objectives.
    * @returns A channel manager.
    */
   public static async create(
-    engine: Engine,
-    chainService: ChainServiceInterface,
+    incomingConfig: IncomingEngineConfig,
     messageServiceFactory: MessageServiceFactory,
-    retryOptions: Partial<SyncOptions> = DEFAULTS
+
+    syncOptions: Partial<SyncOptions> = DEFAULTS
   ): Promise<Wallet> {
-    await chainService.checkChainId(engine.engineConfig.networkConfiguration.chainNetworkID);
-    const wallet = new Wallet(messageServiceFactory, engine, chainService, {
+    const populatedConfig = _.assign({}, defaultConfig, incomingConfig);
+    // Even though the config hasn't been validated we attempt to create a logger
+    // This allows us to log out any config validation errors
+    const logger = createLogger(populatedConfig);
+
+    logger.trace({engineConfig: populatedConfig}, 'Wallet initializing');
+
+    const {errors, valid} = validateEngineConfig(populatedConfig);
+
+    if (!valid) {
+      errors.forEach(error => logger.error({error}, `Validation error occurred ${error.message}`));
+      throw new ConfigValidationError(errors);
+    }
+    const {skipEvmValidation, metricsConfiguration} = populatedConfig;
+    const engineConfig: IncomingEngineConfigV2 = {
+      skipEvmValidation,
+      dbConfig: extractDBConfigFromEngineConfig(populatedConfig),
+      metrics: metricsConfiguration,
+      chainNetworkID: utils.hexlify(populatedConfig.networkConfiguration.chainNetworkID),
+      workerThreadAmount: 0, // Disable threading for now
+    };
+    const engine = await SingleThreadedEngine.create(engineConfig, logger);
+    const chainService = new ChainService({
+      ...populatedConfig.chainServiceConfiguration,
+      logger,
+    });
+    await chainService.checkChainId(populatedConfig.networkConfiguration.chainNetworkID);
+    const networkId = utils.hexlify(populatedConfig.networkConfiguration.chainNetworkID);
+    const wallet = new Wallet(messageServiceFactory, engine, chainService, networkId, logger, {
       ...DEFAULTS,
-      ...retryOptions,
+      ...syncOptions,
     });
     await wallet.registerExistingChannelsWithChainService();
     return wallet;
@@ -72,10 +111,13 @@ export class Wallet extends EventEmitter<WalletEvents> {
   }, this._syncOptions.pollInterval);
 
   private _chainListener: ChainEventSubscriberInterface;
+
   private constructor(
     messageServiceFactory: MessageServiceFactory,
     private _engine: Engine,
     private _chainService: ChainServiceInterface,
+    private _chainNetworkId: string,
+    private _logger: P.Logger,
     private _syncOptions: SyncOptions
   ) {
     super();
@@ -133,7 +175,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
   public async registerAppDefinition(appDefinition: string): Promise<void> {
     const bytecode = await this._chainService.fetchBytecode(appDefinition);
     await this._engine.store.upsertBytecode(
-      utils.hexlify(this._engine.engineConfig.networkConfiguration.chainNetworkID),
+      utils.hexlify(this._chainNetworkId),
       makeAddress(appDefinition),
       bytecode
     );
@@ -193,7 +235,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
             done,
           };
         } catch (error) {
-          this._engine.logger.error({err: error}, 'Uncaught InternalError in CreateChannel');
+          this._logger.error({err: error}, 'Uncaught InternalError in CreateChannel');
           // TODO: This is slightly hacky but it's less painful then having to narrow the type down every time
           // you get a result back from the createChannels method
           // This should be looked at in https://github.com/statechannels/statechannels/issues/3461
@@ -346,7 +388,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
     return new Promise<ObjectiveDoneResult>(resolve => {
       this.on('ObjectiveTimedOut', o => {
         if (o.objectiveId === objectiveId) {
-          this._engine.logger.trace({objective: o}, 'Objective Timed out');
+          this._logger.trace({objective: o}, 'Objective Timed out');
 
           resolve({
             type: 'ObjectiveTimedOutError',
@@ -357,7 +399,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
       });
       this.on('ObjectiveCompleted', o => {
         if (o.objectiveId === objectiveId) {
-          this._engine.logger.trace({objective: o}, 'Objective Suceeded');
+          this._logger.trace({objective: o}, 'Objective Suceeded');
           resolve({type: 'Success', channelId: o.data.targetChannelId});
         }
       });
@@ -401,13 +443,13 @@ export class Wallet extends EventEmitter<WalletEvents> {
         ChallengeRegisteredArg
     ) => {
       const {channelId} = event;
-      this._engine.logger.trace({event}, `${eventName} being handled`);
+      this._logger.trace({event}, `${eventName} being handled`);
       try {
         await storeUpdater(event);
         const result = await this._engine.crank([channelId]);
         await this.handleEngineOutput(result);
       } catch (err) {
-        this._engine.logger.error({err, event}, `Error handling ${eventName}`);
+        this._logger.error({err, event}, `Error handling ${eventName}`);
         throw err;
       }
     };

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -464,6 +464,11 @@ export class Wallet extends EventEmitter<WalletEvents> {
     return this._engine.getSigningAddress();
   }
 
+  public async getChannels(): Promise<ChannelResult[]> {
+    const {channelResults} = await this._engine.getChannels();
+    return channelResults;
+  }
+
   async destroy(): Promise<void> {
     await clearIntervalAsync(this._syncInterval);
     this._chainService.destructor();

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -42,6 +42,7 @@ import {
   ChallengeRegisteredArg,
   ChannelFinalizedArg,
   HoldingUpdatedArg,
+  MockChainService,
 } from '../chain-service';
 import * as ChannelState from '../protocols/state';
 import {createLogger} from '../logger';
@@ -92,10 +93,12 @@ export class Wallet extends EventEmitter<WalletEvents> {
       workerThreadAmount: 0, // Disable threading for now
     };
     const engine = await SingleThreadedEngine.create(engineConfig, logger);
-    const chainService = new ChainService({
-      ...populatedConfig.chainServiceConfiguration,
-      logger,
-    });
+    const chainService = populatedConfig.chainServiceConfiguration.attachChainService
+      ? new ChainService({
+          ...populatedConfig.chainServiceConfiguration,
+          logger,
+        })
+      : new MockChainService();
     await chainService.checkChainId(populatedConfig.networkConfiguration.chainNetworkID);
     const networkId = utils.hexlify(populatedConfig.networkConfiguration.chainNetworkID);
     const wallet = new Wallet(messageServiceFactory, engine, chainService, networkId, logger, {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -22,6 +22,7 @@ import {
   Engine,
   extractDBConfigFromWalletConfig,
   hasNewObjective,
+  IncomingEngineConfigV2,
   IncomingWalletConfig,
   isMultipleChannelOutput,
   MultipleChannelOutput,
@@ -39,11 +40,7 @@ import {
 } from '../chain-service';
 import * as ChannelState from '../protocols/state';
 import {createLogger} from '../logger';
-import {
-  ConfigValidationError,
-  IncomingEngineConfigV2,
-  SingleThreadedEngine,
-} from '../engine/engine';
+import {ConfigValidationError, SingleThreadedEngine} from '../engine/engine';
 
 import {
   SyncOptions,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -20,9 +20,9 @@ import {getMessages} from '../message-service/utils';
 import {
   defaultConfig,
   Engine,
-  extractDBConfigFromEngineConfig,
+  extractDBConfigFromWalletConfig,
   hasNewObjective,
-  IncomingEngineConfig,
+  IncomingWalletConfig,
   isMultipleChannelOutput,
   MultipleChannelOutput,
   SingleChannelOutput,
@@ -63,7 +63,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
    * @returns A channel manager.
    */
   public static async create(
-    incomingConfig: IncomingEngineConfig,
+    incomingConfig: IncomingWalletConfig,
     messageServiceFactory: MessageServiceFactory,
 
     syncOptions: Partial<SyncOptions> = DEFAULTS
@@ -84,7 +84,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
     const {skipEvmValidation, metricsConfiguration} = populatedConfig;
     const engineConfig: IncomingEngineConfigV2 = {
       skipEvmValidation,
-      dbConfig: extractDBConfigFromEngineConfig(populatedConfig),
+      dbConfig: extractDBConfigFromWalletConfig(populatedConfig),
       metrics: metricsConfiguration,
       chainNetworkID: utils.hexlify(populatedConfig.networkConfiguration.chainNetworkID),
       workerThreadAmount: 0, // Disable threading for now


### PR DESCRIPTION
Previously the `Wallet` was constructed by passing in an `engine` and `chainService`. The `engine` would be constructed using a `EngineConfig`, which it would be responsible for validating.

In this PR the `Wallet` is now responsible for creating its own `engine` and `chainService`. The `wallet` takes in a `WalletConfig` configuration object (this used to be `EngineConfig`) and uses that for constructing its `chainService` and `engine`.

`EngineConfig` has been refactored and slimmed down considerably to only the config values the engine actually uses:
```
export type EngineConfig = {  
 skipEvmValidation: boolean;  
 metrics: MetricsConfiguration;
 dbConfig: Config; 
 chainNetworkID: string;
 workerThreadAmount: number;
};
```

The `Wallet` is now responsible for validating the config so we don't have to worry about config validation in the engine anymore.
