### PR TITLE
Add test infrastructure for testing ledger funded channels

### DIFF
--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -88,6 +88,15 @@ async function createLoad() {
     )
   );
 
+  console.log(chalk.whiteBright(`${createRate * duration} will be created.`));
+  console.log(
+    chalk.whiteBright(
+      `${
+        closeRate * duration > 0 ? closeRate * duration : 'None'
+      } of those channels will be closed.`
+    )
+  );
+
   if (closeRate >= createRate) {
     console.log(
       chalk.yellow('The close rate is larger than the create rate! All channels will end up closed')

--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -160,8 +160,8 @@ function generateCreateLedgerSteps(
 ): Step[] {
   const steps: Step[] = [];
   _.times(ledgerRate * duration, () => {
-    const timestamp = generateRandomNumber(0, toMilliseconds(duration));
-    const startIndex = generateRandomNumber(0, Object.keys(roles).length - 1);
+    const timestamp = generateRandomInteger(0, toMilliseconds(duration));
+    const startIndex = generateRandomInteger(0, Object.keys(roles).length - 1);
 
     const participants = generateParticipants(roles, startIndex);
 
@@ -197,7 +197,7 @@ function generateCloseSteps(
       if (createStep) {
         // We want a close timestamp that occurs at least closeDelay time after the create time
         const timestamp = Math.max(
-          generateRandomNumber(createStep.timestamp, toMilliseconds(duration)),
+          generateRandomInteger(createStep.timestamp, toMilliseconds(duration)),
           createStep.timestamp + toMilliseconds(closeDelay)
         );
 
@@ -224,7 +224,7 @@ function generateCreateSteps(
   const steps = _.clone(previousSteps) as Step[];
   const ledgerSteps = steps.filter(s => s.type === 'CreateLedgerChannel');
   _.times(createRate * duration, () => {
-    const startIndex = generateRandomNumber(0, Object.keys(roles).length - 1);
+    const startIndex = generateRandomInteger(0, Object.keys(roles).length - 1);
 
     // Due to https://github.com/statechannels/statechannels/issues/3652 we'll run into duplicate channelIds if we use the same constants.
     // For now we re-order the participants based on who is creating the channel.
@@ -238,13 +238,13 @@ function generateCreateSteps(
     if (funding.type === 'Ledger') {
       const ledgerToUse = getRandomElement(ledgerSteps);
       // We want to wait ledgerDelay before attempting to use the ledger channel
-      timestamp = generateRandomNumber(
+      timestamp = generateRandomInteger(
         ledgerToUse.timestamp + funding.ledgerDelay,
         toMilliseconds(duration)
       );
       fundingInfo = {type: 'Ledger', fundingLedgerJob: ledgerToUse.jobId};
     } else {
-      timestamp = generateRandomNumber(0, toMilliseconds(duration));
+      timestamp = generateRandomInteger(0, toMilliseconds(duration));
       fundingInfo = {type: 'Direct'};
     }
 
@@ -262,7 +262,13 @@ function generateCreateSteps(
   return steps;
 }
 
-function generateRandomNumber(min: number, max: number): number {
+/**
+ * Generates a random integer from [min,max]
+ * @param min The minimum possible value that can be generated
+ * @param max The maximum possible value that can be generated
+ * @returns The generated number
+ */
+function generateRandomInteger(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
@@ -332,7 +338,7 @@ function toMilliseconds(seconds: number): number {
 }
 
 function getRandomElement<T>(array: Array<T>): T {
-  const index = generateRandomNumber(0, array.length - 1);
+  const index = generateRandomInteger(0, array.length - 1);
   return array[index];
 }
 
@@ -349,6 +355,6 @@ function getRandomJobToClose(
     s => s.type === 'CreateChannel' && !jobsAlreadyWithClose.includes(s.jobId)
   );
 
-  const index = generateRandomNumber(0, filtered.length - 1);
+  const index = generateRandomInteger(0, filtered.length - 1);
   return filtered[index];
 }

--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -239,11 +239,10 @@ function generateCreateSteps(
     if (funding.type === 'Ledger') {
       const ledgerToUse = getRandomElement(ledgerSteps);
       // We want to wait ledgerDelay before attempting to use the ledger channel
-      timestamp = Math.max(
-        generateRandomNumber(ledgerToUse.timestamp, toMilliseconds(duration)),
-        ledgerToUse.timestamp + toMilliseconds(funding.ledgerDelay)
+      timestamp = generateRandomNumber(
+        ledgerToUse.timestamp + funding.ledgerDelay,
+        toMilliseconds(duration)
       );
-
       fundingInfo = {type: 'Ledger', fundingLedgerJob: ledgerToUse.jobId};
     } else {
       timestamp = generateRandomNumber(0, toMilliseconds(duration));

--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -235,7 +235,6 @@ function generateCreateSteps(
 
     let timestamp;
     let fundingInfo: FundingInfo;
-    // If  this create channel step will be funded by a ledger grab a random ledger channel that is sceduled to be created before this
     if (funding.type === 'Ledger') {
       const ledgerToUse = getRandomElement(ledgerSteps);
       // We want to wait ledgerDelay before attempting to use the ledger channel

--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -294,10 +294,10 @@ function generateParticipants(roles: Record<string, RoleConfig>, startIndex: num
 }
 
 /**
- * Creates channel parameters based on the provided roles and participants.
- * @param roles
- * @param participants
- * @returns A CreateChannelParams object that can be passed into createChannel
+ * Creates channel parameters based on the provided participants.
+ * @param participants The participants for the channel.
+ * @param fundingAmountPerParticipant The amount of funding each participant has. Defaults to 5.
+ * @returns A CreateChannelParams object (omitting the fundingStrategy)
  */
 function generateChannelParams(
   participants: Participant[],

--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -71,7 +71,7 @@ async function createLoad() {
       describe: 'The number of channels that should be created per a second.',
     })
     .option('createLedgerDuration', {
-      default: 15,
+      default: 5,
       min: 5,
       describe: `The amount of time (in seconds) that create ledger channels can be scheduled for.
       This dictactes the max timestamp a step can have.`,
@@ -82,7 +82,7 @@ async function createLoad() {
       describe: `The number of ledger channels to create per a second during the createLedgerDuration.`,
     })
     .option('ledgerDelay', {
-      default: 15,
+      default: 20,
       min: 0,
       describe: `The minumum amount of time (in seconds) to wait for a ledger channel to be created before scheduling a createChannel job.`,
     })

--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -8,7 +8,7 @@ import * as jsonfile from 'jsonfile';
 import chalk from 'chalk';
 import {generateSlug} from 'random-word-slugs';
 import _ from 'lodash';
-import {BigNumber, ethers, utils} from 'ethers';
+import {BigNumber, ethers} from 'ethers';
 import ms from 'ms';
 
 import {COUNTING_APP_DEFINITION} from '../../src/models/__test__/fixtures/app-bytecode';
@@ -324,7 +324,7 @@ function generateChannelParams(
       },
     ],
     appDefinition: COUNTING_APP_DEFINITION,
-    appData: utils.hexZeroPad('0x0', 32),
+    appData: '0x',
 
     challengeDuration: ms('1d') / 1000, // This is 1 day in seconds,
   };

--- a/packages/server-wallet/e2e-testing/scripts/start-all.ts
+++ b/packages/server-wallet/e2e-testing/scripts/start-all.ts
@@ -24,7 +24,8 @@ async function startAll() {
     .option('loadFile', {
       alias: 'l',
       description: 'The file containing the load data to send to the nodes',
-      default: './e2e-testing/test-data/load-data.json',
+      demandOption: 'true',
+      type: 'string',
     }).argv;
 
   const ganache = execa.command(`npx ts-node ${SCRIPT_DIR}/start-ganache.ts -d off`, {all: true});

--- a/packages/server-wallet/e2e-testing/scripts/start-load-node.ts
+++ b/packages/server-wallet/e2e-testing/scripts/start-load-node.ts
@@ -50,7 +50,7 @@ async function setupNode(): Promise<WalletLoadNode> {
     })
     .option('migrateDB', {
       alias: 'm',
-      default: false,
+      default: true,
       describe: `Whether the db should be migrated (and created if it doesn't exist`,
     })
     .option('clearDB', {

--- a/packages/server-wallet/e2e-testing/test-data/load-data.json
+++ b/packages/server-wallet/e2e-testing/test-data/load-data.json
@@ -1,10 +1,10 @@
 [
  {
-  "type": "CreateChannel",
-  "jobId": "cuddly-raspy-whining-pillow",
+  "type": "CreateLedgerChannel",
+  "jobId": "future-gifted-future-market",
   "serverId": "A",
-  "timestamp": 7806,
-  "channelParams": {
+  "timestamp": 13473,
+  "ledgerChannelParams": {
    "participants": [
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
@@ -22,11 +22,11 @@
      "allocationItems": [
       {
        "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       },
       {
        "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       }
      ],
      "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
@@ -34,16 +34,15 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
   }
  },
  {
-  "type": "CreateChannel",
-  "jobId": "tangy-panicky-little-advertisement",
+  "type": "CreateLedgerChannel",
+  "jobId": "zealous-famous-massive-monkey",
   "serverId": "B",
-  "timestamp": 4128,
-  "channelParams": {
+  "timestamp": 6079,
+  "ledgerChannelParams": {
    "participants": [
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
@@ -61,11 +60,11 @@
      "allocationItems": [
       {
        "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       },
       {
        "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       }
      ],
      "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
@@ -73,16 +72,15 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
   }
  },
  {
-  "type": "CreateChannel",
-  "jobId": "juicy-lazy-rotten-jewellery",
+  "type": "CreateLedgerChannel",
+  "jobId": "billions-mammoth-hundreds-battery",
   "serverId": "A",
-  "timestamp": 248,
-  "channelParams": {
+  "timestamp": 607,
+  "ledgerChannelParams": {
    "participants": [
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
@@ -100,11 +98,11 @@
      "allocationItems": [
       {
        "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       },
       {
        "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       }
      ],
      "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
@@ -112,16 +110,15 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
   }
  },
  {
-  "type": "CreateChannel",
-  "jobId": "screeching-old-clever-window",
+  "type": "CreateLedgerChannel",
+  "jobId": "short-yummy-full-engine",
   "serverId": "B",
-  "timestamp": 5976,
-  "channelParams": {
+  "timestamp": 11076,
+  "ledgerChannelParams": {
    "participants": [
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
@@ -139,11 +136,11 @@
      "allocationItems": [
       {
        "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       },
       {
        "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       }
      ],
      "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
@@ -151,211 +148,15 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
   }
  },
  {
-  "type": "CreateChannel",
-  "jobId": "steep-dirty-numerous-dress",
-  "serverId": "B",
-  "timestamp": 5785,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "creamy-fit-rich-dream",
-  "serverId": "B",
-  "timestamp": 9804,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "cuddly-clean-unkempt-restaurant",
-  "serverId": "B",
-  "timestamp": 521,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "plain-wide-faithful-bear",
-  "serverId": "B",
-  "timestamp": 5401,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "delightful-rancid-immense-quill",
-  "serverId": "B",
-  "timestamp": 5562,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "enough-squeaking-powerful-uganda",
+  "type": "CreateLedgerChannel",
+  "jobId": "most-uneven-quaint-park",
   "serverId": "A",
-  "timestamp": 6655,
-  "channelParams": {
+  "timestamp": 352,
+  "ledgerChannelParams": {
    "participants": [
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
@@ -373,11 +174,11 @@
      "allocationItems": [
       {
        "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       },
       {
        "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
+       "amount": "0x0186a0"
       }
      ],
      "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
@@ -385,37 +186,416 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "microscopic-clumsy-warm-grass",
+  "serverId": "B",
+  "timestamp": 391,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "full-ripe-hallowed-army",
+  "serverId": "B",
+  "timestamp": 6952,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "harsh-mammoth-fast-grandmother",
+  "serverId": "B",
+  "timestamp": 11181,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "narrow-numerous-kind-child",
+  "serverId": "A",
+  "timestamp": 7373,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "sour-great-tight-knife",
+  "serverId": "B",
+  "timestamp": 7098,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "straight-bitter-gorgeous-jackal",
+  "serverId": "A",
+  "timestamp": 7123,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "scarce-wide-damaged-school",
+  "serverId": "A",
+  "timestamp": 1181,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "fit-some-noisy-monkey",
+  "serverId": "B",
+  "timestamp": 1910,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "tight-jolly-orange-flag",
+  "serverId": "A",
+  "timestamp": 4705,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "faint-rhythmic-scary-afternoon",
+  "serverId": "B",
+  "timestamp": 7350,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "challengeDuration": 86400
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "young-careful-strong-night",
-  "serverId": "A",
-  "timestamp": 6854,
+  "jobId": "miniature-shy-ambitious-cat",
+  "serverId": "B",
+  "timestamp": 16944,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -424,15 +604,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "fit-some-noisy-monkey"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "sharp-short-uneven-vase",
+  "jobId": "numerous-slow-future-shoe",
   "serverId": "B",
-  "timestamp": 3919,
+  "timestamp": 44200,
   "channelParams": {
    "participants": [
     {
@@ -463,15 +646,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "short-yummy-full-engine"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "ambitious-strong-high-house",
+  "jobId": "lemon-wailing-rotten-eye",
   "serverId": "A",
-  "timestamp": 7514,
+  "timestamp": 32280,
   "channelParams": {
    "participants": [
     {
@@ -502,15 +688,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "straight-bitter-gorgeous-jackal"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "cold-glamorous-high-ghost",
+  "jobId": "cool-attractive-howling-ocean",
   "serverId": "B",
-  "timestamp": 5834,
+  "timestamp": 45577,
   "channelParams": {
    "participants": [
     {
@@ -541,37 +730,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "billions-mammoth-hundreds-battery"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "wet-crooked-important-parrot",
-  "serverId": "A",
-  "timestamp": 4729,
+  "jobId": "dazzling-agreeable-colossal-yacht",
+  "serverId": "B",
+  "timestamp": 49917,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -580,15 +772,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "sour-great-tight-knife"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "crashing-vast-odd-football",
+  "jobId": "shallow-chubby-aggressive-lawyer",
   "serverId": "A",
-  "timestamp": 1365,
+  "timestamp": 52724,
   "channelParams": {
    "participants": [
     {
@@ -619,37 +814,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "sour-great-tight-knife"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "short-little-stocky-monkey",
-  "serverId": "A",
-  "timestamp": 2620,
+  "jobId": "black-mealy-substantial-airport",
+  "serverId": "B",
+  "timestamp": 50481,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -658,15 +856,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "panicky-sticky-straight-window",
+  "jobId": "grumpy-billions-long-orange",
   "serverId": "A",
-  "timestamp": 4372,
+  "timestamp": 58779,
   "channelParams": {
    "participants": [
     {
@@ -697,37 +898,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "future-gifted-future-market"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "incalculable-thoughtless-square-advertisement",
-  "serverId": "A",
-  "timestamp": 6434,
+  "jobId": "grumpy-little-petite-monkey",
+  "serverId": "B",
+  "timestamp": 22350,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -736,15 +940,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "uninterested-some-jealous-garden",
+  "jobId": "rich-happy-bitter-lion",
   "serverId": "B",
-  "timestamp": 7085,
+  "timestamp": 57334,
   "channelParams": {
    "participants": [
     {
@@ -775,15 +982,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scarce-wide-damaged-school"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "raspy-stocky-black-death",
+  "jobId": "wailing-bitter-fancy-island",
   "serverId": "B",
-  "timestamp": 2576,
+  "timestamp": 55444,
   "channelParams": {
    "participants": [
     {
@@ -814,15 +1024,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "scrawny-mango-witty-iron",
+  "jobId": "tasty-short-brief-tiger",
   "serverId": "A",
-  "timestamp": 6293,
+  "timestamp": 21952,
   "channelParams": {
    "participants": [
     {
@@ -853,37 +1066,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "full-ripe-hallowed-army"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "glamorous-helpless-few-boy",
-  "serverId": "A",
-  "timestamp": 6495,
+  "jobId": "limited-limited-gentle-egg",
+  "serverId": "B",
+  "timestamp": 15352,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -892,15 +1108,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "most-uneven-quaint-park"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "shrilling-teeny-black-egypt",
+  "jobId": "stocky-refined-weak-russia",
   "serverId": "B",
-  "timestamp": 2999,
+  "timestamp": 57258,
   "channelParams": {
    "participants": [
     {
@@ -931,15 +1150,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "future-gifted-future-market"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "few-acidic-fresh-room",
+  "jobId": "numerous-worried-dry-oyster",
   "serverId": "B",
-  "timestamp": 5217,
+  "timestamp": 28473,
   "channelParams": {
    "participants": [
     {
@@ -970,15 +1192,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "future-gifted-future-market"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "numerous-tart-rotten-library",
+  "jobId": "better-calm-putrid-country",
   "serverId": "A",
-  "timestamp": 8599,
+  "timestamp": 24277,
   "channelParams": {
    "participants": [
     {
@@ -1009,37 +1234,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "full-ripe-hallowed-army"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "eager-late-sticky-apple",
-  "serverId": "A",
-  "timestamp": 8957,
+  "jobId": "swift-nice-few-holiday",
+  "serverId": "B",
+  "timestamp": 28473,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1048,15 +1276,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "future-gifted-future-market"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "howling-muscular-zealous-uganda",
+  "jobId": "lazy-long-inexpensive-caravan",
   "serverId": "A",
-  "timestamp": 5258,
+  "timestamp": 57208,
   "channelParams": {
    "participants": [
     {
@@ -1087,15 +1318,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "damp-refined-mushy-raincoat",
+  "jobId": "huge-shallow-shy-lamp",
   "serverId": "B",
-  "timestamp": 9944,
+  "timestamp": 44431,
   "channelParams": {
    "participants": [
     {
@@ -1126,15 +1360,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "sour-great-tight-knife"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "brave-grumpy-unimportant-flag",
+  "jobId": "little-bald-chilly-man",
   "serverId": "B",
-  "timestamp": 6902,
+  "timestamp": 23790,
   "channelParams": {
    "participants": [
     {
@@ -1165,15 +1402,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "billions-mammoth-hundreds-battery"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "short-thousands-quick-garden",
+  "jobId": "strong-thankful-brief-breakfast",
   "serverId": "A",
-  "timestamp": 9211,
+  "timestamp": 16181,
   "channelParams": {
    "participants": [
     {
@@ -1204,15 +1444,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scarce-wide-damaged-school"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "fat-small-slow-window",
+  "jobId": "bitter-deep-thousands-motorcycle",
   "serverId": "A",
-  "timestamp": 9173,
+  "timestamp": 32689,
   "channelParams": {
    "participants": [
     {
@@ -1243,15 +1486,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "sour-great-tight-knife"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "tasty-shrilling-scrawny-lamp",
+  "jobId": "tangy-harsh-salty-wire",
   "serverId": "A",
-  "timestamp": 5518,
+  "timestamp": 45272,
   "channelParams": {
    "participants": [
     {
@@ -1282,15 +1528,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "gentle-fat-nice-glass",
+  "jobId": "enough-gigantic-pitiful-oyster",
   "serverId": "B",
-  "timestamp": 7513,
+  "timestamp": 16181,
   "channelParams": {
    "participants": [
     {
@@ -1321,37 +1570,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scarce-wide-damaged-school"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "sparse-clean-lazy-hydrogen",
-  "serverId": "B",
-  "timestamp": 3359,
+  "jobId": "savory-repulsive-zealous-river",
+  "serverId": "A",
+  "timestamp": 28509,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1360,15 +1612,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "most-uneven-quaint-park"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "careful-crooked-clever-microphone",
+  "jobId": "petite-glamorous-disgusting-garden",
   "serverId": "B",
-  "timestamp": 7773,
+  "timestamp": 59044,
   "channelParams": {
    "participants": [
     {
@@ -1399,37 +1654,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "full-ripe-hallowed-army"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "dry-kind-noisy-television",
-  "serverId": "A",
-  "timestamp": 9402,
+  "jobId": "freezing-careful-polite-airport",
+  "serverId": "B",
+  "timestamp": 53219,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1438,37 +1696,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scarce-wide-damaged-school"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "rough-better-ripe-pencil",
-  "serverId": "A",
-  "timestamp": 2823,
+  "jobId": "wide-microscopic-screeching-football",
+  "serverId": "B",
+  "timestamp": 47009,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1477,37 +1738,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "future-gifted-future-market"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "chubby-big-breezy-table",
-  "serverId": "A",
-  "timestamp": 5498,
+  "jobId": "late-square-faint-nigeria",
+  "serverId": "B",
+  "timestamp": 43825,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1516,15 +1780,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "black-rancid-shrilling-jewellery",
+  "jobId": "mango-disgusting-breezy-answer",
   "serverId": "B",
-  "timestamp": 8586,
+  "timestamp": 26321,
   "channelParams": {
    "participants": [
     {
@@ -1555,15 +1822,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "short-yummy-full-engine"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "tinkling-teeny-high-lighter",
+  "jobId": "billions-limited-chilly-shampoo",
   "serverId": "A",
-  "timestamp": 6354,
+  "timestamp": 22350,
   "channelParams": {
    "participants": [
     {
@@ -1594,15 +1864,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "billions-faint-short-garden",
+  "jobId": "crashing-future-quaint-toothbrush",
   "serverId": "B",
-  "timestamp": 9151,
+  "timestamp": 45584,
   "channelParams": {
    "participants": [
     {
@@ -1633,15 +1906,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "narrow-numerous-kind-child"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "orange-scruffy-brief-shoe",
+  "jobId": "thousands-broad-ambitious-grandmother",
   "serverId": "A",
-  "timestamp": 6333,
+  "timestamp": 28539,
   "channelParams": {
    "participants": [
     {
@@ -1672,37 +1948,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "scarce-few-petite-minister",
-  "serverId": "B",
-  "timestamp": 7331,
+  "jobId": "refined-sticky-delicious-napkin",
+  "serverId": "A",
+  "timestamp": 55677,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1711,37 +1990,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "most-uneven-quaint-park"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "thankful-most-sharp-iron",
-  "serverId": "B",
-  "timestamp": 999,
+  "jobId": "prickly-high-worried-restaurant",
+  "serverId": "A",
+  "timestamp": 21952,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1750,37 +2032,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "full-ripe-hallowed-army"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "mango-damaged-clumsy-dream",
-  "serverId": "B",
-  "timestamp": 6180,
+  "jobId": "square-chilly-prickly-magazine",
+  "serverId": "A",
+  "timestamp": 53598,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1789,37 +2074,40 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "sour-great-tight-knife"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "thundering-broad-square-market",
-  "serverId": "A",
-  "timestamp": 5173,
+  "jobId": "great-late-grumpy-dress",
+  "serverId": "B",
+  "timestamp": 50220,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1828,15 +2116,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "zealous-famous-massive-monkey"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "fresh-nervous-grumpy-xylophone",
+  "jobId": "short-thoughtless-witty-spoon",
   "serverId": "B",
-  "timestamp": 1582,
+  "timestamp": 34519,
   "channelParams": {
    "participants": [
     {
@@ -1867,15 +2158,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "zealous-stocky-better-breakfast",
+  "jobId": "immense-little-bumpy-dream",
   "serverId": "B",
-  "timestamp": 9464,
+  "timestamp": 43477,
   "channelParams": {
    "participants": [
     {
@@ -1906,15 +2200,18 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "long-eager-important-pencil",
+  "jobId": "late-ancient-chubby-sugar",
   "serverId": "B",
-  "timestamp": 6325,
+  "timestamp": 47920,
   "channelParams": {
    "participants": [
     {
@@ -1945,308 +2242,851 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
   }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "sharp-short-uneven-vase",
-  "serverId": "B",
-  "timestamp": 9357
- },
- {
-  "type": "CloseChannel",
-  "jobId": "mango-damaged-clumsy-dream",
-  "serverId": "B",
-  "timestamp": 7566
- },
- {
-  "type": "CloseChannel",
-  "jobId": "cuddly-raspy-whining-pillow",
+  "type": "CreateChannel",
+  "jobId": "future-gray-unkempt-camera",
   "serverId": "A",
-  "timestamp": 9342
+  "timestamp": 30552,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "narrow-numerous-kind-child"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "thankful-most-sharp-iron",
+  "type": "CreateChannel",
+  "jobId": "ancient-hollow-broad-parrot",
   "serverId": "B",
-  "timestamp": 5672
+  "timestamp": 16910,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "fit-some-noisy-monkey"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "fat-small-slow-window",
+  "type": "CreateChannel",
+  "jobId": "nervous-scarce-eager-vegetable",
   "serverId": "A",
-  "timestamp": 10173
+  "timestamp": 40854,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "dry-kind-noisy-television",
+  "type": "CreateChannel",
+  "jobId": "skinny-sticky-hot-toddler",
   "serverId": "A",
-  "timestamp": 10402
+  "timestamp": 58259,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "tight-jolly-orange-flag"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "gentle-fat-nice-glass",
-  "serverId": "B",
-  "timestamp": 9804
- },
- {
-  "type": "CloseChannel",
-  "jobId": "glamorous-helpless-few-boy",
+  "type": "CreateChannel",
+  "jobId": "tender-faithful-gifted-tiger",
   "serverId": "A",
-  "timestamp": 7552
+  "timestamp": 16910,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "fit-some-noisy-monkey"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "howling-muscular-zealous-uganda",
+  "type": "CreateChannel",
+  "jobId": "pitiful-lemon-screeching-battery",
   "serverId": "A",
-  "timestamp": 7095
+  "timestamp": 48164,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "zealous-stocky-better-breakfast",
+  "type": "CreateChannel",
+  "jobId": "rapid-ripe-unkempt-car",
   "serverId": "B",
-  "timestamp": 10464
+  "timestamp": 37965,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "straight-bitter-gorgeous-jackal"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "orange-scruffy-brief-shoe",
+  "type": "CreateChannel",
+  "jobId": "cool-tiny-crashing-lighter",
+  "serverId": "B",
+  "timestamp": 34781,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "billions-mammoth-hundreds-battery"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "prehistoric-salty-dazzling-girl",
+  "serverId": "B",
+  "timestamp": 21079,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "zealous-famous-massive-monkey"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "silly-wonderful-wet-insurance",
+  "serverId": "B",
+  "timestamp": 21079,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "zealous-famous-massive-monkey"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "calm-cool-mysterious-zebra",
   "serverId": "A",
-  "timestamp": 9590
+  "timestamp": 37169,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "tight-jolly-orange-flag"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "wet-crooked-important-parrot",
+  "type": "CreateChannel",
+  "jobId": "rapping-muscular-tall-bear",
   "serverId": "A",
-  "timestamp": 9928
+  "timestamp": 43805,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "sour-great-tight-knife"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "incalculable-thoughtless-square-advertisement",
+  "type": "CreateChannel",
+  "jobId": "red-vast-modern-russia",
+  "serverId": "B",
+  "timestamp": 18072,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "prickly-vast-broad-yak",
+  "serverId": "B",
+  "timestamp": 16826,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "stocky-chilly-cold-tomato",
+  "serverId": "B",
+  "timestamp": 22350,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "nutritious-proud-better-restaurant",
+  "serverId": "B",
+  "timestamp": 28473,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "future-gifted-future-market"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "shrilling-drab-high-sweden",
   "serverId": "A",
-  "timestamp": 7434
+  "timestamp": 26181,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "scarce-few-petite-minister",
+  "type": "CreateChannel",
+  "jobId": "refined-rapid-alive-rocket",
   "serverId": "B",
-  "timestamp": 8331
+  "timestamp": 51610,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "narrow-numerous-kind-child"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "raspy-stocky-black-death",
+  "type": "CreateChannel",
+  "jobId": "repulsive-grumpy-chubby-helicopter",
   "serverId": "B",
-  "timestamp": 7297
+  "timestamp": 26181,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "enough-squeaking-powerful-uganda",
+  "type": "CreateChannel",
+  "jobId": "whining-kind-shapely-insurance",
   "serverId": "A",
-  "timestamp": 9490
- },
- {
-  "type": "CloseChannel",
-  "jobId": "thundering-broad-square-market",
-  "serverId": "A",
-  "timestamp": 6173
- },
- {
-  "type": "CloseChannel",
-  "jobId": "cuddly-clean-unkempt-restaurant",
-  "serverId": "B",
-  "timestamp": 3077
- },
- {
-  "type": "CloseChannel",
-  "jobId": "tangy-panicky-little-advertisement",
-  "serverId": "B",
-  "timestamp": 5128
- },
- {
-  "type": "CloseChannel",
-  "jobId": "numerous-tart-rotten-library",
-  "serverId": "A",
-  "timestamp": 9599
- },
- {
-  "type": "CloseChannel",
-  "jobId": "damp-refined-mushy-raincoat",
-  "serverId": "B",
-  "timestamp": 10944
- },
- {
-  "type": "CloseChannel",
-  "jobId": "panicky-sticky-straight-window",
-  "serverId": "A",
-  "timestamp": 8234
- },
- {
-  "type": "CloseChannel",
-  "jobId": "steep-dirty-numerous-dress",
-  "serverId": "B",
-  "timestamp": 7882
- },
- {
-  "type": "CloseChannel",
-  "jobId": "delightful-rancid-immense-quill",
-  "serverId": "B",
-  "timestamp": 9633
- },
- {
-  "type": "CloseChannel",
-  "jobId": "few-acidic-fresh-room",
-  "serverId": "B",
-  "timestamp": 6217
- },
- {
-  "type": "CloseChannel",
-  "jobId": "scrawny-mango-witty-iron",
-  "serverId": "A",
-  "timestamp": 9699
- },
- {
-  "type": "CloseChannel",
-  "jobId": "tasty-shrilling-scrawny-lamp",
-  "serverId": "A",
-  "timestamp": 6518
- },
- {
-  "type": "CloseChannel",
-  "jobId": "shrilling-teeny-black-egypt",
-  "serverId": "B",
-  "timestamp": 7073
- },
- {
-  "type": "CloseChannel",
-  "jobId": "short-little-stocky-monkey",
-  "serverId": "A",
-  "timestamp": 5019
- },
- {
-  "type": "CloseChannel",
-  "jobId": "careful-crooked-clever-microphone",
-  "serverId": "B",
-  "timestamp": 8773
- },
- {
-  "type": "CloseChannel",
-  "jobId": "uninterested-some-jealous-garden",
-  "serverId": "B",
-  "timestamp": 8085
- },
- {
-  "type": "CloseChannel",
-  "jobId": "creamy-fit-rich-dream",
-  "serverId": "B",
-  "timestamp": 10804
- },
- {
-  "type": "CloseChannel",
-  "jobId": "rough-better-ripe-pencil",
-  "serverId": "A",
-  "timestamp": 4264
- },
- {
-  "type": "CloseChannel",
-  "jobId": "sparse-clean-lazy-hydrogen",
-  "serverId": "B",
-  "timestamp": 9808
- },
- {
-  "type": "CloseChannel",
-  "jobId": "black-rancid-shrilling-jewellery",
-  "serverId": "B",
-  "timestamp": 9586
- },
- {
-  "type": "CloseChannel",
-  "jobId": "crashing-vast-odd-football",
-  "serverId": "A",
-  "timestamp": 3012
- },
- {
-  "type": "CloseChannel",
-  "jobId": "juicy-lazy-rotten-jewellery",
-  "serverId": "A",
-  "timestamp": 8518
- },
- {
-  "type": "CloseChannel",
-  "jobId": "tinkling-teeny-high-lighter",
-  "serverId": "A",
-  "timestamp": 8374
- },
- {
-  "type": "CloseChannel",
-  "jobId": "fresh-nervous-grumpy-xylophone",
-  "serverId": "B",
-  "timestamp": 2582
- },
- {
-  "type": "CloseChannel",
-  "jobId": "screeching-old-clever-window",
-  "serverId": "B",
-  "timestamp": 9191
- },
- {
-  "type": "CloseChannel",
-  "jobId": "eager-late-sticky-apple",
-  "serverId": "A",
-  "timestamp": 9992
- },
- {
-  "type": "CloseChannel",
-  "jobId": "short-thousands-quick-garden",
-  "serverId": "A",
-  "timestamp": 10211
- },
- {
-  "type": "CloseChannel",
-  "jobId": "cold-glamorous-high-ghost",
-  "serverId": "B",
-  "timestamp": 7839
- },
- {
-  "type": "CloseChannel",
-  "jobId": "young-careful-strong-night",
-  "serverId": "A",
-  "timestamp": 9237
- },
- {
-  "type": "CloseChannel",
-  "jobId": "long-eager-important-pencil",
-  "serverId": "B",
-  "timestamp": 9347
- },
- {
-  "type": "CloseChannel",
-  "jobId": "chubby-big-breezy-table",
-  "serverId": "A",
-  "timestamp": 8799
- },
- {
-  "type": "CloseChannel",
-  "jobId": "brave-grumpy-unimportant-flag",
-  "serverId": "B",
-  "timestamp": 7902
- },
- {
-  "type": "CloseChannel",
-  "jobId": "ambitious-strong-high-house",
-  "serverId": "A",
-  "timestamp": 8514
- },
- {
-  "type": "CloseChannel",
-  "jobId": "billions-faint-short-garden",
-  "serverId": "B",
-  "timestamp": 10151
- },
- {
-  "type": "CloseChannel",
-  "jobId": "plain-wide-faithful-bear",
-  "serverId": "B",
-  "timestamp": 7055
+  "timestamp": 46331,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "short-yummy-full-engine"
+  }
  }
 ]

--- a/packages/server-wallet/e2e-testing/test-data/sample-direct-load-data.json
+++ b/packages/server-wallet/e2e-testing/test-data/sample-direct-load-data.json
@@ -1,9 +1,9 @@
 [
  {
   "type": "CreateChannel",
-  "jobId": "cuddly-raspy-whining-pillow",
+  "jobId": "better-massive-shaggy-battery",
   "serverId": "A",
-  "timestamp": 7806,
+  "timestamp": 10415,
   "channelParams": {
    "participants": [
     {
@@ -34,54 +34,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "tangy-panicky-little-advertisement",
-  "serverId": "B",
-  "timestamp": 4128,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "juicy-lazy-rotten-jewellery",
+  "jobId": "tangy-modern-uptight-glass",
   "serverId": "A",
-  "timestamp": 248,
+  "timestamp": 54636,
   "channelParams": {
    "participants": [
     {
@@ -112,15 +75,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "screeching-old-clever-window",
+  "jobId": "dazzling-nutty-most-garden",
   "serverId": "B",
-  "timestamp": 5976,
+  "timestamp": 49650,
   "channelParams": {
    "participants": [
     {
@@ -151,15 +116,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "steep-dirty-numerous-dress",
+  "jobId": "petite-wonderful-harsh-nest",
   "serverId": "B",
-  "timestamp": 5785,
+  "timestamp": 59779,
   "channelParams": {
    "participants": [
     {
@@ -190,15 +157,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "creamy-fit-rich-dream",
+  "jobId": "plain-gentle-disgusting-magazine",
   "serverId": "B",
-  "timestamp": 9804,
+  "timestamp": 50982,
   "channelParams": {
    "participants": [
     {
@@ -229,15 +198,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "cuddly-clean-unkempt-restaurant",
+  "jobId": "ugly-large-tight-book",
   "serverId": "B",
-  "timestamp": 521,
+  "timestamp": 4792,
   "channelParams": {
    "participants": [
     {
@@ -268,15 +239,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "plain-wide-faithful-bear",
+  "jobId": "brief-drab-poor-egg",
   "serverId": "B",
-  "timestamp": 5401,
+  "timestamp": 27341,
   "channelParams": {
    "participants": [
     {
@@ -307,54 +280,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "delightful-rancid-immense-quill",
-  "serverId": "B",
-  "timestamp": 5562,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "enough-squeaking-powerful-uganda",
+  "jobId": "dazzling-creamy-deafening-computer",
   "serverId": "A",
-  "timestamp": 6655,
+  "timestamp": 52738,
   "channelParams": {
    "participants": [
     {
@@ -385,15 +321,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "young-careful-strong-night",
+  "jobId": "kind-quiet-delightful-teacher",
   "serverId": "A",
-  "timestamp": 6854,
+  "timestamp": 1992,
   "channelParams": {
    "participants": [
     {
@@ -424,37 +362,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "sharp-short-uneven-vase",
-  "serverId": "B",
-  "timestamp": 3919,
+  "jobId": "tall-greasy-green-jelly",
+  "serverId": "A",
+  "timestamp": 15480,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -463,15 +403,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "ambitious-strong-high-house",
+  "jobId": "rapping-shapely-tender-country",
   "serverId": "A",
-  "timestamp": 7514,
+  "timestamp": 6540,
   "channelParams": {
    "participants": [
     {
@@ -502,37 +444,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "cold-glamorous-high-ghost",
-  "serverId": "B",
-  "timestamp": 5834,
+  "jobId": "blue-gifted-green-wall",
+  "serverId": "A",
+  "timestamp": 43401,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -541,15 +485,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "wet-crooked-important-parrot",
+  "jobId": "long-mammoth-wide-house",
   "serverId": "A",
-  "timestamp": 4729,
+  "timestamp": 5546,
   "channelParams": {
    "participants": [
     {
@@ -580,37 +526,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "crashing-vast-odd-football",
-  "serverId": "A",
-  "timestamp": 1365,
+  "jobId": "teeny-little-billions-yacht",
+  "serverId": "B",
+  "timestamp": 33256,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -619,15 +567,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "short-little-stocky-monkey",
+  "jobId": "fast-square-plump-bear",
   "serverId": "A",
-  "timestamp": 2620,
+  "timestamp": 29763,
   "channelParams": {
    "participants": [
     {
@@ -658,15 +608,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "panicky-sticky-straight-window",
+  "jobId": "weak-icy-wailing-zoo",
   "serverId": "A",
-  "timestamp": 4372,
+  "timestamp": 42206,
   "channelParams": {
    "participants": [
     {
@@ -697,37 +649,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "incalculable-thoughtless-square-advertisement",
-  "serverId": "A",
-  "timestamp": 6434,
+  "jobId": "sweet-clumsy-melted-lion",
+  "serverId": "B",
+  "timestamp": 12835,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -736,37 +690,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "uninterested-some-jealous-garden",
-  "serverId": "B",
-  "timestamp": 7085,
+  "jobId": "shaggy-melodic-bald-bear",
+  "serverId": "A",
+  "timestamp": 58957,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -775,15 +731,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "raspy-stocky-black-death",
+  "jobId": "drab-shapely-proud-house",
   "serverId": "B",
-  "timestamp": 2576,
+  "timestamp": 9323,
   "channelParams": {
    "participants": [
     {
@@ -814,15 +772,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "scrawny-mango-witty-iron",
+  "jobId": "rapping-ambitious-elegant-river",
   "serverId": "A",
-  "timestamp": 6293,
+  "timestamp": 47557,
   "channelParams": {
    "participants": [
     {
@@ -853,37 +813,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "glamorous-helpless-few-boy",
-  "serverId": "A",
-  "timestamp": 6495,
+  "jobId": "putrid-yummy-short-teacher",
+  "serverId": "B",
+  "timestamp": 23315,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -892,37 +854,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "shrilling-teeny-black-egypt",
-  "serverId": "B",
-  "timestamp": 2999,
+  "jobId": "dry-lazy-yummy-evening",
+  "serverId": "A",
+  "timestamp": 7656,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -931,15 +895,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "few-acidic-fresh-room",
+  "jobId": "curved-crashing-unsightly-branch",
   "serverId": "B",
-  "timestamp": 5217,
+  "timestamp": 8002,
   "channelParams": {
    "participants": [
     {
@@ -970,37 +936,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "numerous-tart-rotten-library",
-  "serverId": "A",
-  "timestamp": 8599,
+  "jobId": "bitter-slimy-gray-train",
+  "serverId": "B",
+  "timestamp": 54027,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1009,37 +977,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "eager-late-sticky-apple",
-  "serverId": "A",
-  "timestamp": 8957,
+  "jobId": "quick-long-acidic-juice",
+  "serverId": "B",
+  "timestamp": 53812,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1048,15 +1018,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "howling-muscular-zealous-uganda",
+  "jobId": "harsh-freezing-old-businessperson",
   "serverId": "A",
-  "timestamp": 5258,
+  "timestamp": 4475,
   "channelParams": {
    "participants": [
     {
@@ -1087,15 +1059,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "damp-refined-mushy-raincoat",
+  "jobId": "tall-long-tasty-rainbow",
   "serverId": "B",
-  "timestamp": 9944,
+  "timestamp": 32821,
   "channelParams": {
    "participants": [
     {
@@ -1126,37 +1100,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "brave-grumpy-unimportant-flag",
-  "serverId": "B",
-  "timestamp": 6902,
+  "jobId": "puny-dirty-chilly-match",
+  "serverId": "A",
+  "timestamp": 45227,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1165,37 +1141,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "short-thousands-quick-garden",
-  "serverId": "A",
-  "timestamp": 9211,
+  "jobId": "curved-clumsy-howling-businessperson",
+  "serverId": "B",
+  "timestamp": 43061,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1204,37 +1182,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "fat-small-slow-window",
-  "serverId": "A",
-  "timestamp": 9173,
+  "jobId": "nutty-sparse-brief-lion",
+  "serverId": "B",
+  "timestamp": 19931,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1243,37 +1223,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "tasty-shrilling-scrawny-lamp",
-  "serverId": "A",
-  "timestamp": 5518,
+  "jobId": "helpless-clean-embarrassed-egg",
+  "serverId": "B",
+  "timestamp": 40044,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1282,37 +1264,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "gentle-fat-nice-glass",
-  "serverId": "B",
-  "timestamp": 7513,
+  "jobId": "nervous-flabby-mango-baby",
+  "serverId": "A",
+  "timestamp": 3382,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1321,15 +1305,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "sparse-clean-lazy-hydrogen",
+  "jobId": "gorgeous-numerous-sticky-restaurant",
   "serverId": "B",
-  "timestamp": 3359,
+  "timestamp": 21515,
   "channelParams": {
    "participants": [
     {
@@ -1360,15 +1346,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "careful-crooked-clever-microphone",
+  "jobId": "chubby-limited-vast-teenager",
   "serverId": "B",
-  "timestamp": 7773,
+  "timestamp": 30855,
   "channelParams": {
    "participants": [
     {
@@ -1399,37 +1387,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "dry-kind-noisy-television",
-  "serverId": "A",
-  "timestamp": 9402,
+  "jobId": "muscular-cold-hissing-vulture",
+  "serverId": "B",
+  "timestamp": 28402,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1438,15 +1428,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "rough-better-ripe-pencil",
+  "jobId": "crashing-uptight-purple-city",
   "serverId": "A",
-  "timestamp": 2823,
+  "timestamp": 31668,
   "channelParams": {
    "participants": [
     {
@@ -1477,15 +1469,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "chubby-big-breezy-table",
+  "jobId": "icy-gifted-broad-banana",
   "serverId": "A",
-  "timestamp": 5498,
+  "timestamp": 38802,
   "channelParams": {
    "participants": [
     {
@@ -1516,15 +1510,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "black-rancid-shrilling-jewellery",
+  "jobId": "steep-calm-tight-hydrogen",
   "serverId": "B",
-  "timestamp": 8586,
+  "timestamp": 12672,
   "channelParams": {
    "participants": [
     {
@@ -1555,15 +1551,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "tinkling-teeny-high-lighter",
+  "jobId": "rich-obnoxious-polite-scooter",
   "serverId": "A",
-  "timestamp": 6354,
+  "timestamp": 644,
   "channelParams": {
    "participants": [
     {
@@ -1594,37 +1592,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "billions-faint-short-garden",
-  "serverId": "B",
-  "timestamp": 9151,
+  "jobId": "ripe-orange-magnificent-oil",
+  "serverId": "A",
+  "timestamp": 12065,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1633,37 +1633,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "orange-scruffy-brief-shoe",
-  "serverId": "A",
-  "timestamp": 6333,
+  "jobId": "handsome-sparse-inexpensive-apple",
+  "serverId": "B",
+  "timestamp": 6152,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1672,15 +1674,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "scarce-few-petite-minister",
+  "jobId": "blue-faint-careful-mother",
   "serverId": "B",
-  "timestamp": 7331,
+  "timestamp": 1925,
   "channelParams": {
    "participants": [
     {
@@ -1711,37 +1715,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "thankful-most-sharp-iron",
-  "serverId": "B",
-  "timestamp": 999,
+  "jobId": "long-wet-green-cricket",
+  "serverId": "A",
+  "timestamp": 15263,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1750,15 +1756,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "mango-damaged-clumsy-dream",
+  "jobId": "bumpy-freezing-sticky-ocean",
   "serverId": "B",
-  "timestamp": 6180,
+  "timestamp": 16586,
   "channelParams": {
    "participants": [
     {
@@ -1789,37 +1797,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "thundering-broad-square-market",
-  "serverId": "A",
-  "timestamp": 5173,
+  "jobId": "important-modern-hundreds-rocket",
+  "serverId": "B",
+  "timestamp": 15247,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
     {
      "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
      "participantId": "B",
      "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       }
      ],
@@ -1828,37 +1838,39 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "fresh-nervous-grumpy-xylophone",
-  "serverId": "B",
-  "timestamp": 1582,
+  "jobId": "rapping-limited-black-raincoat",
+  "serverId": "A",
+  "timestamp": 51804,
   "channelParams": {
    "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
     {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x05"
       },
       {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x05"
       }
      ],
@@ -1867,15 +1879,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "zealous-stocky-better-breakfast",
+  "jobId": "long-mealy-fat-match",
   "serverId": "B",
-  "timestamp": 9464,
+  "timestamp": 24397,
   "channelParams": {
    "participants": [
     {
@@ -1906,15 +1920,17 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "long-eager-important-pencil",
+  "jobId": "freezing-delightful-mammoth-restaurant",
   "serverId": "B",
-  "timestamp": 6325,
+  "timestamp": 58936,
   "channelParams": {
    "participants": [
     {
@@ -1945,308 +1961,502 @@
    ],
    "appDefinition": "0x00000000000000000000000000000000000000ca",
    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "fundingStrategy": "Direct",
    "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
   }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "sharp-short-uneven-vase",
-  "serverId": "B",
-  "timestamp": 9357
- },
- {
-  "type": "CloseChannel",
-  "jobId": "mango-damaged-clumsy-dream",
-  "serverId": "B",
-  "timestamp": 7566
- },
- {
-  "type": "CloseChannel",
-  "jobId": "cuddly-raspy-whining-pillow",
+  "type": "CreateChannel",
+  "jobId": "gray-muscular-teeny-horse",
   "serverId": "A",
-  "timestamp": 9342
+  "timestamp": 34089,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "thankful-most-sharp-iron",
-  "serverId": "B",
-  "timestamp": 5672
- },
- {
-  "type": "CloseChannel",
-  "jobId": "fat-small-slow-window",
+  "type": "CreateChannel",
+  "jobId": "unimportant-yellow-melted-coffeeshop",
   "serverId": "A",
-  "timestamp": 10173
+  "timestamp": 13589,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "dry-kind-noisy-television",
+  "type": "CreateChannel",
+  "jobId": "quick-cold-jolly-football",
   "serverId": "A",
-  "timestamp": 10402
+  "timestamp": 20332,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "gentle-fat-nice-glass",
+  "type": "CreateChannel",
+  "jobId": "tall-young-tender-xylophone",
   "serverId": "B",
-  "timestamp": 9804
+  "timestamp": 51355,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "glamorous-helpless-few-boy",
+  "type": "CreateChannel",
+  "jobId": "salmon-long-dazzling-vase",
+  "serverId": "B",
+  "timestamp": 4882,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "petite-tasteless-rancid-helmet",
+  "serverId": "B",
+  "timestamp": 52829,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "tangy-tall-whining-egg",
+  "serverId": "B",
+  "timestamp": 55850,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "gifted-fluffy-tart-kangaroo",
   "serverId": "A",
-  "timestamp": 7552
+  "timestamp": 49940,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "howling-muscular-zealous-uganda",
+  "type": "CreateChannel",
+  "jobId": "big-nice-vast-vase",
   "serverId": "A",
-  "timestamp": 7095
+  "timestamp": 9415,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "zealous-stocky-better-breakfast",
-  "serverId": "B",
-  "timestamp": 10464
- },
- {
-  "type": "CloseChannel",
-  "jobId": "orange-scruffy-brief-shoe",
+  "type": "CreateChannel",
+  "jobId": "hollow-curved-loose-russia",
   "serverId": "A",
-  "timestamp": 9590
+  "timestamp": 1396,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "wet-crooked-important-parrot",
+  "type": "CreateChannel",
+  "jobId": "gorgeous-tangy-chilly-greece",
   "serverId": "A",
-  "timestamp": 9928
+  "timestamp": 16240,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  },
  {
-  "type": "CloseChannel",
-  "jobId": "incalculable-thoughtless-square-advertisement",
-  "serverId": "A",
-  "timestamp": 7434
- },
- {
-  "type": "CloseChannel",
-  "jobId": "scarce-few-petite-minister",
+  "type": "CreateChannel",
+  "jobId": "crooked-fancy-witty-coat",
   "serverId": "B",
-  "timestamp": 8331
- },
- {
-  "type": "CloseChannel",
-  "jobId": "raspy-stocky-black-death",
-  "serverId": "B",
-  "timestamp": 7297
- },
- {
-  "type": "CloseChannel",
-  "jobId": "enough-squeaking-powerful-uganda",
-  "serverId": "A",
-  "timestamp": 9490
- },
- {
-  "type": "CloseChannel",
-  "jobId": "thundering-broad-square-market",
-  "serverId": "A",
-  "timestamp": 6173
- },
- {
-  "type": "CloseChannel",
-  "jobId": "cuddly-clean-unkempt-restaurant",
-  "serverId": "B",
-  "timestamp": 3077
- },
- {
-  "type": "CloseChannel",
-  "jobId": "tangy-panicky-little-advertisement",
-  "serverId": "B",
-  "timestamp": 5128
- },
- {
-  "type": "CloseChannel",
-  "jobId": "numerous-tart-rotten-library",
-  "serverId": "A",
-  "timestamp": 9599
- },
- {
-  "type": "CloseChannel",
-  "jobId": "damp-refined-mushy-raincoat",
-  "serverId": "B",
-  "timestamp": 10944
- },
- {
-  "type": "CloseChannel",
-  "jobId": "panicky-sticky-straight-window",
-  "serverId": "A",
-  "timestamp": 8234
- },
- {
-  "type": "CloseChannel",
-  "jobId": "steep-dirty-numerous-dress",
-  "serverId": "B",
-  "timestamp": 7882
- },
- {
-  "type": "CloseChannel",
-  "jobId": "delightful-rancid-immense-quill",
-  "serverId": "B",
-  "timestamp": 9633
- },
- {
-  "type": "CloseChannel",
-  "jobId": "few-acidic-fresh-room",
-  "serverId": "B",
-  "timestamp": 6217
- },
- {
-  "type": "CloseChannel",
-  "jobId": "scrawny-mango-witty-iron",
-  "serverId": "A",
-  "timestamp": 9699
- },
- {
-  "type": "CloseChannel",
-  "jobId": "tasty-shrilling-scrawny-lamp",
-  "serverId": "A",
-  "timestamp": 6518
- },
- {
-  "type": "CloseChannel",
-  "jobId": "shrilling-teeny-black-egypt",
-  "serverId": "B",
-  "timestamp": 7073
- },
- {
-  "type": "CloseChannel",
-  "jobId": "short-little-stocky-monkey",
-  "serverId": "A",
-  "timestamp": 5019
- },
- {
-  "type": "CloseChannel",
-  "jobId": "careful-crooked-clever-microphone",
-  "serverId": "B",
-  "timestamp": 8773
- },
- {
-  "type": "CloseChannel",
-  "jobId": "uninterested-some-jealous-garden",
-  "serverId": "B",
-  "timestamp": 8085
- },
- {
-  "type": "CloseChannel",
-  "jobId": "creamy-fit-rich-dream",
-  "serverId": "B",
-  "timestamp": 10804
- },
- {
-  "type": "CloseChannel",
-  "jobId": "rough-better-ripe-pencil",
-  "serverId": "A",
-  "timestamp": 4264
- },
- {
-  "type": "CloseChannel",
-  "jobId": "sparse-clean-lazy-hydrogen",
-  "serverId": "B",
-  "timestamp": 9808
- },
- {
-  "type": "CloseChannel",
-  "jobId": "black-rancid-shrilling-jewellery",
-  "serverId": "B",
-  "timestamp": 9586
- },
- {
-  "type": "CloseChannel",
-  "jobId": "crashing-vast-odd-football",
-  "serverId": "A",
-  "timestamp": 3012
- },
- {
-  "type": "CloseChannel",
-  "jobId": "juicy-lazy-rotten-jewellery",
-  "serverId": "A",
-  "timestamp": 8518
- },
- {
-  "type": "CloseChannel",
-  "jobId": "tinkling-teeny-high-lighter",
-  "serverId": "A",
-  "timestamp": 8374
- },
- {
-  "type": "CloseChannel",
-  "jobId": "fresh-nervous-grumpy-xylophone",
-  "serverId": "B",
-  "timestamp": 2582
- },
- {
-  "type": "CloseChannel",
-  "jobId": "screeching-old-clever-window",
-  "serverId": "B",
-  "timestamp": 9191
- },
- {
-  "type": "CloseChannel",
-  "jobId": "eager-late-sticky-apple",
-  "serverId": "A",
-  "timestamp": 9992
- },
- {
-  "type": "CloseChannel",
-  "jobId": "short-thousands-quick-garden",
-  "serverId": "A",
-  "timestamp": 10211
- },
- {
-  "type": "CloseChannel",
-  "jobId": "cold-glamorous-high-ghost",
-  "serverId": "B",
-  "timestamp": 7839
- },
- {
-  "type": "CloseChannel",
-  "jobId": "young-careful-strong-night",
-  "serverId": "A",
-  "timestamp": 9237
- },
- {
-  "type": "CloseChannel",
-  "jobId": "long-eager-important-pencil",
-  "serverId": "B",
-  "timestamp": 9347
- },
- {
-  "type": "CloseChannel",
-  "jobId": "chubby-big-breezy-table",
-  "serverId": "A",
-  "timestamp": 8799
- },
- {
-  "type": "CloseChannel",
-  "jobId": "brave-grumpy-unimportant-flag",
-  "serverId": "B",
-  "timestamp": 7902
- },
- {
-  "type": "CloseChannel",
-  "jobId": "ambitious-strong-high-house",
-  "serverId": "A",
-  "timestamp": 8514
- },
- {
-  "type": "CloseChannel",
-  "jobId": "billions-faint-short-garden",
-  "serverId": "B",
-  "timestamp": 10151
- },
- {
-  "type": "CloseChannel",
-  "jobId": "plain-wide-faithful-bear",
-  "serverId": "B",
-  "timestamp": 7055
+  "timestamp": 29928,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Direct"
+  }
  }
 ]

--- a/packages/server-wallet/e2e-testing/test-data/sample-direct-load-data.json
+++ b/packages/server-wallet/e2e-testing/test-data/sample-direct-load-data.json
@@ -1,0 +1,2252 @@
+[
+ {
+  "type": "CreateChannel",
+  "jobId": "cuddly-raspy-whining-pillow",
+  "serverId": "A",
+  "timestamp": 7806,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "tangy-panicky-little-advertisement",
+  "serverId": "B",
+  "timestamp": 4128,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "juicy-lazy-rotten-jewellery",
+  "serverId": "A",
+  "timestamp": 248,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "screeching-old-clever-window",
+  "serverId": "B",
+  "timestamp": 5976,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "steep-dirty-numerous-dress",
+  "serverId": "B",
+  "timestamp": 5785,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "creamy-fit-rich-dream",
+  "serverId": "B",
+  "timestamp": 9804,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "cuddly-clean-unkempt-restaurant",
+  "serverId": "B",
+  "timestamp": 521,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "plain-wide-faithful-bear",
+  "serverId": "B",
+  "timestamp": 5401,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "delightful-rancid-immense-quill",
+  "serverId": "B",
+  "timestamp": 5562,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "enough-squeaking-powerful-uganda",
+  "serverId": "A",
+  "timestamp": 6655,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "young-careful-strong-night",
+  "serverId": "A",
+  "timestamp": 6854,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "sharp-short-uneven-vase",
+  "serverId": "B",
+  "timestamp": 3919,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "ambitious-strong-high-house",
+  "serverId": "A",
+  "timestamp": 7514,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "cold-glamorous-high-ghost",
+  "serverId": "B",
+  "timestamp": 5834,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "wet-crooked-important-parrot",
+  "serverId": "A",
+  "timestamp": 4729,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "crashing-vast-odd-football",
+  "serverId": "A",
+  "timestamp": 1365,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "short-little-stocky-monkey",
+  "serverId": "A",
+  "timestamp": 2620,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "panicky-sticky-straight-window",
+  "serverId": "A",
+  "timestamp": 4372,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "incalculable-thoughtless-square-advertisement",
+  "serverId": "A",
+  "timestamp": 6434,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "uninterested-some-jealous-garden",
+  "serverId": "B",
+  "timestamp": 7085,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "raspy-stocky-black-death",
+  "serverId": "B",
+  "timestamp": 2576,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "scrawny-mango-witty-iron",
+  "serverId": "A",
+  "timestamp": 6293,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "glamorous-helpless-few-boy",
+  "serverId": "A",
+  "timestamp": 6495,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "shrilling-teeny-black-egypt",
+  "serverId": "B",
+  "timestamp": 2999,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "few-acidic-fresh-room",
+  "serverId": "B",
+  "timestamp": 5217,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "numerous-tart-rotten-library",
+  "serverId": "A",
+  "timestamp": 8599,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "eager-late-sticky-apple",
+  "serverId": "A",
+  "timestamp": 8957,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "howling-muscular-zealous-uganda",
+  "serverId": "A",
+  "timestamp": 5258,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "damp-refined-mushy-raincoat",
+  "serverId": "B",
+  "timestamp": 9944,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "brave-grumpy-unimportant-flag",
+  "serverId": "B",
+  "timestamp": 6902,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "short-thousands-quick-garden",
+  "serverId": "A",
+  "timestamp": 9211,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "fat-small-slow-window",
+  "serverId": "A",
+  "timestamp": 9173,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "tasty-shrilling-scrawny-lamp",
+  "serverId": "A",
+  "timestamp": 5518,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "gentle-fat-nice-glass",
+  "serverId": "B",
+  "timestamp": 7513,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "sparse-clean-lazy-hydrogen",
+  "serverId": "B",
+  "timestamp": 3359,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "careful-crooked-clever-microphone",
+  "serverId": "B",
+  "timestamp": 7773,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "dry-kind-noisy-television",
+  "serverId": "A",
+  "timestamp": 9402,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "rough-better-ripe-pencil",
+  "serverId": "A",
+  "timestamp": 2823,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "chubby-big-breezy-table",
+  "serverId": "A",
+  "timestamp": 5498,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "black-rancid-shrilling-jewellery",
+  "serverId": "B",
+  "timestamp": 8586,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "tinkling-teeny-high-lighter",
+  "serverId": "A",
+  "timestamp": 6354,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "billions-faint-short-garden",
+  "serverId": "B",
+  "timestamp": 9151,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "orange-scruffy-brief-shoe",
+  "serverId": "A",
+  "timestamp": 6333,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "scarce-few-petite-minister",
+  "serverId": "B",
+  "timestamp": 7331,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "thankful-most-sharp-iron",
+  "serverId": "B",
+  "timestamp": 999,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "mango-damaged-clumsy-dream",
+  "serverId": "B",
+  "timestamp": 6180,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "thundering-broad-square-market",
+  "serverId": "A",
+  "timestamp": 5173,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "fresh-nervous-grumpy-xylophone",
+  "serverId": "B",
+  "timestamp": 1582,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "zealous-stocky-better-breakfast",
+  "serverId": "B",
+  "timestamp": 9464,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "long-eager-important-pencil",
+  "serverId": "B",
+  "timestamp": 6325,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "fundingStrategy": "Direct",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "sharp-short-uneven-vase",
+  "serverId": "B",
+  "timestamp": 9357
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "mango-damaged-clumsy-dream",
+  "serverId": "B",
+  "timestamp": 7566
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "cuddly-raspy-whining-pillow",
+  "serverId": "A",
+  "timestamp": 9342
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "thankful-most-sharp-iron",
+  "serverId": "B",
+  "timestamp": 5672
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "fat-small-slow-window",
+  "serverId": "A",
+  "timestamp": 10173
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "dry-kind-noisy-television",
+  "serverId": "A",
+  "timestamp": 10402
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "gentle-fat-nice-glass",
+  "serverId": "B",
+  "timestamp": 9804
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "glamorous-helpless-few-boy",
+  "serverId": "A",
+  "timestamp": 7552
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "howling-muscular-zealous-uganda",
+  "serverId": "A",
+  "timestamp": 7095
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "zealous-stocky-better-breakfast",
+  "serverId": "B",
+  "timestamp": 10464
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "orange-scruffy-brief-shoe",
+  "serverId": "A",
+  "timestamp": 9590
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "wet-crooked-important-parrot",
+  "serverId": "A",
+  "timestamp": 9928
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "incalculable-thoughtless-square-advertisement",
+  "serverId": "A",
+  "timestamp": 7434
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "scarce-few-petite-minister",
+  "serverId": "B",
+  "timestamp": 8331
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "raspy-stocky-black-death",
+  "serverId": "B",
+  "timestamp": 7297
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "enough-squeaking-powerful-uganda",
+  "serverId": "A",
+  "timestamp": 9490
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "thundering-broad-square-market",
+  "serverId": "A",
+  "timestamp": 6173
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "cuddly-clean-unkempt-restaurant",
+  "serverId": "B",
+  "timestamp": 3077
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "tangy-panicky-little-advertisement",
+  "serverId": "B",
+  "timestamp": 5128
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "numerous-tart-rotten-library",
+  "serverId": "A",
+  "timestamp": 9599
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "damp-refined-mushy-raincoat",
+  "serverId": "B",
+  "timestamp": 10944
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "panicky-sticky-straight-window",
+  "serverId": "A",
+  "timestamp": 8234
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "steep-dirty-numerous-dress",
+  "serverId": "B",
+  "timestamp": 7882
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "delightful-rancid-immense-quill",
+  "serverId": "B",
+  "timestamp": 9633
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "few-acidic-fresh-room",
+  "serverId": "B",
+  "timestamp": 6217
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "scrawny-mango-witty-iron",
+  "serverId": "A",
+  "timestamp": 9699
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "tasty-shrilling-scrawny-lamp",
+  "serverId": "A",
+  "timestamp": 6518
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "shrilling-teeny-black-egypt",
+  "serverId": "B",
+  "timestamp": 7073
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "short-little-stocky-monkey",
+  "serverId": "A",
+  "timestamp": 5019
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "careful-crooked-clever-microphone",
+  "serverId": "B",
+  "timestamp": 8773
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "uninterested-some-jealous-garden",
+  "serverId": "B",
+  "timestamp": 8085
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "creamy-fit-rich-dream",
+  "serverId": "B",
+  "timestamp": 10804
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "rough-better-ripe-pencil",
+  "serverId": "A",
+  "timestamp": 4264
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "sparse-clean-lazy-hydrogen",
+  "serverId": "B",
+  "timestamp": 9808
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "black-rancid-shrilling-jewellery",
+  "serverId": "B",
+  "timestamp": 9586
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "crashing-vast-odd-football",
+  "serverId": "A",
+  "timestamp": 3012
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "juicy-lazy-rotten-jewellery",
+  "serverId": "A",
+  "timestamp": 8518
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "tinkling-teeny-high-lighter",
+  "serverId": "A",
+  "timestamp": 8374
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "fresh-nervous-grumpy-xylophone",
+  "serverId": "B",
+  "timestamp": 2582
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "screeching-old-clever-window",
+  "serverId": "B",
+  "timestamp": 9191
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "eager-late-sticky-apple",
+  "serverId": "A",
+  "timestamp": 9992
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "short-thousands-quick-garden",
+  "serverId": "A",
+  "timestamp": 10211
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "cold-glamorous-high-ghost",
+  "serverId": "B",
+  "timestamp": 7839
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "young-careful-strong-night",
+  "serverId": "A",
+  "timestamp": 9237
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "long-eager-important-pencil",
+  "serverId": "B",
+  "timestamp": 9347
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "chubby-big-breezy-table",
+  "serverId": "A",
+  "timestamp": 8799
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "brave-grumpy-unimportant-flag",
+  "serverId": "B",
+  "timestamp": 7902
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "ambitious-strong-high-house",
+  "serverId": "A",
+  "timestamp": 8514
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "billions-faint-short-garden",
+  "serverId": "B",
+  "timestamp": 10151
+ },
+ {
+  "type": "CloseChannel",
+  "jobId": "plain-wide-faithful-bear",
+  "serverId": "B",
+  "timestamp": 7055
+ }
+]

--- a/packages/server-wallet/e2e-testing/test-data/sample-ledger-load-data.json
+++ b/packages/server-wallet/e2e-testing/test-data/sample-ledger-load-data.json
@@ -1,9 +1,9 @@
 [
  {
   "type": "CreateLedgerChannel",
-  "jobId": "odd-uptight-clever-truck",
+  "jobId": "tender-warm-calm-horse",
   "serverId": "A",
-  "timestamp": 3775,
+  "timestamp": 3915,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -39,47 +39,9 @@
  },
  {
   "type": "CreateLedgerChannel",
-  "jobId": "scarce-long-obedient-helmet",
-  "serverId": "A",
-  "timestamp": 2221,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "worried-prickly-thoughtless-continent",
+  "jobId": "quiet-faint-plump-woman",
   "serverId": "B",
-  "timestamp": 1050,
+  "timestamp": 4598,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -115,9 +77,9 @@
  },
  {
   "type": "CreateLedgerChannel",
-  "jobId": "agreeable-salty-howling-camera",
+  "jobId": "rapid-rotten-rhythmic-jelly",
   "serverId": "A",
-  "timestamp": 3597,
+  "timestamp": 4224,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -153,31 +115,69 @@
  },
  {
   "type": "CreateLedgerChannel",
-  "jobId": "scrawny-thankful-long-rainbow",
-  "serverId": "B",
-  "timestamp": 1351,
+  "jobId": "mysterious-moldy-short-teacher",
+  "serverId": "A",
+  "timestamp": 1079,
   "ledgerChannelParams": {
    "participants": [
     {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
      "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
      "participantId": "A",
      "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
     }
    ],
    "allocations": [
     {
      "allocationItems": [
       {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
        "amount": "0x0186a0"
       },
       {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x0186a0"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  }
+ },
+ {
+  "type": "CreateLedgerChannel",
+  "jobId": "mango-little-uninterested-restaurant",
+  "serverId": "A",
+  "timestamp": 4314,
+  "ledgerChannelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
        "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x0186a0"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
        "amount": "0x0186a0"
       }
      ],
@@ -191,51 +191,9 @@
  },
  {
   "type": "CreateChannel",
-  "jobId": "cool-tasty-attractive-teacher",
-  "serverId": "A",
-  "timestamp": 47328,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "colossal-putrid-long-energy",
+  "jobId": "ugly-modern-slow-branch",
   "serverId": "B",
-  "timestamp": 19113,
+  "timestamp": 29410,
   "channelParams": {
    "participants": [
     {
@@ -270,56 +228,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "short-incalculable-curved-candle",
-  "serverId": "A",
-  "timestamp": 55640,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "petite-few-dead-flag",
+  "jobId": "purple-hissing-square-honey",
   "serverId": "B",
-  "timestamp": 3167,
+  "timestamp": 6011,
   "channelParams": {
    "participants": [
     {
@@ -354,56 +270,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "mysterious-quick-chubby-coat",
-  "serverId": "A",
-  "timestamp": 16600,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "quaint-poor-green-minister",
+  "jobId": "young-fit-spicy-london",
   "serverId": "B",
-  "timestamp": 24810,
+  "timestamp": 29993,
   "channelParams": {
    "participants": [
     {
@@ -438,14 +312,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "quiet-faint-plump-woman"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "quaint-acidic-yellow-doctor",
+  "jobId": "wet-blue-rapid-stone",
   "serverId": "A",
-  "timestamp": 41407,
+  "timestamp": 21333,
   "channelParams": {
    "participants": [
     {
@@ -480,14 +354,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
+   "fundingLedgerJob": "rapid-rotten-rhythmic-jelly"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "little-witty-aggressive-motorcycle",
+  "jobId": "kind-fluffy-pitiful-beach",
   "serverId": "B",
-  "timestamp": 33098,
+  "timestamp": 26524,
   "channelParams": {
    "participants": [
     {
@@ -522,14 +396,56 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
+   "fundingLedgerJob": "tender-warm-calm-horse"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "magnificent-faint-squeaking-ocean",
+  "jobId": "dry-delicious-short-window",
+  "serverId": "A",
+  "timestamp": 4021,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "shaggy-aggressive-worried-helmet",
   "serverId": "B",
-  "timestamp": 33043,
+  "timestamp": 6317,
   "channelParams": {
    "participants": [
     {
@@ -564,14 +480,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
+   "fundingLedgerJob": "tender-warm-calm-horse"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "wailing-clever-black-kangaroo",
+  "jobId": "little-few-dazzling-alligator",
   "serverId": "B",
-  "timestamp": 48787,
+  "timestamp": 15306,
   "channelParams": {
    "participants": [
     {
@@ -606,56 +522,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
+   "fundingLedgerJob": "rapid-rotten-rhythmic-jelly"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "blue-miniature-purring-energy",
-  "serverId": "A",
-  "timestamp": 6602,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "brave-worried-scary-queen",
+  "jobId": "gorgeous-wet-plain-state",
   "serverId": "B",
-  "timestamp": 58458,
+  "timestamp": 25775,
   "channelParams": {
    "participants": [
     {
@@ -690,14 +564,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "high-strong-thankful-nail",
+  "jobId": "silly-short-agreeable-sandwich",
   "serverId": "A",
-  "timestamp": 52808,
+  "timestamp": 21531,
   "channelParams": {
    "participants": [
     {
@@ -732,14 +606,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
+   "fundingLedgerJob": "quiet-faint-plump-woman"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "rough-damp-warm-toddler",
+  "jobId": "hissing-faint-plump-flower",
   "serverId": "A",
-  "timestamp": 51915,
+  "timestamp": 24971,
   "channelParams": {
    "participants": [
     {
@@ -774,14 +648,98 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "tender-warm-calm-horse"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "massive-swift-billions-leather",
+  "jobId": "chilly-proud-rough-window",
+  "serverId": "A",
+  "timestamp": 16006,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "abundant-uneven-victorious-night",
+  "serverId": "A",
+  "timestamp": 17880,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "rapid-rotten-rhythmic-jelly"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "little-hundreds-petite-lawyer",
   "serverId": "B",
-  "timestamp": 41814,
+  "timestamp": 24516,
   "channelParams": {
    "participants": [
     {
@@ -816,14 +774,56 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
+   "fundingLedgerJob": "rapid-rotten-rhythmic-jelly"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "unkempt-puny-glamorous-pencil",
+  "jobId": "thoughtless-handsome-puny-hamburger",
+  "serverId": "A",
+  "timestamp": 8754,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "tender-warm-calm-horse"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "numerous-better-inexpensive-balloon",
   "serverId": "B",
-  "timestamp": 22274,
+  "timestamp": 11200,
   "channelParams": {
    "participants": [
     {
@@ -858,14 +858,56 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "quiet-faint-plump-woman"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "dry-handsome-narrow-wolf",
+  "jobId": "little-mysterious-ripe-school",
+  "serverId": "A",
+  "timestamp": 4897,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "rapid-rotten-rhythmic-jelly"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "millions-unkempt-colossal-night",
   "serverId": "B",
-  "timestamp": 37882,
+  "timestamp": 25055,
   "channelParams": {
    "participants": [
     {
@@ -900,56 +942,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "crooked-raspy-clever-hospital",
-  "serverId": "A",
-  "timestamp": 56405,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "low-bumpy-fat-machine",
+  "jobId": "millions-unkempt-itchy-night",
   "serverId": "B",
-  "timestamp": 23435,
+  "timestamp": 11645,
   "channelParams": {
    "participants": [
     {
@@ -984,14 +984,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "polite-swift-sparse-businessperson",
+  "jobId": "hallowed-sweet-red-army",
   "serverId": "A",
-  "timestamp": 27504,
+  "timestamp": 9169,
   "channelParams": {
    "participants": [
     {
@@ -1026,56 +1026,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "full-shy-puny-vase",
-  "serverId": "A",
-  "timestamp": 33003,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "icy-tinkling-short-apple",
+  "jobId": "damaged-noisy-crashing-oil",
   "serverId": "B",
-  "timestamp": 22162,
+  "timestamp": 28922,
   "channelParams": {
    "participants": [
     {
@@ -1110,14 +1068,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
+   "fundingLedgerJob": "tender-warm-calm-horse"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "little-puny-loud-kitchen",
+  "jobId": "unkempt-big-wet-lighter",
   "serverId": "A",
-  "timestamp": 18774,
+  "timestamp": 7344,
   "channelParams": {
    "participants": [
     {
@@ -1152,98 +1110,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
+   "fundingLedgerJob": "quiet-faint-plump-woman"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "nervous-lemon-cool-quill",
-  "serverId": "A",
-  "timestamp": 3754,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "billions-beautiful-howling-nigeria",
-  "serverId": "A",
-  "timestamp": 8880,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "early-polite-angry-man",
+  "jobId": "rapid-kind-hissing-candle",
   "serverId": "B",
-  "timestamp": 40302,
+  "timestamp": 14982,
   "channelParams": {
    "participants": [
     {
@@ -1278,98 +1152,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
+   "fundingLedgerJob": "quiet-faint-plump-woman"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "poor-cold-silly-uganda",
-  "serverId": "A",
-  "timestamp": 37044,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "petite-melodic-noisy-orange",
-  "serverId": "A",
-  "timestamp": 39316,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "bumpy-white-many-hospital",
+  "jobId": "wet-round-squeaking-country",
   "serverId": "B",
-  "timestamp": 54633,
+  "timestamp": 13528,
   "channelParams": {
    "participants": [
     {
@@ -1404,56 +1194,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "eager-many-strong-dog",
-  "serverId": "A",
-  "timestamp": 31495,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "loose-shallow-deafening-insurance",
+  "jobId": "nervous-mealy-greasy-queen",
   "serverId": "B",
-  "timestamp": 20090,
+  "timestamp": 28407,
   "channelParams": {
    "participants": [
     {
@@ -1488,14 +1236,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "mango-little-uninterested-restaurant"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "dry-tasty-dry-refrigerator",
+  "jobId": "damaged-helpful-happy-napkin",
   "serverId": "A",
-  "timestamp": 10083,
+  "timestamp": 19671,
   "channelParams": {
    "participants": [
     {
@@ -1530,14 +1278,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
+   "fundingLedgerJob": "mysterious-moldy-short-teacher"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "better-lazy-shy-battery",
+  "jobId": "howling-greasy-clever-city",
   "serverId": "B",
-  "timestamp": 31725,
+  "timestamp": 18978,
   "channelParams": {
    "participants": [
     {
@@ -1572,140 +1320,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
+   "fundingLedgerJob": "mango-little-uninterested-restaurant"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "gifted-alive-defeated-coffeeshop",
-  "serverId": "A",
-  "timestamp": 41311,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "bewildered-muscular-thankful-pillow",
-  "serverId": "A",
-  "timestamp": 37337,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "icy-wrong-little-lion",
-  "serverId": "A",
-  "timestamp": 39327,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "helpful-rotten-purple-teenager",
+  "jobId": "wide-few-shaggy-beach",
   "serverId": "B",
-  "timestamp": 21611,
+  "timestamp": 18922,
   "channelParams": {
    "participants": [
     {
@@ -1740,140 +1362,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
+   "fundingLedgerJob": "mango-little-uninterested-restaurant"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "stocky-nutritious-crooked-quill",
-  "serverId": "A",
-  "timestamp": 6155,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "long-brave-savory-potato",
-  "serverId": "A",
-  "timestamp": 46033,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "icy-famous-green-market",
-  "serverId": "A",
-  "timestamp": 55828,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "easy-angry-squeaking-shampoo",
+  "jobId": "famous-many-rapid-egypt",
   "serverId": "B",
-  "timestamp": 35253,
+  "timestamp": 4084,
   "channelParams": {
    "participants": [
     {
@@ -1908,14 +1404,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "tender-warm-calm-horse"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "alive-uneven-young-lion",
+  "jobId": "stale-hollow-little-potato",
   "serverId": "B",
-  "timestamp": 56645,
+  "timestamp": 10889,
   "channelParams": {
    "participants": [
     {
@@ -1950,763 +1446,7 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "noisy-whispering-ambitious-library",
-  "serverId": "A",
-  "timestamp": 41869,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "prickly-some-abundant-animal",
-  "serverId": "A",
-  "timestamp": 37366,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "odd-alive-embarrassed-kite",
-  "serverId": "A",
-  "timestamp": 21618,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "few-bitter-orange-flower",
-  "serverId": "A",
-  "timestamp": 50185,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "red-broad-delicious-telephone",
-  "serverId": "A",
-  "timestamp": 16330,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "wet-uptight-rancid-vegetable",
-  "serverId": "A",
-  "timestamp": 24423,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "gray-great-greasy-rain",
-  "serverId": "A",
-  "timestamp": 56622,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "flat-wooden-ripe-minister",
-  "serverId": "A",
-  "timestamp": 53531,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "ambitious-microscopic-damaged-actor",
-  "serverId": "B",
-  "timestamp": 4283,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "abundant-deep-helpful-book",
-  "serverId": "B",
-  "timestamp": 37408,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "shaggy-weak-nervous-helmet",
-  "serverId": "A",
-  "timestamp": 29831,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "sticky-grumpy-incalculable-planet",
-  "serverId": "A",
-  "timestamp": 16926,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "faint-dirty-chubby-cricket",
-  "serverId": "A",
-  "timestamp": 35839,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-long-obedient-helmet"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "rhythmic-gifted-shaggy-church",
-  "serverId": "A",
-  "timestamp": 5074,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "odd-uptight-clever-truck"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "vast-rotten-uptight-lamp",
-  "serverId": "B",
-  "timestamp": 33207,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "spoiled-red-most-wolf",
-  "serverId": "B",
-  "timestamp": 24730,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "cool-rapid-broad-sandwich",
-  "serverId": "B",
-  "timestamp": 27137,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "agreeable-salty-howling-camera"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "dry-rough-low-stone",
-  "serverId": "B",
-  "timestamp": 19539,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+   "fundingLedgerJob": "tender-warm-calm-horse"
   }
  }
 ]

--- a/packages/server-wallet/e2e-testing/test-data/sample-ledger-load-data.json
+++ b/packages/server-wallet/e2e-testing/test-data/sample-ledger-load-data.json
@@ -1,9 +1,9 @@
 [
  {
   "type": "CreateLedgerChannel",
-  "jobId": "future-gifted-future-market",
+  "jobId": "odd-uptight-clever-truck",
   "serverId": "A",
-  "timestamp": 13473,
+  "timestamp": 3775,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -39,47 +39,9 @@
  },
  {
   "type": "CreateLedgerChannel",
-  "jobId": "zealous-famous-massive-monkey",
-  "serverId": "B",
-  "timestamp": 6079,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "billions-mammoth-hundreds-battery",
+  "jobId": "scarce-long-obedient-helmet",
   "serverId": "A",
-  "timestamp": 607,
+  "timestamp": 2221,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -115,9 +77,9 @@
  },
  {
   "type": "CreateLedgerChannel",
-  "jobId": "short-yummy-full-engine",
+  "jobId": "worried-prickly-thoughtless-continent",
   "serverId": "B",
-  "timestamp": 11076,
+  "timestamp": 1050,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -153,9 +115,9 @@
  },
  {
   "type": "CreateLedgerChannel",
-  "jobId": "most-uneven-quaint-park",
+  "jobId": "agreeable-salty-howling-camera",
   "serverId": "A",
-  "timestamp": 352,
+  "timestamp": 3597,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -191,351 +153,9 @@
  },
  {
   "type": "CreateLedgerChannel",
-  "jobId": "microscopic-clumsy-warm-grass",
+  "jobId": "scrawny-thankful-long-rainbow",
   "serverId": "B",
-  "timestamp": 391,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "full-ripe-hallowed-army",
-  "serverId": "B",
-  "timestamp": 6952,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "harsh-mammoth-fast-grandmother",
-  "serverId": "B",
-  "timestamp": 11181,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "narrow-numerous-kind-child",
-  "serverId": "A",
-  "timestamp": 7373,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "sour-great-tight-knife",
-  "serverId": "B",
-  "timestamp": 7098,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "straight-bitter-gorgeous-jackal",
-  "serverId": "A",
-  "timestamp": 7123,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "scarce-wide-damaged-school",
-  "serverId": "A",
-  "timestamp": 1181,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "fit-some-noisy-monkey",
-  "serverId": "B",
-  "timestamp": 1910,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "tight-jolly-orange-flag",
-  "serverId": "A",
-  "timestamp": 4705,
-  "ledgerChannelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    },
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x0186a0"
-      },
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x0186a0"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  }
- },
- {
-  "type": "CreateLedgerChannel",
-  "jobId": "faint-rhythmic-scary-afternoon",
-  "serverId": "B",
-  "timestamp": 7350,
+  "timestamp": 1351,
   "ledgerChannelParams": {
    "participants": [
     {
@@ -571,93 +191,9 @@
  },
  {
   "type": "CreateChannel",
-  "jobId": "miniature-shy-ambitious-cat",
-  "serverId": "B",
-  "timestamp": 16944,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "fit-some-noisy-monkey"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "numerous-slow-future-shoe",
-  "serverId": "B",
-  "timestamp": 44200,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "short-yummy-full-engine"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "lemon-wailing-rotten-eye",
+  "jobId": "cool-tasty-attractive-teacher",
   "serverId": "A",
-  "timestamp": 32280,
+  "timestamp": 47328,
   "channelParams": {
    "participants": [
     {
@@ -692,14 +228,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "straight-bitter-gorgeous-jackal"
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "cool-attractive-howling-ocean",
+  "jobId": "colossal-putrid-long-energy",
   "serverId": "B",
-  "timestamp": 45577,
+  "timestamp": 19113,
   "channelParams": {
    "participants": [
     {
@@ -734,56 +270,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "billions-mammoth-hundreds-battery"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "dazzling-agreeable-colossal-yacht",
-  "serverId": "B",
-  "timestamp": 49917,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "sour-great-tight-knife"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "shallow-chubby-aggressive-lawyer",
+  "jobId": "short-incalculable-curved-candle",
   "serverId": "A",
-  "timestamp": 52724,
+  "timestamp": 55640,
   "channelParams": {
    "participants": [
     {
@@ -818,14 +312,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "sour-great-tight-knife"
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "black-mealy-substantial-airport",
+  "jobId": "petite-few-dead-flag",
   "serverId": "B",
-  "timestamp": 50481,
+  "timestamp": 3167,
   "channelParams": {
    "participants": [
     {
@@ -860,14 +354,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "grumpy-billions-long-orange",
+  "jobId": "mysterious-quick-chubby-coat",
   "serverId": "A",
-  "timestamp": 58779,
+  "timestamp": 16600,
   "channelParams": {
    "participants": [
     {
@@ -902,14 +396,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "future-gifted-future-market"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "grumpy-little-petite-monkey",
+  "jobId": "quaint-poor-green-minister",
   "serverId": "B",
-  "timestamp": 22350,
+  "timestamp": 24810,
   "channelParams": {
    "participants": [
     {
@@ -944,98 +438,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "rich-happy-bitter-lion",
-  "serverId": "B",
-  "timestamp": 57334,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-wide-damaged-school"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "wailing-bitter-fancy-island",
-  "serverId": "B",
-  "timestamp": 55444,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "tasty-short-brief-tiger",
+  "jobId": "quaint-acidic-yellow-doctor",
   "serverId": "A",
-  "timestamp": 21952,
+  "timestamp": 41407,
   "channelParams": {
    "participants": [
     {
@@ -1070,14 +480,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "full-ripe-hallowed-army"
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "limited-limited-gentle-egg",
+  "jobId": "little-witty-aggressive-motorcycle",
   "serverId": "B",
-  "timestamp": 15352,
+  "timestamp": 33098,
   "channelParams": {
    "participants": [
     {
@@ -1112,14 +522,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "most-uneven-quaint-park"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "stocky-refined-weak-russia",
+  "jobId": "magnificent-faint-squeaking-ocean",
   "serverId": "B",
-  "timestamp": 57258,
+  "timestamp": 33043,
   "channelParams": {
    "participants": [
     {
@@ -1154,14 +564,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "future-gifted-future-market"
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "numerous-worried-dry-oyster",
+  "jobId": "wailing-clever-black-kangaroo",
   "serverId": "B",
-  "timestamp": 28473,
+  "timestamp": 48787,
   "channelParams": {
    "participants": [
     {
@@ -1196,14 +606,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "future-gifted-future-market"
+   "fundingLedgerJob": "odd-uptight-clever-truck"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "better-calm-putrid-country",
+  "jobId": "blue-miniature-purring-energy",
   "serverId": "A",
-  "timestamp": 24277,
+  "timestamp": 6602,
   "channelParams": {
    "participants": [
     {
@@ -1238,14 +648,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "full-ripe-hallowed-army"
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "swift-nice-few-holiday",
+  "jobId": "brave-worried-scary-queen",
   "serverId": "B",
-  "timestamp": 28473,
+  "timestamp": 58458,
   "channelParams": {
    "participants": [
     {
@@ -1280,14 +690,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "future-gifted-future-market"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "lazy-long-inexpensive-caravan",
+  "jobId": "high-strong-thankful-nail",
   "serverId": "A",
-  "timestamp": 57208,
+  "timestamp": 52808,
   "channelParams": {
    "participants": [
     {
@@ -1322,98 +732,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "huge-shallow-shy-lamp",
-  "serverId": "B",
-  "timestamp": 44431,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "sour-great-tight-knife"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "little-bald-chilly-man",
-  "serverId": "B",
-  "timestamp": 23790,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "billions-mammoth-hundreds-battery"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "strong-thankful-brief-breakfast",
+  "jobId": "rough-damp-warm-toddler",
   "serverId": "A",
-  "timestamp": 16181,
+  "timestamp": 51915,
   "channelParams": {
    "participants": [
     {
@@ -1448,14 +774,140 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "scarce-wide-damaged-school"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "bitter-deep-thousands-motorcycle",
+  "jobId": "massive-swift-billions-leather",
+  "serverId": "B",
+  "timestamp": 41814,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "unkempt-puny-glamorous-pencil",
+  "serverId": "B",
+  "timestamp": 22274,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "dry-handsome-narrow-wolf",
+  "serverId": "B",
+  "timestamp": 37882,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "crooked-raspy-clever-hospital",
   "serverId": "A",
-  "timestamp": 32689,
+  "timestamp": 56405,
   "channelParams": {
    "participants": [
     {
@@ -1490,14 +942,56 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "sour-great-tight-knife"
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "tangy-harsh-salty-wire",
+  "jobId": "low-bumpy-fat-machine",
+  "serverId": "B",
+  "timestamp": 23435,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "polite-swift-sparse-businessperson",
   "serverId": "A",
-  "timestamp": 45272,
+  "timestamp": 27504,
   "channelParams": {
    "participants": [
     {
@@ -1532,56 +1026,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
+   "fundingLedgerJob": "odd-uptight-clever-truck"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "enough-gigantic-pitiful-oyster",
-  "serverId": "B",
-  "timestamp": 16181,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-wide-damaged-school"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "savory-repulsive-zealous-river",
+  "jobId": "full-shy-puny-vase",
   "serverId": "A",
-  "timestamp": 28509,
+  "timestamp": 33003,
   "channelParams": {
    "participants": [
     {
@@ -1616,14 +1068,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "most-uneven-quaint-park"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "petite-glamorous-disgusting-garden",
+  "jobId": "icy-tinkling-short-apple",
   "serverId": "B",
-  "timestamp": 59044,
+  "timestamp": 22162,
   "channelParams": {
    "participants": [
     {
@@ -1658,182 +1110,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "full-ripe-hallowed-army"
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "freezing-careful-polite-airport",
-  "serverId": "B",
-  "timestamp": 53219,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "scarce-wide-damaged-school"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "wide-microscopic-screeching-football",
-  "serverId": "B",
-  "timestamp": 47009,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "future-gifted-future-market"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "late-square-faint-nigeria",
-  "serverId": "B",
-  "timestamp": 43825,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "mango-disgusting-breezy-answer",
-  "serverId": "B",
-  "timestamp": 26321,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "short-yummy-full-engine"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "billions-limited-chilly-shampoo",
+  "jobId": "little-puny-loud-kitchen",
   "serverId": "A",
-  "timestamp": 22350,
+  "timestamp": 18774,
   "channelParams": {
    "participants": [
     {
@@ -1868,56 +1152,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
+   "fundingLedgerJob": "odd-uptight-clever-truck"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "crashing-future-quaint-toothbrush",
-  "serverId": "B",
-  "timestamp": 45584,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "narrow-numerous-kind-child"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "thousands-broad-ambitious-grandmother",
+  "jobId": "nervous-lemon-cool-quill",
   "serverId": "A",
-  "timestamp": 28539,
+  "timestamp": 3754,
   "channelParams": {
    "participants": [
     {
@@ -1952,14 +1194,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "refined-sticky-delicious-napkin",
+  "jobId": "billions-beautiful-howling-nigeria",
   "serverId": "A",
-  "timestamp": 55677,
+  "timestamp": 8880,
   "channelParams": {
    "participants": [
     {
@@ -1994,14 +1236,56 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "most-uneven-quaint-park"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "prickly-high-worried-restaurant",
+  "jobId": "early-polite-angry-man",
+  "serverId": "B",
+  "timestamp": 40302,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "odd-uptight-clever-truck"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "poor-cold-silly-uganda",
   "serverId": "A",
-  "timestamp": 21952,
+  "timestamp": 37044,
   "channelParams": {
    "participants": [
     {
@@ -2036,14 +1320,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "full-ripe-hallowed-army"
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "square-chilly-prickly-magazine",
+  "jobId": "petite-melodic-noisy-orange",
   "serverId": "A",
-  "timestamp": 53598,
+  "timestamp": 39316,
   "channelParams": {
    "participants": [
     {
@@ -2078,14 +1362,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "sour-great-tight-knife"
+   "fundingLedgerJob": "odd-uptight-clever-truck"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "great-late-grumpy-dress",
+  "jobId": "bumpy-white-many-hospital",
   "serverId": "B",
-  "timestamp": 50220,
+  "timestamp": 54633,
   "channelParams": {
    "participants": [
     {
@@ -2120,140 +1404,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "zealous-famous-massive-monkey"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "short-thoughtless-witty-spoon",
-  "serverId": "B",
-  "timestamp": 34519,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "immense-little-bumpy-dream",
-  "serverId": "B",
-  "timestamp": 43477,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "late-ancient-chubby-sugar",
-  "serverId": "B",
-  "timestamp": 47920,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "future-gray-unkempt-camera",
+  "jobId": "eager-many-strong-dog",
   "serverId": "A",
-  "timestamp": 30552,
+  "timestamp": 31495,
   "channelParams": {
    "participants": [
     {
@@ -2288,14 +1446,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "narrow-numerous-kind-child"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "ancient-hollow-broad-parrot",
+  "jobId": "loose-shallow-deafening-insurance",
   "serverId": "B",
-  "timestamp": 16910,
+  "timestamp": 20090,
   "channelParams": {
    "participants": [
     {
@@ -2330,14 +1488,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "fit-some-noisy-monkey"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "nervous-scarce-eager-vegetable",
+  "jobId": "dry-tasty-dry-refrigerator",
   "serverId": "A",
-  "timestamp": 40854,
+  "timestamp": 10083,
   "channelParams": {
    "participants": [
     {
@@ -2372,14 +1530,56 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
+   "fundingLedgerJob": "odd-uptight-clever-truck"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "skinny-sticky-hot-toddler",
+  "jobId": "better-lazy-shy-battery",
+  "serverId": "B",
+  "timestamp": 31725,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "odd-uptight-clever-truck"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "gifted-alive-defeated-coffeeshop",
   "serverId": "A",
-  "timestamp": 58259,
+  "timestamp": 41311,
   "channelParams": {
    "participants": [
     {
@@ -2414,14 +1614,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "tight-jolly-orange-flag"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "tender-faithful-gifted-tiger",
+  "jobId": "bewildered-muscular-thankful-pillow",
   "serverId": "A",
-  "timestamp": 16910,
+  "timestamp": 37337,
   "channelParams": {
    "participants": [
     {
@@ -2456,14 +1656,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "fit-some-noisy-monkey"
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "pitiful-lemon-screeching-battery",
+  "jobId": "icy-wrong-little-lion",
   "serverId": "A",
-  "timestamp": 48164,
+  "timestamp": 39327,
   "channelParams": {
    "participants": [
     {
@@ -2498,14 +1698,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "rapid-ripe-unkempt-car",
+  "jobId": "helpful-rotten-purple-teenager",
   "serverId": "B",
-  "timestamp": 37965,
+  "timestamp": 21611,
   "channelParams": {
    "participants": [
     {
@@ -2540,140 +1740,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "straight-bitter-gorgeous-jackal"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "cool-tiny-crashing-lighter",
-  "serverId": "B",
-  "timestamp": 34781,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "billions-mammoth-hundreds-battery"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "prehistoric-salty-dazzling-girl",
-  "serverId": "B",
-  "timestamp": 21079,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "zealous-famous-massive-monkey"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "silly-wonderful-wet-insurance",
-  "serverId": "B",
-  "timestamp": 21079,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "zealous-famous-massive-monkey"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "calm-cool-mysterious-zebra",
+  "jobId": "stocky-nutritious-crooked-quill",
   "serverId": "A",
-  "timestamp": 37169,
+  "timestamp": 6155,
   "channelParams": {
    "participants": [
     {
@@ -2708,14 +1782,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "tight-jolly-orange-flag"
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "rapping-muscular-tall-bear",
+  "jobId": "long-brave-savory-potato",
   "serverId": "A",
-  "timestamp": 43805,
+  "timestamp": 46033,
   "channelParams": {
    "participants": [
     {
@@ -2750,182 +1824,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "sour-great-tight-knife"
+   "fundingLedgerJob": "odd-uptight-clever-truck"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "red-vast-modern-russia",
-  "serverId": "B",
-  "timestamp": 18072,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "prickly-vast-broad-yak",
-  "serverId": "B",
-  "timestamp": 16826,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "microscopic-clumsy-warm-grass"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "stocky-chilly-cold-tomato",
-  "serverId": "B",
-  "timestamp": 22350,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "faint-rhythmic-scary-afternoon"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "nutritious-proud-better-restaurant",
-  "serverId": "B",
-  "timestamp": 28473,
-  "channelParams": {
-   "participants": [
-    {
-     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
-     "participantId": "B",
-     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
-    },
-    {
-     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
-     "participantId": "A",
-     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
-    }
-   ],
-   "allocations": [
-    {
-     "allocationItems": [
-      {
-       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
-       "amount": "0x05"
-      },
-      {
-       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
-       "amount": "0x05"
-      }
-     ],
-     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
-    }
-   ],
-   "appDefinition": "0x00000000000000000000000000000000000000ca",
-   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
-   "challengeDuration": 86400
-  },
-  "fundingInfo": {
-   "type": "Ledger",
-   "fundingLedgerJob": "future-gifted-future-market"
-  }
- },
- {
-  "type": "CreateChannel",
-  "jobId": "shrilling-drab-high-sweden",
+  "jobId": "icy-famous-green-market",
   "serverId": "A",
-  "timestamp": 26181,
+  "timestamp": 55828,
   "channelParams": {
    "participants": [
     {
@@ -2960,14 +1866,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "refined-rapid-alive-rocket",
+  "jobId": "easy-angry-squeaking-shampoo",
   "serverId": "B",
-  "timestamp": 51610,
+  "timestamp": 35253,
   "channelParams": {
    "participants": [
     {
@@ -3002,14 +1908,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "narrow-numerous-kind-child"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "repulsive-grumpy-chubby-helicopter",
+  "jobId": "alive-uneven-young-lion",
   "serverId": "B",
-  "timestamp": 26181,
+  "timestamp": 56645,
   "channelParams": {
    "participants": [
     {
@@ -3044,14 +1950,14 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "harsh-mammoth-fast-grandmother"
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  },
  {
   "type": "CreateChannel",
-  "jobId": "whining-kind-shapely-insurance",
+  "jobId": "noisy-whispering-ambitious-library",
   "serverId": "A",
-  "timestamp": 46331,
+  "timestamp": 41869,
   "channelParams": {
    "participants": [
     {
@@ -3086,7 +1992,721 @@
   },
   "fundingInfo": {
    "type": "Ledger",
-   "fundingLedgerJob": "short-yummy-full-engine"
+   "fundingLedgerJob": "odd-uptight-clever-truck"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "prickly-some-abundant-animal",
+  "serverId": "A",
+  "timestamp": 37366,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "odd-alive-embarrassed-kite",
+  "serverId": "A",
+  "timestamp": 21618,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "few-bitter-orange-flower",
+  "serverId": "A",
+  "timestamp": 50185,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "red-broad-delicious-telephone",
+  "serverId": "A",
+  "timestamp": 16330,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "odd-uptight-clever-truck"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "wet-uptight-rancid-vegetable",
+  "serverId": "A",
+  "timestamp": 24423,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "odd-uptight-clever-truck"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "gray-great-greasy-rain",
+  "serverId": "A",
+  "timestamp": 56622,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "flat-wooden-ripe-minister",
+  "serverId": "A",
+  "timestamp": 53531,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "ambitious-microscopic-damaged-actor",
+  "serverId": "B",
+  "timestamp": 4283,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "abundant-deep-helpful-book",
+  "serverId": "B",
+  "timestamp": 37408,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "shaggy-weak-nervous-helmet",
+  "serverId": "A",
+  "timestamp": 29831,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "sticky-grumpy-incalculable-planet",
+  "serverId": "A",
+  "timestamp": 16926,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "faint-dirty-chubby-cricket",
+  "serverId": "A",
+  "timestamp": 35839,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scarce-long-obedient-helmet"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "rhythmic-gifted-shaggy-church",
+  "serverId": "A",
+  "timestamp": 5074,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    },
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "odd-uptight-clever-truck"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "vast-rotten-uptight-lamp",
+  "serverId": "B",
+  "timestamp": 33207,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "spoiled-red-most-wolf",
+  "serverId": "B",
+  "timestamp": 24730,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "worried-prickly-thoughtless-continent"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "cool-rapid-broad-sandwich",
+  "serverId": "B",
+  "timestamp": 27137,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "agreeable-salty-howling-camera"
+  }
+ },
+ {
+  "type": "CreateChannel",
+  "jobId": "dry-rough-low-stone",
+  "serverId": "B",
+  "timestamp": 19539,
+  "channelParams": {
+   "participants": [
+    {
+     "signingAddress": "0x2222E21c8019b14dA16235319D34b5Dd83E644A9",
+     "participantId": "B",
+     "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39"
+    },
+    {
+     "signingAddress": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
+     "participantId": "A",
+     "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31"
+    }
+   ],
+   "allocations": [
+    {
+     "allocationItems": [
+      {
+       "destination": "0x000000000000000000000000d4Fa489Eacc52BA59438993f37Be9fcC20090E39",
+       "amount": "0x05"
+      },
+      {
+       "destination": "0x000000000000000000000000D9995BAE12FEe327256FFec1e3184d492bD94C31",
+       "amount": "0x05"
+      }
+     ],
+     "assetHolderAddress": "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+    }
+   ],
+   "appDefinition": "0x00000000000000000000000000000000000000ca",
+   "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "challengeDuration": 86400
+  },
+  "fundingInfo": {
+   "type": "Ledger",
+   "fundingLedgerJob": "scrawny-thankful-long-rainbow"
   }
  }
 ]

--- a/packages/server-wallet/e2e-testing/types.ts
+++ b/packages/server-wallet/e2e-testing/types.ts
@@ -1,13 +1,31 @@
 import {CreateChannelParams, UpdateChannelParams} from '@statechannels/client-api-schema';
 
-export type CreateChannelStep = {
-  type: 'CreateChannel';
+import {CreateLedgerChannelParams} from '../wallet';
+
+export type CreateDirectlyFundedChannelStep = {
+  type: 'CreateDirectlyFundedChannel';
   serverId: string;
   jobId: string;
   timestamp: number;
-  channelParams: CreateChannelParams;
+  channelParams: Omit<CreateChannelParams, 'fundingLedgerChannelId' | 'fundingStrategy'>;
 };
 
+export type CreateLedgerFundedChannelStep = {
+  type: 'CreateLedgerFundedChannel';
+  serverId: string;
+  jobId: string;
+  timestamp: number;
+  fundingLedgerJobId: string;
+  channelParams: Omit<CreateChannelParams, 'fundingLedgerChannelId' | 'fundingStrategy'>;
+};
+
+export type CreateLedgerChannelStep = {
+  serverId: string;
+  type: 'CreateLedgerChannel';
+  jobId: string;
+  timestamp: number;
+  ledgerChannelParams: CreateLedgerChannelParams;
+};
 export type CloseChannelStep = {
   serverId: string;
   type: 'CloseChannel';
@@ -23,7 +41,12 @@ export type UpdateChannelStep = {
   updateParams: Omit<UpdateChannelParams, 'channelId'>;
 };
 
-export type Step = CreateChannelStep | CloseChannelStep | UpdateChannelStep;
+export type Step =
+  | CreateLedgerChannelStep
+  | CreateLedgerFundedChannelStep
+  | CreateDirectlyFundedChannelStep
+  | CloseChannelStep
+  | UpdateChannelStep;
 
 /**
  * A job is just a collection of steps all with the same job id

--- a/packages/server-wallet/e2e-testing/types.ts
+++ b/packages/server-wallet/e2e-testing/types.ts
@@ -1,30 +1,24 @@
 import {CreateChannelParams, UpdateChannelParams} from '@statechannels/client-api-schema';
 
-import {CreateLedgerChannelParams} from '../wallet';
+import {CreateLedgerChannelParams} from '../src/wallet';
 
-export type CreateDirectlyFundedChannelStep = {
-  type: 'CreateDirectlyFundedChannel';
+export type CreateChannelStep = {
+  type: 'CreateChannel';
   serverId: string;
   jobId: string;
   timestamp: number;
   channelParams: Omit<CreateChannelParams, 'fundingLedgerChannelId' | 'fundingStrategy'>;
+  fundingInfo: FundingInfo;
 };
 
-export type CreateLedgerFundedChannelStep = {
-  type: 'CreateLedgerFundedChannel';
-  serverId: string;
-  jobId: string;
-  timestamp: number;
-  fundingLedgerJobId: string;
-  channelParams: Omit<CreateChannelParams, 'fundingLedgerChannelId' | 'fundingStrategy'>;
-};
+export type FundingInfo = {type: 'Direct'} | {type: 'Ledger'; fundingLedgerJob: string};
 
 export type CreateLedgerChannelStep = {
   serverId: string;
   type: 'CreateLedgerChannel';
   jobId: string;
   timestamp: number;
-  ledgerChannelParams: CreateLedgerChannelParams;
+  ledgerChannelParams: Omit<CreateLedgerChannelParams, 'fundingStrategy'>;
 };
 export type CloseChannelStep = {
   serverId: string;
@@ -43,8 +37,7 @@ export type UpdateChannelStep = {
 
 export type Step =
   | CreateLedgerChannelStep
-  | CreateLedgerFundedChannelStep
-  | CreateDirectlyFundedChannelStep
+  | CreateChannelStep
   | CloseChannelStep
   | UpdateChannelStep;
 

--- a/packages/server-wallet/e2e-testing/wallet-load-node.ts
+++ b/packages/server-wallet/e2e-testing/wallet-load-node.ts
@@ -210,29 +210,35 @@ export class WalletLoadNode {
         const [result] = await this.serverWallet.createChannels([
           {...request.channelParams, fundingStrategy: 'Direct'},
         ]);
+
         const {jobId} = request;
         const {channelId} = result;
 
         this.jobToChannelMap.push({jobId, channelId});
         await this.shareChannelIdsWithPeers({jobId, channelId});
+
         return result.done;
       } else {
         const ledgerResult = this.jobToChannelMap.find(
           j => j.jobId === fundingInfo.fundingLedgerJob
         );
+
         if (!ledgerResult) {
           throw new Error(`Cannot find channel id for ledger job ${fundingInfo.fundingLedgerJob}`);
         }
 
         const {channelId: fundingLedgerChannelId} = ledgerResult;
+
         const [result] = await this.serverWallet.createChannels([
           {...request.channelParams, fundingStrategy: 'Ledger', fundingLedgerChannelId},
         ]);
+
         const {jobId} = request;
         const {channelId} = result;
 
         this.jobToChannelMap.push({jobId, channelId});
         await this.shareChannelIdsWithPeers({jobId, channelId});
+
         return result.done;
       }
     },
@@ -257,6 +263,7 @@ export class WalletLoadNode {
         ...req.ledgerChannelParams,
         fundingStrategy: 'Direct',
       });
+
       const {jobId} = req;
       const {channelId} = result;
 

--- a/packages/server-wallet/e2e-testing/wallet-load-node.ts
+++ b/packages/server-wallet/e2e-testing/wallet-load-node.ts
@@ -27,6 +27,7 @@ export class WalletLoadNode {
   private jobToChannelMap: JobChannelLink[] = [];
   private completedSteps = 0;
   private server: Express;
+  private proposedObjectives = new Set<string>();
 
   private constructor(
     private serverWallet: Wallet,
@@ -37,8 +38,13 @@ export class WalletLoadNode {
     // This will approve any new objectives proposed by other participants
     this.serverWallet.on('ObjectiveProposed', async o => {
       if (o.type === 'OpenChannel') {
-        this.logger.trace({objectiveId: o.objectiveId}, 'Auto approving objective');
-        this.serverWallet.approveObjectives([o.objectiveId]);
+        // This is an easy work around for https://github.com/statechannels/statechannels/issues/3668
+
+        if (!this.proposedObjectives.has(o.objectiveId)) {
+          this.logger.trace({objectiveId: o.objectiveId}, 'Auto approving objective');
+          this.serverWallet.approveObjectives([o.objectiveId]);
+          this.proposedObjectives.add(o.objectiveId);
+        }
       }
     });
 

--- a/packages/server-wallet/e2e-testing/wallet-load-node.ts
+++ b/packages/server-wallet/e2e-testing/wallet-load-node.ts
@@ -203,15 +203,15 @@ export class WalletLoadNode {
    * These are the various handlers for different step types
    * TODO: Typing should not use any type for the request
    */
-  private stepHandlers: Record<Step['type'], (req: any) => Promise<ObjectiveDoneResult>> = {
-    CreateChannel: async (request: CreateChannelStep) => {
-      const {fundingInfo} = request;
+  private stepHandlers: Record<Step['type'], (step: any) => Promise<ObjectiveDoneResult>> = {
+    CreateChannel: async (step: CreateChannelStep) => {
+      const {fundingInfo} = step;
       if (fundingInfo.type === 'Direct') {
         const [result] = await this.serverWallet.createChannels([
-          {...request.channelParams, fundingStrategy: 'Direct'},
+          {...step.channelParams, fundingStrategy: 'Direct'},
         ]);
 
-        const {jobId} = request;
+        const {jobId} = step;
         const {channelId} = result;
 
         this.jobToChannelMap.push({jobId, channelId});
@@ -230,10 +230,10 @@ export class WalletLoadNode {
         const {channelId: fundingLedgerChannelId} = ledgerResult;
 
         const [result] = await this.serverWallet.createChannels([
-          {...request.channelParams, fundingStrategy: 'Ledger', fundingLedgerChannelId},
+          {...step.channelParams, fundingStrategy: 'Ledger', fundingLedgerChannelId},
         ]);
 
-        const {jobId} = request;
+        const {jobId} = step;
         const {channelId} = result;
 
         this.jobToChannelMap.push({jobId, channelId});
@@ -242,29 +242,29 @@ export class WalletLoadNode {
         return result.done;
       }
     },
-    CloseChannel: async (request: CloseChannelStep) => {
-      const channelId = this.getChannelIdForJob(request.jobId);
+    CloseChannel: async (step: CloseChannelStep) => {
+      const channelId = this.getChannelIdForJob(step.jobId);
 
       const [result] = await this.serverWallet.closeChannels([channelId]);
 
       return result.done;
     },
-    UpdateChannel: async (req: UpdateChannelStep) => {
-      const channelId = this.getChannelIdForJob(req.jobId);
+    UpdateChannel: async (step: UpdateChannelStep) => {
+      const channelId = this.getChannelIdForJob(step.jobId);
 
-      const {allocations, appData} = req.updateParams;
+      const {allocations, appData} = step.updateParams;
       const result = await this.serverWallet.updateChannel(channelId, allocations, appData);
 
       return result;
     },
 
-    CreateLedgerChannel: async (req: CreateLedgerChannelStep) => {
+    CreateLedgerChannel: async (step: CreateLedgerChannelStep) => {
       const result = await this.serverWallet.createLedgerChannel({
-        ...req.ledgerChannelParams,
+        ...step.ledgerChannelParams,
         fundingStrategy: 'Direct',
       });
 
-      const {jobId} = req;
+      const {jobId} = step;
       const {channelId} = result;
 
       this.jobToChannelMap.push({jobId, channelId});

--- a/packages/server-wallet/server-wallet.api.md
+++ b/packages/server-wallet/server-wallet.api.md
@@ -64,6 +64,11 @@ export type ChainServiceConfiguration = {
     attachChainService: boolean;
 } & Partial<Exclude<ChainServiceArgs, 'logger'>>;
 
+// @public (undocumented)
+export type CreateLedgerChannelParams = Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration' | 'fundingStrategy'> & {
+    fundingStrategy: 'Direct' | 'Fake';
+};
+
 // @public
 export type DatabaseConfiguration = RequiredDatabaseConfiguration & OptionalDatabaseConfiguration;
 
@@ -452,9 +457,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
     // Warning: (ae-forgotten-export) The symbol "MessageServiceFactory" needs to be exported by the entry point index.d.ts
     static create(incomingConfig: IncomingWalletConfig, messageServiceFactory: MessageServiceFactory): Promise<Wallet>;
     createChannels(channelParameters: CreateChannelParams[]): Promise<ObjectiveResult[]>;
-    createLedgerChannel(channelParams: Pick<CreateChannelParams, 'participants' | 'allocations' | 'challengeDuration' | 'fundingStrategy'> & {
-        fundingStrategy: 'Direct' | 'Fake';
-    }): Promise<ObjectiveResult>;
+    createLedgerChannel(channelParams: CreateLedgerChannelParams): Promise<ObjectiveResult>;
     // (undocumented)
     destroy(): Promise<void>;
     // (undocumented)
@@ -491,7 +494,7 @@ export interface WalletEvents {
 //
 // src/engine/types.ts:31:3 - (ae-forgotten-export) The symbol "ChainRequest" needs to be exported by the entry point index.d.ts
 // src/engine/types.ts:69:39 - (ae-forgotten-export) The symbol "WalletObjective" needs to be exported by the entry point index.d.ts
-// src/wallet/types.ts:44:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
+// src/wallet/types.ts:49:3 - (ae-forgotten-export) The symbol "ObjectiveStatus" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/server-wallet/src/wallet/types.ts
+++ b/packages/server-wallet/src/wallet/types.ts
@@ -1,9 +1,14 @@
-import {ChannelResult} from '@statechannels/client-api-schema';
+import {ChannelResult, CreateChannelParams} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 
 import {ObjectiveStatus, WalletObjective} from '../models/objective';
 
 export type ObjectiveError = ObjectiveTimedOutError | InternalError;
+
+export type CreateLedgerChannelParams = Pick<
+  CreateChannelParams,
+  'participants' | 'allocations' | 'challengeDuration' | 'fundingStrategy'
+> & {fundingStrategy: 'Direct' | 'Fake'};
 
 /**
  * The objective timed out without being completed.

--- a/packages/server-wallet/src/wallet/wallet.ts
+++ b/packages/server-wallet/src/wallet/wallet.ts
@@ -50,7 +50,13 @@ import * as ChannelState from '../protocols/state';
 import {createLogger} from '../logger';
 import {ConfigValidationError, SingleThreadedEngine} from '../engine/engine';
 
-import {ObjectiveResult, WalletEvents, ObjectiveDoneResult, UpdateChannelResult} from './types';
+import {
+  ObjectiveResult,
+  WalletEvents,
+  ObjectiveDoneResult,
+  UpdateChannelResult,
+  CreateLedgerChannelParams,
+} from './types';
 
 export class Wallet extends EventEmitter<WalletEvents> {
   /**
@@ -192,10 +198,7 @@ export class Wallet extends EventEmitter<WalletEvents> {
    * @returns An ObjectiveResult indicating success or the error that occured
    */
   public async createLedgerChannel(
-    channelParams: Pick<
-      CreateChannelParams,
-      'participants' | 'allocations' | 'challengeDuration' | 'fundingStrategy'
-    > & {fundingStrategy: 'Direct' | 'Fake'}
+    channelParams: CreateLedgerChannelParams
   ): Promise<ObjectiveResult> {
     try {
       const createResult = await this._engine.createLedgerChannel(


### PR DESCRIPTION
Fixes #3657

The load generator and load node now support ledger-funded channels.

The load generator has some new options.
- `--fundingStrategy`: Either direct or ledger
- `--createLedgerDuration`:  The amount of time ledger channels will be created for. If `createLedgerDuration==duration` then ledger channels will constantly be created. If `createLedgerDuration < duration` ledger channels only get created for the first `createLedgerDuration`.
- `--ledgerDelay`: The amount of time to wait before attempting to use a ledger channel for funding. This is used to allow time for the ledger channels to be directly funded.
- `--ledgerRate`: How many ledger channels per second to create.

The basic load generator flow :
- we create `createLedgerDuration*ledgerRate`of CreateLedger steps.
- For each CreateChannel step we want to create we randomly select one of the CreateLedger steps 
- We create a CreateChannel step that has `c.timestamp= Random(l.timestamp+ledgerDelay, duration)` This allows us to be reasonably certain that the ledger channel has had enough time to be created and funded.