### PR TITLE
Wallet tweaks for testing infrastructure

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -361,6 +361,7 @@ export class SingleThreadedEngine implements EngineInterface {
         objectives: WalletObjective[];
         messages: Message_2[];
         chainRequests: ChainRequest[];
+        channelResults: ChannelResult[];
     }>;
     // (undocumented)
     chainNetworkId: string;

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -303,6 +303,7 @@ export interface OptionalWalletConfig {
     loggingConfiguration: LoggingConfiguration;
     // (undocumented)
     metricsConfiguration: MetricsConfiguration;
+    privateKey?: string;
     // (undocumented)
     skipEvmValidation: boolean;
     // (undocumented)
@@ -469,6 +470,8 @@ export type WalletConfig = RequiredWalletConfig & OptionalWalletConfig;
 
 // @public (undocumented)
 export interface WalletEvents {
+    // (undocumented)
+    ChannelUpdated: (c: ChannelResult) => void;
     // (undocumented)
     ObjectiveCompleted: (o: WalletObjective) => void;
     // (undocumented)

--- a/packages/server-wallet/src/config/types.ts
+++ b/packages/server-wallet/src/config/types.ts
@@ -94,6 +94,11 @@ export interface OptionalWalletConfig {
   loggingConfiguration: LoggingConfiguration;
   metricsConfiguration: MetricsConfiguration;
   syncConfiguration: SyncConfiguration;
+  /**
+   * This is the private key used to sign channel updates.
+   * If not provided one will be generated.
+   */
+  privateKey?: string;
 }
 
 /**

--- a/packages/server-wallet/src/config/validation.ts
+++ b/packages/server-wallet/src/config/validation.ts
@@ -82,6 +82,10 @@ const engine = joi.object({
   loggingConfiguration: loggingConfigurationSchema.optional(),
   metricsConfiguration: metricsConfigurationSchema.optional(),
   syncConfiguration: syncConfigurationSchema.optional(),
+  privateKey: joi
+    .string()
+    .regex(/^0x[a-fA-F0-9]{64}$/)
+    .optional(),
 });
 
 export function validateEngineConfig(

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -8,6 +8,7 @@ import {
   Participant as APIParticipant,
   ChannelId,
   Message,
+  ChannelResult,
 } from '@statechannels/client-api-schema';
 import {
   deserializeAllocations,
@@ -445,7 +446,12 @@ export class SingleThreadedEngine implements EngineInterface {
 
   async approveObjectives(
     objectiveIds: string[]
-  ): Promise<{objectives: WalletObjective[]; messages: Message[]; chainRequests: ChainRequest[]}> {
+  ): Promise<{
+    objectives: WalletObjective[];
+    messages: Message[];
+    chainRequests: ChainRequest[];
+    channelResults: ChannelResult[];
+  }> {
     const channelIds: string[] = [];
     const response = EngineResponse.initialize();
     let objectives = await this.store.getObjectivesByIds(objectiveIds);
@@ -466,6 +472,7 @@ export class SingleThreadedEngine implements EngineInterface {
       objectives,
       messages: getMessages(response.multipleChannelOutput()),
       chainRequests: response.chainRequests,
+      channelResults: response.channelResults,
     };
   }
 

--- a/packages/server-wallet/src/engine/store.ts
+++ b/packages/server-wallet/src/engine/store.ts
@@ -668,11 +668,13 @@ export class Store {
   async updateTransferredOut(
     channelId: string,
     assetHolder: Address,
-    transferredOut: TransferredOutEntry[]
+    transferredOut: TransferredOutEntry[],
+    newHoldings: string
   ): Promise<void> {
-    this.lockApp(channelId, tx =>
-      Funding.updateTransferredOut(tx, channelId, assetHolder, transferredOut)
-    );
+    this.lockApp(channelId, async tx => {
+      await Funding.updateTransferredOut(tx, channelId, assetHolder, transferredOut);
+      await Funding.updateFunding(tx, channelId, newHoldings, assetHolder);
+    });
   }
 
   async nextNonce(signingAddresses: Address[]): Promise<number> {

--- a/packages/server-wallet/src/message-service/socket-io-message-service.ts
+++ b/packages/server-wallet/src/message-service/socket-io-message-service.ts
@@ -23,7 +23,9 @@ export class SocketIOMessageService implements MessageServiceInterface {
   }
 
   public async send(messages: Message[]): Promise<void> {
-    this.server.emit('message', messages);
+    if (messages.length > 0) {
+      this.server.emit('message', messages);
+    }
   }
 
   public async destroy(): Promise<void> {

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -71,4 +71,5 @@ export interface WalletEvents {
   ObjectiveCompleted: (o: WalletObjective) => void;
   ObjectiveProposed: (o: WalletObjective) => void;
   ObjectiveTimedOut: (o: WalletObjective) => void;
+  ChannelUpdated: (c: ChannelResult) => void;
 }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -130,9 +130,6 @@ export class Wallet extends EventEmitter<WalletEvents> {
 
     const handler: MessageHandler = async message => {
       const result = await this._engine.pushMessage(message.data);
-      const {channelResults} = result;
-
-      await this.registerChannels(channelResults);
 
       await this.handleEngineOutput(result);
     };
@@ -198,10 +195,14 @@ export class Wallet extends EventEmitter<WalletEvents> {
    * @returns A promise that resolves to a collection of ObjectiveResult.
    */
   public async approveObjectives(objectiveIds: string[]): Promise<ObjectiveResult[]> {
-    const {objectives, messages, chainRequests} = await this._engine.approveObjectives(
-      objectiveIds
-    );
+    const {
+      objectives,
+      messages,
+      chainRequests,
+      channelResults,
+    } = await this._engine.approveObjectives(objectiveIds);
 
+    await this.registerChannels(channelResults);
     const results = objectives.map(async o => ({
       objectiveId: o.objectiveId,
       currentStatus: o.status,

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -145,13 +145,12 @@ export class Wallet extends EventEmitter<WalletEvents> {
           toAddress: makeDestination(ai.destination),
           amount: ai.amount as Uint256,
         }));
-        // holdingUpdated only fires for the deposit event
-        // so we also need to update the funding in this event
-        await this._engine.store.updateFunding(e.channelId, e.newHoldings, e.assetHolderAddress);
+
         await this._engine.store.updateTransferredOut(
           e.channelId,
           e.assetHolderAddress,
-          transferredOut
+          transferredOut,
+          e.newHoldings
         );
       }),
       challengeRegistered: this.createChainEventlistener('challengeRegistered', e =>

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -84,6 +84,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
       workerThreadAmount: 0, // Disable threading for now
     };
     const engine = await SingleThreadedEngine.create(engineConfig, logger);
+
     const chainService = populatedConfig.chainServiceConfiguration.attachChainService
       ? new ChainService({
           ...populatedConfig.chainServiceConfiguration,
@@ -348,8 +349,11 @@ export class Wallet extends EventEmitter<WalletEvents> {
     return Promise.all(results);
   }
 
-  private emitObjectiveEvents(result: MultipleChannelOutput | SingleChannelOutput): void {
+  private emitEvents(result: MultipleChannelOutput | SingleChannelOutput): void {
     if (isMultipleChannelOutput(result)) {
+      for (const c of result.channelResults) {
+        this.emit('ChannelUpdated', c);
+      }
       // Receiving messages from other participants may have resulted in completed objectives
       for (const o of result.completedObjectives) {
         this.emit('ObjectiveCompleted', o);
@@ -362,6 +366,8 @@ export class Wallet extends EventEmitter<WalletEvents> {
         }
       }
     } else {
+      this.emit('ChannelUpdated', result.channelResult);
+
       if (hasNewObjective(result)) {
         if (result.newObjective.status === 'pending') {
           this.emit('ObjectiveProposed', result.newObjective);
@@ -377,7 +383,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
   private async handleEngineOutput(
     output: MultipleChannelOutput | SingleChannelOutput
   ): Promise<void> {
-    this.emitObjectiveEvents(output);
+    this.emitEvents(output);
     await this._messageService.send(getMessages(output));
     await this._chainService.handleChainRequests(output.chainRequests);
   }

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -11,6 +11,7 @@ import {
   makeAddress,
   makeDestination,
   Address,
+  makePrivateKey,
 } from '@statechannels/wallet-core';
 import {utils} from 'ethers';
 import {setIntervalAsync, clearIntervalAsync} from 'set-interval-async/dynamic';
@@ -84,6 +85,10 @@ export class Wallet extends EventEmitter<WalletEvents> {
       workerThreadAmount: 0, // Disable threading for now
     };
     const engine = await SingleThreadedEngine.create(engineConfig, logger);
+
+    if (populatedConfig.privateKey) {
+      await engine.addSigningKey(makePrivateKey(populatedConfig.privateKey));
+    }
 
     const chainService = populatedConfig.chainServiceConfiguration.attachChainService
       ? new ChainService({

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -142,7 +142,9 @@ export class Wallet extends EventEmitter<WalletEvents> {
           toAddress: makeDestination(ai.destination),
           amount: ai.amount as Uint256,
         }));
-
+        // holdingUpdated only fires for the deposit event
+        // so we also need to update the funding in this event
+        await this._engine.store.updateFunding(e.channelId, e.newHoldings, e.assetHolderAddress);
         await this._engine.store.updateTransferredOut(
           e.channelId,
           e.assetHolderAddress,


### PR DESCRIPTION
These are a collection of changes that I've made to the wallet and message service while working on testing infrastructure.

# Changes
- Wallet now emits a ChannelUpdated event
- Wallet accepts a private key to use to create its address (useful for testing)
- call updateFunding in the AssetOutcomeUpdated event handler so the holdings are correctly updated when closing a channel.

Happy to break these into separate PRs if needed/wanted.