### PR TITLE
update chain service to not use asset holders or pushoutcome

### DIFF
--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -19,7 +19,7 @@
         },
         "asset": {
           "$ref": "#/definitions/Address",
-          "description": "The asset holder contract address"
+          "description": "The contract address of the asset"
         }
       },
       "required": [

--- a/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
@@ -57,7 +57,7 @@ export function createConcludeAndTransferAllAssetsTransaction(
   };
 }
 
-export function transferAllAssetsArgs(
+function transferAllAssetsArgs(
   state: State,
   challengerAddress: string,
   overrideStateHash = false // set to true if channel concluded happily

--- a/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
@@ -1,6 +1,7 @@
-import {utils, providers, Signature} from 'ethers';
+import {utils, providers, Signature, constants} from 'ethers';
 
 import NitroAdjudicatorArtifact from '../../../artifacts/contracts/NitroAdjudicator.sol/NitroAdjudicator.json';
+import {getChannelId, hashState} from '../../';
 import {encodeOutcome} from '../outcome';
 import {getFixedPart, hashAppPart, State} from '../state';
 
@@ -52,6 +53,30 @@ export function createConcludeAndTransferAllAssetsTransaction(
     data: NitroAdjudicatorContractInterface.encodeFunctionData(
       'concludeAndTransferAllAssets',
       concludeAndTransferAllAssetsArgs(states, signatures, whoSignedWhat)
+    ),
+  };
+}
+
+export function transferAllAssetsArgs(
+  state: State,
+  challengerAddress: string,
+  overrideStateHash = false // set to true if channel concluded happily
+): any[] {
+  const channelId = getChannelId(state.channel);
+  const outcomeBytes = encodeOutcome(state.outcome);
+  const stateHash = overrideStateHash ? constants.HashZero : hashState(state);
+  return [channelId, outcomeBytes, stateHash, challengerAddress];
+}
+
+export function createTransferAllAssetsTransaction(
+  state: State,
+  challengerAddress: string,
+  overrideStateHash = false // set to true if channel concluded happily
+): providers.TransactionRequest {
+  return {
+    data: NitroAdjudicatorContractInterface.encodeFunctionData(
+      'transferAllAssets',
+      transferAllAssetsArgs(state, challengerAddress, overrideStateHash)
     ),
   };
 }

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -65,6 +65,13 @@ export function createConcludeAndTransferAllAssetsTransaction(
   );
 }
 
