### PR TITLE
[docs-website] remove mention of "thumbprint"

### DIFF
--- a/packages/docs-website/docs/docs/protocol-tutorial/understand-adjudicator-status.md
+++ b/packages/docs-website/docs/docs/protocol-tutorial/understand-adjudicator-status.md
@@ -9,7 +9,6 @@ The adjudicator contract stores certain information about any channel that it kn
 
 - `uint48 turnNumRecord`
 - `uint48 finalizesAt`
-- `uint160 thumbprint`
 - `bytes32 stateHash // keccak256(abi.encode(State))`
 - `address challengerAddress`
 - `bytes32 outcomeHash`


### PR DESCRIPTION
This is a hangover from an old terminology we no longer use,
and is inaccurate / confusing.

