### PR TITLE
Implement Message Service that can work between servers

### DIFF
--- a/packages/interop-tests/src/message-service.ts
+++ b/packages/interop-tests/src/message-service.ts
@@ -13,7 +13,9 @@ export class BrowserServerMessageService implements MessageServiceInterface {
     const convertedMessages = message.map(generatePushMessage);
     await Promise.all(convertedMessages.map(m => this.browserWallet.pushMessage(m, 'dummyDomain')));
   }
-
+  public registerPeer(_peerUrl: string): Promise<void> {
+    throw new Error('Not Implemented');
+  }
   public async destroy(): Promise<void> {
     this.browserWallet.destroy();
   }

--- a/packages/server-wallet/package.json
+++ b/packages/server-wallet/package.json
@@ -25,6 +25,8 @@
     "pino": "6.2.0",
     "rxjs": "6.6.3",
     "set-interval-async": "^2.0.3",
+    "socket.io": "^4.1.2",
+    "socket.io-client": "^4.1.2",
     "tarn": "3.0.0"
   },
   "devDependencies": {
@@ -35,7 +37,7 @@
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/jest": "26.0.21",
     "@types/lodash": "4.14.161",
-    "@types/node": "14.11.2",
+    "@types/node": "14.11.8",
     "@types/pg": "7.14.0",
     "@types/pino": "6.0.0",
     "@types/prettier": "1.19.0",

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -460,6 +460,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
     // (undocumented)
     get messageService(): MessageServiceInterface;
     registerAppDefinition(appDefinition: string): Promise<void>;
+    registerPeerMessageService(peerUrl: string): Promise<void>;
     updateChannel(channelId: string, allocations: Allocation[], appData: string): Promise<UpdateChannelResult>;
 }
 

