### PR TITLE
Attempt to fix signature checks in embedded application

### DIFF
--- a/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
+++ b/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
@@ -47,7 +47,6 @@ interface IForceMoveApp2 {
 }
 
 library ForceMoveAppUtilities {
-
     /**
      * @notice Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
      * @dev Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
@@ -74,8 +73,8 @@ library ForceMoveAppUtilities {
         uint48 turnNumA = turnNumB - 1;
         require(
             turnNumB > 0 &&
-                isSignedBy(signedByFrom, 2 ** (turnNumA % nParticipants)) &&
-                isSignedBy(signedByTo,   2 ** (turnNumB % nParticipants)),
+                isSignedBy(signedByFrom, 2**(turnNumA % nParticipants)) &&
+                isSignedBy(signedByTo, 2**(turnNumB % nParticipants)),
             'roundRobin violation'
         );
         return true;
@@ -162,12 +161,11 @@ contract EmbeddedApplication is
     uint8 internal constant AIndex = 0;
     uint8 internal constant BIndex = 1;
     uint8 internal constant IIndex = 2;
-    uint256 internal constant AllMask = 2 ** AIndex + 2**BIndex + 2**IIndex;
-    uint256 internal constant AIMask = 2 ** AIndex + 2**IIndex;
-    uint256 internal constant BIMask = 2 ** BIndex + 2**IIndex;
-    uint256 internal constant AMask = 2 ** AIndex;
-    uint256 internal constant BMask = 2 ** BIndex;
-
+    uint256 internal constant AllMask = 2**AIndex + 2**BIndex + 2**IIndex;
+    uint256 internal constant AIMask = 2**AIndex + 2**IIndex;
+    uint256 internal constant BIMask = 2**BIndex + 2**IIndex;
+    uint256 internal constant AMask = 2**AIndex;
+    uint256 internal constant BMask = 2**BIndex;
 
     function validTransition(
         VariablePart memory from,
@@ -175,7 +173,7 @@ contract EmbeddedApplication is
         uint48, // turnNumTo (unused)
         uint256, // nParticipants (unused)
         uint256 signedByFrom, // Bitmap of who has signed the "from" state
-        uint256 signedByTo    // Bitmap of who has signed the "to" state
+        uint256 signedByTo // Bitmap of who has signed the "to" state
     ) public override pure returns (bool) {
         AppData memory fromAppData = abi.decode(from.appData, (AppData));
         AppData memory toAppData = abi.decode(to.appData, (AppData));
@@ -211,27 +209,51 @@ contract EmbeddedApplication is
 
         if (fromAppData.alreadyMoved == AlreadyMoved.None) {
             if (toAppData.alreadyMoved == AlreadyMoved.A) {
-                require(ForceMoveAppUtilities.isSignedBy(signedByFrom, BIMask), 'None->A: from not signed by BI');
-                require(ForceMoveAppUtilities.isSignedBy(signedByTo, AMask), 'None->A: to not signed by A');
-            } else if (toAppData.alreadyMoved == AlreadyMoved.B){
-                require(ForceMoveAppUtilities.isSignedBy(signedByFrom, AIMask), 'None->B: from not signed by AI');
-                require(ForceMoveAppUtilities.isSignedBy(signedByTo, BMask), 'None->B: to not signed by B');
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByFrom, BIMask),
+                    'None->A: from not signed by BI'
+                );
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByTo, AMask),
+                    'None->A: to not signed by A'
+                );
+            } else if (toAppData.alreadyMoved == AlreadyMoved.B) {
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByFrom, AIMask),
+                    'None->B: from not signed by AI'
+                );
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByTo, BMask),
+                    'None->B: to not signed by B'
+                );
             } else {
                 revert('None -> None or AB not allowed');
             }
         } else {
             if (fromAppData.alreadyMoved == AlreadyMoved.A) {
-                require(ForceMoveAppUtilities.isSignedBy(signedByFrom, AMask), 'A->AB: from not signed by A');
-                require(ForceMoveAppUtilities.isSignedBy(signedByTo, BMask), 'A->AB: to not signed by B');
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByFrom, AMask),
+                    'A->AB: from not signed by A'
+                );
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByTo, BMask),
+                    'A->AB: to not signed by B'
+                );
             } else if (fromAppData.alreadyMoved == AlreadyMoved.B) {
-                require(ForceMoveAppUtilities.isSignedBy(signedByFrom, BMask), 'B->AB: from not signed by B');
-                require(ForceMoveAppUtilities.isSignedBy(signedByTo, AMask), 'B->AB: to not signed by A');
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByFrom, BMask),
+                    'B->AB: from not signed by B'
+                );
+                require(
+                    ForceMoveAppUtilities.isSignedBy(signedByTo, AMask),
+                    'B->AB: to not signed by A'
+                );
             } else {
                 revert('AB->? not allowed');
             }
 
             // This should be an A -> AB or B -> AB
-            require(toAppData.alreadyMoved == AlreadyMoved.AB , 'must transition to AB');
+            require(toAppData.alreadyMoved == AlreadyMoved.AB, 'must transition to AB');
 
             // Since a support proof has already been supplied, the current support proof must be greater
             require(

--- a/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
+++ b/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
@@ -51,12 +51,16 @@ library ForceMoveAppUtilities {
     /**
      * @notice Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
      * @dev Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
-     * @param signedBy uint256 bitmap of which participants has provided a signature
-     * @param participantIndex index of participant in channel's participants array
-     * @return whether the participantIndex-th bit of signedBy is 1 or 0
+     * @param signedBy uint256 bitmap of which participants has provided a signature.
+     *                 The right-most bit is for participant 0, the next for participant 1, etc.
+     *                 Therefore, signedBy = sum_{participants p} (2 ** p.index if p signed else 0;)
+     * @param participants uint256 bitmask of participant in channel's participants array
+     *                 As with signedBy, the right most bit is 1 when we want to know if participant 0 signed.
+     *                 The next-significant bit is 1 when we want to know if participant 1 signed, etc.
+     * @return whether the given participants has signed the state
      */
-    function isSignedBy(uint256 signedBy, uint8 participantIndex) internal pure returns (bool) {
-        return ((signedBy >> participantIndex) % 2 == 1);
+    function isSignedBy(uint256 signedBy, uint256 participants) internal pure returns (bool) {
+        return (signedBy & participants) == participants;
     }
 
     // This function can be used inside validTransition
@@ -67,10 +71,11 @@ library ForceMoveAppUtilities {
         uint256 signedByFrom,
         uint256 signedByTo
     ) internal pure returns (bool) {
+        uint48 turnNumA = turnNumB - 1;
         require(
             turnNumB > 0 &&
-                isSignedBy(signedByFrom, uint8((turnNumB - 1) % nParticipants)) &&
-                isSignedBy(signedByTo, uint8(turnNumB % nParticipants)),
+                isSignedBy(signedByFrom, 2 ** (turnNumA % nParticipants)) &&
+                isSignedBy(signedByTo,   2 ** (turnNumB % nParticipants)),
             'roundRobin violation'
         );
         return true;
@@ -157,18 +162,22 @@ contract EmbeddedApplication is
     uint8 internal constant AIndex = 0;
     uint8 internal constant BIndex = 1;
     uint8 internal constant IIndex = 2;
+    uint256 internal constant AllMask = 2 ** AIndex + 2**BIndex + 2**IIndex;
+    uint256 internal constant AMask = 2 ** AIndex;
+    uint256 internal constant BMask = 2 ** BIndex;
+
 
     function validTransition(
         VariablePart memory from,
         VariablePart memory to,
         uint48, // turnNumTo (unused)
         uint256, // nParticipants (unused)
-        uint256, // signedByFrom - Bitmap of who has signed the "from" state?
-        uint256 signedByTo // Bitmap of who has signed the "to" state?
+        uint256 signedByFrom, // Bitmap of who has signed the "from" state
+        uint256 signedByTo    // Bitmap of who has signed the "to" state
     ) public override pure returns (bool) {
         // parameter wrangling
-        bool signedByA = ForceMoveAppUtilities.isSignedBy(signedByTo, AIndex);
-        bool signedByB = ForceMoveAppUtilities.isSignedBy(signedByTo, BIndex);
+        bool signedByA = ForceMoveAppUtilities.isSignedBy(signedByTo, AMask ); // 0b001
+        bool signedByB = ForceMoveAppUtilities.isSignedBy(signedByTo, BMask);  // 0b010
         AppData memory fromAppData = abi.decode(from.appData, (AppData));
         AppData memory toAppData = abi.decode(to.appData, (AppData));
         Outcome.AllocationItem[] memory fromAllocation = decode3PartyAllocation(from.outcome);
@@ -202,6 +211,8 @@ contract EmbeddedApplication is
         //   None
 
         if (fromAppData.alreadyMoved == AlreadyMoved.None) {
+            require(ForceMoveAppUtilities.isSignedBy(signedByFrom, AllMask), 'Everyone must sign None state');
+
             require(
                 (toAppData.alreadyMoved == AlreadyMoved.A && signedByA) ||
                     (toAppData.alreadyMoved == AlreadyMoved.B && signedByB),

--- a/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
+++ b/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
@@ -46,7 +46,7 @@ interface IForceMoveApp2 {
     // 0b111 = 7 : everyone
 }
 
-library ForceMoveAppUtilities {
+library NitroAppUtils {
     /**
      * @notice Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
      * @dev Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
@@ -210,44 +210,32 @@ contract EmbeddedApplication is
         if (fromAppData.alreadyMoved == AlreadyMoved.None) {
             if (toAppData.alreadyMoved == AlreadyMoved.A) {
                 require(
-                    ForceMoveAppUtilities.isSignedBy(signedByFrom, BIMask),
+                    NitroAppUtils.isSignedBy(signedByFrom, BIMask),
                     'None->A: from not signed by BI'
                 );
-                require(
-                    ForceMoveAppUtilities.isSignedBy(signedByTo, AMask),
-                    'None->A: to not signed by A'
-                );
+                require(NitroAppUtils.isSignedBy(signedByTo, AMask), 'None->A: to not signed by A');
             } else if (toAppData.alreadyMoved == AlreadyMoved.B) {
                 require(
-                    ForceMoveAppUtilities.isSignedBy(signedByFrom, AIMask),
+                    NitroAppUtils.isSignedBy(signedByFrom, AIMask),
                     'None->B: from not signed by AI'
                 );
-                require(
-                    ForceMoveAppUtilities.isSignedBy(signedByTo, BMask),
-                    'None->B: to not signed by B'
-                );
+                require(NitroAppUtils.isSignedBy(signedByTo, BMask), 'None->B: to not signed by B');
             } else {
                 revert('None -> None or AB not allowed');
             }
         } else {
             if (fromAppData.alreadyMoved == AlreadyMoved.A) {
                 require(
-                    ForceMoveAppUtilities.isSignedBy(signedByFrom, AMask),
+                    NitroAppUtils.isSignedBy(signedByFrom, AMask),
                     'A->AB: from not signed by A'
                 );
-                require(
-                    ForceMoveAppUtilities.isSignedBy(signedByTo, BMask),
-                    'A->AB: to not signed by B'
-                );
+                require(NitroAppUtils.isSignedBy(signedByTo, BMask), 'A->AB: to not signed by B');
             } else if (fromAppData.alreadyMoved == AlreadyMoved.B) {
                 require(
-                    ForceMoveAppUtilities.isSignedBy(signedByFrom, BMask),
+                    NitroAppUtils.isSignedBy(signedByFrom, BMask),
                     'B->AB: from not signed by B'
                 );
-                require(
-                    ForceMoveAppUtilities.isSignedBy(signedByTo, AMask),
-                    'B->AB: to not signed by A'
-                );
+                require(NitroAppUtils.isSignedBy(signedByTo, AMask), 'B->AB: to not signed by A');
             } else {
                 revert('AB->? not allowed');
             }
@@ -340,14 +328,14 @@ contract EmbeddedApplication is
             (toAppData.supportProofForX.whoSignedWhat[1] == 0)
         ) {
             require(
-                (ForceMoveAppUtilities._recoverSigner(
+                (NitroAppUtils._recoverSigner(
                     greaterStateHash,
                     toAppData.supportProofForX.sigs[0]
                 ) == toAppData.supportProofForX.fixedPart.participants[0]),
                 'sig0 !by participant0'
             );
             require(
-                ForceMoveAppUtilities._recoverSigner(
+                NitroAppUtils._recoverSigner(
                     greaterStateHash,
                     toAppData.supportProofForX.sigs[1]
                 ) == toAppData.supportProofForX.fixedPart.participants[1],
@@ -371,14 +359,14 @@ contract EmbeddedApplication is
                 (toAppData.supportProofForX.whoSignedWhat[1] == 1)
             ) {
                 require(
-                    (ForceMoveAppUtilities._recoverSigner(
+                    (NitroAppUtils._recoverSigner(
                         lesserStateHash,
                         toAppData.supportProofForX.sigs[0]
                     ) == toAppData.supportProofForX.fixedPart.participants[0]),
                     'sig0 on state0 !by participant0'
                 );
                 require(
-                    ForceMoveAppUtilities._recoverSigner(
+                    NitroAppUtils._recoverSigner(
                         greaterStateHash,
                         toAppData.supportProofForX.sigs[1]
                     ) == toAppData.supportProofForX.fixedPart.participants[1],
@@ -389,14 +377,14 @@ contract EmbeddedApplication is
                 (toAppData.supportProofForX.whoSignedWhat[1] == 0)
             ) {
                 require(
-                    (ForceMoveAppUtilities._recoverSigner(
+                    (NitroAppUtils._recoverSigner(
                         greaterStateHash,
                         toAppData.supportProofForX.sigs[0]
                     ) == toAppData.supportProofForX.fixedPart.participants[0]),
                     'sig0 on state1 !by participant0'
                 );
                 require(
-                    ForceMoveAppUtilities._recoverSigner(
+                    NitroAppUtils._recoverSigner(
                         lesserStateHash,
                         toAppData.supportProofForX.sigs[1]
                     ) == toAppData.supportProofForX.fixedPart.participants[1],

--- a/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
+++ b/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
@@ -47,6 +47,14 @@ interface IForceMoveApp2 {
 }
 
 library ForceMoveAppUtilities {
+
+    /**
+     * @notice Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
+     * @dev Given a "signedBy" bitmap and a participant index, indicate whether the participant has provided a signature
+     * @param signedBy uint256 bitmap of which participants has provided a signature
+     * @param participantIndex index of participant in channel's participants array
+     * @return whether the participantIndex-th bit of signedBy is 1 or 0
+     */
     function isSignedBy(uint256 signedBy, uint8 participantIndex) internal pure returns (bool) {
         return ((signedBy >> participantIndex) % 2 == 1);
     }
@@ -155,8 +163,8 @@ contract EmbeddedApplication is
         VariablePart memory to,
         uint48, // turnNumTo (unused)
         uint256, // nParticipants (unused)
-        uint256, // signedByFrom (unused) - Who has signed the "from" state?
-        uint256 signedByTo // Who has signed the "to" state?
+        uint256, // signedByFrom - Bitmap of who has signed the "from" state?
+        uint256 signedByTo // Bitmap of who has signed the "to" state?
     ) public override pure returns (bool) {
         // parameter wrangling
         bool signedByA = ForceMoveAppUtilities.isSignedBy(signedByTo, 0);

--- a/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
+++ b/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
@@ -220,7 +220,6 @@ contract EmbeddedApplication is
                 revert('None -> None or AB not allowed');
             }
         } else {
-            require(toAppData.alreadyMoved == AlreadyMoved.AB , 'must transition to AB');
             if (fromAppData.alreadyMoved == AlreadyMoved.A) {
                 require(ForceMoveAppUtilities.isSignedBy(signedByFrom, AMask), 'A->AB: from not signed by A');
                 require(ForceMoveAppUtilities.isSignedBy(signedByTo, BMask), 'A->AB: to not signed by B');
@@ -228,8 +227,11 @@ contract EmbeddedApplication is
                 require(ForceMoveAppUtilities.isSignedBy(signedByFrom, BMask), 'B->AB: from not signed by B');
                 require(ForceMoveAppUtilities.isSignedBy(signedByTo, AMask), 'B->AB: to not signed by A');
             } else {
-                revert('AB->AB not allowed');
+                revert('AB->? not allowed');
             }
+
+            // This should be an A -> AB or B -> AB
+            require(toAppData.alreadyMoved == AlreadyMoved.AB , 'must transition to AB');
 
             // Since a support proof has already been supplied, the current support proof must be greater
             require(

--- a/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
+++ b/packages/nitro-protocol/contracts/examples/EmbeddedApplication.sol
@@ -154,9 +154,9 @@ contract EmbeddedApplication is
         AlreadyMoved alreadyMoved;
     }
 
-    uint256 internal constant AIndex = 0;
-    uint256 internal constant BIndex = 1;
-    uint256 internal constant IIndex = 2;
+    uint8 internal constant AIndex = 0;
+    uint8 internal constant BIndex = 1;
+    uint8 internal constant IIndex = 2;
 
     function validTransition(
         VariablePart memory from,
@@ -167,8 +167,8 @@ contract EmbeddedApplication is
         uint256 signedByTo // Bitmap of who has signed the "to" state?
     ) public override pure returns (bool) {
         // parameter wrangling
-        bool signedByA = ForceMoveAppUtilities.isSignedBy(signedByTo, 0);
-        bool signedByB = ForceMoveAppUtilities.isSignedBy(signedByTo, 1);
+        bool signedByA = ForceMoveAppUtilities.isSignedBy(signedByTo, AIndex);
+        bool signedByB = ForceMoveAppUtilities.isSignedBy(signedByTo, BIndex);
         AppData memory fromAppData = abi.decode(from.appData, (AppData));
         AppData memory toAppData = abi.decode(to.appData, (AppData));
         Outcome.AllocationItem[] memory fromAllocation = decode3PartyAllocation(from.outcome);

--- a/packages/nitro-protocol/test/contracts/examples/EmbeddedApplication/validTransition.test.ts
+++ b/packages/nitro-protocol/test/contracts/examples/EmbeddedApplication/validTransition.test.ts
@@ -192,7 +192,12 @@ beforeAll(async () => {
 
 const turnNumTo = 0; // TODO this is unused, but presumably it _should_ be used
 const nParticipants = 0; // TODO this is unused
-const signedByFrom = 0b00; // TODO this is unused
+
+const signedBy = {
+  all: 0b111,
+  alice: 0b001,
+  bob: 0b010,
+};
 
 describe('EmbeddedApplication: named state transitions', () => {
   it('returns true / reverts for a correct / incorrect None => A transition', async () => {
@@ -201,8 +206,8 @@ describe('EmbeddedApplication: named state transitions', () => {
       AvariablePartForJ,
       turnNumTo,
       nParticipants,
-      signedByFrom,
-      0b01 // signedByTo = just Alice
+      signedBy.all,
+      signedBy.alice
     );
     expect(result).toBe(true);
     await expectRevert(
@@ -212,8 +217,8 @@ describe('EmbeddedApplication: named state transitions', () => {
           AvariablePartForJ,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b10 // signedByTo = just Bob
+          signedBy.all,
+          signedBy.bob
         ),
       'incorrect move from None'
     );
@@ -224,8 +229,8 @@ describe('EmbeddedApplication: named state transitions', () => {
       BvariablePartForJ,
       turnNumTo,
       nParticipants,
-      signedByFrom,
-      0b10 // signedByTo = just Bob
+      signedBy.all,
+      signedBy.bob
     );
     expect(result).toBe(true);
     await expectRevert(
@@ -235,8 +240,8 @@ describe('EmbeddedApplication: named state transitions', () => {
           BvariablePartForJ,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'incorrect move from None'
     );
@@ -247,8 +252,8 @@ describe('EmbeddedApplication: named state transitions', () => {
       ABvariablePartForJ,
       turnNumTo,
       nParticipants,
-      signedByFrom,
-      0b10 // signedByTo = just Bob
+      signedBy.alice,
+      signedBy.bob
     );
     expect(result).toBe(true);
     await expectRevert(
@@ -258,8 +263,8 @@ describe('EmbeddedApplication: named state transitions', () => {
           ABvariablePartForJ,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.alice,
+          signedBy.alice
         ),
       'incorrect move from A'
     );
@@ -270,8 +275,8 @@ describe('EmbeddedApplication: named state transitions', () => {
       ABvariablePartForJ,
       turnNumTo,
       nParticipants,
-      signedByFrom,
-      0b01 // signedByTo = just Alice
+      signedBy.alice,
+      signedBy.alice
     );
     expect(result).toBe(true);
     await expectRevert(
@@ -281,8 +286,8 @@ describe('EmbeddedApplication: named state transitions', () => {
           ABvariablePartForJ,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b10 // signedByTo = just Bob
+          signedBy.alice,
+          signedBy.bob
         ),
       'incorrect move from B'
     );
@@ -303,8 +308,8 @@ describe('EmbeddedApplication: named state transitions', () => {
           evenGreaterSupportProofForX,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b10 // signedByTo = just Bob
+          signedBy.alice,
+          signedBy.bob
         ),
       'move from None,A,B only'
     );
@@ -322,8 +327,8 @@ describe('EmbeddedApplication: reversions', () => {
           {...AvariablePartForJ, outcome: encodeOutcome(maliciousOutcome)},
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'destinations may not change'
     );
@@ -338,8 +343,8 @@ describe('EmbeddedApplication: reversions', () => {
           {...AvariablePartForJ, outcome: encodeOutcome(maliciousOutcome)},
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'p2.amt !constant'
     );
@@ -354,8 +359,8 @@ describe('EmbeddedApplication: reversions', () => {
           {...AvariablePartForJ, outcome: encodeOutcome(maliciousOutcome)},
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'total allocation changed'
     );
@@ -374,8 +379,8 @@ describe('EmbeddedApplication: reversions', () => {
             inferiorSupportProof,
             turnNumTo,
             nParticipants,
-            signedByFrom,
-            0b10 // signedByTo = just Bob
+            signedBy.all,
+            signedBy.bob
           ),
         'inferior support proof'
       );
@@ -390,8 +395,8 @@ describe('EmbeddedApplication: reversions', () => {
           notProperlyAbsorbed,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'X / J outcome mismatch'
     );
@@ -410,8 +415,8 @@ describe('EmbeddedApplication: reversions', () => {
           appDefinitionChanged,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'X.appDefinition changed'
     );
@@ -430,8 +435,8 @@ describe('EmbeddedApplication: reversions', () => {
           challengeDurationChanged,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'X.challengeDuration changed'
     );
@@ -450,8 +455,8 @@ describe('EmbeddedApplication: reversions', () => {
           malicious,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       '1 or 2 states required'
     );
@@ -470,8 +475,8 @@ describe('EmbeddedApplication: reversions', () => {
           malicious,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'invalid whoSignedWhat'
     );
@@ -493,8 +498,8 @@ describe('EmbeddedApplication: reversions', () => {
           malicious,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'sig0 !by participant0'
     );
@@ -516,8 +521,8 @@ describe('EmbeddedApplication: reversions', () => {
           malicious,
           turnNumTo,
           nParticipants,
-          signedByFrom,
-          0b01 // signedByTo = just Alice
+          signedBy.all,
+          signedBy.alice
         ),
       'sig1 !by participant1'
     );

--- a/packages/nitro-protocol/test/contracts/examples/EmbeddedApplication/validTransition.test.ts
+++ b/packages/nitro-protocol/test/contracts/examples/EmbeddedApplication/validTransition.test.ts
@@ -15,17 +15,20 @@ import {getTestProvider, setupContract} from '../../../test-helpers';
 
 type RevertReason =
   // each reason represents a distinct code path that we should check in this test
+  | 'None->B: from not signed by AI' // tested
+  | 'None->B: to not signed by B' // tested
+  | 'None->A: from not signed by BI' // tested
+  | 'None->A: to not signed by A' // tested
+  | 'A->AB: to not signed by B' // tested
+  | 'A->AB: from not signed by A' // tested
+  | 'B->AB: to not signed by A' // tested
+  | 'B->AB: from not signed by B' // tested
+  | 'must transition to AB' // tested
+  | 'AB->? not allowed' // tested
   | 'destinations may not change' // tested
   | 'p2.amt !constant' // tested
   | 'total allocation changed' // tested
-  | 'None->B: from not signed by AI'
-  | 'None->B: to not signed by B'
-  | 'None->A: from not signed by BI'
-  | 'None->A: to not signed by A'
   | 'inferior support proof' // tested
-  | 'incorrect move from A' // tested
-  | 'incorrect move from B' // tested
-  | 'move from None,A,B only' //tested
   | 'X / J outcome mismatch' // tested
   | 'X.appDefinition changed' // tested
   | 'X.challengeDuration changed' // tested
@@ -37,8 +40,7 @@ type RevertReason =
   | 'sig0 on state1 !by participant0'
   | 'sig0 on state0 !by participant1'
   | 'invalid whoSignedWhat' // tested
-  | 'invalid transition in X'
-  | 'Everyone must sign None state';
+  | 'invalid transition in X';
 
 async function expectRevert(fn: () => void, reason: RevertReason) {
   return innerExpectRevert(fn, reason);
@@ -209,157 +211,122 @@ const signedBy = {
 };
 
 describe('EmbeddedApplication: named state transitions', () => {
-  test('signature checks on transitions from None state', async () => {
-    const tx = (to: 'a' | 'b', signedByFrom, signedByTo) =>
-      embeddedApplication.validTransition(
-        NoneVariablePartForJ,
-        to == 'a' ? AvariablePartForJ : BvariablePartForJ,
-        turnNumTo,
-        nParticipants,
-        signedByFrom,
-        signedByTo
-      );
-    let msg: RevertReason = 'None->A: from not signed by BI';
-    await expectRevert(() => tx('a', signedBy.alice, signedBy.alice), msg);
-    await expectRevert(() => tx('a', signedBy.bob, signedBy.alice), msg);
-    await expectRevert(() => tx('a', signedBy.ai, signedBy.alice), msg);
-    await expectRevert(() => tx('a', signedBy.none, signedBy.alice), msg);
-
-    msg = 'None->A: to not signed by A';
-    await expectRevert(() => tx('a', signedBy.bi, signedBy.bob), msg);
-    await expectRevert(() => tx('a', signedBy.bi, signedBy.irene), msg);
-    await expectRevert(() => tx('a', signedBy.all, signedBy.none), msg);
-
-    msg = 'None->B: to not signed by B';
-    await expectRevert(() => tx('b', signedBy.all, signedBy.irene), msg);
-    await expectRevert(() => tx('b', signedBy.all, signedBy.alice), msg);
-    await expectRevert(() => tx('b', signedBy.all, signedBy.ai), msg);
-    await expectRevert(() => tx('b', signedBy.all, signedBy.none), msg);
-
-    msg = 'None->B: from not signed by AI';
-    await expectRevert(() => tx('b', signedBy.bi, signedBy.all), msg);
-    await expectRevert(() => tx('b', signedBy.irene, signedBy.all), msg);
-    await expectRevert(() => tx('b', signedBy.none, signedBy.ai), msg);
-
-    await expect(tx('a', signedBy.all, signedBy.alice)).resolves.toEqual(true);
-    await expect(tx('a', signedBy.bi, signedBy.alice)).resolves.toEqual(true);
-    await expect(tx('b', signedBy.all, signedBy.bob)).resolves.toEqual(true);
-    await expect(tx('b', signedBy.ai, signedBy.bob)).resolves.toEqual(true);
-  });
-
-  it('returns true / reverts for a correct / incorrect None => A transition', async () => {
-    const result = await embeddedApplication.validTransition(
-      NoneVariablePartForJ,
-      AvariablePartForJ,
+  type State = 'none' | 'a' | 'b' | 'ab';
+  const variables: Record<State, any> = {
+    none: NoneVariablePartForJ,
+    a: AvariablePartForJ,
+    b: BvariablePartForJ,
+    ab: ABvariablePartForJ,
+  };
+  const tx = (from: State, to: State, signedByFrom, signedByTo) =>
+    embeddedApplication.validTransition(
+      variables[from],
+      variables[to],
       turnNumTo,
       nParticipants,
-      signedBy.all,
-      signedBy.alice
+      signedByFrom,
+      signedByTo
     );
-    expect(result).toBe(true);
-    await expectRevert(
-      () =>
-        embeddedApplication.validTransition(
-          NoneVariablePartForJ,
-          AvariablePartForJ,
-          turnNumTo,
-          nParticipants,
-          signedBy.all,
-          signedBy.bob
-        ),
-      'incorrect move from None'
-    );
+
+  describe('transitions from None state', () => {
+    test('None->A: reverts when from is not signed by BI', async () => {
+      const msg: RevertReason = 'None->A: from not signed by BI';
+      await expectRevert(() => tx('none', 'a', signedBy.alice, signedBy.alice), msg);
+      await expectRevert(() => tx('none', 'a', signedBy.bob, signedBy.alice), msg);
+      await expectRevert(() => tx('none', 'a', signedBy.ai, signedBy.alice), msg);
+      await expectRevert(() => tx('none', 'a', signedBy.none, signedBy.alice), msg);
+    });
+
+    test('None->A: reverts when to is not signed by A', async () => {
+      const msg: RevertReason = 'None->A: to not signed by A';
+      await expectRevert(() => tx('none', 'a', signedBy.bi, signedBy.bob), msg);
+      await expectRevert(() => tx('none', 'a', signedBy.bi, signedBy.irene), msg);
+      await expectRevert(() => tx('none', 'a', signedBy.all, signedBy.none), msg);
+    });
+
+    test('None->B: reverts when to is not signed by B', async () => {
+      const msg: RevertReason = 'None->B: to not signed by B';
+      await expectRevert(() => tx('none', 'b', signedBy.all, signedBy.irene), msg);
+      await expectRevert(() => tx('none', 'b', signedBy.all, signedBy.alice), msg);
+      await expectRevert(() => tx('none', 'b', signedBy.all, signedBy.ai), msg);
+      await expectRevert(() => tx('none', 'b', signedBy.all, signedBy.none), msg);
+    });
+
+    test('None->B: reverts when from is not signed by AI', async () => {
+      const msg: RevertReason = 'None->B: from not signed by AI';
+      await expectRevert(() => tx('none', 'b', signedBy.bi, signedBy.all), msg);
+      await expectRevert(() => tx('none', 'b', signedBy.irene, signedBy.all), msg);
+      await expectRevert(() => tx('none', 'b', signedBy.none, signedBy.ai), msg);
+    });
+
+    test('valid transitions', async () => {
+      await expect(tx('none', 'a', signedBy.all, signedBy.alice)).resolves.toEqual(true);
+      await expect(tx('none', 'a', signedBy.bi, signedBy.alice)).resolves.toEqual(true);
+      await expect(tx('none', 'b', signedBy.all, signedBy.bob)).resolves.toEqual(true);
+      await expect(tx('none', 'b', signedBy.ai, signedBy.bob)).resolves.toEqual(true);
+    });
   });
-  it('returns true / reverts for a correct / incorrect None => B transition', async () => {
-    const result = await embeddedApplication.validTransition(
-      NoneVariablePartForJ,
-      BvariablePartForJ,
-      turnNumTo,
-      nParticipants,
-      signedBy.all,
-      signedBy.bob
-    );
-    expect(result).toBe(true);
-    await expectRevert(
-      () =>
-        embeddedApplication.validTransition(
-          NoneVariablePartForJ,
-          BvariablePartForJ,
-          turnNumTo,
-          nParticipants,
-          signedBy.all,
-          signedBy.alice
-        ),
-      'incorrect move from None'
-    );
+
+  describe('transitions from A', () => {
+    test('valid signatures', async () => {
+      await expect(tx('a', 'ab', signedBy.alice, signedBy.bob)).resolves.toEqual(true);
+      await expect(tx('a', 'ab', signedBy.ai, signedBy.bob)).resolves.toEqual(true);
+    });
+
+    let msg: RevertReason = 'A->AB: from not signed by A';
+    test('A->AB: from not signed from A', async () => {
+      msg = 'A->AB: from not signed by A';
+      await expectRevert(() => tx('a', 'ab', signedBy.bi, signedBy.all), msg);
+    });
+
+    test('A->AB: to not signed by B', async () => {
+      msg = 'A->AB: to not signed by B';
+      await expectRevert(() => tx('a', 'ab', signedBy.all, signedBy.alice), msg);
+      await expectRevert(() => tx('a', 'ab', signedBy.all, signedBy.ai), msg);
+    });
+
+    test('A->invalid transition', async () => {
+      msg = 'must transition to AB';
+      await expectRevert(() => tx('a', 'none', signedBy.all, signedBy.all), msg);
+      await expectRevert(() => tx('a', 'a', signedBy.all, signedBy.all), msg);
+      await expectRevert(() => tx('a', 'b', signedBy.all, signedBy.all), msg);
+    });
   });
-  it('returns true / reverts for a correct / incorrect A => AB transition', async () => {
-    const result = await embeddedApplication.validTransition(
-      AvariablePartForJ,
-      ABvariablePartForJ,
-      turnNumTo,
-      nParticipants,
-      signedBy.alice,
-      signedBy.bob
-    );
-    expect(result).toBe(true);
-    await expectRevert(
-      () =>
-        embeddedApplication.validTransition(
-          AvariablePartForJ,
-          ABvariablePartForJ,
-          turnNumTo,
-          nParticipants,
-          signedBy.alice,
-          signedBy.alice
-        ),
-      'incorrect move from A'
-    );
+
+  describe('transitions from B', () => {
+    test('valid signatures', async () => {
+      await expect(tx('b', 'ab', signedBy.bob, signedBy.alice)).resolves.toEqual(true);
+      await expect(tx('b', 'ab', signedBy.bi, signedBy.alice)).resolves.toEqual(true);
+    });
+
+    let msg: RevertReason = 'B->AB: from not signed by B';
+
+    test('B->AB: from not signed by B', async () => {
+      msg = 'B->AB: from not signed by B';
+      await expectRevert(() => tx('b', 'ab', signedBy.ai, signedBy.all), msg);
+    });
+
+    test('B->AB: to not signed by A', async () => {
+      msg = 'B->AB: to not signed by A';
+      await expectRevert(() => tx('b', 'ab', signedBy.all, signedBy.bob), msg);
+      await expectRevert(() => tx('b', 'ab', signedBy.all, signedBy.bi), msg);
+    });
+
+    test('B->invalid transition', async () => {
+      msg = 'must transition to AB';
+      await expectRevert(() => tx('b', 'none', signedBy.all, signedBy.all), msg);
+      await expectRevert(() => tx('b', 'a', signedBy.all, signedBy.all), msg);
+      await expectRevert(() => tx('b', 'b', signedBy.all, signedBy.all), msg);
+    });
   });
-  it('returns true / reverts for a correct / incorrect B => AB transition', async () => {
-    const result = await embeddedApplication.validTransition(
-      BvariablePartForJ,
-      ABvariablePartForJ,
-      turnNumTo,
-      nParticipants,
-      signedBy.alice,
-      signedBy.alice
-    );
-    expect(result).toBe(true);
-    await expectRevert(
-      () =>
-        embeddedApplication.validTransition(
-          BvariablePartForJ,
-          ABvariablePartForJ,
-          turnNumTo,
-          nParticipants,
-          signedBy.alice,
-          signedBy.bob
-        ),
-      'incorrect move from B'
-    );
-  });
-  it('reverts when trying to move from AB', async () => {
-    const evenGreaterSupportProofForX = {
-      ...ABvariablePartForJ,
-      appData: encodeEmbeddedApplicationData({
-        alreadyMoved: AlreadyMoved.A,
-        channelIdForX: getChannelId(stateForX.channel),
-        supportProofForX: supportProofForX({...greaterStateForX, turnNum: 99}),
-      }),
-    };
-    await expectRevert(
-      () =>
-        embeddedApplication.validTransition(
-          ABvariablePartForJ,
-          evenGreaterSupportProofForX,
-          turnNumTo,
-          nParticipants,
-          signedBy.alice,
-          signedBy.bob
-        ),
-      'move from None,A,B only'
-    );
+
+  test('transitions from AB always revert', async () => {
+    const msg: RevertReason = 'AB->? not allowed';
+
+    await expectRevert(() => tx('ab', 'none', signedBy.all, signedBy.all), msg);
+    await expectRevert(() => tx('ab', 'a', signedBy.all, signedBy.all), msg);
+    await expectRevert(() => tx('ab', 'b', signedBy.all, signedBy.all), msg);
+    await expectRevert(() => tx('ab', 'ab', signedBy.all, signedBy.all), msg);
   });
 });
 


### PR DESCRIPTION
The existing `EmbeddedApplication.sol` did not check the `signedBy` of the `from` state (`signedBy` is meant to be computed by the core protocol.) This PR fixes that issue, presenting one fair means of checking "is this state supported?" in a version of Nitro with dynamic turn taking.

The `EmbeddedApp.sol` now encodes this signature checking logic:
1. A `None -> A` transition is valid if B & I sign the `from` state and A signs the `to` state.
2. A `None -> B` transition is valid if A & I sign the `from` state and B signs the `to` state
3. A `A -> AB` transition is valid if A signed the `from` state and B signed the `to` state
4. A `B -> AB` transition is valid if B signed the `from` state and A signed the `to` state
5. All other transitions are invalid

The isSignedBy utility is modified to allow app rules to check whether a _set_ of participants has signed a state, rather than just one participant. This lets us express the logic described in 1-5.

## Issues with this change
This change does not address the following problem:
- the `EmbeddedApplication.sol` example was written without specifying how the adjudicator could or should check whether a state is supported

Originally, I intended to address this problem by checking signatures on .

For instance, Alice & Bob can collude to create a valid transition from an A state to an AB state that does not include any signature from Irene. It is not clear from the existing work whether this type of transition should be allowed.

This highlights the requirement that, with dynamic turn taking, a Nitro app should expose a `validSupportProof` function instead of a `validTransition` function.


---

Then, following a single blank line, a summary of the change and which issue is fixed, including 
- [ ] what is the problem being solved
- [ ] why this is a good approach
- [ ] what are the shortcomings of this approach, if any

It may include
- [ ] background information, such as "Fixes #"
- [ ] benchmark results
- [ ] links to design documents
- [ ] dependencies required for this change

The summary may omit some of these details if this PR fixes a single ticket that includes these details. It is the reviewer's discretion. 

## Changes [Optional] 
Multiple changes are not recommended, so this section should normally be omitted. Unfortunately, they are sometimes unavoidable. If there are multiple logical changes, list them separately.

1. `'foo'` is replaced by `'bar'`
2. `'fizzbuzz'` is optimized for gas

## How Has This Been Tested? [Optional] 

Did you need to run manual tests to verify this change? If so, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## :warning: Does this require multiple approvals? [Optional]
Please explain which reason, if any, why this requires more than one approval.
- [ ] Is it security related?
- [ ] Is it a significant process change?
- [ ] Is it a significant change to architectural, design?

---
## Checklist:

### Code quality
- [ ] I have written clear commit messages
- [ ] I have performed a self-review of my own code
- [ ] This change does not have an unduly wide scope
- [ ] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [ ] I have commented my code wherever necessary (can be 0)
- [ ] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [ ] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [ ] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [ ] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [ ] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
