### PR TITLE
Add the CreateLedger channel to the Wallet API

### DIFF
--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -377,7 +377,9 @@ export class SingleThreadedEngine implements EngineInterface {
         newObjective: WalletObjective;
     }>;
     createChannels(args: CreateChannelParams, numberOfChannels: number): Promise<MultipleChannelOutput>;
-    createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput>;
+    createLedgerChannel(args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>, fundingStrategy?: 'Direct' | 'Fake'): Promise<SingleChannelOutput & {
+        newObjective: WalletObjective;
+    }>;
     destroy(): Promise<void>;
     getApprovedObjectives(): Promise<WalletObjective[]>;
     getChannels(): Promise<MultipleChannelOutput>;
@@ -450,6 +452,9 @@ export class Wallet extends EventEmitter<WalletEvents> {
     // Warning: (ae-forgotten-export) The symbol "MessageServiceFactory" needs to be exported by the entry point index.d.ts
     static create(incomingConfig: IncomingWalletConfig, messageServiceFactory: MessageServiceFactory): Promise<Wallet>;
     createChannels(channelParameters: CreateChannelParams[]): Promise<ObjectiveResult[]>;
+    createLedgerChannel(channelParams: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration' | 'fundingStrategy'> & {
+        fundingStrategy: 'Direct' | 'Fake';
+    }): Promise<ObjectiveResult>;
     // (undocumented)
     destroy(): Promise<void>;
     // (undocumented)

--- a/packages/server-wallet/src/__test-with-peers__/utils.ts
+++ b/packages/server-wallet/src/__test-with-peers__/utils.ts
@@ -15,11 +15,15 @@ export async function expectLatestStateToMatch(
   expect(latest.channelResult).toMatchObject(partial);
 }
 
-export function getWithPeersCreateChannelsArgs(peerSetup: PeerSetup): CreateChannelParams {
-  return createChannelArgs({
-    participants: [peerSetup.participantA, peerSetup.participantB],
+export function getWithPeersCreateChannelsArgs(
+  peerSetup: PeerSetup
+): CreateChannelParams & {fundingStrategy: 'Fake'} {
+  return {
+    ...createChannelArgs({
+      participants: [peerSetup.participantA, peerSetup.participantB],
+    }),
     fundingStrategy: 'Fake',
-  });
+  };
 }
 
 export function waitForObjectiveProposals(objectiveIds: string[], wallet: Wallet): Promise<void> {

--- a/packages/server-wallet/src/__test-with-peers__/wallet/create-ledger-channel.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/create-ledger-channel.test.ts
@@ -1,0 +1,64 @@
+import {
+  teardownPeerSetup,
+  setupPeerWallets,
+  PeerSetupWithWallets,
+} from '../../../jest/with-peers-setup-teardown';
+import {LatencyOptions, TestMessageService} from '../../message-service/test-message-service';
+import {getWithPeersCreateChannelsArgs, waitForObjectiveProposals} from '../utils';
+
+jest.setTimeout(60_000);
+let peerSetup: PeerSetupWithWallets;
+
+beforeAll(async () => {
+  peerSetup = await setupPeerWallets();
+});
+afterAll(async () => {
+  await teardownPeerSetup(peerSetup);
+});
+
+describe('CreateLedger', () => {
+  // This is the percentages of messages that get dropped
+  const testCases: LatencyOptions[] = [
+    // No latency/message dropping
+    {
+      dropRate: 0,
+      meanDelay: undefined,
+    },
+    // Lots of messages dropping but no delay
+    {dropRate: 0.3, meanDelay: undefined},
+    // delay but no dropping
+    {dropRate: 0, meanDelay: 50},
+    // Delay and drop
+    {dropRate: 0.2, meanDelay: 25},
+  ];
+  test.each(testCases)(
+    'can successfully create a ledger channel with the latency options: %o',
+    async options => {
+      const {peerWallets, peerEngines} = peerSetup;
+      TestMessageService.setLatencyOptions(peerWallets, options);
+
+      const response = await peerWallets.a.createLedgerChannel(
+        getWithPeersCreateChannelsArgs(peerSetup)
+      );
+      const {objectiveId} = response;
+      const proposalPromise = waitForObjectiveProposals([objectiveId], peerWallets.b);
+
+      await proposalPromise;
+      const bResponse = await peerWallets.b.approveObjectives([objectiveId]);
+      expect(await response.done).toMatchObject({type: 'Success'});
+      await expect(bResponse).toBeObjectiveDoneType('Success');
+
+      // Ensure that all of A's channels are running
+      const {channelResults: aChannels} = await peerEngines.a.getChannels();
+      for (const a of aChannels) {
+        expect(a.status).toEqual('running');
+      }
+
+      // Ensure that all of B's channels are running
+      const {channelResults: bChannels} = await peerEngines.a.getChannels();
+      for (const b of bChannels) {
+        expect(b.status).toEqual('running');
+      }
+    }
+  );
+});

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -288,7 +288,7 @@ export class SingleThreadedEngine implements EngineInterface {
   async createLedgerChannel(
     args: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration'>,
     fundingStrategy: 'Direct' | 'Fake' = 'Direct'
-  ): Promise<SingleChannelOutput> {
+  ): Promise<SingleChannelOutput & {newObjective: WalletObjective}> {
     const response = EngineResponse.initialize();
 
     await this._createChannel(
@@ -304,7 +304,13 @@ export class SingleThreadedEngine implements EngineInterface {
 
     // NB: We intentionally do not call this.takeActions, because there are no actions to take when creating a channel.
 
-    return response.singleChannelOutput();
+    const result = response.singleChannelOutput();
+
+    if (!hasNewObjective(result)) {
+      throw new Error('No new objective created for create channel');
+    } else {
+      return result;
+    }
   }
   /**
    * Creates a channel.

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -291,7 +291,7 @@ export class SingleThreadedEngine implements EngineInterface {
   ): Promise<SingleChannelOutput & {newObjective: WalletObjective}> {
     const response = EngineResponse.initialize();
 
-    await this._createChannel(
+    const channelId = await this._createChannel(
       response,
       {
         ...args,
@@ -302,8 +302,7 @@ export class SingleThreadedEngine implements EngineInterface {
       'ledger'
     );
 
-    // NB: We intentionally do not call this.takeActions, because there are no actions to take when creating a channel.
-
+    await this.takeActions([channelId], response);
     const result = response.singleChannelOutput();
 
     if (!hasNewObjective(result)) {


### PR DESCRIPTION
Fixes #3656 

Adds CreateLedgerChannel to the wallet API. 

Essentially we're exposing the existing CreateLedgerChannel on the engine via the wallet.