--- a/packages/server-wallet/src/__chain-test__/socket-io-directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/socket-io-directly-funded-channel.test.ts
@@ -116,9 +116,9 @@ beforeAll(async () => {
     bWalletConfig,
     await SocketIOMessageService.createFactory('localhost', B_PORT)
   );
-  // TODO: There should be a cleaner way of doing this
-  await (a.messageService as SocketIOMessageService).registerPeer('localhost', B_PORT);
-  await (a.messageService as SocketIOMessageService).registerPeer('localhost', A_PORT);
+
+  await a.registerPeerMessageService(`http://localhost:${B_PORT}`);
+  await b.registerPeerMessageService(`http://localhost:${A_PORT}`);
 
   const assetHolder = new Contract(
     ethAssetHolderAddress,

--- a/packages/server-wallet/src/__chain-test__/socket-io-directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/socket-io-directly-funded-channel.test.ts
@@ -1,0 +1,201 @@
+import path from 'path';
+
+import {CreateChannelParams, Participant, Allocation} from '@statechannels/client-api-schema';
+import {TEST_ACCOUNTS} from '@statechannels/devtools';
+import {ContractArtifacts} from '@statechannels/nitro-protocol';
+import {BN, makeAddress, makeDestination} from '@statechannels/wallet-core';
+import {BigNumber, constants, Contract, ethers, providers} from 'ethers';
+import _ from 'lodash';
+
+import {
+  defaultTestWalletConfig,
+  overwriteConfigWithDatabaseConnection,
+  WalletConfig,
+} from '../config';
+import {DBAdmin} from '../db-admin/db-admin';
+import {Wallet} from '../wallet';
+import {ONE_DAY} from '../__test__/test-helpers';
+import {waitForObjectiveProposals} from '../__test-with-peers__/utils';
+import {ARTIFACTS_DIR} from '../../jest/chain-setup';
+import {SocketIOMessageService} from '../message-service/socket-io-message-service';
+
+jest.setTimeout(60_000);
+
+// eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
+const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
+// eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
+if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
+// eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
+const rpcEndpoint = process.env.RPC_ENDPOINT;
+
+const config = {
+  ...defaultTestWalletConfig(),
+  networkConfiguration: {
+    ...defaultTestWalletConfig().networkConfiguration,
+    // eslint-disable-next-line no-process-env
+    chainNetworkID: parseInt(process.env.CHAIN_NETWORK_ID || '0'),
+  },
+};
+
+let provider: providers.JsonRpcProvider;
+let a: Wallet;
+let b: Wallet;
+
+const bWalletConfig: WalletConfig = {
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_b'}),
+  loggingConfiguration: {
+    logDestination: path.join(ARTIFACTS_DIR, 'direct-funding.log'),
+    logLevel: 'trace',
+  },
+  chainServiceConfiguration: {
+    attachChainService: true,
+    provider: rpcEndpoint,
+    /* eslint-disable-next-line no-process-env */
+    pk: process.env.CHAIN_SERVICE_PK ?? TEST_ACCOUNTS[1].privateKey,
+    allowanceMode: 'MaxUint',
+  },
+  syncConfiguration: {pollInterval: 1_000, timeOutThreshold: 60_000, staleThreshold: 10_000},
+};
+const aWalletConfig: WalletConfig = {
+  ...overwriteConfigWithDatabaseConnection(config, {database: 'server_wallet_test_a'}),
+  loggingConfiguration: {
+    logDestination: path.join(ARTIFACTS_DIR, 'direct-funding.log'),
+    logLevel: 'trace',
+  },
+  chainServiceConfiguration: {
+    attachChainService: true,
+    provider: rpcEndpoint,
+    /* eslint-disable-next-line no-process-env */
+    pk: process.env.CHAIN_SERVICE_PK2 ?? TEST_ACCOUNTS[2].privateKey,
+    allowanceMode: 'MaxUint',
+  },
+  syncConfiguration: {pollInterval: 1_000, timeOutThreshold: 60_000, staleThreshold: 10_000},
+};
+
+const aAddress = '0x50Bcf60D1d63B7DD3DAF6331a688749dCBD65d96';
+const bAddress = '0x632d0b05c78A83cEd439D3bd6C710c4814D3a6db';
+
+const aFunding = BN.from(3);
+const bFunding = BN.from(2);
+
+async function getBalance(address: string): Promise<BigNumber> {
+  return await provider.getBalance(address);
+}
+
+async function mineBlocks(confirmations = 5) {
+  for (const _i in _.range(confirmations)) {
+    await provider.send('evm_mine', []);
+  }
+}
+
+const mineBlocksForEvent = () => mineBlocks();
+
+function mineOnEvent(contract: Contract) {
+  contract.on('Deposited', mineBlocksForEvent);
+  contract.on('AllocationUpdated', mineBlocksForEvent);
+}
+
+beforeAll(async () => {
+  provider = new providers.JsonRpcProvider(rpcEndpoint);
+
+  await Promise.all(
+    [aWalletConfig, bWalletConfig].map(async config => {
+      await DBAdmin.dropDatabase(config);
+      await DBAdmin.createDatabase(config);
+      await DBAdmin.migrateDatabase(config);
+    })
+  );
+  const A_PORT = 3050;
+  const B_PORT = 3051;
+
+  a = await Wallet.create(
+    aWalletConfig,
+    await SocketIOMessageService.createFactory('localhost', A_PORT)
+  );
+  b = await Wallet.create(
+    bWalletConfig,
+    await SocketIOMessageService.createFactory('localhost', B_PORT)
+  );
+  // TODO: There should be a cleaner way of doing this
+  await (a.messageService as SocketIOMessageService).registerPeer('localhost', B_PORT);
+  await (a.messageService as SocketIOMessageService).registerPeer('localhost', A_PORT);
+
+  const assetHolder = new Contract(
+    ethAssetHolderAddress,
+    ContractArtifacts.EthAssetHolderArtifact.abi,
+    provider
+  );
+  mineOnEvent(assetHolder);
+});
+
+afterAll(async () => {
+  await Promise.all([a.destroy(), b.destroy()]);
+  await Promise.all([DBAdmin.dropDatabase(aWalletConfig), DBAdmin.dropDatabase(bWalletConfig)]);
+  provider.polling = false;
+  provider.removeAllListeners();
+});
+
+test.each(['A', 'B'])(
+  `can successfully fund and defund a channel between two wallets with %s closing`,
+  async closer => {
+    const participantA: Participant = {
+      signingAddress: await a.getSigningAddress(),
+      participantId: 'a',
+      destination: makeDestination(aAddress),
+    };
+    const participantB: Participant = {
+      signingAddress: await b.getSigningAddress(),
+      participantId: 'b',
+      destination: makeDestination(bAddress),
+    };
+
+    const allocation: Allocation = {
+      allocationItems: [
+        {
+          destination: participantA.destination,
+          amount: aFunding,
+        },
+        {
+          destination: participantB.destination,
+          amount: bFunding,
+        },
+      ],
+      assetHolderAddress: ethAssetHolderAddress,
+    };
+
+    const channelParams: CreateChannelParams = {
+      participants: [participantA, participantB],
+      allocations: [allocation],
+      appDefinition: ethers.constants.AddressZero,
+      appData: constants.HashZero,
+      fundingStrategy: 'Direct',
+      challengeDuration: ONE_DAY,
+    };
+    const aBalanceInit = await getBalance(aAddress);
+    const bBalanceInit = await getBalance(bAddress);
+    const assetHolderBalanceInit = await getBalance(ethAssetHolderAddress);
+
+    const response = await a.createChannels([channelParams]);
+    await waitForObjectiveProposals([response[0].objectiveId], b);
+    const bResponse = await b.approveObjectives([response[0].objectiveId]);
+
+    await expect(response).toBeObjectiveDoneType('Success');
+    await expect(bResponse).toBeObjectiveDoneType('Success');
+
+    const assetHolderBalanceUpdated = await getBalance(ethAssetHolderAddress);
+    expect(BN.sub(assetHolderBalanceUpdated, assetHolderBalanceInit)).toEqual(
+      BN.add(aFunding, bFunding)
+    );
+
+    const {channelId} = response[0];
+    const closeResponse =
+      closer === 'A' ? await a.closeChannels([channelId]) : await b.closeChannels([channelId]);
+    await expect(closeResponse).toBeObjectiveDoneType('Success');
+
+    const aBalanceFinal = await getBalance(aAddress);
+    const bBalanceFinal = await getBalance(bAddress);
+
+    expect(BN.sub(aBalanceFinal, aBalanceInit)).toEqual(aFunding);
+    expect(BN.sub(bBalanceFinal, bBalanceInit)).toEqual(bFunding);
+  }
+);

--- a/packages/server-wallet/src/message-service/legacy-test-message-service.ts
+++ b/packages/server-wallet/src/message-service/legacy-test-message-service.ts
@@ -30,6 +30,10 @@ export class LegacyTestMessageHandler implements MessageServiceInterface {
     }
   }
 
+  public async registerPeer(_peerUrl: string): Promise<void> {
+    throw new Error('Not supported');
+  }
+
   public async destroy(): Promise<void> {
     this._destroyed = true;
   }

--- a/packages/server-wallet/src/message-service/socket-io-message-service.ts
+++ b/packages/server-wallet/src/message-service/socket-io-message-service.ts
@@ -11,8 +11,8 @@ export class SocketIOMessageService implements MessageServiceInterface {
     this.server = new Server();
     this.server.listen(port);
   }
-  public async registerPeer(hostName: string, port: number): Promise<void> {
-    const socket = io(`http://${hostName}:${port}`);
+  public async registerPeer(url: string): Promise<void> {
+    const socket = io(url);
     socket.on('message', async (messages: Message[]) => {
       for (const m of messages) {
         await this.handler(m);

--- a/packages/server-wallet/src/message-service/socket-io-message-service.ts
+++ b/packages/server-wallet/src/message-service/socket-io-message-service.ts
@@ -1,0 +1,43 @@
+import {Server} from 'socket.io';
+import {io, Socket as ClientSocket} from 'socket.io-client';
+import {Message} from '@statechannels/client-api-schema';
+
+import {MessageHandler, MessageServiceFactory, MessageServiceInterface} from './types';
+
+export class SocketIOMessageService implements MessageServiceInterface {
+  private server: Server;
+  private peers: ClientSocket[] = [];
+  constructor(private handler: MessageHandler, hostName: string, port: number) {
+    this.server = new Server();
+    this.server.listen(port);
+  }
+  public registerPeer(hostName: string, port: number): void {
+    const socket = io(`http://${hostName}:${port}`);
+    socket.on('message', async (messages: Message[]) => {
+      for (const m of messages) {
+        await this.handler(m);
+      }
+    });
+
+    this.peers.push(socket);
+  }
+
+  public async send(messages: Message[]): Promise<void> {
+    this.server.emit('message', messages);
+  }
+
+  public async destroy(): Promise<void> {
+    this.server.close();
+
+    for (const p of this.peers) {
+      p.disconnect();
+    }
+  }
+
+  public static async createFactory(
+    hostname: string,
+    port: number
+  ): Promise<MessageServiceFactory> {
+    return (handler: MessageHandler) => new SocketIOMessageService(handler, hostname, port);
+  }
+}

--- a/packages/server-wallet/src/message-service/socket-io-message-service.ts
+++ b/packages/server-wallet/src/message-service/socket-io-message-service.ts
@@ -11,7 +11,7 @@ export class SocketIOMessageService implements MessageServiceInterface {
     this.server = new Server();
     this.server.listen(port);
   }
-  public registerPeer(hostName: string, port: number): void {
+  public async registerPeer(hostName: string, port: number): Promise<void> {
     const socket = io(`http://${hostName}:${port}`);
     socket.on('message', async (messages: Message[]) => {
       for (const m of messages) {

--- a/packages/server-wallet/src/message-service/test-message-service.ts
+++ b/packages/server-wallet/src/message-service/test-message-service.ts
@@ -134,6 +134,12 @@ export class TestMessageService implements MessageServiceInterface {
   public setLatencyOptions(incomingOptions: Partial<LatencyOptions>): void {
     this._options = _.merge(this._options, incomingOptions);
   }
+
+  public async registerPeer(_peerId: string): Promise<void> {
+    throw new Error(
+      'The TestMessageService does not support register peer. Use TestMessageService.LinkMessageServices instead'
+    );
+  }
   async send(messages: Message[]): Promise<void> {
     if (this._frozen) {
       this._messageQueue.push(...messages);

--- a/packages/server-wallet/src/message-service/types.ts
+++ b/packages/server-wallet/src/message-service/types.ts
@@ -24,7 +24,7 @@ export interface MessageServiceInterface {
 
   // TODO: Is a url/string too restrictive for addressing a peer?
   /**
-   * Registers a peer so messages can be sent ot that peer
+   * Registers a peer so messages can be sent to that peer
    * @param peerUrl The url for the peer
    */
   registerPeer(peerUrl: string): Promise<void>;

--- a/packages/server-wallet/src/message-service/types.ts
+++ b/packages/server-wallet/src/message-service/types.ts
@@ -22,6 +22,12 @@ export interface MessageServiceInterface {
    */
   send(message: Message[]): Promise<void>;
 
+  // TODO: Is a url/string too restrictive for addressing a peer?
+  /**
+   * Registers a peer so messages can be sent ot that peer
+   * @param peerUrl The url for the peer
+   */
+  registerPeer(peerUrl: string): Promise<void>;
   /**
    * This is called when the message service is no longer needed
    */

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -464,6 +464,14 @@ export class Wallet extends EventEmitter<WalletEvents> {
     return channelResults;
   }
 
+  /**
+   * Registers a peer with the message service so messages can be sent to the peer.
+   * @param peerUrl The endpoint for the peer.
+   */
+  public async registerPeerMessageService(peerUrl: string): Promise<void> {
+    await this.messageService.registerPeer(peerUrl);
+  }
+
   async destroy(): Promise<void> {
     await clearIntervalAsync(this._syncInterval);
     this._chainService.destructor();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7342,6 +7342,11 @@
   resolved "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/component-emitter@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz#ef5b1589b9f16544642e473db5ea5639107ef3ea"
+  integrity sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==
+
 "@types/connect-history-api-fallback@*":
   version "1.3.4"
   resolved "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.4.tgz#8c0f0e6e5d8252b699f5a662f51bdf82fd9d8bb8"
@@ -7356,6 +7361,16 @@
   integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
   dependencies:
     "@types/node" "*"
+
+"@types/cookie@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz#14f854c0f93d326e39da6e3b6f34f7d37513d108"
+  integrity sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==
+
+"@types/cors@^2.8.8":
+  version "2.8.10"
+  resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz#61cc8469849e5bcdd0c7044122265c39cec10cf4"
+  integrity sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==
 
 "@types/detect-port@1.1.0":
   version "1.1.0"
@@ -7739,6 +7754,16 @@
   version "10.17.13"
   resolved "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
+
+"@types/node@14.11.8":
+  version "14.11.8"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
+  integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
+
+"@types/node@>=10.0.0":
+  version "15.12.2"
+  resolved "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
+  integrity sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==
 
 "@types/node@^12.12.6":
   version "12.12.64"
@@ -10351,6 +10376,11 @@ babylon@^6.18.0:
   resolved "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
+backo2@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
+
 backoff@^2.5.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz#f616eda9d3e4b66b8ca7fca79f695722c5f8e26f"
@@ -10385,10 +10415,20 @@ base64-arraybuffer-es6@^0.7.0:
   resolved "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz#dbe1e6c87b1bf1ca2875904461a7de40f21abc86"
   integrity sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==
 
+base64-arraybuffer@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"
+  integrity sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=
+
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
+base64id@2.0.0, base64id@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
+  integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
 base@^0.11.1:
   version "0.11.2"
@@ -11858,7 +11898,7 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -12129,7 +12169,7 @@ cookie@0.4.0:
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookie@^0.4.1:
+cookie@^0.4.1, cookie@~0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
@@ -12254,7 +12294,7 @@ corejs-upgrade-webpack-plugin@^2.2.0:
     resolve-from "^5.0.0"
     webpack "^4.38.0"
 
-cors@^2.8.1:
+cors@^2.8.1, cors@~2.8.5:
   version "2.8.5"
   resolved "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
   integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
@@ -13126,6 +13166,13 @@ debug@^3.0.0:
   dependencies:
     ms "^2.1.1"
 
+debug@~4.3.1:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -13904,6 +13951,41 @@ endent@^2.0.1:
     dedent "^0.7.0"
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.4"
+
+engine.io-client@~5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/engine.io-client/-/engine.io-client-5.1.1.tgz#f5c3aaaef1bdc9443aac6ffde48b3b2fb2dc56fc"
+  integrity sha512-jPFpw2HLL0lhZ2KY0BpZhIJdleQcUO9W1xkIpo0h3d6s+5D6+EV/xgQw9qWOmymszv2WXef/6KUUehyxEKomlQ==
+  dependencies:
+    base64-arraybuffer "0.1.4"
+    component-emitter "~1.3.0"
+    debug "~4.3.1"
+    engine.io-parser "~4.0.1"
+    has-cors "1.1.0"
+    parseqs "0.0.6"
+    parseuri "0.0.6"
+    ws "~7.4.2"
+    yeast "0.1.2"
+
+engine.io-parser@~4.0.0, engine.io-parser@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz#e41d0b3fb66f7bf4a3671d2038a154024edb501e"
+  integrity sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==
+  dependencies:
+    base64-arraybuffer "0.1.4"
+
+engine.io@~5.1.0:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/engine.io/-/engine.io-5.1.1.tgz#a1f97e51ddf10cbd4db8b5ff4b165aad3760cdd3"
+  integrity sha512-aMWot7H5aC8L4/T8qMYbLdvKlZOdJTH54FxfdFunTGvhMx1BHkJOntWArsVfgAZVwAO9LC2sryPWRcEeUzCe5w==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~4.0.0"
+    ws "~7.4.2"
 
 enhanced-resolve@^4.0.0, enhanced-resolve@^4.3.0:
   version "4.3.0"
@@ -16843,6 +16925,11 @@ has-bigints@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+  integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -22656,6 +22743,16 @@ parse5@^6.0.0:
   resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
+parseqs@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz#8e4bb5a19d1cdc844a08ac974d34e273afa670d5"
+  integrity sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==
+
+parseuri@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz#e1496e829e3ac2ff47f39a4dd044b32823c4a25a"
+  integrity sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -26707,6 +26804,48 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+socket.io-adapter@~2.3.0:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.1.tgz#a442720cb09a4823cfb81287dda1f9b52d4ccdb2"
+  integrity sha512-8cVkRxI8Nt2wadkY6u60Y4rpW3ejA1rxgcK2JuyIhmF+RMNpTy1QRtkHIDUOf3B4HlQwakMsWbKftMv/71VMmw==
+
+socket.io-client@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.1.2.tgz#95ad7113318ea01fba0860237b96d71e1b1fd2eb"
+  integrity sha512-RDpWJP4DQT1XeexmeDyDkm0vrFc0+bUsHDKiVGaNISJvJonhQQOMqV9Vwfg0ZpPJ27LCdan7iqTI92FRSOkFWQ==
+  dependencies:
+    "@types/component-emitter" "^1.2.10"
+    backo2 "~1.0.2"
+    component-emitter "~1.3.0"
+    debug "~4.3.1"
+    engine.io-client "~5.1.1"
+    parseuri "0.0.6"
+    socket.io-parser "~4.0.4"
+
+socket.io-parser@~4.0.3, socket.io-parser@~4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
+  integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
+  dependencies:
+    "@types/component-emitter" "^1.2.10"
+    component-emitter "~1.3.0"
+    debug "~4.3.1"
+
+socket.io@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.1.2.tgz#f90f9002a8d550efe2aa1d320deebb9a45b83233"
+  integrity sha512-xK0SD1C7hFrh9+bYoYCdVt+ncixkSLKtNLCax5aEy1o3r5PaO5yQhVb97exIe67cE7lAK+EpyMytXWTWmyZY8w==
+  dependencies:
+    "@types/cookie" "^0.4.0"
+    "@types/cors" "^2.8.8"
+    "@types/node" ">=10.0.0"
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    debug "~4.3.1"
+    engine.io "~5.1.0"
+    socket.io-adapter "~2.3.0"
+    socket.io-parser "~4.0.3"
+
 sockjs-client@1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz#c9f2568e19c8fd8173b4997ea3420e0bb306c7d5"
@@ -30255,6 +30394,11 @@ ws@^7.2.3:
   resolved "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
   integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
 
+ws@~7.4.2:
+  version "7.4.6"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
@@ -30474,6 +30618,11 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+  integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Fixes #3616

This implements a basic but viable message service that can be used by the server wallet to communicate.

It uses the socket.io library to communicate. The socket.IO library defaults to webSocket and falls back to http long polling if that doesn't work.

Unlike the `TestMessageService` it can work between processes or servers.

Currently, peer registry is pretty rudimentary. I've added a `registerPeerMessageService` method to the `wallet` that can be used to register a url for a peer message service. Right now the method accepts a `peerUrl:string` but that may be limiting in the future (if we want to use a more complex addressing system than a `string`). 