### PR TITLE
Remove (another) duplicate abi.encode call

### DIFF
--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -120,10 +120,11 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         outcome[assetIndex].assetOutcomeBytes = abi.encode(
             Outcome.AssetOutcome(Outcome.AssetOutcomeType.Allocation, abi.encode(allocation))
         );
-        bytes32 outcomeHash = keccak256(abi.encode(outcome));
+        outcomeBytes = abi.encode(outcome);
+        bytes32 outcomeHash = keccak256(outcomeBytes);
         _updateFingerprint(fromChannelId, stateHash, challengerAddress, outcomeHash);
-        emit FingerprintUpdated(fromChannelId, abi.encode(outcome));
-        return abi.encode(outcome);
+        emit FingerprintUpdated(fromChannelId, outcomeBytes);
+        return outcomeBytes;
     }
 
     /**

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 4039323, // Singleton
+      NitroAdjudicator: 4025938, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {


### PR DESCRIPTION
This was spotted by Andrew and is similar to the previous PR.

Notable:
- this change **only** had effects on the deploy gas cost. It looks like the benchmarking suite takes the `transferAllAssets` route for each case. In the happy-path it gets there via [concludeAndTransferAllAssets](https://github.com/statechannels/statechannels/blob/cfba1f6975cbdd85958254ff8abb54c9722fc351/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts#L91), and [directly](https://github.com/statechannels/statechannels/blob/cfba1f6975cbdd85958254ff8abb54c9722fc351/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts#L126) in the sad-path. Do we consider this a gap in the benchmarking?
- unlike the previous PR, this one re-uses the `outcomeBytes memory` function parameter, which I think in context is OK, but I thought worth pointing out in case it isn't

## How Has This Been Tested? [Optional] 

`yarn prepare && yarn test:gas`
