### PR TITLE
swap `assetHolderAddress` column for `isLedgerChannel` column in channels table

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -379,7 +379,7 @@ export class SingleThreadedEngine implements EngineInterface {
     destroy(): Promise<void>;
     getApprovedObjectives(): Promise<WalletObjective[]>;
     getChannels(): Promise<MultipleChannelOutput>;
-    getLedgerChannels(assetHolderAddress: string, participants: Participant_2[]): Promise<MultipleChannelOutput>;
+    getLedgerChannels(participants: Participant_2[]): Promise<MultipleChannelOutput>;
     getObjective(objectiveId: string): Promise<WalletObjective>;
     getSigningAddress(): Promise<Address>;
     getState({ channelId }: GetStateParams): Promise<SingleChannelOutput>;

--- a/packages/server-wallet/src/db/migrations/20201014174041_ledgers.ts
+++ b/packages/server-wallet/src/db/migrations/20201014174041_ledgers.ts
@@ -2,14 +2,14 @@ import * as Knex from 'knex';
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.table('channels', function (table) {
-    table.string('asset_holder_address');
+    table.boolean('is_ledger_channel').notNullable().defaultTo(false);
     table.string('funding_ledger_channel_id');
   });
 }
 
 export async function down(knex: Knex): Promise<any> {
   await knex.schema.table('channels', function (table) {
-    table.dropColumn('asset_holder_address');
+    table.dropColumn('is_ledger_channel');
     table.dropColumn('funding_ledger_channel_id');
   });
 }

--- a/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
+++ b/packages/server-wallet/src/db/migrations/20201027090001_channels_indexes.ts
@@ -1,6 +1,6 @@
 import * as Knex from 'knex';
 
-const COLUMNS = ['asset_holder_address', 'participants'];
+const COLUMNS = ['participants'];
 
 export async function up(knex: Knex): Promise<any> {
   await knex.schema.alterTable('channels', function (t) {

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
@@ -314,7 +314,7 @@ export class TestChannel {
 
     // make it a ledger here
     if (this.isLedger) {
-      await Channel.setLedger(this.channelId, this.startOutcome.assetHolderAddress, store.knex);
+      await Channel.setLedger(this.channelId, store.knex);
     }
 
     const {fundingStrategy, fundingLedgerChannelId} = objective.data;

--- a/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/create-ledger-channel.test.ts
@@ -76,9 +76,7 @@ describe('happy path', () => {
       supported: undefined,
     });
 
-    await expect(
-      w.getLedgerChannels(allocations[0].assetHolderAddress, participants)
-    ).resolves.toMatchObject({
+    await expect(w.getLedgerChannels(participants)).resolves.toMatchObject({
       channelResults: [
         {
           channelId,

--- a/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
+++ b/packages/server-wallet/src/engine/__test__/integration/join-channel.test.ts
@@ -5,7 +5,6 @@ import {
   serializeAllocation,
   serializeOutcome,
 } from '@statechannels/wallet-core';
-import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
 import Objection from 'objection';
 
 import {Channel} from '../../../models/channel';
@@ -230,7 +229,7 @@ describe('ledger funded app scenarios', () => {
       })
     );
 
-    await Channel.setLedger(ledger.channelId, ETH_ASSET_HOLDER_ADDRESS, w.knex);
+    await Channel.setLedger(ledger.channelId, w.knex);
 
     // Generate application channel
     app = channel({

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -641,18 +641,13 @@ export class SingleThreadedEngine implements EngineInterface {
   /**
    * Gets the latest state for each ledger channel in the engine's store.
    *
-   * @param assetHolderAddress - The on chain address of an asset holder contract funding the ledger channels (filters the query).
    * @param participants - The list of participants in the ledger channel (filters the query).
    * @returns A promise that resolves to the channel output.
    */
-  async getLedgerChannels(
-    assetHolderAddress: string,
-    participants: APIParticipant[]
-  ): Promise<MultipleChannelOutput> {
+  async getLedgerChannels(participants: APIParticipant[]): Promise<MultipleChannelOutput> {
     const response = EngineResponse.initialize();
 
     const channelStates = await this.store.getLedgerChannels(
-      assetHolderAddress,
       participants.map(convertToParticipant)
     );
 

--- a/packages/server-wallet/src/models/__test__/fixtures/channel.ts
+++ b/packages/server-wallet/src/models/__test__/fixtures/channel.ts
@@ -21,6 +21,7 @@ export const channel: Fixture<Channel> = (props?: DeepPartial<RequiredColumns>) 
     signingAddress: alice().address,
     vars: [],
     fundingStrategy: 'Direct',
+    isLedgerChannel: false,
   };
 
   const columns: RequiredColumns = _.merge(defaults, props);


### PR DESCRIPTION
Our server wallet database schema has a `channels` table with an `assetHolderAddress` column.  This is currently only used for flagging when a channel is a ledger channel.  This is needlessly indirect and potentially confusing, as well as making refactoring the contract architecture difficult (what if there aren't any asset holders). 



This approach is good because the new column name and data type more accurately reflect the semantic meaning of the information being stored. It also makes #3624 easier to achieve. 

There's one point of contention, which is the way I have updated the db migrations here. I have just edited an existing migration file rather than adding a new migration to rename the column name. I figured this was preferable because we have no DBs in production right now, and we already have many meanders in the list of migrations that make it more difficult to infer what the actual db schema is. 

### Changes 
DB schema modified
Channel model modified
isLedger, setLedger etc changed to not require an asset holder address.

---
Aside: My guess for the original motivation for using asset holder address to stand for a ledger channel is as follows: 
* ledger channels must be directly funded (incorrect); 
* ledger channels can only have one asset holding contract (incorrect)
* application channels will not be directly funded (incorrect); 
* being directly funded means that there is an contract holding assets for the channel (correct); 
* being indirectly funded means there is no contract holding assets for the channel (mostly incorrect, because if I have to liquidate ledger or virtual channels via the sad path they become directly funded). 

So generally based on (at best) a long list of implicit assumptions or (at worst) things that are simply untrue.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue

