### PR TITLE
remove timeout configuration

### DIFF
--- a/packages/nitro-protocol/test/contracts/ForceMove/_validSignatures.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/_validSignatures.test.ts
@@ -7,8 +7,6 @@ import {sign} from '../../../src/signatures';
 const provider = getTestProvider();
 let ForceMove: Contract;
 
-jest.setTimeout(10_000);
-
 beforeAll(async () => {
   ForceMove = setupContract(provider, ForceMoveArtifact, process.env.TEST_FORCE_MOVE_ADDRESS);
 });


### PR DESCRIPTION
This test consistently fails due to timeout on at least one dev machine (mine!) with tests run in parallel (`yarn test`), but succeeds as is when run independently (eg: `yarn test _validSignatures`).

With this timeout config removed, the test is still constrained by the global timeout config of 90 seconds.

Incremental adjustments to the timeout (20 seconds, 30 seconds, 40 seconds) resulted in fewer and less predictable errors but failing tests nonetheless.

### Shortcoming

Relaxing the timeout constraint makes the feedback from a successful test run less informative.

### Alternative approach

Alternatively, the test suite could be adjusted to run tests sequentially by default. This slows the test suite runs substantially.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
