### PR TITLE
Minor With Peers Test Tweaks

### DIFF
--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -112,11 +112,6 @@ export async function setupPeerWallets(withWalletsSeeding = false): Promise<Peer
 export async function setupPeerEngines(withWalletSeeding = false): Promise<PeerSetup> {
   try {
     await Promise.all([
-      DBAdmin.truncateDatabase(aWalletConfig),
-      DBAdmin.truncateDatabase(bWalletConfig),
-    ]);
-
-    await Promise.all([
       DBAdmin.createDatabase(aWalletConfig),
       DBAdmin.createDatabase(bWalletConfig),
     ]);
@@ -124,6 +119,11 @@ export async function setupPeerEngines(withWalletSeeding = false): Promise<PeerS
     await Promise.all([
       DBAdmin.migrateDatabase(aWalletConfig),
       DBAdmin.migrateDatabase(bWalletConfig),
+    ]);
+
+    await Promise.all([
+      DBAdmin.truncateDatabase(aWalletConfig),
+      DBAdmin.truncateDatabase(bWalletConfig),
     ]);
 
     const peerEngines = {

--- a/packages/server-wallet/jest/with-peers-setup-teardown.ts
+++ b/packages/server-wallet/jest/with-peers-setup-teardown.ts
@@ -46,7 +46,7 @@ const baseConfig = defaultTestWalletConfig({
     logLevel: 'trace',
     logDestination: path.join(ARTIFACTS_DIR, 'with-peers.log'),
   },
-  syncConfiguration: {pollInterval: 50, staleThreshold: 1_000, timeOutThreshold: 45_000},
+  syncConfiguration: {pollInterval: 500, staleThreshold: 1_000, timeOutThreshold: 45_000},
 });
 export const aWalletConfig = overwriteConfigWithDatabaseConnection(baseConfig, {
   database: aDatabase,

--- a/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
+++ b/packages/server-wallet/src/__test-with-peers__/wallet/jumpstart.test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await teardownPeerSetup(peerSetup);
 });
-jest.setTimeout(600000_000);
+jest.setTimeout(60_000);
 
 describe('jumpstartObjectives', () => {
   it('returns an empty array when there are no objectives', async () => {


### PR DESCRIPTION
Three minor changes:
- Truncate databases after trying to create them. Previously the first test that would run would fail to truncate the databases as they did not exist yet.
- Fix an accidentally large timeout value
- increase the poll time for syncing as checking for stale objectives every `50ms` seems a little overboard. 