### PR TITLE
More performant random channel/destination generation

### DIFF
--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -2,7 +2,6 @@ import {expectRevert} from '@statechannels/devtools';
 import {Contract, constants, BigNumber} from 'ethers';
 
 import {
-  getRandomNonce,
   getTestProvider,
   randomChannelId,
   randomExternalDestination,
@@ -62,7 +61,6 @@ describe('claim', () => {
   `(
     '$name',
     async ({
-      name,
       heldBefore,
       guaranteeDestinations,
       tOutcomeBefore,
@@ -72,7 +70,6 @@ describe('claim', () => {
       payouts,
       reason,
     }: {
-      name;
       heldBefore: AssetOutcomeShortHand;
       guaranteeDestinations;
       tOutcomeBefore: AssetOutcomeShortHand;
@@ -83,10 +80,8 @@ describe('claim', () => {
       reason;
     }) => {
       // Compute channelIds
-      const tNonce = getRandomNonce(name);
-      const gNonce = getRandomNonce(name + 'g');
-      const targetId = randomChannelId(tNonce);
-      const guarantorId = randomChannelId(gNonce);
+      const targetId = randomChannelId();
+      const guarantorId = randomChannelId();
       addresses.t = targetId;
       addresses.g = guarantorId;
 

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
@@ -59,13 +59,12 @@ describe('transfer', () => {
     ${'16. incorrect fingerprint        '} | ${{c: 1}}  | ${{}}                 | ${[0]}       | ${{}}                 | ${{}}           | ${{A: 1}}       | ${reason2}
   `(
     `$name: heldBefore: $heldBefore, setOutcome: $setOutcome, newOutcome: $newOutcome, heldAfter: $heldAfter, payouts: $payouts`,
-    async ({name, heldBefore, setOutcome, indices, newOutcome, heldAfter, reason}) => {
+    async ({heldBefore, setOutcome, indices, newOutcome, heldAfter, reason}) => {
       // Compute channelId
-      const nonce = getRandomNonce(name);
-      addresses.c = randomChannelId(nonce);
+      addresses.c = randomChannelId();
       const channelId = addresses.c;
-      addresses.C = randomChannelId(nonce + 1);
-      addresses.X = randomChannelId(nonce + 2);
+      addresses.C = randomChannelId();
+      addresses.X = randomChannelId();
       // Transform input data (unpack addresses and BigNumberify amounts)
       heldBefore = replaceAddressesAndBigNumberify(heldBefore, addresses);
       setOutcome = replaceAddressesAndBigNumberify(setOutcome, addresses);

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
@@ -2,7 +2,6 @@ import {expectRevert} from '@statechannels/devtools';
 import {BigNumber, constants, Contract} from 'ethers';
 
 import {
-  getRandomNonce,
   getTestProvider,
   randomChannelId,
   randomExternalDestination,

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -1,13 +1,4 @@
-import {
-  Contract,
-  ethers,
-  BigNumberish,
-  BigNumber,
-  constants,
-  providers,
-  utils,
-  Event,
-} from 'ethers';
+import {Contract, ethers, BigNumberish, BigNumber, constants, providers, Event} from 'ethers';
 
 import {ChallengeClearedEvent, ChallengeRegisteredStruct} from '../src/contract/challenge';
 import {Bytes} from '../src/contract/types';
@@ -175,20 +166,12 @@ export const newDepositedEvent = (
   });
 };
 
-export function randomChannelId(channelNonce = 0): Bytes32 {
-  // Populate participants array (every test run targets a unique channel)
-  const participants = [];
-  for (let i = 0; i < 3; i++) {
-    participants[i] = ethers.Wallet.createRandom().address;
-  }
-  // Compute channelId
-  const channelId = utils.keccak256(
-    utils.defaultAbiCoder.encode(
-      ['uint256', 'address[]', 'uint256'],
-      [1234, participants, channelNonce]
-    )
-  );
-  return channelId;
+// Copied from https://stackoverflow.com/questions/58325771/how-to-generate-random-hex-string-in-javascript
+const genRanHex = size =>
+  [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+
+export function randomChannelId(): Bytes32 {
+  return '0x' + genRanHex(64);
 }
 
 export const randomExternalDestination = (): string =>

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -170,12 +170,8 @@ export const newDepositedEvent = (
 const genRanHex = size =>
   [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
 
-export function randomChannelId(): Bytes32 {
-  return '0x' + genRanHex(64);
-}
-
-export const randomExternalDestination = (): string =>
-  '0x' + ethers.Wallet.createRandom().address.slice(2, 42).padStart(64, '0').toLowerCase();
+export const randomChannelId = (): Bytes32 => '0x' + genRanHex(64);
+export const randomExternalDestination = (): Bytes32 => '0x' + genRanHex(40).padStart(64, '0');
 
 export async function sendTransaction(
   provider: ethers.providers.JsonRpcProvider,


### PR DESCRIPTION
(Rewrite of the commit history of #3687 , originally authored by @andrewgordstewart )

The affected test helpers do not require knowing the private key corresponding to the signing address that generates:

the destination; or
the channel id
When this is the case, it's much faster to generate a random hex string. Creating an ethers wallet is already slow; doing so in a jest environment is very slow (I believe it takes on the order of 100ms.)


