### PR TITLE
add claim implementation

### DIFF
--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -253,7 +253,7 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
             Outcome.SingleAssetExit[] memory targetOutcome,
             address asset,
             uint256 initialAssetHoldings
-        ) = _apply_claim_checks(claimArgs);
+        ) = _apply_claim_checks(claimArgs); // view
 
         Outcome.Allocation[] memory newSourceAllocations;
         Outcome.Allocation[] memory newTargetAllocations;
@@ -352,7 +352,7 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
     }
 
     /**
-     * @dev Computes side effects for the claim function. First, computes the amount the source channel can afford for the target. Then, computes and returns an updated allocations for the source and for the target, as well as exit allocations (to be paid out). It does this by walking the target allocations, testing against the guarantee in the source, and conditionally siphoning money out. See the Nitro paper.
+     * @dev Computes side effects for the claim function. First, computes the amount the source channel can afford for the target. Then, computes and returns updated allocations for the source and for the target, as well as exit allocations (to be paid out). It does this by walking the target allocations, testing against the guarantee in the source, and conditionally siphoning money out. See the Nitro paper.
      */
     function compute_claim_effects_and_interactions(
         uint256 initialHoldings,

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -296,6 +296,9 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
         _apply_claim_interactions(targetOutcome[claimArgs.targetAssetIndex], exitAllocations);
     }
 
+    /**
+     * @dev Checks that indices are increasing; that the source and target channels are finalized; that the supplied outcomes match the stored fingerprints; that the asset is identical in source and target. Computes and returns: the decoded outcomes, the asset being targetted; the number of assets held against the guarantor.
+     */
     function _apply_claim_checks(ClaimArgs memory claimArgs)
         internal
         view
@@ -348,6 +351,9 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
         );
     }
 
+    /**
+     * @dev Computes side effects for the claim function. First, computes the amount the source channel can afford for the target. Then, computes and returns an updated allocations for the source and for the target, as well as exit allocations (to be paid out). It does this by walking the target allocations, testing against the guarantee in the source, and conditionally siphoning money out. See the Nitro paper.
+     */
     function compute_claim_effects_and_interactions(
         uint256 initialHoldings,
         Outcome.Allocation[] memory sourceAllocations,
@@ -444,6 +450,9 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
         }
     }
 
+    /**
+     * @dev Applies precomputed side effects for claim. Updates the holdings of the source channel. Updates the fingerprint of the outcome for the source and the target channel. Emits an event for each channel.
+     */
     function _apply_claim_effects(
         ClaimArgs memory claimArgs,
         address asset,
@@ -487,6 +496,9 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
         emit AllocationUpdated(targetChannelId, targetAssetIndex, initialHoldings);
     }
 
+    /**
+     * @dev Applies precomputed side effects for claim that interact with external contracts. "Executes" the supplied exit (pays out the money).
+     */
     function _apply_claim_interactions(
         Outcome.SingleAssetExit memory singleAssetExit,
         Outcome.Allocation[] memory exitAllocations
@@ -502,10 +514,9 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
     }
 
     /**
-     * @notice Executes a single asset exit by paying out the asset and calling external contracts
-     * @dev Executes a single asset exit by paying out the asset and calling external contracts
+     * @notice Executes a single asset exit by paying out the asset and calling external contracts, as well as updating the holdings stored in this contract.
+     * @dev Executes a single asset exit by paying out the asset and calling external contracts, as well as updating the holdings stored in this contract.
      * @param singleAssetExit The single asset exit to be paid out.
-     * TODO absorb into exit format repo
      */
     function executeSingleAssetExit(Outcome.SingleAssetExit memory singleAssetExit) internal {
         address asset = singleAssetExit.asset;

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -254,6 +254,7 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
             address asset,
             uint256 initialAssetHoldings
         ) = _apply_claim_checks(claimArgs);
+
         Outcome.Allocation[] memory newSourceAllocations;
         Outcome.Allocation[] memory newTargetAllocations;
         Outcome.Allocation[] memory exitAllocations;

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -373,7 +373,9 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
         // `targetAllocationIndicesToPayout == []` means "pay out to all"
         // Note: by initializing exitAllocations to be an array of fixed length, its entries are initialized to be `0`
         exitAllocations = new Outcome.Allocation[](
-            targetAllocationIndicesToPayout.length > 0 ? targetAllocationIndicesToPayout.length : targetAllocations.length
+            targetAllocationIndicesToPayout.length > 0
+                ? targetAllocationIndicesToPayout.length
+                : targetAllocations.length
         );
         totalPayouts = 0;
         uint256 k = 0; // indexes the `targetAllocationIndicesToPayout` array
@@ -428,7 +430,11 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
                     uint256 affordsForDestination = min(targetAllocations[i].amount, targetSurplus);
                     // decrease surplus by the current amount regardless of hitting a specified index
                     targetSurplus -= affordsForDestination;
