### PR TITLE
gas optimise `transferAllAssets`

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 3954624, // Singleton
+      NitroAdjudicator: 4045127, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -63,11 +63,11 @@ export const gasRequiredTo: GasRequiredTo = {
   },
   ETHexit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 153944,
+    vanillaNitro: 149232,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 144333,
+    vanillaNitro: 139621,
   },
   ETHexitSad: {
     // Scenario: Counterparty Bob goes offline
@@ -76,8 +76,8 @@ export const gasRequiredTo: GasRequiredTo = {
     // transferAllAssets         ⬛ --------> 👩
     vanillaNitro: {
       challenge: 93193,
-      transferAllAssets: 115660,
-      total: 208853,
+      transferAllAssets: 110955,
+      total: 204148,
     },
   },
   ETHexitSadLedgerFunded: {
@@ -89,9 +89,9 @@ export const gasRequiredTo: GasRequiredTo = {
       // transferAllAssetsX          ⬛ ---------------> 👩
       challengeX: 93193,
       challengeL: 92127,
-      transferAllAssetsL: 65206,
-      transferAllAssetsX: 115660,
-      total: 366186,
+      transferAllAssetsL: 60920,
+      transferAllAssetsX: 110955,
+      total: 357195,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -106,10 +106,10 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeG: 94386,
       challengeJ: 101504,
       challengeX: 93193,
-      transferAllAssetsL: 65206,
+      transferAllAssetsL: 60920,
       claimG: 80266,
-      transferAllAssetsX: 115660,
-      total: 642342,
+      transferAllAssetsX: 110955,
+      total: 633351,
     },
   },
 };

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
@@ -160,10 +160,8 @@ describe('transferAllAssets', () => {
       } else {
         const {events: eventsFromTx} = await (await tx1).wait();
 
-        // we expect a FingerprintUpdated event for each asset. This may change under future optimizations
+        // we expect a single FingerprintUpdated event.
         expect(eventsFromTx[0].event).toEqual('FingerprintUpdated');
-        // expect(eventsFromTx[1].event).toEqual('Transfer'); // TODO I do not know why the "event" property does not exist on this one
-        expect(eventsFromTx[2].event).toEqual('FingerprintUpdated');
 
         // Check new status
         const outcomeAfter: Outcome = computeOutcome(newOutcome);


### PR DESCRIPTION
The existing implementation of this function calls into an "outer" `transfer` function in a loop. This is inefficient because for every asset
* indices are checked for validity (monotonically increasing) unnecessarily
* events are emitted
* storage is checked and written to

This PR has the function in question call in to the inner `_transfer` function in the loop, and then has the requisite checks and writes to storage performed once before/after the loop.

~The commit history will show that~ I flirted with deleting the `statusOf` storage variable as a further optimisation, but decided against doing that now (see #3394). 

