### PR TITLE
update gas benchmarking code

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -1,5 +1,3 @@
-import {constants} from 'ethers';
-
 import {encodeOutcome} from '../src';
 import {MAGIC_ADDRESS_INDICATING_ETH} from '../src/transactions';
 
@@ -41,17 +39,19 @@ describe('Consumes the expected gas for deployments', () => {
 describe('Consumes the expected gas for deposits', () => {
   it(`when directly funding a channel with ETH (first deposit)`, async () => {
     await expect(
-      await nitroAdjudicator.deposit(constants.AddressZero, X.channelId, 0, 5, {value: 5})
+      await nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, X.channelId, 0, 5, {value: 5})
     ).toConsumeGas(gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro);
   });
 
   it(`when directly funding a channel with ETH (second deposit)`, async () => {
     // begin setup
-    const setupTX = nitroAdjudicator.deposit(constants.AddressZero, X.channelId, 0, 5, {value: 5});
+    const setupTX = nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, X.channelId, 0, 5, {
+      value: 5,
+    });
     await (await setupTX).wait();
     // end setup
     await expect(
-      await nitroAdjudicator.deposit(constants.AddressZero, X.channelId, 5, 5, {value: 5})
+      await nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, X.channelId, 5, 5, {value: 5})
     ).toConsumeGas(gasRequiredTo.directlyFundAChannelWithETHSecond.vanillaNitro);
   });
 
@@ -250,10 +250,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
       await nitroAdjudicator.claim(
         0,
         G.channelId,
-        encodeOutcome(G.outcome(constants.AddressZero)),
+        encodeOutcome(G.outcome(MAGIC_ADDRESS_INDICATING_ETH)),
         guarantorProof.stateHash,
         guarantorProof.challengerAddress,
-        encodeOutcome(J.outcome(constants.AddressZero)),
+        encodeOutcome(J.outcome(MAGIC_ADDRESS_INDICATING_ETH)),
         jointProof.stateHash,
         jointProof.challengerAddress,
         [] // meaning "all"

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -1,4 +1,7 @@
-import {Allocation, encodeAllocation, encodeGuarantee, Guarantee} from '../src';
+import {constants} from 'ethers';
+
+import {encodeOutcome} from '../src';
+import {MAGIC_ADDRESS_INDICATING_ETH} from '../src/transactions';
 
 import {
   waitForChallengesToTimeOut,
@@ -11,12 +14,12 @@ import {
   J,
 } from './fixtures';
 import {gasRequiredTo} from './gas';
-import {erc20AssetHolder, ethAssetHolder, nitroAdjudicator, token} from './vanillaSetup';
+import {nitroAdjudicator, token} from './vanillaSetup';
 
 /**
  * Ensures the supplied asset holder always has a nonzero token balance.
  */
-async function addResidualTokenBalanceToAssetHolder(assetHolder: typeof erc20AssetHolder) {
+async function addResidualTokenBalance(asset: string) {
   /**
    * Funding someOtherChannel with tokens, as well as the channel in question
    * makes the benchmark more realistic. In practice many other
@@ -25,7 +28,7 @@ async function addResidualTokenBalanceToAssetHolder(assetHolder: typeof erc20Ass
    * in the token contract (setting the token balance of the asset holder to 0)
    * which we would only expect in rare cases.
    */
-  await (await assetHolder.deposit(Y.channelId, 0, 1)).wait(); // other channels are funded by this asset holder
+  await (await nitroAdjudicator.deposit(asset, Y.channelId, 0, 1)).wait(); // other channels are funded by this asset holder
 }
 
 describe('Consumes the expected gas for deployments', () => {
@@ -34,58 +37,46 @@ describe('Consumes the expected gas for deployments', () => {
       gasRequiredTo.deployInfrastructureContracts.vanillaNitro.NitroAdjudicator
     );
   });
-
-  it(`when deploying the ETHAssetHolder`, async () => {
-    await expect(await ethAssetHolder.deployTransaction).toConsumeGas(
-      gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ETHAssetHolder
-    );
-  });
-
-  it(`when deploying the ERC20AssetHolder`, async () => {
-    await expect(await erc20AssetHolder.deployTransaction).toConsumeGas(
-      gasRequiredTo.deployInfrastructureContracts.vanillaNitro.ERC20AssetHolder
-    );
-  });
 });
 describe('Consumes the expected gas for deposits', () => {
   it(`when directly funding a channel with ETH (first deposit)`, async () => {
-    await expect(await ethAssetHolder.deposit(X.channelId, 0, 5, {value: 5})).toConsumeGas(
-      gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro
-    );
+    await expect(
+      await nitroAdjudicator.deposit(constants.AddressZero, X.channelId, 0, 5, {value: 5})
+    ).toConsumeGas(gasRequiredTo.directlyFundAChannelWithETHFirst.vanillaNitro);
   });
 
   it(`when directly funding a channel with ETH (second deposit)`, async () => {
     // begin setup
-    const setupTX = ethAssetHolder.deposit(X.channelId, 0, 5, {value: 5});
+    const setupTX = nitroAdjudicator.deposit(constants.AddressZero, X.channelId, 0, 5, {value: 5});
     await (await setupTX).wait();
     // end setup
-    await expect(await ethAssetHolder.deposit(X.channelId, 5, 5, {value: 5})).toConsumeGas(
-      gasRequiredTo.directlyFundAChannelWithETHSecond.vanillaNitro
-    );
+    await expect(
+      await nitroAdjudicator.deposit(constants.AddressZero, X.channelId, 5, 5, {value: 5})
+    ).toConsumeGas(gasRequiredTo.directlyFundAChannelWithETHSecond.vanillaNitro);
   });
 
   it(`when directly funding a channel with an ERC20 (first deposit)`, async () => {
     // begin setup
-    await (await token.transfer(erc20AssetHolder.address, 1)).wait(); // The asset holder already has some tokens (for other channels)
+    await (await token.transfer(nitroAdjudicator.address, 1)).wait(); // The asset holder already has some tokens (for other channels)
     // end setup
-    await expect(await token.increaseAllowance(erc20AssetHolder.address, 100)).toConsumeGas(
+    await expect(await token.increaseAllowance(nitroAdjudicator.address, 100)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20First.vanillaNitro.approve
     );
-    await expect(await erc20AssetHolder.deposit(X.channelId, 0, 5)).toConsumeGas(
+    await expect(await nitroAdjudicator.deposit(token.address, X.channelId, 0, 5)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20First.vanillaNitro.deposit
     );
   });
 
   it(`when directly funding a channel with an ERC20 (second deposit)`, async () => {
     // begin setup
-    await (await token.increaseAllowance(erc20AssetHolder.address, 100)).wait();
-    await (await erc20AssetHolder.deposit(X.channelId, 0, 5)).wait(); // The asset holder already has some tokens *for this channel*
-    await (await token.decreaseAllowance(erc20AssetHolder.address, 95)).wait(); // reset allowance to zero
+    await (await token.increaseAllowance(nitroAdjudicator.address, 100)).wait();
+    await (await nitroAdjudicator.deposit(token.address, X.channelId, 0, 5)).wait(); // The asset holder already has some tokens *for this channel*
+    await (await token.decreaseAllowance(nitroAdjudicator.address, 95)).wait(); // reset allowance to zero
     // end setup
-    await expect(await token.increaseAllowance(erc20AssetHolder.address, 100)).toConsumeGas(
+    await expect(await token.increaseAllowance(nitroAdjudicator.address, 100)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20Second.vanillaNitro.approve
     );
-    await expect(await erc20AssetHolder.deposit(X.channelId, 5, 5)).toConsumeGas(
+    await expect(await nitroAdjudicator.deposit(token.address, X.channelId, 5, 5)).toConsumeGas(
       gasRequiredTo.directlyFundAChannelWithERC20Second.vanillaNitro.deposit
     );
   });
@@ -93,34 +84,38 @@ describe('Consumes the expected gas for deposits', () => {
 describe('Consumes the expected gas for happy-path exits', () => {
   it(`when exiting a directly funded (with ETH) channel`, async () => {
     // begin setup
-    await (await ethAssetHolder.deposit(X.channelId, 0, 10, {value: 10})).wait();
+    await (
+      await nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, X.channelId, 0, 10, {value: 10})
+    ).wait();
     // end setup
-    await expect(await X.concludePushOutcomeAndTransferAllTx(ethAssetHolder.address)).toConsumeGas(
+    await expect(await X.concludeAndTransferAllAssetsTx(MAGIC_ADDRESS_INDICATING_ETH)).toConsumeGas(
       gasRequiredTo.ETHexit.vanillaNitro
     );
   });
 
   it(`when exiting a directly funded (with ERC20s) channel`, async () => {
     // begin setup
-    await (await token.increaseAllowance(erc20AssetHolder.address, 100)).wait();
-    await (await erc20AssetHolder.deposit(X.channelId, 0, 10)).wait();
-    await addResidualTokenBalanceToAssetHolder(erc20AssetHolder);
+    await (await token.increaseAllowance(nitroAdjudicator.address, 100)).wait();
+    await (await nitroAdjudicator.deposit(token.address, X.channelId, 0, 10)).wait();
+    await addResidualTokenBalance(token.address);
     // end setup
-    await expect(
-      await X.concludePushOutcomeAndTransferAllTx(erc20AssetHolder.address)
-    ).toConsumeGas(gasRequiredTo.ERC20exit.vanillaNitro);
+    await expect(await X.concludeAndTransferAllAssetsTx(token.address)).toConsumeGas(
+      gasRequiredTo.ERC20exit.vanillaNitro
+    );
   });
 });
 
 describe('Consumes the expected gas for sad-path exits', () => {
   it(`when exiting a directly funded (with ETH) channel`, async () => {
     // begin setup
-    await (await ethAssetHolder.deposit(X.channelId, 0, 10, {value: 10})).wait();
+    await (
+      await nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, X.channelId, 0, 10, {value: 10})
+    ).wait();
     // end setup
     // initially                 ⬛ ->  X  -> 👩
     const {proof, finalizesAt} = await challengeChannelAndExpectGas(
       X,
-      ethAssetHolder.address,
+      MAGIC_ADDRESS_INDICATING_ETH,
       gasRequiredTo.ETHexitSad.vanillaNitro.challenge
     );
     // begin wait
@@ -128,35 +123,37 @@ describe('Consumes the expected gas for sad-path exits', () => {
     // end wait
     // challenge + timeout       ⬛ -> (X) -> 👩
     await expect(
-      await nitroAdjudicator.pushOutcomeAndTransferAll(
+      await nitroAdjudicator.transferAllAssets(
         X.channelId,
-        proof.largestTurnNum,
-        finalizesAt, // finalizesAt
+        proof.outcomeBytes, // outcomeBytes,
         proof.stateHash, // stateHash
-        proof.challengerAddress, // challengerAddress
-        proof.outcomeBytes // outcomeBytes
+        proof.challengerAddress // challengerAddress
       )
-    ).toConsumeGas(gasRequiredTo.ETHexitSad.vanillaNitro.pushOutcomeAndTransferAll);
-    // pushOutcomeAndTransferAll ⬛ --------> 👩
+    ).toConsumeGas(gasRequiredTo.ETHexitSad.vanillaNitro.transferAllAssets);
+    // transferAllAssets ⬛ --------> 👩
     expect(
       gasRequiredTo.ETHexitSad.vanillaNitro.challenge +
-        gasRequiredTo.ETHexitSad.vanillaNitro.pushOutcomeAndTransferAll
+        gasRequiredTo.ETHexitSad.vanillaNitro.transferAllAssets
     ).toEqual(gasRequiredTo.ETHexitSad.vanillaNitro.total);
   });
 
   it(`when exiting a ledger funded (with ETH) channel`, async () => {
     // begin setup
-    await (await ethAssetHolder.deposit(LforX.channelId, 0, 10, {value: 10})).wait();
+    await (
+      await nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, LforX.channelId, 0, 10, {
+        value: 10,
+      })
+    ).wait();
     // end setup
     // initially                   ⬛ ->  L  ->  X  -> 👩
     const {proof: ledgerProof, finalizesAt: ledgerFinalizesAt} = await challengeChannelAndExpectGas(
       LforX,
-      ethAssetHolder.address,
+      MAGIC_ADDRESS_INDICATING_ETH,
       gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.challengeL
     );
     const {proof, finalizesAt} = await challengeChannelAndExpectGas(
       X,
-      ethAssetHolder.address,
+      MAGIC_ADDRESS_INDICATING_ETH,
       gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.challengeX
     );
     // begin wait
@@ -164,47 +161,47 @@ describe('Consumes the expected gas for sad-path exits', () => {
     // end wait
     // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
     await expect(
-      await nitroAdjudicator.pushOutcomeAndTransferAll(
+      await nitroAdjudicator.transferAllAssets(
         LforX.channelId,
-        ledgerProof.largestTurnNum,
-        ledgerFinalizesAt, // finalizesAt
+        ledgerProof.outcomeBytes, // outcomeBytes
         ledgerProof.stateHash, // stateHash
-        ledgerProof.challengerAddress, // challengerAddress
-        ledgerProof.outcomeBytes // outcomeBytes
+        ledgerProof.challengerAddress // challengerAddress
       )
-    ).toConsumeGas(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.pushOutcomeAndTransferAllL);
-    // pushOutcomeAndTransferAllL  ⬛ --------> (X) -> 👩
+    ).toConsumeGas(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.transferAllAssetsL);
+    // transferAllAssetsL  ⬛ --------> (X) -> 👩
     await expect(
-      await nitroAdjudicator.pushOutcomeAndTransferAll(
+      await nitroAdjudicator.transferAllAssets(
         X.channelId,
-        proof.largestTurnNum,
-        finalizesAt, // finalizesAt
+        proof.outcomeBytes, // outcomeBytes
         proof.stateHash, // stateHash
-        proof.challengerAddress, // challengerAddress
-        proof.outcomeBytes // outcomeBytes
+        proof.challengerAddress // challengerAddress
       )
-    ).toConsumeGas(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.pushOutcomeAndTransferAllX);
-    // pushOutcomeAndTransferAllX  ⬛ ---------------> 👩
+    ).toConsumeGas(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.transferAllAssetsX);
+    // transferAllAssetsX  ⬛ ---------------> 👩
 
     // meta-test here to confirm the total recorded in gas.ts is up to date
     // with the recorded costs of each step
     expect(
       gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.challengeL +
-        gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.pushOutcomeAndTransferAllL +
+        gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.transferAllAssetsL +
         gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.challengeX +
-        gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.pushOutcomeAndTransferAllX
+        gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.transferAllAssetsX
     ).toEqual(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.total);
   });
 
   it(`when exiting a virtual funded (with ETH) channel`, async () => {
     // begin setup
-    await (await ethAssetHolder.deposit(LforG.channelId, 0, 10, {value: 10})).wait();
+    await (
+      await nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, LforG.channelId, 0, 10, {
+        value: 10,
+      })
+    ).wait();
     // end setup
     // initially                   ⬛ ->  L  ->  G  ->  J  ->  X  -> 👩
     // challenge L
     const {proof: ledgerProof, finalizesAt: ledgerFinalizesAt} = await challengeChannelAndExpectGas(
       LforG,
-      ethAssetHolder.address,
+      MAGIC_ADDRESS_INDICATING_ETH,
       gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.challengeL
     );
     // challenge G
@@ -213,7 +210,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
       finalizesAt: guarantorFinalizesAt,
     } = await challengeChannelAndExpectGas(
       G,
-      ethAssetHolder.address,
+      MAGIC_ADDRESS_INDICATING_ETH,
       gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.challengeG
     );
     // challenge J
@@ -222,13 +219,13 @@ describe('Consumes the expected gas for sad-path exits', () => {
       finalizesAt: jointChannelFinalizesAt,
     } = await challengeChannelAndExpectGas(
       J,
-      ethAssetHolder.address,
+      MAGIC_ADDRESS_INDICATING_ETH,
       gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.challengeJ
     );
     // challenge X
     const {proof, finalizesAt} = await challengeChannelAndExpectGas(
       X,
-      ethAssetHolder.address,
+      MAGIC_ADDRESS_INDICATING_ETH,
       gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.challengeX
     );
     // begin wait
@@ -241,58 +238,37 @@ describe('Consumes the expected gas for sad-path exits', () => {
     // end wait
     // challenge L,G,J,X + timeout ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
     await expect(
-      await nitroAdjudicator.pushOutcomeAndTransferAll(
+      await nitroAdjudicator.transferAllAssets(
         LforG.channelId,
-        ledgerProof.largestTurnNum,
-        ledgerFinalizesAt, // finalizesAt
+        ledgerProof.outcomeBytes, // outcomeBytes
         ledgerProof.stateHash, // stateHash
-        ledgerProof.challengerAddress, // challengerAddress
-        ledgerProof.outcomeBytes // outcomeBytes
+        ledgerProof.challengerAddress // challengerAddress
       )
-    ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.pushOutcomeAndTransferAllL);
-    // pushOutcomeAndTransferAllL  ⬛ --------> (G) -> (J) -> (X) -> 👩
+    ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.transferAllAssetsL);
+    // transferAllAssetsL  ⬛ --------> (G) -> (J) -> (X) -> 👩
     await expect(
-      await nitroAdjudicator.pushOutcome(
+      await nitroAdjudicator.claim(
+        0,
         G.channelId,
-        guarantorProof.largestTurnNum,
-        guarantorFinalizesAt,
+        encodeOutcome(G.outcome(constants.AddressZero)),
         guarantorProof.stateHash,
         guarantorProof.challengerAddress,
-        guarantorProof.outcomeBytes
-      )
-    ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.pushOutcomeG);
-    // pushOutcomeG                ⬛ --------> (G) -> (J) -> (X) -> 👩
-    await expect(
-      await nitroAdjudicator.pushOutcome(
-        J.channelId,
-        jointProof.largestTurnNum,
-        jointChannelFinalizesAt,
+        encodeOutcome(J.outcome(constants.AddressZero)),
         jointProof.stateHash,
         jointProof.challengerAddress,
-        jointProof.outcomeBytes
-      )
-    ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.pushOutcomeJ);
-    // pushOutcomeJ                ⬛ --------> (G) -> (J) -> (X) -> 👩
-    await expect(
-      await ethAssetHolder.claim(
-        G.channelId,
-        encodeGuarantee(G.guaranteeOrAllocation as Guarantee),
-        encodeAllocation(J.guaranteeOrAllocation as Allocation),
         [] // meaning "all"
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.claimG);
     // claimG                      ⬛ ----------------------> (X) -> 👩
     await expect(
-      await nitroAdjudicator.pushOutcomeAndTransferAll(
+      await nitroAdjudicator.transferAllAssets(
         X.channelId,
-        proof.largestTurnNum,
-        finalizesAt, // finalizesAt
+        proof.outcomeBytes, // outcomeBytes
         proof.stateHash, // stateHash
-        proof.challengerAddress, // challengerAddress
-        proof.outcomeBytes // outcomeBytes
+        proof.challengerAddress // challengerAddress
       )
-    ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.pushOutcomeAndTransferAllX);
-    // pushOutcomeAndTransferAllX  ⬛ -----------------------------> 👩
+    ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.transferAllAssetsX);
+    // transferAllAssetsX  ⬛ -----------------------------> 👩
 
     // meta-test here to confirm the total recorded in gas.ts is up to date
     // with the recorded costs of each step

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,17 +28,15 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 2416171, // Singleton
-      ETHAssetHolder: 1636603, // Singleton (could be more in principle)
-      ERC20AssetHolder: 1659990, // Per Token (could be more in principle)
+      NitroAdjudicator: 3954624, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
-    vanillaNitro: 47608,
+    vanillaNitro: 48754,
   },
   directlyFundAChannelWithETHSecond: {
     // meaning the second participant in the channel
-    vanillaNitro: 30520,
+    vanillaNitro: 31666,
   },
   directlyFundAChannelWithERC20First: {
     // The depositor begins with zero tokens approved for the AssetHolder
@@ -50,7 +48,7 @@ export const gasRequiredTo: GasRequiredTo = {
       // ^^^^^
       // In principle this only needs to be done once per account
       // (the cost may be amortized over several deposits into this AssetHolder)
-      deposit: 72854,
+      deposit: 72132,
     },
   },
   directlyFundAChannelWithERC20Second: {
@@ -60,26 +58,26 @@ export const gasRequiredTo: GasRequiredTo = {
       // ^^^^^
       // In principle this only needs to be done once per account
       // (the cost may be amortized over several deposits into this AssetHolder)
-      deposit: 55766,
+      deposit: 55044,
     },
   },
   ETHexit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 146769,
+    vanillaNitro: 153944,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 139124,
+    vanillaNitro: 144333,
   },
   ETHexitSad: {
     // Scenario: Counterparty Bob goes offline
     // initially                 ⬛ ->  X  -> 👩
     // challenge + timeout       ⬛ -> (X) -> 👩
-    // pushOutcomeAndTransferAll ⬛ --------> 👩
+    // transferAllAssets         ⬛ --------> 👩
     vanillaNitro: {
-      challenge: 93390,
-      pushOutcomeAndTransferAll: 107733,
-      total: 201123,
+      challenge: 93193,
+      transferAllAssets: 115660,
+      total: 208853,
     },
   },
   ETHexitSadLedgerFunded: {
@@ -87,13 +85,13 @@ export const gasRequiredTo: GasRequiredTo = {
     vanillaNitro: {
       // initially                   ⬛ ->  L  ->  X  -> 👩
       // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
-      // pushOutcomeAndTransferAllL  ⬛ --------> (X) -> 👩
-      // pushOutcomeAndTransferAllX  ⬛ ---------------> 👩
-      challengeX: 93390,
-      challengeL: 92324,
-      pushOutcomeAndTransferAllL: 58631,
-      pushOutcomeAndTransferAllX: 107733,
-      total: 352078,
+      // transferAllAssetsL          ⬛ --------> (X) -> 👩
+      // transferAllAssetsX          ⬛ ---------------> 👩
+      challengeX: 93193,
+      challengeL: 92127,
+      transferAllAssetsL: 65206,
+      transferAllAssetsX: 115660,
+      total: 366186,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -101,21 +99,17 @@ export const gasRequiredTo: GasRequiredTo = {
     vanillaNitro: {
       // initially                   ⬛ ->  L  ->  G  ->  J  ->  X  -> 👩
       // challenge L,G,J,X + timeout ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
-      // pushOutcomeAndTransferAllL  ⬛ --------> (G) -> (J) -> (X) -> 👩
-      // pushOutcomeG                ⬛ --------> (G) -> (J) -> (X) -> 👩
-      // pushOutcomeJ                ⬛ --------> (G) -> (J) -> (X) -> 👩
+      // transferAllAssetsL          ⬛ --------> (G) -> (J) -> (X) -> 👩
       // claimG                      ⬛ ----------------------> (X) -> 👩
-      // pushOutcomeAndTransferAllX  ⬛ -----------------------------> 👩
-      challengeL: 92336,
-      challengeG: 94607,
-      challengeJ: 101741,
-      challengeX: 93390,
-      pushOutcomeAndTransferAllL: 58643,
-      pushOutcomeG: 61410,
-      pushOutcomeJ: 60558,
-      claimG: 58492,
-      pushOutcomeAndTransferAllX: 107733,
-      total: 728910,
+      // transferAllAssetsX          ⬛ -----------------------------> 👩
+      challengeL: 92127,
+      challengeG: 94386,
+      challengeJ: 101504,
+      challengeX: 93193,
+      transferAllAssetsL: 65206,
+      claimG: 80266,
+      transferAllAssetsX: 115660,
+      total: 642342,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
+++ b/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
@@ -8,12 +8,8 @@ import kill from 'tree-kill';
 import {BigNumber} from '@ethersproject/bignumber';
 
 import nitroAdjudicatorArtifact from '../artifacts/contracts/NitroAdjudicator.sol/NitroAdjudicator.json';
-import ethAssetHolderArtifact from '../artifacts/contracts/ETHAssetHolder.sol/ETHAssetHolder.json';
-import erc20AssetHolderArtifact from '../artifacts/contracts/ERC20AssetHolder.sol/ERC20AssetHolder.json';
 import tokenArtifact from '../artifacts/contracts/Token.sol/Token.json';
 import {NitroAdjudicator} from '../typechain/NitroAdjudicator';
-import {ETHAssetHolder} from '../typechain/ETHAssetHolder';
-import {ERC20AssetHolder} from '../typechain/ERC20AssetHolder';
 import {Token} from '../typechain/Token';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -24,8 +20,6 @@ declare global {
   }
 }
 
-export let ethAssetHolder: ETHAssetHolder & Contract;
-export let erc20AssetHolder: ERC20AssetHolder & Contract;
 export let nitroAdjudicator: NitroAdjudicator & Contract;
 export let token: Token & Contract;
 
@@ -44,19 +38,9 @@ export const provider = new providers.JsonRpcProvider(hardHatNetworkEndpoint);
 
 let snapshotId = 0;
 
-const ethAssetHolderFactory = new ContractFactory(
-  ethAssetHolderArtifact.abi,
-  ethAssetHolderArtifact.bytecode
-).connect(provider.getSigner(0));
-
 const tokenFactory = new ContractFactory(tokenArtifact.abi, tokenArtifact.bytecode).connect(
   provider.getSigner(0)
 );
-
-const erc20AssetHolderFactory = new ContractFactory(
-  erc20AssetHolderArtifact.abi,
-  erc20AssetHolderArtifact.bytecode
-).connect(provider.getSigner(0));
 
 const nitroAdjudicatorFactory = new ContractFactory(
   nitroAdjudicatorArtifact.abi,
@@ -66,14 +50,7 @@ const nitroAdjudicatorFactory = new ContractFactory(
 beforeAll(async () => {
   await waitOn({resources: [hardHatNetworkEndpoint]});
   nitroAdjudicator = (await nitroAdjudicatorFactory.deploy()) as NitroAdjudicator & Contract;
-  ethAssetHolder = (await ethAssetHolderFactory.deploy(
-    nitroAdjudicator.address
-  )) as ETHAssetHolder & Contract;
   token = (await tokenFactory.deploy(provider.getSigner(0).getAddress())) as Token & Contract;
-  erc20AssetHolder = (await erc20AssetHolderFactory.deploy(
-    nitroAdjudicator.address,
-    token.address
-  )) as ERC20AssetHolder & Contract;
   snapshotId = await provider.send('evm_snapshot', []);
 });
 

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -1,4 +1,4 @@
-import {providers, Signature} from 'ethers';
+import {constants, providers, Signature} from 'ethers';
 
 import {State} from './contract/state';
 import * as forceMoveTrans from './contract/transaction-creators/force-move';
@@ -6,6 +6,7 @@ import * as nitroAdjudicatorTrans from './contract/transaction-creators/nitro-ad
 import {getStateSignerAddress, SignedState} from './signatures';
 
 // CONSTANTS
+export const MAGIC_ADDRESS_INDICATING_ETH = constants.AddressZero;
 export const MAX_TX_DATA_SIZE = 128 * 1024; // (bytes) https://github.com/ethereum/go-ethereum/blob/f59ed3565d18c1fa676fd34f4fd41ecccad707e8/core/tx_pool.go#L51
 export const NITRO_MAX_GAS = 6_000_000; // should be below the block gas limit, which can change over time and is generally different on mainnet, testnet and ganache.
 // sampling some recent blocks on 26/11/2020:
@@ -53,11 +54,11 @@ export function createCheckpointTransaction(
   });
 }
 
-export function createConcludePushOutcomeAndTransferAllTransaction(
+export function createConcludeAndTransferAllAssetsTransaction(
   signedStates: SignedState[]
 ): providers.TransactionRequest {
   const {states, signatures, whoSignedWhat} = createSignatureArguments(signedStates);
-  return nitroAdjudicatorTrans.createConcludePushOutcomeAndTransferAllTransaction(
+  return nitroAdjudicatorTrans.createConcludeAndTransferAllAssetsTransaction(
     states,
     signatures,
     whoSignedWhat
@@ -70,16 +71,6 @@ export function createConcludeTransaction(
   const {states, signatures, whoSignedWhat} = createSignatureArguments(conclusionProof);
   return forceMoveTrans.createConcludeTransaction(states, signatures, whoSignedWhat);
 }
-
-export const createPushOutcomeTransaction: (
-  arg: nitroAdjudicatorTrans.PushOutcomeTransactionArg
-) => providers.TransactionRequest = nitroAdjudicatorTrans.createPushOutcomeTransactionFactory(
-  false
-);
-
-export const createPushOutcomeAndTransferAllTransaction: (
-  arg: nitroAdjudicatorTrans.PushOutcomeTransactionArg
-) => providers.TransactionRequest = nitroAdjudicatorTrans.createPushOutcomeTransactionFactory(true);
 
 // Currently we assume each signedState is a unique combination of state/signature
 // So if multiple participants sign a state we expect a SignedState for each participant


### PR DESCRIPTION
...to reflect removal of pushOutcome. 

This PR shows off the new flows enabled by the new architecture. 

It also shows off the fact that the new implementation is not gas optimised; although we still get some gas savings by removing `pushOutcome` I expect there is quite a lot of room for improvement in future PRs. 

⚠️ base not master. 

Expected to pass:
* `yarn contract:compile` in nitro-protocol
* `yarn test:gas` in nitro-protocol

Expected to fail
* everything else



