### PR TITLE
point AssetHolder tests at MultiAssetHolder

### DIFF
--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/computeNewAllocationWithGuarantee.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/computeNewAllocationWithGuarantee.test.ts
@@ -1,4 +1,4 @@
-import {Contract, BigNumber} from 'ethers';
+import {BigNumber} from 'ethers';
 import shuffle from 'lodash.shuffle';
 
 import {
@@ -7,22 +7,18 @@ import {
   randomExternalDestination,
   randomChannelId,
 } from '../../test-helpers';
+import {TESTNitroAdjudicator} from '../../../typechain/TESTNitroAdjudicator';
 // eslint-disable-next-line import/order
-import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
+import TESTNitroAdjudicatorArtifact from '../../../artifacts/contracts/test/TESTNitroAdjudicator.sol/TESTNitroAdjudicator.json';
 
-const provider = getTestProvider();
-
-let AssetHolder: Contract;
-
-beforeAll(async () => {
-  AssetHolder = setupContract(provider, AssetHolderArtifact, process.env.TEST_ASSET_HOLDER_ADDRESS);
-});
+const testNitroAdjudicator = (setupContract(
+  getTestProvider(),
+  TESTNitroAdjudicatorArtifact,
+  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS
+) as unknown) as TESTNitroAdjudicator;
 
 import {AllocationItem, Guarantee} from '../../../src';
-import {
-  computeNewAllocation,
-  computeNewAllocationWithGuarantee,
-} from '../../../src/contract/asset-holder';
+import {computeNewAllocationWithGuarantee} from '../../../src/contract/multi-asset-holder';
 
 const randomAllocation = (numAllocationItems: number): AllocationItem[] => {
   return numAllocationItems > 0
@@ -59,12 +55,12 @@ describe('AsserHolder._computeNewAllocationWithGuarantee', () => {
       guarantee
     );
 
-    const result = (await AssetHolder._computeNewAllocationWithGuarantee(
+    const result = await testNitroAdjudicator._computeNewAllocationWithGuarantee(
       BigNumber.from(heldBefore),
       allocation,
       indices,
       guarantee
-    )) as ReturnType<typeof computeNewAllocation>;
+    );
 
     expect(result).toBeDefined();
     expect(result.newAllocation).toMatchObject(

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/isExternalDestination.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/isExternalDestination.test.ts
@@ -1,11 +1,14 @@
-import {Contract, Wallet} from 'ethers';
+import {Wallet} from 'ethers';
 
-import AssetHolderArtifact from '../../../artifacts/contracts/test/TESTAssetHolder.sol/TESTAssetHolder.json';
 import {getTestProvider, setupContract} from '../../test-helpers';
+import {TESTNitroAdjudicator} from '../../../typechain/TESTNitroAdjudicator';
+import TESTNitroAdjudicatorArtifact from '../../../artifacts/contracts/test/TESTNitroAdjudicator.sol/TESTNitroAdjudicator.json';
 
-const provider = getTestProvider();
-
-let AssetHolder: Contract;
+const testNitroAdjudicator = (setupContract(
+  getTestProvider(),
+  TESTNitroAdjudicatorArtifact,
+  process.env.TEST_NITRO_ADJUDICATOR_ADDRESS
+) as unknown) as TESTNitroAdjudicator;
 
 const participants = ['', '', ''];
 const wallets = new Array(3);
@@ -16,19 +19,19 @@ for (let i = 0; i < 3; i++) {
   participants[i] = wallets[i].address;
 }
 
-beforeAll(async () => {
-  AssetHolder = setupContract(provider, AssetHolderArtifact, process.env.TEST_ASSET_HOLDER_ADDRESS);
-});
-
 describe('isExternalDestination', () => {
   it('verifies an external destination', async () => {
     const zerosPaddedExternalDestination =
       '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padStart(64, '0');
-    expect(await AssetHolder.isExternalDestination(zerosPaddedExternalDestination)).toBe(true);
+    expect(await testNitroAdjudicator.isExternalDestination(zerosPaddedExternalDestination)).toBe(
+      true
+    );
   });
   it('rejects a non-external-address', async () => {
     const onesPaddedExternalDestination =
       '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padStart(64, '1');
-    expect(await AssetHolder.isExternalDestination(onesPaddedExternalDestination)).toBe(false);
+    expect(await testNitroAdjudicator.isExternalDestination(onesPaddedExternalDestination)).toBe(
+      false
+    );
   });
 });

--- a/packages/nitro-protocol/test/src/contract/multi-asset-holder.test.ts
+++ b/packages/nitro-protocol/test/src/contract/multi-asset-holder.test.ts
@@ -1,4 +1,4 @@
-import {convertBytes32ToAddress} from '../../../src/contract/asset-holder';
+import {convertBytes32ToAddress} from '../../../src/contract/multi-asset-holder';
 
 describe('convertBytes32ToAddress', () => {
   it.each`


### PR DESCRIPTION
This is just a simple change so that the existing test suite can run against the new architecture.