### PR TITLE
Check guarantee and target outcome assets match

### DIFF
--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -253,12 +253,12 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         // Note: by initializing payouts to be an array of fixed length, its entries are initialized to be `0`
         payouts = new uint256[](indices.length > 0 ? indices.length : allocation.length);
         totalPayouts = 0;
-        newAllocation = new Outcome.AllocationItem[](allocation.length);
         allocatesOnlyZeros = true; // switched to false if there is an item remaining with amount > 0
         uint256 surplus = initialHoldings; // tracks funds available during calculation
         uint256 k = 0; // indexes the `indices` array
 
         // copy allocation
+        newAllocation = new Outcome.AllocationItem[](allocation.length);
         for (uint256 i = 0; i < allocation.length; i++) {
             newAllocation[i].destination = allocation[i].destination;
             newAllocation[i].amount = allocation[i].amount;

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -237,9 +237,7 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
     // **************
     // Internal methods
     // **************
-    /**
-     * 
-     */
+
     function _computeNewAllocationWithGuarantee(
         uint256 initialHoldings,
         Outcome.AllocationItem[] memory allocation,
@@ -304,9 +302,6 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         }
     }
 
-    /**
-     * @notice 
-     */
     function _computeNewAllocation(
         uint256 initialHoldings,
         Outcome.AllocationItem[] memory allocation,

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -190,10 +190,7 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
                 targetOutcomeBytes,
                 (Outcome.OutcomeItem[])
             );
-            require(
-                outcome[assetIndex].asset == asset,
-                'targetAsset != guaranteeAsset'
-            );
+            require(outcome[assetIndex].asset == asset, 'targetAsset != guaranteeAsset');
             {
                 Outcome.AssetOutcome memory assetOutcome = abi.decode(
                     outcome[assetIndex].assetOutcomeBytes,

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -190,6 +190,10 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
                 targetOutcomeBytes,
                 (Outcome.OutcomeItem[])
             );
+            require(
+                outcome[assetIndex].asset == asset,
+                'targetAsset != guaranteeAsset'
+            );
             {
                 Outcome.AssetOutcome memory assetOutcome = abi.decode(
                     outcome[assetIndex].assetOutcomeBytes,
@@ -233,7 +237,9 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
     // **************
     // Internal methods
     // **************
-
+    /**
+     * 
+     */
     function _computeNewAllocationWithGuarantee(
         uint256 initialHoldings,
         Outcome.AllocationItem[] memory allocation,
@@ -298,6 +304,9 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         }
     }
 
+    /**
+     * @notice 
+     */
     function _computeNewAllocation(
         uint256 initialHoldings,
         Outcome.AllocationItem[] memory allocation,

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 4027411, // Singleton
+      NitroAdjudicator: 4055872, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -107,9 +107,9 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeJ: 101504,
       challengeX: 93193,
       transferAllAssetsL: 56162,
-      claimG: 73531,
+      claimG: 73656,
       transferAllAssetsX: 105543,
-      total: 616446,
+      total: 616571,
     },
   },
 };

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -31,6 +31,7 @@ const addresses = {
 };
 
 const reason5 = 'Channel not finalized';
+const reason6 = 'targetAsset != guaranteeAsset';
 
 // 1. claim G1 (step 1 of figure 23 of nitro paper)
 // 2. claim G2 (step 2 of figure 23 of nitro paper)
@@ -57,6 +58,7 @@ describe('claim', () => {
     ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
     ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
     ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
   `(
     '$name',
     async ({
@@ -152,7 +154,10 @@ describe('claim', () => {
         targetChannelId: targetId,
       };
 
-      const guaranteeOutcome: Outcome = [{asset: MAGIC_ADDRESS_INDICATING_ETH, guarantee}];
+      const guaranteeOutcome: Outcome =
+        reason === reason6
+          ? [{asset: '0xdac17f958d2ee523a2206206994597c13d831ec7', guarantee}] // USDT
+          : [{asset: MAGIC_ADDRESS_INDICATING_ETH, guarantee}];
       const guarantorOutcomeBytes = encodeOutcome(guaranteeOutcome);
       const guarantorOutcomeHash = hashOutcome(guaranteeOutcome);
 

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/computeNewAllocationWithGuarantee.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/computeNewAllocationWithGuarantee.test.ts
@@ -41,7 +41,7 @@ const allocation = randomAllocation(Math.ceil(Math.random() * 20));
 const indices = shuffle([...Array(allocation.length).keys()]); // [0, 1, 2, 3,...] but shuffled
 const guarantee = randomGuarantee(allocation);
 
-describe('AsserHolder._computeNewAllocationWithGuarantee', () => {
+describe('MultiAssetHolder._computeNewAllocationWithGuarantee', () => {
   it(`matches on chain method for input \n heldBefore: ${heldBefore}, \n allocation: ${JSON.stringify(
     allocation,
     null,


### PR DESCRIPTION
This PR closes #3672. The problem is described in some detail in the issue thread, and summarized here:

> [the] issue is that there are **no checks in place** to confirm that the target channel's outcome[assetIndex] refers to the same determined asset as the guarantee, which opens up a potential attack vector where, say, a guarantee of USDT tokens is used to update the ETH allocation on a target channel.

Changes here include
- a test case in `claim.test.ts` which constructs a guarantee on the asset address for USDT and attempts to apply this guarantee to a target channel with ETH at the same index of its outcome. The test case is expected to revert (we should not be able to trade USDT for ETH!), but did not.
- the addition of a check on asset addresses of guarantees and target channel outcomes in `MultiAssetHolder.claim(...)`, which correctly reverts the above

### Shortcomings
The ternary-conditional creation of the guarantee in the test runner makes code harder to read for the previously existing 16 cases


The summary may omit some of these details if this PR fixes a single ticket that includes these details. It is the reviewer's 

## How Has This Been Tested?

`yarn test:contracts`, `yarn test:gas`, `yarn test`

## :warning: Does this require multiple approvals? [Optional]
Please explain which reason, if any, why this requires more than one approval.
- [x] Is it security related?

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
