### PR TITLE
remove challengerAddress from ChannelData

### DIFF
--- a/packages/docs-website/docs/docs/implementation-notes/force-move.md
+++ b/packages/docs-website/docs/docs/implementation-notes/force-move.md
@@ -336,7 +336,6 @@ The `fingerprint` is the 160 least significant bits of `keccak256(abi.encode(cha
         uint256 turnNumRecord;
         uint256 finalizesAt;
         bytes32 stateHash; // keccak256(abi.encode(State))
-        address challengerAddress;
         bytes32 outcomeHash // keccak256(abi.encode(Outcome));
     }
 ```
@@ -384,7 +383,6 @@ Effects:
   - `turnNumRecord` to the `largestTurnNum`
   - `finalizesAt` to `currentTime` + `challengeInterval`
   - `stateHash`
-  - `challengerAddress`
 - Emit a `ChallengeRegistered` event
 
 :::note
@@ -465,7 +463,6 @@ Effects:
 - Sets `outcomeHash` to be consistent with finalization proof
 - Clears `stateHash`
 - Clears `turnNumRecord`
-- Clears `challengerAddress`
 
 ### `checkpoint`
 

--- a/packages/docs-website/docs/docs/protocol-tutorial/release-assets.md
+++ b/packages/docs-website/docs/docs/protocol-tutorial/release-assets.md
@@ -34,10 +34,9 @@ const outcomeBytes = encodeOutcome([
 
 const assetIndex = 0; // implies we are paying out the 0th asset (in this case the only asset, ETH)
 const stateHash = constants.HashZero; // if the channel was concluded on the happy path, we can use this default value
-const challengerAddress = constants.AddressZero; // if the channel was concluded on the happy path, we can use this default value
 const indices = []; // this magic value (a zero length array) implies we want to pay out all of the allocationItems (in this case there is only one)
 
-const tx2 = NitroAdjudicator.transfer(assetIndex, channelId, outcomeBytes, stateHash, challengerAddress, indices);
+const tx2 = NitroAdjudicator.transfer(assetIndex, channelId, outcomeBytes, stateHash, indices);
 
 /*
   Check that a AllocationUpdated event was emitted.
@@ -114,7 +113,6 @@ const guarantorOutcomeBytes = encodeOutcome([assetOutcomeForTheGuarantorChannel]
 
 const assetIndex = 0; // implies we are paying out the 0th asset (in this case the only asset, ETH)
 const stateHash = (targetStateHash = constants.HashZero); // if the channels were concluded on the happy path, we can use this default value
-const challengerAddress = (targetChallengerAddress = constants.AddressZero); // if the channels were concluded on the happy path, we can use this default value
 const indices = []; // this magic value (a zero length array) implies we want to pay out all of the allocationItems (in this case there is only one)
 
 const tx3 = NitroAdjudicator.claim(
@@ -122,10 +120,8 @@ const tx3 = NitroAdjudicator.claim(
   guarantorId,
   guarantorOutcomeBytes,
   stateHash,
-  challengerAddress,
   targetOutcomeBytes,
   targetStateHash,
-  targetChallengerAddress,
   indices
 );
 

--- a/packages/docs-website/docs/docs/protocol-tutorial/understand-adjudicator-status.md
+++ b/packages/docs-website/docs/docs/protocol-tutorial/understand-adjudicator-status.md
@@ -10,7 +10,6 @@ The adjudicator contract stores certain information about any channel that it kn
 - `uint48 turnNumRecord`
 - `uint48 finalizesAt`
 - `bytes32 stateHash // keccak256(abi.encode(State))`
-- `address challengerAddress`
 - `bytes32 outcomeHash`
 
 The derived data is stored inside the following mapping (with `channelId` as the key):
@@ -33,7 +32,6 @@ uint160(
             keccak256(
                 abi.encode(
                     channelData.stateHash,
-                    channelData.challengerAddress,
                     channelData.outcomeHash
                 )
             )

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -156,12 +156,7 @@ contract ForceMove is IForceMove {
         // checks
 
         _requireSpecificChallenge(
-            ChannelData(
-                turnNumRecord,
-                finalizesAt,
-                challengeStateHash,
-                challengeOutcomeHash
-            ),
+            ChannelData(turnNumRecord, finalizesAt, challengeStateHash, challengeOutcomeHash),
             channelId
         );
 
@@ -798,20 +793,16 @@ contract ForceMove is IForceMove {
 
         // logical or with the last 160 bits of the hash the remaining channelData fields
         // (we call this the fingerprint)
-        result |= uint256(
-            _generateFingerprint(
-                channelData.stateHash,
-                channelData.outcomeHash
-            )
-        );
+        result |= uint256(_generateFingerprint(channelData.stateHash, channelData.outcomeHash));
 
         status = bytes32(result);
     }
 
-    function _generateFingerprint(
-        bytes32 stateHash,
-        bytes32 outcomeHash
-    ) internal pure returns (uint160) {
+    function _generateFingerprint(bytes32 stateHash, bytes32 outcomeHash)
+        internal
+        pure
+        returns (uint160)
+    {
         return uint160(uint256(keccak256(abi.encode(stateHash, outcomeHash))));
     }
 

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -19,7 +19,7 @@ contract ForceMove is IForceMove {
      * @param channelId Unique identifier for a state channel.
      * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
      * @return finalizesAt The unix timestamp when `channelId` will finalize.
-     * @return fingerprint The last 160 bits of kecca256(stateHash, challengerAddress, outcomeHash)
+     * @return fingerprint The last 160 bits of kecca256(stateHash, outcomeHash)
      */
     function unpackStatus(bytes32 channelId)
         external
@@ -825,8 +825,7 @@ contract ForceMove is IForceMove {
      * @param channelId Unique identifier for a state channel.
      * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
      * @return finalizesAt The unix timestamp when `channelId` will finalize.
-     * @return fingerprint The last 160 bits of kecca256(stateHash, challengerAddress, outcomeHash)
-
+     * @return fingerprint The last 160 bits of kecca256(stateHash, outcomeHash)
      */
     function _unpackStatus(bytes32 channelId)
         internal

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -81,11 +81,7 @@ contract ForceMove is IForceMove {
             whoSignedWhat
         );
 
-        address challenger = _requireChallengerIsParticipant(
-            supportedStateHash,
-            fixedPart.participants,
-            challengerSig
-        );
+        _requireChallengerIsParticipant(supportedStateHash, fixedPart.participants, challengerSig);
 
         // effects
 
@@ -94,7 +90,6 @@ contract ForceMove is IForceMove {
             largestTurnNum,
             uint48(block.timestamp) + fixedPart.challengeDuration, //solhint-disable-line not-rely-on-time
             // This could overflow, so don't join a channel with a huge challengeDuration
-            challenger,
             isFinalCount > 0,
             fixedPart,
             variableParts,
@@ -338,8 +333,8 @@ contract ForceMove is IForceMove {
         bytes32 supportedStateHash,
         address[] memory participants,
         Signature memory challengerSignature
-    ) internal pure returns (address challenger) {
-        challenger = _recoverSigner(
+    ) internal pure {
+        address challenger = _recoverSigner(
             keccak256(abi.encode(supportedStateHash, 'forceMove')),
             challengerSignature
         );

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -85,7 +85,6 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
      * @param fromChannelId Unique identifier for state channel to transfer funds *from*.
      * @param outcomeBytes The encoded Outcome of this state channel
      * @param stateHash The hash of the state stored when the channel finalized.
-     * @param challengerAddress The challengerAddress stored when the channel finalized (zero for collaborative concludes)
      * @param indices Array with each entry denoting the index of a destination to transfer funds to. An empty array indicates "all".
      */
     function transfer(
@@ -93,15 +92,13 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         bytes32 fromChannelId,
         bytes memory outcomeBytes,
         bytes32 stateHash,
-        address challengerAddress,
-        uint256[] calldata indices
+        uint256[] memory indices
     ) external override {
         // checks
         _requireIncreasingIndices(indices); // This assumption relied on by _computeNewAllocation (below)
         _requireChannelFinalized(fromChannelId);
         _requireMatchingFingerprint(
             stateHash,
-            challengerAddress,
             keccak256(outcomeBytes),
             fromChannelId
         );
@@ -137,7 +134,6 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         _updateFingerprint(
             fromChannelId,
             stateHash,
-            challengerAddress,
             keccak256(abi.encode(outcome))
         );
 
@@ -152,10 +148,8 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
      * @param guarantorOutcomeBytes The abi.encode of guarantor channel outcome
      * @param guarantorChannelId Unique identifier for a guarantor state channel.
      * @param guarantorStateHash Hash of the state stored when the guarantor channel finalized.
-     * @param guarantorChallengerAddress Address of the challenger stored when the guarantor channel finalized. Zero for collaborative concludes.
      * @param targetOutcomeBytes The abi.encode of target channel outcome
      * @param targetStateHash Hash of the state stored when the target channel finalized.
-     * @param targetChallengerAddress Address of the challenger stored when the target channel finalized. Zero for collaborative concludes.
      * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all"
      */
     function claim(
@@ -163,10 +157,8 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         bytes32 guarantorChannelId,
         bytes memory guarantorOutcomeBytes,
         bytes32 guarantorStateHash,
-        address guarantorChallengerAddress,
         bytes memory targetOutcomeBytes,
         bytes32 targetStateHash,
-        address targetChallengerAddress,
         uint256[] memory indices
     ) external override {
         // checks
@@ -180,7 +172,6 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
             bytes32 guarantorOutcomeHash = keccak256(guarantorOutcomeBytes);
             _requireMatchingFingerprint(
                 guarantorStateHash,
-                guarantorChallengerAddress,
                 guarantorOutcomeHash,
                 guarantorChannelId
             );
@@ -206,7 +197,6 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
             _requireChannelFinalized(guarantee.targetChannelId);
             _requireMatchingFingerprint(
                 targetStateHash,
-                targetChallengerAddress,
                 keccak256(targetOutcomeBytes),
                 guarantee.targetChannelId
             );
@@ -250,7 +240,6 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
                 _updateFingerprint(
                     guarantee.targetChannelId,
                     targetStateHash,
-                    targetChallengerAddress,
                     outcomeHash
                 );
             }
@@ -530,13 +519,12 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
      */
     function _requireMatchingFingerprint(
         bytes32 stateHash,
-        address challengerAddress,
         bytes32 outcomeHash,
         bytes32 channelId
     ) internal view {
         (, , uint160 fingerprint) = _unpackStatus(channelId);
         require(
-            fingerprint == _generateFingerprint(stateHash, challengerAddress, outcomeHash),
+            fingerprint == _generateFingerprint(stateHash, outcomeHash),
             'incorrect fingerprint'
         );
     }

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -97,11 +97,7 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         // checks
         _requireIncreasingIndices(indices); // This assumption relied on by _computeNewAllocation (below)
         _requireChannelFinalized(fromChannelId);
-        _requireMatchingFingerprint(
-            stateHash,
-            keccak256(outcomeBytes),
-            fromChannelId
-        );
+        _requireMatchingFingerprint(stateHash, keccak256(outcomeBytes), fromChannelId);
 
         Outcome.OutcomeItem[] memory outcome = abi.decode(outcomeBytes, (Outcome.OutcomeItem[]));
         Outcome.AssetOutcome memory assetOutcome = abi.decode(
@@ -131,11 +127,7 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
         outcome[assetIndex].assetOutcomeBytes = abi.encode(
             Outcome.AssetOutcome(Outcome.AssetOutcomeType.Allocation, abi.encode(allocation))
         );
-        _updateFingerprint(
-            fromChannelId,
-            stateHash,
-            keccak256(abi.encode(outcome))
-        );
+        _updateFingerprint(fromChannelId, stateHash, keccak256(abi.encode(outcome)));
 
         // Emit the information needed to compute the new outcome stored in the fingerprint
         emit AllocationUpdated(fromChannelId, assetIndex, initialHoldings);
@@ -237,11 +229,7 @@ contract MultiAssetHolder is IMultiAssetHolder, ForceMove {
             );
             {
                 bytes32 outcomeHash = keccak256(abi.encode(outcome));
-                _updateFingerprint(
-                    guarantee.targetChannelId,
-                    targetStateHash,
-                    outcomeHash
-                );
+                _updateFingerprint(guarantee.targetChannelId, targetStateHash, outcomeHash);
             }
             emit AllocationUpdated(guarantee.targetChannelId, assetIndex, initialHoldings);
         }

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -58,11 +58,7 @@ contract NitroAdjudicator is MultiAssetHolder {
     ) public {
         // checks
         _requireChannelFinalized(channelId);
-        _requireMatchingFingerprint(
-            stateHash,
-            keccak256(outcomeBytes),
-            channelId
-        );
+        _requireMatchingFingerprint(stateHash, keccak256(outcomeBytes), channelId);
         Outcome.OutcomeItem[] memory outcome = abi.decode(outcomeBytes, (Outcome.OutcomeItem[]));
 
         for (uint256 assetIndex = 0; assetIndex < outcome.length; assetIndex++) {

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -41,7 +41,7 @@ contract NitroAdjudicator is MultiAssetHolder {
             sigs
         );
 
-        transferAllAssets(channelId, outcomeBytes, bytes32(0), address(0));
+        transferAllAssets(channelId, outcomeBytes, bytes32(0));
     }
 
     /**
@@ -50,19 +50,16 @@ contract NitroAdjudicator is MultiAssetHolder {
      * @param channelId Unique identifier for a state channel
      * @param outcomeBytes abi.encode of an array of Outcome.OutcomeItem structs.
      * @param stateHash stored state hash for the channel
-     * @param challengerAddress stored challenger address for the channel
      */
     function transferAllAssets(
         bytes32 channelId,
         bytes memory outcomeBytes,
-        bytes32 stateHash,
-        address challengerAddress
+        bytes32 stateHash
     ) public {
         // checks
         _requireChannelFinalized(channelId);
         _requireMatchingFingerprint(
             stateHash,
-            challengerAddress,
             keccak256(outcomeBytes),
             channelId
         );
@@ -97,7 +94,7 @@ contract NitroAdjudicator is MultiAssetHolder {
         }
         outcomeBytes = abi.encode(outcome);
         bytes32 outcomeHash = keccak256(outcomeBytes);
-        _updateFingerprint(channelId, stateHash, challengerAddress, outcomeHash);
+        _updateFingerprint(channelId, stateHash, outcomeHash);
     }
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -41,7 +41,6 @@ interface IForceMove {
         uint48 turnNumRecord;
         uint48 finalizesAt;
         bytes32 stateHash; // keccak256(abi.encode(State))
-        address challengerAddress;
         bytes32 outcomeHash;
     }
 
@@ -71,14 +70,12 @@ interface IForceMove {
     /**
      * @notice Repsonds to an ongoing challenge registered against a state channel.
      * @dev Repsonds to an ongoing challenge registered against a state channel.
-     * @param challenger The address of the participant whom registered the challenge.
      * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
      * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
      * @param sig The responder's signature on the `responseStateHash`.
      */
     function respond(
-        address challenger,
         bool[2] calldata isFinalAB,
         FixedPart calldata fixedPart,
         IForceMoveApp.VariablePart[2] calldata variablePartAB,

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -131,7 +131,6 @@ interface IForceMove {
      * @param channelId Unique identifier for a state channel.
      * @param turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
      * @param finalizesAt The unix timestamp when `channelId` will finalize.
-     * @param challenger The address of the participant whom registered the challenge.
      * @param isFinal Boolean denoting whether the challenge state is final.
      * @param fixedPart Data describing properties of the state channel that do not change with state updates.
      * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
@@ -140,10 +139,8 @@ interface IForceMove {
      */
     event ChallengeRegistered(
         bytes32 indexed channelId,
-        // everything needed to respond or checkpoint
         uint48 turnNumRecord,
         uint48 finalizesAt,
-        address challenger,
         bool isFinal,
         FixedPart fixedPart,
         IForceMoveApp.VariablePart[] variableParts,

--- a/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
@@ -15,7 +15,6 @@ interface IMultiAssetHolder {
      * @param fromChannelId Unique identifier for state channel to transfer funds *from*.
      * @param outcomeBytes The abi.encode of AssetOutcome.Allocation
      * @param stateHash the hash of the state stored on chain
-     * @param challengerAddress the challengerAddress stored on chain
      * @param indices Array with each entry denoting the index of a destination to transfer funds to.
      */
     function transfer(
@@ -23,7 +22,6 @@ interface IMultiAssetHolder {
         bytes32 fromChannelId,
         bytes calldata outcomeBytes,
         bytes32 stateHash,
-        address challengerAddress,
         uint256[] memory indices
     ) external;
 
@@ -34,10 +32,8 @@ interface IMultiAssetHolder {
      * @param guarantorChannelId Unique identifier for a guarantor state channel.
      * @param guarantorOutcomeBytes The abi.encode of the guarantor outcome.
      * @param guarantorStateHash the hash of the state stored on chain for the guarantor
-     * @param guarantorChallengerAddress the challengerAddress stored on chain for the guarantor channel
      * @param targetOutcomeBytes The abi.encode of the guarantor outcome.
      * @param targetStateHash the hash of the state stored on chain for the guarantor
-     * @param targetChallengerAddress the challengerAddress stored on chain for the guarantor channel
      * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all".
      */
     function claim(
@@ -45,10 +41,8 @@ interface IMultiAssetHolder {
         bytes32 guarantorChannelId,
         bytes memory guarantorOutcomeBytes,
         bytes32 guarantorStateHash,
-        address guarantorChallengerAddress,
         bytes memory targetOutcomeBytes,
         bytes32 targetStateHash,
-        address targetChallengerAddress,
         uint256[] memory indices
     ) external;
 

--- a/packages/nitro-protocol/contracts/test/TESTForceMove.sol
+++ b/packages/nitro-protocol/contracts/test/TESTForceMove.sol
@@ -80,7 +80,6 @@ contract TESTForceMove is ForceMove {
         if (channelData.finalizesAt == 0) {
             require(
                 channelData.stateHash == bytes32(0) &&
-                    channelData.challengerAddress == address(0) &&
                     channelData.outcomeHash == bytes32(0),
                 'Invalid open channel'
             );

--- a/packages/nitro-protocol/contracts/test/TESTForceMove.sol
+++ b/packages/nitro-protocol/contracts/test/TESTForceMove.sol
@@ -79,8 +79,7 @@ contract TESTForceMove is ForceMove {
     function setStatusFromChannelData(bytes32 channelId, ChannelData memory channelData) public {
         if (channelData.finalizesAt == 0) {
             require(
-                channelData.stateHash == bytes32(0) &&
-                    channelData.outcomeHash == bytes32(0),
+                channelData.stateHash == bytes32(0) && channelData.outcomeHash == bytes32(0),
                 'Invalid open channel'
             );
         }

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -126,8 +126,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
       await nitroAdjudicator.transferAllAssets(
         X.channelId,
         proof.outcomeBytes, // outcomeBytes,
-        proof.stateHash, // stateHash
-        proof.challengerAddress // challengerAddress
+        proof.stateHash // stateHash
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSad.vanillaNitro.transferAllAssets);
     // transferAllAssets ⬛ --------> 👩
@@ -164,8 +163,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
       await nitroAdjudicator.transferAllAssets(
         LforX.channelId,
         ledgerProof.outcomeBytes, // outcomeBytes
-        ledgerProof.stateHash, // stateHash
-        ledgerProof.challengerAddress // challengerAddress
+        ledgerProof.stateHash // stateHash
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.transferAllAssetsL);
     // transferAllAssetsL  ⬛ --------> (X) -> 👩
@@ -173,8 +171,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
       await nitroAdjudicator.transferAllAssets(
         X.channelId,
         proof.outcomeBytes, // outcomeBytes
-        proof.stateHash, // stateHash
-        proof.challengerAddress // challengerAddress
+        proof.stateHash // stateHash
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.transferAllAssetsX);
     // transferAllAssetsX  ⬛ ---------------> 👩
@@ -241,8 +238,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
       await nitroAdjudicator.transferAllAssets(
         LforG.channelId,
         ledgerProof.outcomeBytes, // outcomeBytes
-        ledgerProof.stateHash, // stateHash
-        ledgerProof.challengerAddress // challengerAddress
+        ledgerProof.stateHash // stateHash
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.transferAllAssetsL);
     // transferAllAssetsL  ⬛ --------> (G) -> (J) -> (X) -> 👩
@@ -252,10 +248,8 @@ describe('Consumes the expected gas for sad-path exits', () => {
         G.channelId,
         encodeOutcome(G.outcome(MAGIC_ADDRESS_INDICATING_ETH)),
         guarantorProof.stateHash,
-        guarantorProof.challengerAddress,
         encodeOutcome(J.outcome(MAGIC_ADDRESS_INDICATING_ETH)),
         jointProof.stateHash,
-        jointProof.challengerAddress,
         [] // meaning "all"
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.claimG);
@@ -264,8 +258,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
       await nitroAdjudicator.transferAllAssets(
         X.channelId,
         proof.outcomeBytes, // outcomeBytes
-        proof.stateHash, // stateHash
-        proof.challengerAddress // challengerAddress
+        proof.stateHash // stateHash
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.transferAllAssetsX);
     // transferAllAssetsX  ⬛ -----------------------------> 👩

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -85,7 +85,6 @@ class TestChannel {
     challengeSignature: Signature;
     outcomeBytes: string;
     stateHash: string;
-    challengerAddress: string;
   } {
     return {
       largestTurnNum: state.turnNum,
@@ -97,7 +96,6 @@ class TestChannel {
       challengeSignature: signChallengeMessage([{state} as SignedState], Alice.privateKey),
       outcomeBytes: encodeOutcome(state.outcome),
       stateHash: hashState(state),
-      challengerAddress: Alice.address,
     };
   }
 

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 3970996, // Singleton
+      NitroAdjudicator: 3965152, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -75,9 +75,9 @@ export const gasRequiredTo: GasRequiredTo = {
     // challenge + timeout       ⬛ -> (X) -> 👩
     // transferAllAssets         ⬛ --------> 👩
     vanillaNitro: {
-      challenge: 93111,
+      challenge: 92799,
       transferAllAssets: 115014,
-      total: 208125,
+      total: 207813,
     },
   },
   ETHexitSadLedgerFunded: {
@@ -87,11 +87,11 @@ export const gasRequiredTo: GasRequiredTo = {
       // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
       // transferAllAssetsL          ⬛ --------> (X) -> 👩
       // transferAllAssetsX          ⬛ ---------------> 👩
-      challengeX: 93111,
-      challengeL: 92045,
+      challengeX: 92799,
+      challengeL: 91733,
       transferAllAssetsL: 65546,
       transferAllAssetsX: 115014,
-      total: 365716,
+      total: 365092,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -102,14 +102,14 @@ export const gasRequiredTo: GasRequiredTo = {
       // transferAllAssetsL          ⬛ --------> (G) -> (J) -> (X) -> 👩
       // claimG                      ⬛ ----------------------> (X) -> 👩
       // transferAllAssetsX          ⬛ -----------------------------> 👩
-      challengeL: 92045,
-      challengeG: 94304,
-      challengeJ: 101422,
-      challengeX: 93111,
+      challengeL: 91733,
+      challengeG: 93992,
+      challengeJ: 101110,
+      challengeX: 92799,
       transferAllAssetsL: 65546,
       claimG: 82495,
       transferAllAssetsX: 115014,
-      total: 643937,
+      total: 642689,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 4052839, // Singleton
+      NitroAdjudicator: 3970996, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -63,11 +63,11 @@ export const gasRequiredTo: GasRequiredTo = {
   },
   ETHexit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 153934,
+    vanillaNitro: 153672,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 144323,
+    vanillaNitro: 144062,
   },
   ETHexitSad: {
     // Scenario: Counterparty Bob goes offline
@@ -75,9 +75,9 @@ export const gasRequiredTo: GasRequiredTo = {
     // challenge + timeout       ⬛ -> (X) -> 👩
     // transferAllAssets         ⬛ --------> 👩
     vanillaNitro: {
-      challenge: 93193,
-      transferAllAssets: 115661,
-      total: 208854,
+      challenge: 93111,
+      transferAllAssets: 115014,
+      total: 208125,
     },
   },
   ETHexitSadLedgerFunded: {
@@ -87,11 +87,11 @@ export const gasRequiredTo: GasRequiredTo = {
       // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
       // transferAllAssetsL          ⬛ --------> (X) -> 👩
       // transferAllAssetsX          ⬛ ---------------> 👩
-      challengeX: 93193,
-      challengeL: 92127,
-      transferAllAssetsL: 66193,
-      transferAllAssetsX: 115661,
-      total: 367174,
+      challengeX: 93111,
+      challengeL: 92045,
+      transferAllAssetsL: 65546,
+      transferAllAssetsX: 115014,
+      total: 365716,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -102,14 +102,14 @@ export const gasRequiredTo: GasRequiredTo = {
       // transferAllAssetsL          ⬛ --------> (G) -> (J) -> (X) -> 👩
       // claimG                      ⬛ ----------------------> (X) -> 👩
       // transferAllAssetsX          ⬛ -----------------------------> 👩
-      challengeL: 92127,
-      challengeG: 94386,
-      challengeJ: 101504,
-      challengeX: 93193,
-      transferAllAssetsL: 66193,
-      claimG: 83687,
-      transferAllAssetsX: 115661,
-      total: 646751,
+      challengeL: 92045,
+      challengeG: 94304,
+      challengeJ: 101422,
+      challengeX: 93111,
+      transferAllAssetsL: 65546,
+      claimG: 82495,
+      transferAllAssetsX: 115014,
+      total: 643937,
     },
   },
 };

--- a/packages/nitro-protocol/notes/force-move-implementation.md
+++ b/packages/nitro-protocol/notes/force-move-implementation.md
@@ -123,7 +123,6 @@ With these considerations in mind, the ForceMove interface should be something l
         uint256 turnNumRecord;
         uint256 finalizesAt;
         bytes32 stateHash; // keccak256(abi.encode(State))
-        address challengerAddress;
         bytes32 outcomeHash;
     }
 

--- a/packages/nitro-protocol/notes/force-move-implementation.md
+++ b/packages/nitro-protocol/notes/force-move-implementation.md
@@ -39,7 +39,6 @@ For example, as ForceMove only works if the channel is open, which implies that 
   - Can deduce `turnNumRecord`
   - Needs to read `finalizesAt`
 - Refute
-  - Can deduce `challengerAddress` (from recoverSignature)
   - Needs to read `turnNumRecord`, `finalizesAt`
 - ConcludeFromOpen
   - Can deduce all fields apart from `turnNumRecord` (they must all be null)

--- a/packages/nitro-protocol/src/contract/challenge.ts
+++ b/packages/nitro-protocol/src/contract/challenge.ts
@@ -17,7 +17,6 @@ export function hashChallengeMessage(challengeState: State): Bytes32 {
 
 export interface ChallengeRegisteredEvent {
   channelId: Bytes32;
-  challengerAddress: string;
   finalizesAt: number;
   challengeStates: SignedState[];
 }

--- a/packages/nitro-protocol/src/contract/challenge.ts
+++ b/packages/nitro-protocol/src/contract/challenge.ts
@@ -73,7 +73,7 @@ export function getChallengeRegisteredEvent(eventResult: any[]): ChallengeRegist
     };
     return {state, signature};
   });
-  return {channelId, challengeStates, finalizesAt, challengerAddress: challenger};
+  return {channelId, challengeStates, finalizesAt};
 }
 
 export interface ChallengeClearedEvent {

--- a/packages/nitro-protocol/src/contract/challenge.ts
+++ b/packages/nitro-protocol/src/contract/challenge.ts
@@ -36,7 +36,6 @@ export function getChallengeRegisteredEvent(eventResult: any[]): ChallengeRegist
     channelId,
     turnNumRecord,
     finalizesAt,
-    challenger,
     isFinal,
     fixedPart,
     variableParts: variablePartsUnstructured,

--- a/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
@@ -70,12 +70,10 @@ export function respondArgs({
   responseState,
   responseSignature,
 }: RespondArgs): any[] {
-  const {participants} = challengeState.channel;
-  const challengerAddress = participants[challengeState.turnNum % participants.length];
   const isFinalAB = [challengeState.isFinal, responseState.isFinal];
   const fixedPart = getFixedPart(responseState);
   const variablePartAB = [getVariablePart(challengeState), getVariablePart(responseState)];
-  return [challengerAddress, isFinalAB, fixedPart, variablePartAB, responseSignature];
+  return [isFinalAB, fixedPart, variablePartAB, responseSignature];
 }
 
 export function createRespondTransaction(args: RespondArgs): ethers.providers.TransactionRequest {

--- a/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
@@ -59,24 +59,22 @@ export function createConcludeAndTransferAllAssetsTransaction(
 
 function transferAllAssetsArgs(
   state: State,
-  challengerAddress: string,
   overrideStateHash = false // set to true if channel concluded happily
 ): any[] {
   const channelId = getChannelId(state.channel);
   const outcomeBytes = encodeOutcome(state.outcome);
   const stateHash = overrideStateHash ? constants.HashZero : hashState(state);
-  return [channelId, outcomeBytes, stateHash, challengerAddress];
+  return [channelId, outcomeBytes, stateHash];
 }
 
 export function createTransferAllAssetsTransaction(
   state: State,
-  challengerAddress: string,
   overrideStateHash = false // set to true if channel concluded happily
 ): providers.TransactionRequest {
   return {
     data: NitroAdjudicatorContractInterface.encodeFunctionData(
       'transferAllAssets',
-      transferAllAssetsArgs(state, challengerAddress, overrideStateHash)
+      transferAllAssetsArgs(state, overrideStateHash)
     ),
   };
 }

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -65,11 +65,8 @@ export function createConcludeAndTransferAllAssetsTransaction(
   );
 }
 
-export function createTransferAllAssetsTransaction(
-  state: State,
-  challengerAddress: string
-): providers.TransactionRequest {
-  return nitroAdjudicatorTrans.createTransferAllAssetsTransaction(state, challengerAddress);
+export function createTransferAllAssetsTransaction(state: State): providers.TransactionRequest {
+  return nitroAdjudicatorTrans.createTransferAllAssetsTransaction(state);
 }
 
 export function createConcludeTransaction(

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -245,7 +245,6 @@ describe('challenge', () => {
           turnNumRecord: largestTurnNum,
           finalizesAt: eventFinalizesAt,
           state: states[states.length - 1],
-          challengerAddress: challenger.address,
           outcome,
         };
         const expectedFingerprint = channelDataToStatus(expectedChannelStorage);

--- a/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/challenge.test.ts
@@ -216,7 +216,6 @@ describe('challenge', () => {
           channelId: eventChannelId,
           turnNumRecord: eventTurnNumRecord,
           finalizesAt: eventFinalizesAt,
-          challenger: eventChallenger,
           isFinal: eventIsFinal,
           fixedPart: eventFixedPart,
           variableParts: eventVariableParts,
@@ -225,7 +224,6 @@ describe('challenge', () => {
         // Check this information is enough to respond
         expect(eventChannelId).toEqual(channelId);
         expect(eventTurnNumRecord).toEqual(largestTurnNum);
-        expect(eventChallenger).toEqual(challenger.address);
         expect(
           ethers.BigNumber.from(eventFixedPart[0]).eq(ethers.BigNumber.from(fixedPart.chainId))
         ).toBe(true);

--- a/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
@@ -86,17 +86,17 @@ describe('checkpoint', () => {
   let channelNonce = getRandomNonce('checkpoint');
   beforeEach(() => (channelNonce += 1));
   it.each`
-    description | largestTurnNum       | support              | challenger    | finalizesAt  | reason
-    ${accepts1} | ${turnNumRecord + 1} | ${valid}             | ${wallets[1]} | ${undefined} | ${undefined}
-    ${accepts2} | ${turnNumRecord + 3} | ${valid}             | ${wallets[1]} | ${never}     | ${undefined}
-    ${accepts3} | ${turnNumRecord + 4} | ${valid}             | ${wallets[1]} | ${future}    | ${undefined}
-    ${reverts1} | ${turnNumRecord}     | ${valid}             | ${wallets[1]} | ${never}     | ${TURN_NUM_RECORD_NOT_INCREASED}
-    ${reverts2} | ${turnNumRecord + 1} | ${invalidTransition} | ${wallets[1]} | ${never}     | ${COUNTING_APP_INVALID_TRANSITION}
-    ${reverts3} | ${turnNumRecord + 1} | ${unsupported}       | ${wallets[1]} | ${never}     | ${UNACCEPTABLE_WHO_SIGNED_WHAT}
-    ${reverts4} | ${turnNumRecord}     | ${valid}             | ${wallets[1]} | ${future}    | ${TURN_NUM_RECORD_NOT_INCREASED}
-    ${reverts5} | ${turnNumRecord + 1} | ${invalidTransition} | ${wallets[1]} | ${future}    | ${COUNTING_APP_INVALID_TRANSITION}
-    ${reverts6} | ${turnNumRecord + 1} | ${unsupported}       | ${wallets[1]} | ${future}    | ${UNACCEPTABLE_WHO_SIGNED_WHAT}
-    ${reverts7} | ${turnNumRecord + 1} | ${valid}             | ${wallets[1]} | ${past}      | ${CHANNEL_FINALIZED}
+    description | largestTurnNum       | support              | finalizesAt  | reason
+    ${accepts1} | ${turnNumRecord + 1} | ${valid}             | ${undefined} | ${undefined}
+    ${accepts2} | ${turnNumRecord + 3} | ${valid}             | ${never}     | ${undefined}
+    ${accepts3} | ${turnNumRecord + 4} | ${valid}             | ${future}    | ${undefined}
+    ${reverts1} | ${turnNumRecord}     | ${valid}             | ${never}     | ${TURN_NUM_RECORD_NOT_INCREASED}
+    ${reverts2} | ${turnNumRecord + 1} | ${invalidTransition} | ${never}     | ${COUNTING_APP_INVALID_TRANSITION}
+    ${reverts3} | ${turnNumRecord + 1} | ${unsupported}       | ${never}     | ${UNACCEPTABLE_WHO_SIGNED_WHAT}
+    ${reverts4} | ${turnNumRecord}     | ${valid}             | ${future}    | ${TURN_NUM_RECORD_NOT_INCREASED}
+    ${reverts5} | ${turnNumRecord + 1} | ${invalidTransition} | ${future}    | ${COUNTING_APP_INVALID_TRANSITION}
+    ${reverts6} | ${turnNumRecord + 1} | ${unsupported}       | ${future}    | ${UNACCEPTABLE_WHO_SIGNED_WHAT}
+    ${reverts7} | ${turnNumRecord + 1} | ${valid}             | ${past}      | ${CHANNEL_FINALIZED}
   `('$description', async ({largestTurnNum, support, finalizesAt, reason}) => {
     const {appDatas, whoSignedWhat} = support;
     const channel: Channel = {chainId, channelNonce, participants};

--- a/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
@@ -97,7 +97,7 @@ describe('checkpoint', () => {
     ${reverts5} | ${turnNumRecord + 1} | ${invalidTransition} | ${wallets[1]} | ${future}    | ${COUNTING_APP_INVALID_TRANSITION}
     ${reverts6} | ${turnNumRecord + 1} | ${unsupported}       | ${wallets[1]} | ${future}    | ${UNACCEPTABLE_WHO_SIGNED_WHAT}
     ${reverts7} | ${turnNumRecord + 1} | ${valid}             | ${wallets[1]} | ${past}      | ${CHANNEL_FINALIZED}
-  `('$description', async ({largestTurnNum, support, challenger, finalizesAt, reason}) => {
+  `('$description', async ({largestTurnNum, support, finalizesAt, reason}) => {
     const {appDatas, whoSignedWhat} = support;
     const channel: Channel = {chainId, channelNonce, participants};
     const channelId = getChannelId(channel);

--- a/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/checkpoint.test.ts
@@ -114,7 +114,6 @@ describe('checkpoint', () => {
 
     const isOpen = !!finalizesAt;
     const outcome = isOpen ? undefined : defaultOutcome;
-    const challengerAddress = isOpen ? undefined : challenger.address;
     const challengeState: State = isOpen
       ? undefined
       : {
@@ -132,7 +131,6 @@ describe('checkpoint', () => {
           turnNumRecord,
           finalizesAt,
           state: challengeState,
-          challengerAddress,
           outcome,
         })
       : HashZero;

--- a/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
@@ -111,7 +111,6 @@ describe('respond', () => {
             turnNumRecord,
             finalizesAt,
             state: challenger ? challengeState : undefined,
-            challengerAddress: challenger.address,
             outcome,
           });
 

--- a/packages/nitro-protocol/test/contracts/ForceMove/storage.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/storage.test.ts
@@ -14,7 +14,6 @@ beforeAll(async () => {
 const zeroData = {
   stateHash: ethers.constants.HashZero,
   outcomeHash: ethers.constants.HashZero,
-  challengerAddress: ethers.constants.AddressZero,
 };
 describe('storage', () => {
   it.each`

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -176,10 +176,8 @@ describe('claim', () => {
         guarantorId,
         guarantorOutcomeBytes,
         stateHash,
-
         targetOutcomeBytes,
         stateHash,
-
         indices
       );
 
@@ -210,7 +208,6 @@ describe('claim', () => {
           finalizesAt,
           // stateHash will be set to HashZero by this helper fn
           // if state property of this object is undefined
-
           outcome: outcomeAfter,
         });
         expect(await testNitroAdjudicator.statusOf(targetId)).toEqual(expectedStatusAfter);

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -131,7 +131,6 @@ describe('claim', () => {
 
       // Set adjudicator status
       const stateHash = constants.HashZero; // not realistic, but OK for purpose of this test
-      const challengerAddress = constants.AddressZero; // not realistic, but OK for purpose of this test
       const finalizesAt = 42;
       const turnNumRecord = 7;
 
@@ -141,7 +140,6 @@ describe('claim', () => {
             turnNumRecord,
             finalizesAt,
             stateHash,
-            challengerAddress,
             outcomeHash,
           })
         ).wait();
@@ -168,7 +166,6 @@ describe('claim', () => {
             turnNumRecord,
             finalizesAt,
             stateHash,
-            challengerAddress,
             outcomeHash: guarantorOutcomeHash,
           })
         ).wait();
@@ -179,10 +176,10 @@ describe('claim', () => {
         guarantorId,
         guarantorOutcomeBytes,
         stateHash,
-        challengerAddress,
+
         targetOutcomeBytes,
         stateHash,
-        challengerAddress,
+
         indices
       );
 
@@ -213,7 +210,7 @@ describe('claim', () => {
           finalizesAt,
           // stateHash will be set to HashZero by this helper fn
           // if state property of this object is undefined
-          challengerAddress,
+
           outcome: outcomeAfter,
         });
         expect(await testNitroAdjudicator.statusOf(targetId)).toEqual(expectedStatusAfter);

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
@@ -103,7 +103,6 @@ describe('transfer', () => {
 
       // Set adjudicator status
       const stateHash = constants.HashZero; // not realistic, but OK for purpose of this test
-      const challengerAddress = constants.AddressZero; // not realistic, but OK for purpose of this test
       const finalizesAt = 42;
       const turnNumRecord = 7;
 
@@ -113,7 +112,6 @@ describe('transfer', () => {
             turnNumRecord,
             finalizesAt,
             stateHash,
-            challengerAddress,
             outcomeHash,
           })
         ).wait();
@@ -124,7 +122,6 @@ describe('transfer', () => {
         channelId,
         reason == 'incorrect fingerprint' ? '0xdeadbeef' : outcomeBytes,
         stateHash,
-        challengerAddress,
         indices
       );
 
@@ -155,7 +152,7 @@ describe('transfer', () => {
           finalizesAt,
           // stateHash will be set to HashZero by this helper fn
           // if state property of this object is undefined
-          challengerAddress,
+
           outcome: outcomeAfter,
         });
         expect(await testNitroAdjudicator.statusOf(channelId)).toEqual(expectedStatusAfter);

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/transfer.test.ts
@@ -152,7 +152,6 @@ describe('transfer', () => {
           finalizesAt,
           // stateHash will be set to HashZero by this helper fn
           // if state property of this object is undefined
-
           outcome: outcomeAfter,
         });
         expect(await testNitroAdjudicator.statusOf(channelId)).toEqual(expectedStatusAfter);

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
@@ -130,7 +130,6 @@ describe('transferAllAssets', () => {
       const outcomeHash = hashOutcome(outcome);
       // Call public wrapper to set state (only works on test contract)
       const stateHash = constants.HashZero;
-      const challengerAddress = constants.AddressZero;
       const finalizesAt = 42;
       const turnNumRecord = 7;
       await (
@@ -138,18 +137,12 @@ describe('transferAllAssets', () => {
           turnNumRecord,
           finalizesAt,
           stateHash,
-          challengerAddress,
           outcomeHash,
         })
       ).wait();
       const encodedOutcome = encodeOutcome(outcome);
 
-      const tx1 = testNitroAdjudicator.transferAllAssets(
-        channelId,
-        encodedOutcome,
-        stateHash,
-        challengerAddress
-      );
+      const tx1 = testNitroAdjudicator.transferAllAssets(channelId, encodedOutcome, stateHash);
 
       // Call method in a slightly different way if expecting a revert
       if (reasonString) {
@@ -171,7 +164,7 @@ describe('transferAllAssets', () => {
           finalizesAt,
           // stateHash will be set to HashZero by this helper fn
           // if state property of this object is undefined
-          challengerAddress,
+
           outcome: outcomeAfter,
         });
         expect(await testNitroAdjudicator.statusOf(channelId)).toEqual(expectedStatusAfter);

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/transferAllAssets.test.ts
@@ -164,7 +164,6 @@ describe('transferAllAssets', () => {
           finalizesAt,
           // stateHash will be set to HashZero by this helper fn
           // if state property of this object is undefined
-
           outcome: outcomeAfter,
         });
         expect(await testNitroAdjudicator.statusOf(channelId)).toEqual(expectedStatusAfter);

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -79,7 +79,6 @@ export const ongoingChallengeFingerprint = (turnNumRecord = 5): Bytes32 =>
   channelDataToStatus({
     turnNumRecord,
     finalizesAt: 1e12,
-    challengerAddress: constants.AddressZero,
     outcome: [],
   });
 
@@ -87,15 +86,13 @@ export const finalizedFingerprint = (
   turnNumRecord = 5,
   finalizesAt = 1,
   outcome: Outcome = [],
-  state = undefined,
-  challengerAddress = undefined
+  state = undefined
 ): Bytes32 =>
   channelDataToStatus({
     turnNumRecord,
     finalizesAt,
     outcome,
     state,
-    challengerAddress,
   });
 
 export const newChallengeRegisteredEvent = (

--- a/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
+++ b/packages/server-wallet/src/chain-service/__chain-test__/chain-service.test.ts
@@ -626,9 +626,7 @@ describe('challenge', () => {
 
     await Promise.all(channelsFinalized);
     await Promise.all(
-      state1s.map(
-        async state1 => await (await chainService.withdraw(state1, aWallet().address)).wait()
-      )
+      state1s.map(async state1 => await (await chainService.withdraw(state1)).wait())
     );
 
     expect(await provider.getBalance(aDestinationAddress)).toEqual(BigNumber.from(2));

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -155,7 +155,7 @@ export class ChainService implements ChainServiceInterface {
           response = await this.fundChannel(chainRequest);
           break;
         case 'Withdraw':
-          response = await this.withdraw(chainRequest.state, chainRequest.challengerAddress);
+          response = await this.withdraw(chainRequest.state);
 
           break;
         default:
@@ -314,12 +314,12 @@ export class ChainService implements ChainServiceInterface {
     return this.sendTransaction(challengeTransactionRequest);
   }
 
-  async withdraw(state: State, challengerAddress: Address): Promise<providers.TransactionResponse> {
+  async withdraw(state: State): Promise<providers.TransactionResponse> {
     this.logger.info('withdraw: entry');
     const lastState = toNitroState(state);
 
     const transactionRequest = {
-      ...Transactions.createTransferAllAssetsTransaction(lastState, challengerAddress),
+      ...Transactions.createTransferAllAssetsTransaction(lastState),
       to: this.nitroAdjudicator.address,
     };
     return this.sendTransaction(transactionRequest);

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -59,7 +59,7 @@ export class MockChainService implements ChainServiceInterface {
           responses.push(await this.fundChannel(chainRequest));
           break;
         case 'Withdraw':
-          responses.push(await this.withdraw(chainRequest.state, chainRequest.challengerAddress));
+          responses.push(await this.withdraw(chainRequest.state));
           break;
         default:
           unreachable(chainRequest);
@@ -91,7 +91,7 @@ export class MockChainService implements ChainServiceInterface {
     return Promise.resolve(mockTransactoinResponse);
   }
 
-  withdraw(_state: State, _challengerAddress: Address): Promise<providers.TransactionResponse> {
+  withdraw(_state: State): Promise<providers.TransactionResponse> {
     return Promise.resolve(mockTransactoinResponse);
   }
 

--- a/packages/server-wallet/src/chain-service/mock-chain-service.ts
+++ b/packages/server-wallet/src/chain-service/mock-chain-service.ts
@@ -111,10 +111,7 @@ export class MockChainService implements ChainServiceInterface {
   }
 }
 export class ErorringMockChainService extends MockChainService {
-  pushOutcomeAndWithdraw(
-    _state: State,
-    _challengerAddress: Address
-  ): Promise<providers.TransactionResponse> {
+  withdraw(_state: State): Promise<providers.TransactionResponse> {
     throw new Error('Failed to submit transaction');
   }
 }

--- a/packages/server-wallet/src/chain-service/types.ts
+++ b/packages/server-wallet/src/chain-service/types.ts
@@ -66,7 +66,6 @@ export type ConcludeAndWithdrawRequest = {
 export type WithdrawRequest = {
   type: 'Withdraw';
   state: State;
-  challengerAddress: Address;
 };
 
 export type ChallengeRequest = {

--- a/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defund-channel.test.ts
@@ -125,7 +125,6 @@ describe('when the channel is finalized on chain', () => {
     expect(response.chainRequests[0]).toMatchObject({
       type: 'Withdraw',
       state: expect.objectContaining(challengeState),
-      challengerAddress: testChan.participantA.signingAddress,
     });
     const reloadedObjective = await store.getObjective(objective.objectiveId);
     expect(reloadedObjective.status).toEqual('succeeded');

--- a/packages/server-wallet/src/protocols/__test__/defunder.test.ts
+++ b/packages/server-wallet/src/protocols/__test__/defunder.test.ts
@@ -227,7 +227,6 @@ describe('Direct channel defunding', () => {
       expect(response.chainRequests[0]).toMatchObject({
         type: 'Withdraw',
         state: state4,
-        challengerAddress: channel.myAddress,
       });
       // The channel has been fully defunded
       // Defunder completes

--- a/packages/server-wallet/src/protocols/defunder.ts
+++ b/packages/server-wallet/src/protocols/defunder.ts
@@ -131,7 +131,6 @@ export class Defunder {
         {
           type: 'Withdraw',
           state: adjudicatorStatus.states[0],
-          challengerAddress: channel.myAddress,
         },
       ]);
 


### PR DESCRIPTION
`challengerAddress` is a variable that is computed on chain when raising a challenge: and is used to ensure only participants can raise challenges. It is also stored (inside a hash with some other data), and is a required to be resubmitted in the calldata of `transfer`, `claim`, `respond`, `checkpoint`... etc. However, the `challengerAddress` stored on-chain is never referenced.

It therefore costs a small amount of gas, bloats our API significantly, and heightens the chance of a "stack too deep" error (and the gymnastics that is often required to get around it).

This PR removes the `challengerAddress` from the storage and the calldata of the mentioned methods. It is still computed and checked on chain. 

Shortcomings / Open questions: 
- **what was the original motivation to store this variable?** My guess for this is that it would allow a mechanism for preventing multiple consecutive challenges from the same participant and/or a mechanism to **slash** the participant if they challenged with a state later proven to be "stale". We have no such mechanism in place at present.
- **is it important to restrict challenges to participants?** If we wanted that slashing mechanism, we might need to store the challenger address -- although the funds in the channel aren't always assignable to one participant or another (destinations are not always 1-1 with participants) so we would probably need to introduce separate "slashing deposits" for each participant, then. So we might argue that the check on the challenger being a participant could be removed (it is **not removed**, yet, on this PR). 

The summary may omit some of these details if this PR fixes a single ticket that includes these details. It is the reviewer's discretion. 

### Changes
Ih particular, don't emit `challenger` in the `ChallengeRegistered` event. This saves 300 gas or so from each challenge. 

## :warning: Does this require multiple approvals? 
Yes

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue




