### PR TITLE
Sync Ledger Channels for OpenChannel Objective

### DIFF
--- a/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
+++ b/packages/server-wallet/src/engine/__test__/sync-objectives.test.ts
@@ -68,6 +68,8 @@ describe('SyncObjective', () => {
   });
 
   it('includes the ledger channel when syncing a ledger funded open channel objective', async () => {
+    // We up the nonce to avoid collisions with the other tests not using TestChannel
+    TestChannel.maximumNonce = 100;
     const ledger = TestLedgerChannel.create({});
     const app = TestChannel.create({
       fundingStrategy: 'Ledger',
@@ -98,13 +100,13 @@ describe('SyncObjective', () => {
       data: {
         // We expect states for the app channel as well as the ledger channel that funds it
         signedStates: [
-          expect.objectContaining({channelId: app.channelId}),
           expect.objectContaining({channelId: ledger.channelId}),
+          expect.objectContaining({channelId: app.channelId}),
         ],
         // We expect a getChannel request (from syncChannel) for both channels
         requests: [
-          expect.objectContaining({channelId: app.channelId, type: 'GetChannel'}),
           expect.objectContaining({channelId: ledger.channelId, type: 'GetChannel'}),
+          expect.objectContaining({channelId: app.channelId, type: 'GetChannel'}),
         ],
       },
     };

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -200,13 +200,9 @@ export class SingleThreadedEngine implements EngineInterface {
       const {participants} = channel;
       response.queueSendObjective(o, channel.myIndex, participants);
 
-      // Sync any ledger channels used for an open channel objective
-      if (
-        o.type === 'OpenChannel' &&
-        o.data.fundingStrategy === 'Ledger' &&
-        !!o.data.fundingLedgerChannelId
-      ) {
-        await this._syncChannel(o.data.fundingLedgerChannelId, response);
+      // Sync any ledger channels used for the objective
+      if (channel.fundingStrategy === 'Ledger' && channel.fundingLedgerChannelId) {
+        await this._syncChannel(channel.fundingLedgerChannelId, response);
       }
     }
 

--- a/packages/server-wallet/src/engine/engine.ts
+++ b/packages/server-wallet/src/engine/engine.ts
@@ -199,6 +199,15 @@ export class SingleThreadedEngine implements EngineInterface {
 
       const {participants} = channel;
       response.queueSendObjective(o, channel.myIndex, participants);
+
+      // Sync any ledger channels used for an open channel objective
+      if (
+        o.type === 'OpenChannel' &&
+        o.data.fundingStrategy === 'Ledger' &&
+        !!o.data.fundingLedgerChannelId
+      ) {
+        await this._syncChannel(o.data.fundingLedgerChannelId, response);
+      }
     }
 
     return response.allMessages;


### PR DESCRIPTION
Fixes #3583  (maybe?)


When syncing an OpenChannel Objective we now sync the funding ledger channel as well.

Previously syncObjective method would only send the **app** channel to peers and not **ledger** channels. This meant that if the initial message containing the ledger channel was dropped no amount of syncing would complete the objective.

I believe this explains the flickering tests. We have a test scenario using `{dropRate:0.1}` which means 10% of messages should be dropped. If the first message happens to be dropped then the test was doomed to fail, since syncing wouldn't include the ledger info.

