### PR TITLE
[nitro-protocol] Do not cast enum type to uint8

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -405,10 +405,7 @@ contract AssetHolder is IAssetHolder {
             assetOutcomeHashes[channelId] ==
                 keccak256(
                     abi.encode(
-                        Outcome.AssetOutcome(
-                            Outcome.AssetOutcomeType.Allocation,
-                            allocationBytes
-                        )
+                        Outcome.AssetOutcome(Outcome.AssetOutcomeType.Allocation, allocationBytes)
                     )
                 ),
             'h(allocation)!=assetOutcomeHash'
@@ -423,10 +420,7 @@ contract AssetHolder is IAssetHolder {
             assetOutcomeHashes[guarantorChannelId] ==
                 keccak256(
                     abi.encode(
-                        Outcome.AssetOutcome(
-                            Outcome.AssetOutcomeType.Guarantee,
-                            guaranteeBytes
-                        )
+                        Outcome.AssetOutcome(Outcome.AssetOutcomeType.Guarantee, guaranteeBytes)
                     )
                 ),
             'h(guarantee)!=assetOutcomeHash'

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -254,7 +254,7 @@ contract AssetHolder is IAssetHolder {
             assetOutcomeHashes[fromChannelId] = keccak256(
                 abi.encode(
                     Outcome.AssetOutcome(
-                        uint8(Outcome.AssetOutcomeType.Allocation),
+                        Outcome.AssetOutcomeType.Allocation,
                         abi.encode(newAllocation)
                     )
                 )
@@ -319,7 +319,7 @@ contract AssetHolder is IAssetHolder {
             assetOutcomeHashes[guarantee.targetChannelId] = keccak256(
                 abi.encode(
                     Outcome.AssetOutcome(
-                        uint8(Outcome.AssetOutcomeType.Allocation),
+                        Outcome.AssetOutcomeType.Allocation,
                         abi.encode(newAllocation)
                     )
                 )
@@ -406,7 +406,7 @@ contract AssetHolder is IAssetHolder {
                 keccak256(
                     abi.encode(
                         Outcome.AssetOutcome(
-                            uint8(Outcome.AssetOutcomeType.Allocation),
+                            Outcome.AssetOutcomeType.Allocation,
                             allocationBytes
                         )
                     )
@@ -424,7 +424,7 @@ contract AssetHolder is IAssetHolder {
                 keccak256(
                     abi.encode(
                         Outcome.AssetOutcome(
-                            uint8(Outcome.AssetOutcomeType.Guarantee),
+                            Outcome.AssetOutcomeType.Guarantee,
                             guaranteeBytes
                         )
                     )

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -129,7 +129,7 @@ contract NitroAdjudicator is IAdjudicator, ForceMove {
                 outcome[i].assetOutcomeBytes,
                 (Outcome.AssetOutcome)
             );
-            if (assetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation)) {
+            if (assetOutcome.assetOutcomeType == Outcome.AssetOutcomeType.Allocation) {
                 AssetHolder(outcome[i].assetHolderAddress).transferAllAdjudicatorOnly(
                     channelId,
                     assetOutcome.allocationOrGuaranteeBytes

--- a/packages/nitro-protocol/contracts/Outcome.sol
+++ b/packages/nitro-protocol/contracts/Outcome.sol
@@ -20,7 +20,7 @@ library Outcome {
     enum AssetOutcomeType {Allocation, Guarantee}
 
     struct AssetOutcome {
-        uint8 assetOutcomeType; // AssetOutcomeType.Allocation or AssetOutcomeType.Guarantee
+        AssetOutcomeType assetOutcomeType;
         bytes allocationOrGuaranteeBytes; // abi.encode(AllocationItem[]) or abi.encode(Guarantee), depending on OutcomeType
     }
 

--- a/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
+++ b/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
@@ -403,7 +403,7 @@ contract EmbeddedApplication is
 
         // Throws unless the assetoutcome is an allocation
         require(
-            assetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
+            assetOutcome.assetOutcomeType == Outcome.AssetOutcomeType.Allocation,
             'AssetOutcome must be Allocation'
         );
 
@@ -432,7 +432,7 @@ contract EmbeddedApplication is
 
         // Throws unless the assetoutcome is an allocation
         require(
-            assetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
+            assetOutcome.assetOutcomeType == Outcome.AssetOutcomeType.Allocation,
             'AssetOutcome must be Allocation'
         );
 

--- a/packages/nitro-protocol/contracts/examples/HashLockedSwap.sol
+++ b/packages/nitro-protocol/contracts/examples/HashLockedSwap.sol
@@ -76,7 +76,7 @@ contract HashLockedSwap is IForceMoveApp {
 
         // Throws unless the assetoutcome is an allocation
         require(
-            assetOutcome.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
+            assetOutcome.assetOutcomeType == Outcome.AssetOutcomeType.Allocation,
             'AssetOutcome must be Allocation'
         );
 

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -41,11 +41,11 @@ contract SingleAssetPayments is IForceMoveApp {
             (Outcome.AssetOutcome)
         );
         require(
-            assetOutcomeA.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
+            assetOutcomeA.assetOutcomeType == Outcome.AssetOutcomeType.Allocation,
             'AssetOutcomeA must be Allocation'
         );
         require(
-            assetOutcomeB.assetOutcomeType == uint8(Outcome.AssetOutcomeType.Allocation),
+            assetOutcomeB.assetOutcomeType == Outcome.AssetOutcomeType.Allocation,
             'AssetOutcomeB must be Allocation'
         );
 

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,9 +28,9 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 2421830, // Singleton
-      ETHAssetHolder: 1634011, // Singleton (could be more in principle)
-      ERC20AssetHolder: 1657410, // Per Token (could be more in principle)
+      NitroAdjudicator: 2416171, // Singleton
+      ETHAssetHolder: 1636603, // Singleton (could be more in principle)
+      ERC20AssetHolder: 1659990, // Per Token (could be more in principle)
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -65,11 +65,11 @@ export const gasRequiredTo: GasRequiredTo = {
   },
   ETHexit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 146793,
+    vanillaNitro: 146769,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 139148,
+    vanillaNitro: 139124,
   },
   ETHexitSad: {
     // Scenario: Counterparty Bob goes offline
@@ -77,9 +77,9 @@ export const gasRequiredTo: GasRequiredTo = {
     // challenge + timeout       ⬛ -> (X) -> 👩
     // pushOutcomeAndTransferAll ⬛ --------> 👩
     vanillaNitro: {
-      challenge: 93404,
-      pushOutcomeAndTransferAll: 107742,
-      total: 201146,
+      challenge: 93390,
+      pushOutcomeAndTransferAll: 107733,
+      total: 201123,
     },
   },
   ETHexitSadLedgerFunded: {
@@ -89,11 +89,11 @@ export const gasRequiredTo: GasRequiredTo = {
       // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
       // pushOutcomeAndTransferAllL  ⬛ --------> (X) -> 👩
       // pushOutcomeAndTransferAllX  ⬛ ---------------> 👩
-      challengeX: 93404,
-      challengeL: 92338,
-      pushOutcomeAndTransferAllL: 58640,
-      pushOutcomeAndTransferAllX: 107742,
-      total: 352124,
+      challengeX: 93390,
+      challengeL: 92324,
+      pushOutcomeAndTransferAllL: 58631,
+      pushOutcomeAndTransferAllX: 107733,
+      total: 352078,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -106,16 +106,16 @@ export const gasRequiredTo: GasRequiredTo = {
       // pushOutcomeJ                ⬛ --------> (G) -> (J) -> (X) -> 👩
       // claimG                      ⬛ ----------------------> (X) -> 👩
       // pushOutcomeAndTransferAllX  ⬛ -----------------------------> 👩
-      challengeL: 92350,
-      challengeG: 94621,
-      challengeJ: 101748,
-      challengeX: 93404,
-      pushOutcomeAndTransferAllL: 58652,
+      challengeL: 92336,
+      challengeG: 94607,
+      challengeJ: 101741,
+      challengeX: 93390,
+      pushOutcomeAndTransferAllL: 58643,
       pushOutcomeG: 61410,
       pushOutcomeJ: 60558,
-      claimG: 58432,
-      pushOutcomeAndTransferAllX: 107742,
-      total: 728917,
+      claimG: 58492,
+      pushOutcomeAndTransferAllX: 107733,
+      total: 728910,
     },
   },
 };


### PR DESCRIPTION
This is unnecessary.

The change also saves a tiny bit of gas. 