### PR TITLE
set gas limit explicitly

### DIFF
--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludeAndTransferAllAssets.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/concludeAndTransferAllAssets.test.ts
@@ -207,7 +207,8 @@ describe('concludeAndTransferAllAssets', () => {
         encodeOutcome(outcome),
         numStates,
         whoSignedWhat,
-        sigs
+        sigs,
+        {gasLimit: NITRO_MAX_GAS}
       );
 
       // Switch on overall test expectation


### PR DESCRIPTION
this might prevent a test flicker we are seeing Flickering test [nitro-protocol/concludeAndTransferAllAssets] #3682