+export function createTransferAllAssetsTransaction(
+  state: State,
+  challengerAddress: string
+): providers.TransactionRequest {
+  return nitroAdjudicatorTrans.createTransferAllAssetsTransaction(state, challengerAddress);
+}
+
 export function createConcludeTransaction(
   conclusionProof: SignedState[]
 ): providers.TransactionRequest {

--- a/packages/server-wallet/src/__chain-test__/socket-io-directly-funded-channel.test.ts
+++ b/packages/server-wallet/src/__chain-test__/socket-io-directly-funded-channel.test.ts
@@ -22,7 +22,7 @@ import {SocketIOMessageService} from '../message-service/socket-io-message-servi
 jest.setTimeout(60_000);
 
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
-const ethAssetHolderAddress = makeAddress(process.env.ETH_ASSET_HOLDER_ADDRESS!);
+const nitroAdjudicatorAddress = makeAddress(process.env.NITRO_ADJUDICATOR_ADDRESS!);
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
 if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
 // eslint-disable-next-line no-process-env, @typescript-eslint/no-non-null-assertion
@@ -120,12 +120,12 @@ beforeAll(async () => {
   await a.registerPeerMessageService(`http://localhost:${B_PORT}`);
   await b.registerPeerMessageService(`http://localhost:${A_PORT}`);
 
-  const assetHolder = new Contract(
-    ethAssetHolderAddress,
-    ContractArtifacts.EthAssetHolderArtifact.abi,
+  const nitroAdjudicator = new Contract(
+    nitroAdjudicatorAddress,
+    ContractArtifacts.NitroAdjudicatorArtifact.abi,
     provider
   );
-  mineOnEvent(assetHolder);
+  mineOnEvent(nitroAdjudicator);
 });
 
 afterAll(async () => {
@@ -160,7 +160,7 @@ test.each(['A', 'B'])(
           amount: bFunding,
         },
       ],
-      assetHolderAddress: ethAssetHolderAddress,
+      asset: constants.AddressZero,
     };
 
     const channelParams: CreateChannelParams = {
@@ -173,7 +173,7 @@ test.each(['A', 'B'])(
     };
     const aBalanceInit = await getBalance(aAddress);
     const bBalanceInit = await getBalance(bAddress);
-    const assetHolderBalanceInit = await getBalance(ethAssetHolderAddress);
+    const assetHolderBalanceInit = await getBalance(nitroAdjudicatorAddress);
 
     const response = await a.createChannels([channelParams]);
     await waitForObjectiveProposals([response[0].objectiveId], b);
@@ -182,7 +182,7 @@ test.each(['A', 'B'])(
     await expect(response).toBeObjectiveDoneType('Success');
     await expect(bResponse).toBeObjectiveDoneType('Success');
 
-    const assetHolderBalanceUpdated = await getBalance(ethAssetHolderAddress);
+    const assetHolderBalanceUpdated = await getBalance(nitroAdjudicatorAddress);
     expect(BN.sub(assetHolderBalanceUpdated, assetHolderBalanceInit)).toEqual(
       BN.add(aFunding, bFunding)
     );

--- a/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/create-and-close-channel/fake-funding.test.ts
@@ -3,7 +3,6 @@ import {
   Allocation,
   CloseChannelParams,
 } from '@statechannels/client-api-schema';
-import {makeAddress} from '@statechannels/wallet-core';
 import {BigNumber, ethers, constants} from 'ethers';
 
 import {ONE_DAY} from '../../__test__/test-helpers';
@@ -25,14 +24,13 @@ afterAll(async () => {
 });
 
 it('Create a fake-funded channel between two engines ', async () => {
-  const assetHolderAddress = makeAddress(constants.AddressZero);
   const aBal = BigNumber.from(1).toHexString();
 
   const {participantA, participantB, peerEngines, messageService} = peerSetup;
 
   const allocation: Allocation = {
     allocationItems: [{destination: participantA.destination, amount: aBal}],
-    assetHolderAddress,
+    asset: constants.AddressZero,
   };
 
   const channelParams: CreateChannelParams = {

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -237,7 +237,7 @@ describe('registerChannel', () => {
     expect(channelFinalizedHandler).toHaveBeenCalledWith(expect.objectContaining({channelId}));
   });
 
-  it.only('Successfully registers channel and receives follow on funding event', async () => {
+  it('Successfully registers channel and receives follow on funding event', async () => {
     const channelId = randomChannelId();
     const wrongChannelId = randomChannelId();
     let counter = 0;
@@ -301,13 +301,13 @@ describe('registerChannel', () => {
     );
   });
 
-  it('Channel with multiple asset holders', async () => {
+  it('Channel with multiple assets', async () => {
     const channelId = randomChannelId();
     let resolve: (value: unknown) => void;
     const p = new Promise(r => (resolve = r));
     const objectsToMatch = _.flatten(
       [0, 5].map(amount =>
-        [erc20Address, zeroAddress].map(address => ({
+        [zeroAddress, erc20Address].map(address => ({
           channelId,
           asset: address,
           amount: BN.from(amount),
@@ -327,7 +327,7 @@ describe('registerChannel', () => {
       objectsToMatch.splice(index, 1);
       if (!objectsToMatch.length) resolve(true);
     };
-    chainService.registerChannel(channelId, [zeroAddress, erc20Address], {
+    chainService.registerChannel(channelId, [erc20Address, zeroAddress], {
       ...defaultNoopListeners,
       holdingUpdated,
     });
@@ -347,7 +347,7 @@ describe('unconfirmedEvents', () => {
       await waitForChannelFunding(expectedHeld, 1, channelId);
     }
 
-    // Some depositied events are unconfirmed when we register channel,
+    // Some deposited events are unconfirmed when we register channel,
     // make sure they're not missed
     let lastObservedAmount = -1;
     let numberOfEventsObserved = 0;

--- a/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/stress.test.ts
@@ -9,7 +9,6 @@ import {ChainService} from '../chain-service';
 const pk = TEST_ACCOUNTS[0].privateKey;
 
 /* eslint-disable no-process-env, @typescript-eslint/no-non-null-assertion */
-const erc20AssetHolderAddress = makeAddress(process.env.ERC20_ASSET_HOLDER_ADDRESS!);
 const erc20Address = makeAddress(process.env.ERC20_ADDRESS!);
 if (!process.env.RPC_ENDPOINT) throw new Error('RPC_ENDPOINT must be defined');
 const rpcEndpoint = process.env.RPC_ENDPOINT;
@@ -52,7 +51,7 @@ describe('fundChannel', () => {
       chainService
         .fundChannel({
           channelId: randomChannelId(),
-          assetHolderAddress: erc20AssetHolderAddress,
+          asset: erc20Address,
           expectedHeld: BN.from(0),
           amount: BN.from(depositAmount),
         })

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -24,8 +24,8 @@ import {NonceManager} from '@ethersproject/experimental';
 import PQueue from 'p-queue';
 import {Logger} from 'pino';
 import _ from 'lodash';
-import {MAGIC_ADDRESS_INDICATING_ETH} from '@statechannels/nitro-protocol/src/transactions';
 
+const MAGIC_ADDRESS_INDICATING_ETH = constants.AddressZero;
 import {Bytes32} from '../type-aliases';
 import {createLogger} from '../logger';
 import {defaultTestWalletConfig} from '../config';

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -94,7 +94,8 @@ export class ChainService implements ChainServiceInterface {
 
     this.nitroAdjudicator = new Contract(
       nitroAdjudicatorAddress,
-      ContractArtifacts.NitroAdjudicatorArtifact.abi
+      ContractArtifacts.NitroAdjudicatorArtifact.abi,
+      this.ethWallet
     );
 
     this.nitroAdjudicator.on(ChallengeRegistered, (...args) => {

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -209,7 +209,7 @@ export class ChainService implements ChainServiceInterface {
         ...createETHDepositTransaction(arg.channelId, arg.expectedHeld, arg.amount),
       };
     } else {
-      await this.increaseAllowance(makeAddress(this.nitroAdjudicator.address), arg.amount);
+      await this.increaseAllowance(arg.asset, arg.amount);
       depositRequest = {
         to: this.nitroAdjudicator.address,
         ...createERC20DepositTransaction(arg.asset, arg.channelId, arg.expectedHeld, arg.amount),
@@ -550,7 +550,11 @@ export class ChainService implements ChainServiceInterface {
   }
 
   private async increaseAllowance(tokenAddress: Address, amount: string): Promise<void> {
-    const tokenContract = new Contract(tokenAddress, TestContractArtifacts.TokenArtifact.abi);
+    const tokenContract = new Contract(
+      tokenAddress,
+      TestContractArtifacts.TokenArtifact.abi,
+      this.ethWallet
+    );
     switch (this.allowanceMode) {
       case 'PerDeposit': {
         const increaseAllowance = tokenContract.interface.encodeFunctionData('increaseAllowance', [

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -512,7 +512,6 @@ export class ChainService implements ChainServiceInterface {
       case Deposited:
         {
           const depositedEvent = await this.getDepositedEvent(ethersEvent);
-          console.log(`got deposited event for ${depositedEvent.channelId}`);
           this.channelToEventTrackers.get(depositedEvent.channelId)?.forEach(eventTracker => {
             eventTracker.holdingUpdated(
               depositedEvent,

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -432,7 +432,7 @@ export class ChainService implements ChainServiceInterface {
         blockTag: confirmedBlock,
       };
 
-      confirmedHolding = BN.from(await this.nitroAdjudicator.holdings(channelId, overrides));
+      confirmedHolding = BN.from(await this.nitroAdjudicator.holdings(asset, channelId, overrides));
       this.logger.debug(
         `Successfully read confirmedHoldings (${confirmedHolding}), from block ${confirmedBlock}.`
       );

--- a/packages/server-wallet/src/chain-service/event-tracker.ts
+++ b/packages/server-wallet/src/chain-service/event-tracker.ts
@@ -3,7 +3,7 @@ import {Logger} from 'pino';
 
 import {
   HoldingUpdatedArg,
-  AssetOutcomeUpdatedArg,
+  FingerprintUpdatedArg,
   ChannelFinalizedArg,
   ChallengeRegisteredArg,
   ChainEventSubscriberInterface,
@@ -72,9 +72,15 @@ export class EventTracker {
   }
 
   // Pass event to managed subscriber only if new
-  assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg, blockNumber: number, logIndex: number): void {
-    if (this.isNewEvent(arg.assetHolderAddress, blockNumber, logIndex)) {
-      this.managedSubscriber.assetOutcomeUpdated(arg);
+  fingerprintUpdated(arg: FingerprintUpdatedArg, blockNumber: number, logIndex: number): void {
+    if (
+      this.isNewEvent(
+        arg.channelId, // TODO does this make sense to put here?
+        blockNumber,
+        logIndex
+      )
+    ) {
+      this.managedSubscriber.fingerprintUpdated(arg);
     }
   }
 

--- a/packages/server-wallet/src/chain-service/event-tracker.ts
+++ b/packages/server-wallet/src/chain-service/event-tracker.ts
@@ -46,6 +46,8 @@ export class EventTracker {
 
     if (isNew) {
       // Save latest event ever seen
+      this.blockNumber = blockNumber;
+      this.logIndex = logIndex;
       this.logger.debug('Event is new');
       return true;
     } else {

--- a/packages/server-wallet/src/chain-service/event-tracker.ts
+++ b/packages/server-wallet/src/chain-service/event-tracker.ts
@@ -1,3 +1,4 @@
+import {Address} from '@statechannels/nitro-protocol/src/contract/types';
 import {Logger} from 'pino';
 
 import {
@@ -18,36 +19,38 @@ import {
  */
 export class EventTracker {
   private logger: Logger;
-  private blockNumber = 0;
-  private logIndex = 0;
+  private assetMap: Map<Address, {blockNumber: number; logIndex: number}>;
   private managedSubscriber: ChainEventSubscriberInterface;
 
   constructor(managedSubscriber: ChainEventSubscriberInterface, logger: Logger) {
     this.logger = logger;
     this.managedSubscriber = managedSubscriber;
     this.logger = logger;
+    this.assetMap = new Map<string, {blockNumber: number; logIndex: number}>();
   }
 
-  private isNewEvent(blockNumber: number, logIndex: number): boolean {
+  private isNewEvent(asset: Address, blockNumber: number, logIndex: number): boolean {
+    const eventRecord = this.assetMap.get(asset);
     this.logger.debug(
-      `EventTracker.isNewEvent: ${blockNumber}, ${logIndex}, ${this.blockNumber}, ${this.logIndex}`
+      `EventTracker.isNewEvent: ${asset}, ${blockNumber}, ${logIndex}, ${JSON.stringify(
+        eventRecord
+      )}`
     );
 
     let isNew = false;
-    if (this.blockNumber == 0 && this.logIndex == 0) {
+    if (!eventRecord) {
       isNew = true;
-    } else if (blockNumber > this.blockNumber) {
+    } else if (blockNumber > eventRecord.blockNumber) {
       isNew = true;
-    } else if (blockNumber === this.blockNumber) {
-      if (logIndex > this.logIndex) {
+    } else if (blockNumber === eventRecord.blockNumber) {
+      if (logIndex > eventRecord.logIndex) {
         isNew = true;
       }
     }
 
     if (isNew) {
       // Save latest event ever seen
-      this.blockNumber = blockNumber;
-      this.logIndex = logIndex;
+      this.assetMap.set(asset, {blockNumber: blockNumber, logIndex: logIndex});
       this.logger.debug('Event is new');
       return true;
     } else {
@@ -63,14 +66,14 @@ export class EventTracker {
     logIndex: number = Number.MAX_SAFE_INTEGER // Why default to max: getInitialHoldings can call this without logIndex,
     // in which case should be considered the latest balance in block
   ): void {
-    if (this.isNewEvent(blockNumber, logIndex)) {
+    if (this.isNewEvent(arg.asset, blockNumber, logIndex)) {
       this.managedSubscriber.holdingUpdated(arg);
     }
   }
 
   // Pass event to managed subscriber only if new
   assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg, blockNumber: number, logIndex: number): void {
-    if (this.isNewEvent(blockNumber, logIndex)) {
+    if (this.isNewEvent(arg.assetHolderAddress, blockNumber, logIndex)) {
       this.managedSubscriber.assetOutcomeUpdated(arg);
     }
   }

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -58,10 +58,8 @@ export class MockChainService implements ChainServiceInterface {
         case 'FundChannel':
           responses.push(await this.fundChannel(chainRequest));
           break;
-        case 'PushOutcomeAndWithdraw':
-          responses.push(
-            await this.pushOutcomeAndWithdraw(chainRequest.state, chainRequest.challengerAddress)
-          );
+        case 'Withdraw':
+          responses.push(await this.withdraw(chainRequest.state, chainRequest.challengerAddress));
           break;
         default:
           unreachable(chainRequest);
@@ -93,10 +91,7 @@ export class MockChainService implements ChainServiceInterface {
     return Promise.resolve(mockTransactoinResponse);
   }
 
-  pushOutcomeAndWithdraw(
-    _state: State,
-    _challengerAddress: Address
-  ): Promise<providers.TransactionResponse> {
+  withdraw(_state: State, _challengerAddress: Address): Promise<providers.TransactionResponse> {
     return Promise.resolve(mockTransactoinResponse);
   }
 

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -1,4 +1,4 @@
-import {Address, PrivateKey, SignedState, State, Uint256, Bytes} from '@statechannels/wallet-core';
+import {Address, PrivateKey, SignedState, State, Uint256} from '@statechannels/wallet-core';
 import {providers} from 'ethers';
 import {Logger} from 'pino';
 
@@ -12,7 +12,7 @@ export type HoldingUpdatedArg = {
 
 export type FingerprintUpdatedArg = {
   channelId: Bytes32;
-  outcomeBytes: Bytes;
+  outcomeBytes: string;
 };
 
 export type FundChannelArg = {

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -1,5 +1,4 @@
-import {AllocationItem, AssetOutcome} from '@statechannels/nitro-protocol';
-import {Address, PrivateKey, SignedState, State, Uint256} from '@statechannels/wallet-core';
+import {Address, PrivateKey, SignedState, State, Uint256, Bytes} from '@statechannels/wallet-core';
 import {providers} from 'ethers';
 import {Logger} from 'pino';
 
@@ -11,13 +10,9 @@ export type HoldingUpdatedArg = {
   amount: Uint256;
 };
 
-export type AssetOutcomeUpdatedArg = {
+export type FingerprintUpdatedArg = {
   channelId: Bytes32;
-  assetHolderAddress: Address;
-  newHoldings: Uint256;
-  externalPayouts: AllocationItem[];
-  internalPayouts: AllocationItem[];
-  newAssetOutcome: AssetOutcome | '0x00'; // '0x00' in case the asset outcome hash was deleted on chain
+  outcomeBytes: Bytes;
 };
 
 export type FundChannelArg = {
@@ -42,7 +37,7 @@ export type ChallengeRegisteredArg = {
 
 export interface ChainEventSubscriberInterface<T extends void = void> {
   holdingUpdated(arg: HoldingUpdatedArg): T;
-  assetOutcomeUpdated(arg: AssetOutcomeUpdatedArg): T;
+  fingerprintUpdated(arg: FingerprintUpdatedArg): T;
   channelFinalized(arg: ChannelFinalizedArg): T;
   challengeRegistered(arg: ChallengeRegisteredArg): T;
 }

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -63,8 +63,8 @@ export type ConcludeAndWithdrawRequest = {
   type: 'ConcludeAndWithdraw';
   finalizationProof: SignedState[];
 };
-export type PushOutcomeAndWithdrawRequest = {
-  type: 'PushOutcomeAndWithdraw';
+export type WithdrawRequest = {
+  type: 'Withdraw';
   state: State;
   challengerAddress: Address;
 };
@@ -78,11 +78,10 @@ export type ChallengeRequest = {
 export type ChainRequest =
   | FundChannelRequest
   | ConcludeAndWithdrawRequest
-  | PushOutcomeAndWithdrawRequest
+  | WithdrawRequest
   | ChallengeRequest;
 interface ChainModifierInterface {
   handleChainRequests(chainRequests: ChainRequest[]): Promise<providers.TransactionResponse[]>;
-
   fetchBytecode(address: string): Promise<string>;
 }
 

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -7,7 +7,7 @@ import {Bytes32} from '../type-aliases';
 
 export type HoldingUpdatedArg = {
   channelId: Bytes32;
-  assetHolderAddress: Address;
+  asset: Address;
   amount: Uint256;
 };
 
@@ -51,7 +51,7 @@ interface ChainEventEmitterInterface {
   checkChainId(networkChainId: number): Promise<void>;
   registerChannel(
     channelId: Bytes32,
-    assetHolders: Address[],
+    assets: Address[],
     listener: ChainEventSubscriberInterface
   ): void;
   unregisterChannel(channelId: Bytes32): void;

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -22,7 +22,7 @@ export type AssetOutcomeUpdatedArg = {
 
 export type FundChannelArg = {
   channelId: Bytes32;
-  assetHolderAddress: Address;
+  asset: Address;
   expectedHeld: Uint256;
   amount: Uint256;
 };

--- a/packages/server-wallet/src/db/migrations/20200818083933_funding.ts
+++ b/packages/server-wallet/src/db/migrations/20200818083933_funding.ts
@@ -5,9 +5,9 @@ export async function up(knex: Knex): Promise<any> {
   await knex.schema.createTable(funding, function (table) {
     table.string('channel_id').notNullable();
     table.string('amount').notNullable();
-    table.string('asset_holder').notNullable();
+    table.string('asset').notNullable();
 
-    table.primary(['channel_id', 'asset_holder']);
+    table.primary(['channel_id', 'asset']);
     table.foreign('channel_id').references('channels.channel_id');
   });
 }

--- a/packages/server-wallet/src/engine/__test__/add-signed-state.test.ts
+++ b/packages/server-wallet/src/engine/__test__/add-signed-state.test.ts
@@ -38,7 +38,7 @@ describe('addSignedState', () => {
       turnNum: 0,
       outcome: [
         {
-          assetHolderAddress: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
+          asset: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
           allocationItems: [
             {destination: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9', amount: '0x00'},
           ],

--- a/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/test-channel.ts
@@ -21,9 +21,8 @@ import {
   OpenChannel,
   Destination,
 } from '@statechannels/wallet-core';
-import {ETH_ASSET_HOLDER_ADDRESS} from '@statechannels/wallet-core/lib/src/config';
 import {SignedState as WireState, Payload} from '@statechannels/wire-format';
-import {utils} from 'ethers';
+import {constants, utils} from 'ethers';
 
 import {Channel} from '../../../models/channel';
 import {defaultTestWalletConfig} from '../../../config';
@@ -66,6 +65,7 @@ export class TestChannel {
   public fundingLedgerChannelId: Bytes32 | undefined;
   static maximumNonce = 0;
 
+  public asset = makeAddress(constants.AddressZero);
   public get participants(): Participant[] {
     return [this.participantA, this.participantB];
   }
@@ -240,10 +240,6 @@ export class TestChannel {
     };
   }
 
-  public get assetHolderAddress(): Address {
-    return ETH_ASSET_HOLDER_ADDRESS;
-  }
-
   public get getChannelRequest(): Payload {
     return {
       walletVersion: WALLET_VERSION,
@@ -334,7 +330,7 @@ export class TestChannel {
 
     // set the funds as specified
     if (funds > 0) {
-      await store.updateFunding(this.channelId, BN.from(funds), this.assetHolderAddress);
+      await store.updateFunding(this.channelId, BN.from(funds), this.asset);
     }
 
     // patch the funding strategy

--- a/packages/server-wallet/src/engine/__test__/fixtures/update-channel.ts
+++ b/packages/server-wallet/src/engine/__test__/fixtures/update-channel.ts
@@ -12,7 +12,7 @@ const defaultVars: UpdateChannelParams = {
   channelId: channel().channelId,
   allocations: [
     {
-      assetHolderAddress: makeAddress(constants.AddressZero),
+      asset: makeAddress(constants.AddressZero),
       allocationItems: [
         {destination: alice().destination, amount: BN.from(1)},
         {destination: bob().destination, amount: BN.from(3)},

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -630,12 +630,8 @@ export class Store {
     await Channel.setInitialSupport(channelId, support, tx ?? this.knex);
   }
 
-  async updateFunding(
-    channelId: string,
-    fromAmount: Uint256,
-    assetHolderAddress: Address
-  ): Promise<void> {
-    await Funding.updateFunding(this.knex, channelId, fromAmount, assetHolderAddress);
+  async updateFunding(channelId: string, fromAmount: Uint256, asset: Address): Promise<void> {
+    await Funding.updateFunding(this.knex, channelId, fromAmount, asset);
   }
 
   async insertAdjudicatorStatus(

--- a/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
+++ b/packages/server-wallet/src/handlers/__test__/single-app-updater.test.ts
@@ -103,7 +103,7 @@ describe('not an app channel', () => {
 
     await store.pushMessage(testLedger.wirePayload(5));
     await store.pushMessage(testLedger.wirePayload(6));
-    await store.updateFunding(testLedger.channelId, BN.from(10), testLedger.assetHolderAddress);
+    await store.updateFunding(testLedger.channelId, BN.from(10), testLedger.asset);
 
     await expect(singleAppUpdater.update(testLedger.wirePayload(7), response)).rejects.toThrow(
       'The update sent to pushUpdate must be for an application channel'
@@ -120,5 +120,5 @@ const setup = async ({states}: SetupParams): Promise<void> => {
   for (const state of states) {
     await store.pushMessage(state);
   }
-  await store.updateFunding(testChan.channelId, BN.from(10), testChan.assetHolderAddress);
+  await store.updateFunding(testChan.channelId, BN.from(10), testChan.asset);
 };

--- a/packages/server-wallet/src/models/__test__/channel.test.ts
+++ b/packages/server-wallet/src/models/__test__/channel.test.ts
@@ -136,13 +136,13 @@ describe('Channel funding', () => {
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
-    await store.updateFunding(testChannel.channelId, BN.from(1), testChannelObj.assetHolderAddress);
+    await store.updateFunding(testChannel.channelId, BN.from(1), testChannelObj.asset);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
     expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
-    await store.updateFunding(testChannel.channelId, BN.from(8), testChannelObj.assetHolderAddress);
+    await store.updateFunding(testChannel.channelId, BN.from(8), testChannelObj.asset);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
     expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(true);
@@ -159,13 +159,13 @@ describe('Channel funding', () => {
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
-    await store.updateFunding(testChannel.channelId, BN.from(6), testChannelObj.assetHolderAddress);
+    await store.updateFunding(testChannel.channelId, BN.from(6), testChannelObj.asset);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
     expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(false);
 
     // Update funding and refetch channel
-    await store.updateFunding(testChannel.channelId, BN.from(8), testChannelObj.assetHolderAddress);
+    await store.updateFunding(testChannel.channelId, BN.from(8), testChannelObj.asset);
     testChannel = await Channel.forId(testChannelObj.channelId, knex);
     expect(testChannel.isPartlyDirectFunded).toEqual(true);
     expect(testChannel.isFullyDirectFunded).toEqual(true);

--- a/packages/server-wallet/src/models/channel.ts
+++ b/packages/server-wallet/src/models/channel.ts
@@ -238,10 +238,10 @@ export class Channel extends Model implements ChannelColumns {
       fundingStrategy,
       fundingLedgerChannelId,
     } = this;
-    const funding = (assetHolder: Address): ChannelStateFunding | undefined => {
+    const funding = (asset: Address): ChannelStateFunding | undefined => {
       const noFunding = {amount: Zero, transferredOut: []};
       if (!this.funding) return undefined; // funding hasn't been fetched from db
-      const result = this.funding.find(f => f.assetHolder === assetHolder);
+      const result = this.funding.find(f => f.asset === asset);
       return result ? {amount: result.amount, transferredOut: result.transferredOut} : noFunding;
     };
     // directFundingStatus will return 'Uncategorized' e.g. if there's no supported outcome, even if
@@ -460,8 +460,8 @@ export class Channel extends Model implements ChannelColumns {
       throw new ChannelError(ChannelError.reasons.noSupportedState);
     }
 
-    const {assetHolderAddress, allocationItems} = checkThat(outcome, isSimpleAllocation);
-    const channelFunds = this.funding.find(f => f.assetHolder === assetHolderAddress);
+    const {asset, allocationItems} = checkThat(outcome, isSimpleAllocation);
+    const channelFunds = this.funding.find(f => f.asset === asset);
     if (!channelFunds) return false;
 
     switch (threshold) {

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -113,12 +113,7 @@ describe('when there is an active challenge', () => {
 describe('when the channel is finalized on chain', () => {
   it('should call pushOutcome if the outcome has not been pushed', async () => {
     // If there is a funding entry that means the outcome has not been pushed
-    await Funding.updateFunding(
-      knex,
-      testChan.channelId,
-      '0x05',
-      makeAddress(testChan.assetHolderAddress)
-    );
+    await Funding.updateFunding(knex, testChan.channelId, '0x05', makeAddress(testChan.asset));
 
     const challengeState = stateSignedBy([alice()])();
     await setAdjudicatorStatus('finalized', testChan.channelId, challengeState);

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -178,7 +178,7 @@ describe('Direct channel defunding', () => {
 
       // The channel has NOT been fully defunded.
       // Defunder does not complete
-      await Funding.updateFunding(tx, channel.channelId, '0x03', testChannel.assetHolderAddress);
+      await Funding.updateFunding(tx, channel.channelId, '0x03', testChannel.asset);
       expect(await defunder.crank(channel, objective, response, tx)).toEqual({
         didSubmitTransaction: false,
         isChannelDefunded: false,
@@ -186,7 +186,7 @@ describe('Direct channel defunding', () => {
 
       // The channel has been fully defunded
       // Defunder completes
-      await Funding.updateFunding(tx, channel.channelId, '0x00', testChannel.assetHolderAddress);
+      await Funding.updateFunding(tx, channel.channelId, '0x00', testChannel.asset);
       expect(await defunder.crank(channel, objective, response, tx)).toEqual({
         didSubmitTransaction: false,
         isChannelDefunded: true,
@@ -231,7 +231,7 @@ describe('Direct channel defunding', () => {
       });
       // The channel has been fully defunded
       // Defunder completes
-      await Funding.updateFunding(tx, channel.channelId, '0x00', testChannel.assetHolderAddress);
+      await Funding.updateFunding(tx, channel.channelId, '0x00', testChannel.asset);
       expect(await defunder.crank(channel, objective, response, tx)).toEqual({
         didSubmitTransaction: false,
         isChannelDefunded: true,

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -129,7 +129,7 @@ export class Defunder {
       // This is not a valid assumption as the defunder protocol can be run no matter how the channel was finalized
       response.queueChainRequest([
         {
-          type: 'PushOutcomeAndWithdraw',
+          type: 'Withdraw',
           state: adjudicatorStatus.states[0],
           challengerAddress: channel.myAddress,
         },

--- a/packages/server-wallet/src/protocols/direct-funder.ts
+++ b/packages/server-wallet/src/protocols/direct-funder.ts
@@ -37,10 +37,10 @@ export class DirectFunder {
     response: EngineResponse,
     tx: Transaction
   ): Promise<boolean> {
-    const assetHolderAddress = this.assetHolder(channel);
+    const asset = this.asset(channel);
     const {targetBefore, targetAfter, targetTotal} = channel.fundingMilestones;
 
-    const currentFunding = await this.store.getFunding(channel.channelId, assetHolderAddress, tx);
+    const currentFunding = await this.store.getFunding(channel.channelId, asset, tx);
     const currentAmount = currentFunding?.amount || 0;
 
     // if we're fully funded, we're done
@@ -62,7 +62,7 @@ export class DirectFunder {
       {
         type: 'FundChannel',
         channelId: channel.channelId,
-        assetHolderAddress: assetHolderAddress,
+        asset,
         expectedHeld: BN.from(currentAmount),
         amount: BN.from(amountToDeposit),
       },
@@ -71,14 +71,14 @@ export class DirectFunder {
     return false;
   }
 
-  private assetHolder(channel: Channel): Address {
+  private asset(channel: Channel): Address {
     const supported = channel.supported;
     if (!supported) {
       throw new Error(`Channel passed to DirectFunder has no supported state`);
     }
 
-    const {assetHolderAddress} = checkThat(supported?.outcome, isSimpleAllocation);
+    const {asset} = checkThat(supported?.outcome, isSimpleAllocation);
 
-    return assetHolderAddress;
+    return asset;
   }
 }

--- a/packages/server-wallet/src/protocols/state.ts
+++ b/packages/server-wallet/src/protocols/state.ts
@@ -119,7 +119,7 @@ export function directFundingStatus(
     return 'Uncategorized';
   }
 
-  const {allocationItems, assetHolderAddress} = checkThat(outcome, isSimpleAllocation);
+  const {allocationItems, asset} = checkThat(outcome, isSimpleAllocation);
 
   // Collapse all allocation items with my destination into one
   const myDestination = myParticipant.destination;
@@ -128,7 +128,7 @@ export function directFundingStatus(
     .map(ai => ai.amount)
     .reduce(BN.add, BN.from(0));
 
-  const funding = fundingFn(assetHolderAddress);
+  const funding = fundingFn(asset);
   if (!funding) return undefined;
 
   const amountTransferredToMe = funding.transferredOut

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -36,7 +36,7 @@ import {
   SyncConfiguration,
 } from '../engine';
 import {
-  AssetOutcomeUpdatedArg,
+  FingerprintUpdatedArg,
   ChainEventSubscriberInterface,
   ChainService,
   ChainServiceInterface,
@@ -135,19 +135,15 @@ export class Wallet extends EventEmitter<WalletEvents> {
 
     this._chainListener = {
       holdingUpdated: this.createChainEventlistener('holdingUpdated', e =>
-        this._engine.store.updateFunding(e.channelId, e.amount, e.assetHolderAddress)
+        this._engine.store.updateFunding(e.channelId, e.amount, e.asset)
       ),
-      assetOutcomeUpdated: this.createChainEventlistener('assetOutcomeUpdated', async e => {
+      fingerprintUpdated: this.createChainEventlistener('fingerprintUpdated', async e => {
         const transferredOut = e.externalPayouts.map(ai => ({
           toAddress: makeDestination(ai.destination),
           amount: ai.amount as Uint256,
         }));
 
-        await this._engine.store.updateTransferredOut(
-          e.channelId,
-          e.assetHolderAddress,
-          transferredOut
-        );
+        await this._engine.store.updateTransferredOut(e.channelId, e.asset, transferredOut);
       }),
       challengeRegistered: this.createChainEventlistener('challengeRegistered', e =>
         this._engine.store.insertAdjudicatorStatus(e.channelId, e.finalizesAt, e.challengeStates)
@@ -438,7 +434,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
   >(eventName: K, storeUpdater: EH) {
     return async (
       event: HoldingUpdatedArg &
-        AssetOutcomeUpdatedArg &
+        FingerprintUpdatedArg &
         ChannelFinalizedArg &
         ChallengeRegisteredArg
     ) => {

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -423,7 +423,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
 
   private async registerChannels(channelsToRegister: ChannelResult[]): Promise<void> {
     const channelsWithAssetHolders = channelsToRegister.map(cr => ({
-      assetHolderAddresses: cr.allocations.map(a => makeAddress(a.assetHolderAddress)),
+      assetHolderAddresses: cr.allocations.map(a => makeAddress(a.asset)),
       channelId: cr.channelId,
     }));
 


### PR DESCRIPTION
Tests that pass on this branch:
`chain-service.test.ts` ( but only if `yarn link @statechannels/native-utils` against https://github.com/statechannels/native-utils/pull/26 )
`stress.test.ts` (confirmed manually, it doesn't run by default)

