### PR TITLE
add missing dependency

### DIFF
--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -4,6 +4,7 @@
   "version": "0.15.0",
   "author": "Alex Gap",
   "dependencies": {
+    "@statechannels/client-api-schema": "0.10.2",
     "@statechannels/nitro-protocol": "0.17.1",
     "@statechannels/wire-format": "0.9.2",
     "ethers": "5.0.12",


### PR DESCRIPTION
Things like this are difficult to spot in a `yarn` monorepo -- that is, until someone tries to use one of our packages by installing from npm.


I discovered this while experimenting with pinning dependants of nitro-protocol to a version published to npm.