-                    if ((targetAllocationIndicesToPayout.length == 0) || ((k < targetAllocationIndicesToPayout.length) && (targetAllocationIndicesToPayout[k] == i))) {
+                    if (
+                        (targetAllocationIndicesToPayout.length == 0) ||
+                        ((k < targetAllocationIndicesToPayout.length) &&
+                            (targetAllocationIndicesToPayout[k] == i))
+                    ) {
                         // only if specified in supplied targetAllocationIndicesToPayout, or we if we are doing "all"
                         // reduce the new allocationItem.amount
                         newTargetAllocations[i].amount -= affordsForDestination;

--- a/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
@@ -49,7 +49,7 @@ interface IMultiAssetHolder {
      * @param targetStateHash Hash of the state stored when the target channel finalized.
      * @param targetOutcomeBytes The abi.encode of target channel outcome
      * @param targetAssetIndex the index of the targetted asset in the target outcome.
-     * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all"
+     * @param targetAllocationIndicesToPayout Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all"
      */
     struct ClaimArgs {
         bytes32 sourceChannelId;
@@ -60,7 +60,7 @@ interface IMultiAssetHolder {
         bytes32 targetStateHash;
         bytes targetOutcomeBytes;
         uint256 targetAssetIndex;
-        uint256[] indices;
+        uint256[] targetAllocationIndicesToPayout;
     }
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
@@ -41,7 +41,6 @@ interface IMultiAssetHolder {
     ) external;
 
     /**
-     * @param assetIndex Will be used to slice the outcome into a single asset outcome.
      * @param sourceChannelId Unique identifier for a guarantor state channel.
      * @param sourceStateHash Hash of the state stored when the guarantor channel finalized.
      * @param sourceOutcomeBytes The abi.encode of guarantor channel outcome

--- a/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
@@ -41,6 +41,37 @@ interface IMultiAssetHolder {
     ) external;
 
     /**
+     * @param assetIndex Will be used to slice the outcome into a single asset outcome.
+     * @param sourceChannelId Unique identifier for a guarantor state channel.
+     * @param sourceStateHash Hash of the state stored when the guarantor channel finalized.
+     * @param sourceOutcomeBytes The abi.encode of guarantor channel outcome
+     * @param indexOfTargetInSource The index of the guarantee allocation to the target channel in the source outcome.
+     * @param targetStateHash Hash of the state stored when the target channel finalized.
+     * @param targetOutcomeBytes The abi.encode of target channel outcome
+     * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all"
+     */
+    struct ClaimArgs {
+        bytes32 sourceChannelId;
+        bytes32 sourceStateHash;
+        bytes sourceOutcomeBytes;
+        uint256 indexOfTargetInSource;
+        bytes32 targetStateHash;
+        bytes targetOutcomeBytes;
+        uint256[] indices;
+    }
+
+    /**
+     * @notice Transfers as many funds escrowed against `sourceChannelId` as can be afforded for the destinations specified by indices in the beneficiaries of the __target__ of the channel at indexOfTargetInSource.
+     * @dev Transfers as many funds escrowed against `sourceChannelId` as can be afforded for the destinations specified by indices in the beneficiaries of the __target__ of the channel at indexOfTargetInSource.
+     * @param assetIndex Will be used to slice the outcome into a single asset outcome.
+     * @param claimArgs arguments used in the claim function. Used to avoid stack too deep error.
+     */
+    function claim(
+        uint256 assetIndex, // TODO consider a uint48?
+        ClaimArgs memory claimArgs
+    ) external;
+
+    /**
      * @dev Indicates that `amountDeposited` has been deposited into `destination`.
      * @param destination The channel being deposited into.
      * @param amountDeposited The amount being deposited.

--- a/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IMultiAssetHolder.sol
@@ -45,31 +45,31 @@ interface IMultiAssetHolder {
      * @param sourceChannelId Unique identifier for a guarantor state channel.
      * @param sourceStateHash Hash of the state stored when the guarantor channel finalized.
      * @param sourceOutcomeBytes The abi.encode of guarantor channel outcome
+     * @param sourceAssetIndex the index of the targetted asset in the source outcome.
      * @param indexOfTargetInSource The index of the guarantee allocation to the target channel in the source outcome.
      * @param targetStateHash Hash of the state stored when the target channel finalized.
      * @param targetOutcomeBytes The abi.encode of target channel outcome
+     * @param targetAssetIndex the index of the targetted asset in the target outcome.
      * @param indices Array with each entry denoting the index of a destination (in the target channel) to transfer funds to. Should be in increasing order. An empty array indicates "all"
      */
     struct ClaimArgs {
         bytes32 sourceChannelId;
         bytes32 sourceStateHash;
         bytes sourceOutcomeBytes;
+        uint256 sourceAssetIndex;
         uint256 indexOfTargetInSource;
         bytes32 targetStateHash;
         bytes targetOutcomeBytes;
+        uint256 targetAssetIndex;
         uint256[] indices;
     }
 
     /**
      * @notice Transfers as many funds escrowed against `sourceChannelId` as can be afforded for the destinations specified by indices in the beneficiaries of the __target__ of the channel at indexOfTargetInSource.
      * @dev Transfers as many funds escrowed against `sourceChannelId` as can be afforded for the destinations specified by indices in the beneficiaries of the __target__ of the channel at indexOfTargetInSource.
-     * @param assetIndex Will be used to slice the outcome into a single asset outcome.
      * @param claimArgs arguments used in the claim function. Used to avoid stack too deep error.
      */
-    function claim(
-        uint256 assetIndex, // TODO consider a uint48?
-        ClaimArgs memory claimArgs
-    ) external;
+    function claim(ClaimArgs memory claimArgs) external;
 
     /**
      * @dev Indicates that `amountDeposited` has been deposited into `destination`.


### PR DESCRIPTION
I have had to use some tricks to avoid[ `stack too deep`. ](https://soliditydeveloper.com/stacktoodeep)

Notably, block scoping and the use of a new struct `ClaimArgs` to reduce the number of variables on the stack. 

See #3683 