### PR TITLE
Stop store from always logging to console

### DIFF
--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -49,8 +49,6 @@ import {ChainServiceRequest} from '../models/chain-service-request';
 import {AdjudicatorStatusModel} from '../models/adjudicator-status';
 import {WaitingFor as OpenChannelWaitingFor} from '../protocols/channel-opener';
 
-const defaultLogger = createLogger(defaultTestWalletConfig());
-
 export type AppHandler<T> = (tx: Transaction, channelRecord: Channel) => T;
 export type MissingAppHandler<T> = (channelId: string) => T;
 
@@ -59,8 +57,7 @@ const throwMissingChannel: MissingAppHandler<any> = (channelId: string) => {
 };
 
 export class Store {
-  readonly logger: Logger = defaultLogger;
-
+  readonly logger: Logger;
   constructor(
     public readonly knex: Knex,
     readonly timingMetrics: boolean,
@@ -68,6 +65,7 @@ export class Store {
     readonly chainNetworkID: string,
     logger?: Logger
   ) {
+    this.logger = logger ?? createLogger(defaultTestWalletConfig());
     if (timingMetrics) {
       this.getOrCreateSigningAddress = recordFunctionMetrics(this.getOrCreateSigningAddress);
       this.lockApp = recordFunctionMetrics(this.lockApp);
@@ -79,7 +77,6 @@ export class Store {
       this.addSignedState = recordFunctionMetrics(this.addSignedState);
 
       setupDBMetrics(this.knex);
-      if (logger) this.logger = logger;
     }
   }
 


### PR DESCRIPTION
Previously the store would only set the logger if `timingMetrics` were enabled. Otherwise, it defaulted to a logger that outputted to the console. This means that it would log out to the console instead of using the logger provided from the wallet/engine.

Now the store properly sets the logger if one is provided. This gets rid of those annoying "missing bytecode" console logs that we see all the time.
