### PR TITLE
Chain service tweaks for testing infrastructure

### DIFF
--- a/packages/server-wallet/deployment/deploy.ts
+++ b/packages/server-wallet/deployment/deploy.ts
@@ -15,10 +15,10 @@ export type TestNetworkContext = {
 
 // NOTE: deploying contracts like this allows the onchain service package to
 // be easily extracted
-
-export async function deploy(): Promise<TestNetworkContext> {
-  // eslint-disable-next-line no-process-env
-  const rpcEndPoint = 'http://localhost:' + process.env.GANACHE_PORT;
+// eslint-disable-next-line no-process-env
+export async function deploy(
+  rpcEndPoint = 'http://localhost:' + process.env.GANACHE_PORT
+): Promise<TestNetworkContext> {
   const provider = new providers.JsonRpcProvider(rpcEndPoint);
 
   const [

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -140,6 +140,10 @@ export class ChainService implements ChainServiceInterface {
   public async handleChainRequests(
     chainRequests: ChainRequest[]
   ): Promise<providers.TransactionResponse[]> {
+    // Bail early so we don't add chatter to the logs
+    if (chainRequests.length === 0) {
+      return [];
+    }
     const responses: providers.TransactionResponse[] = [];
 
     this.logger.trace({chainRequests}, 'Handling chain requests');

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -52,20 +52,6 @@ type AllocationUpdatedEvent = {
   ethersEvent: Event;
 } & AssetOutcomeUpdatedArg;
 
-// TODO: is it reasonable to assume that the ethAssetHolder address is defined as runtime configuration?
-/* eslint-disable no-process-env, */
-const ethAssetHolderAddress = makeAddress(
-  process.env.ETH_ASSET_HOLDER_ADDRESS || constants.AddressZero
-);
-const nitroAdjudicatorAddress = makeAddress(
-  process.env.NITRO_ADJUDICATOR_ADDRESS || constants.AddressZero
-);
-/* eslint-enable no-process-env */
-
-function isEthAssetHolder(address: Address): boolean {
-  return address === ethAssetHolderAddress;
-}
-
 export class ChainService implements ChainServiceInterface {
   private logger: Logger;
   private readonly ethWallet: NonceManager;
@@ -81,6 +67,9 @@ export class ChainService implements ChainServiceInterface {
   private transactionQueue = new PQueue({concurrency: 1});
 
   private finalizingChannels: {finalizesAtS: number; channelId: Bytes32}[] = [];
+
+  private ethAssetHolderAddress: Address;
+  private nitroAdjudicatorAddress: Address;
 
   constructor({
     provider,
@@ -104,8 +93,18 @@ export class ChainService implements ChainServiceInterface {
     }
     if (pollingInterval) this.provider.pollingInterval = pollingInterval;
 
+    this.ethAssetHolderAddress = makeAddress(
+      // eslint-disable-next-line no-process-env
+      process.env.ETH_ASSET_HOLDER_ADDRESS || constants.AddressZero
+    );
+
+    this.nitroAdjudicatorAddress = makeAddress(
+      // eslint-disable-next-line no-process-env
+      process.env.NITRO_ADJUDICATOR_ADDRESS || constants.AddressZero
+    );
+
     this.nitroAdjudicator = this.getOrAddContractMapping(
-      nitroAdjudicatorAddress,
+      this.nitroAdjudicatorAddress,
       ContractArtifacts.NitroAdjudicatorArtifact.abi
     );
 
@@ -199,7 +198,7 @@ export class ChainService implements ChainServiceInterface {
   ): Contract {
     const abi =
       contractInterface ??
-      (isEthAssetHolder(assetHolderAddress)
+      (assetHolderAddress === this.ethAssetHolderAddress
         ? ContractArtifacts.EthAssetHolderArtifact.abi
         : ContractArtifacts.Erc20AssetHolderArtifact.abi);
     const contract: Contract = new Contract(assetHolderAddress, abi, this.ethWallet);
@@ -237,7 +236,7 @@ export class ChainService implements ChainServiceInterface {
     this.logger.info({...arg}, 'fundChannel: entry');
 
     const assetHolderAddress = arg.assetHolderAddress;
-    const isEthFunding = isEthAssetHolder(assetHolderAddress);
+    const isEthFunding = assetHolderAddress === this.ethAssetHolderAddress;
 
     if (!isEthFunding) {
       await this.increaseAllowance(assetHolderAddress, arg.amount);
@@ -283,7 +282,7 @@ export class ChainService implements ChainServiceInterface {
       ...Transactions.createConcludePushOutcomeAndTransferAllTransaction(
         finalizationProof.flatMap(toNitroSignedState)
       ),
-      to: nitroAdjudicatorAddress,
+      to: this.nitroAdjudicatorAddress,
     };
 
     const captureExpectedErrors = async (reason: any) => {
@@ -341,7 +340,7 @@ export class ChainService implements ChainServiceInterface {
         challengeStates.flatMap(toNitroSignedState),
         privateKey
       ),
-      to: nitroAdjudicatorAddress,
+      to: this.nitroAdjudicatorAddress,
     };
     return this.sendTransaction(challengeTransactionRequest);
   }
@@ -365,7 +364,7 @@ export class ChainService implements ChainServiceInterface {
         outcome: lastState.outcome,
         challengerAddress,
       }),
-      to: nitroAdjudicatorAddress,
+      to: this.nitroAdjudicatorAddress,
     };
     return this.sendTransaction(pushTransactionRequest);
   }
@@ -684,7 +683,7 @@ export class ChainService implements ChainServiceInterface {
 
     const {newAssetOutcome, newHoldings, externalPayouts, internalPayouts} = computeNewAssetOutcome(
       contract.address,
-      nitroAdjudicatorAddress,
+      this.nitroAdjudicatorAddress,
       {channelId, initialHoldings},
       tx
     );

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -82,19 +82,7 @@ export type ChainRequest =
   | ChallengeRequest;
 interface ChainModifierInterface {
   handleChainRequests(chainRequests: ChainRequest[]): Promise<providers.TransactionResponse[]>;
-  // TODO: should these APIs return ethers TransactionResponses? Or is that too detailed for API consumers
-  fundChannel(arg: FundChannelArg): Promise<providers.TransactionResponse>;
-  concludeAndWithdraw(
-    finalizationProof: SignedState[]
-  ): Promise<providers.TransactionResponse | void>;
-  pushOutcomeAndWithdraw(
-    state: State,
-    challengerAddress: Address
-  ): Promise<providers.TransactionResponse>;
-  challenge(
-    challengeStates: SignedState[],
-    privateKey: PrivateKey
-  ): Promise<providers.TransactionResponse>;
+
   fetchBytecode(address: string): Promise<string>;
 }
 


### PR DESCRIPTION
These are a collection of changes that I've made to the chain service while working on testing infrastructure.

# Changes
- deploy now be passed an rpc endpoint (nice for scripting)
- chain service now reads env vars when constructed (nice for scripting) 
- remove some obsolete methods from the chain service interface