### PR TITLE
import/export computeNewOutcome thru entry point

### DIFF
--- a/packages/nitro-protocol/src/index.ts
+++ b/packages/nitro-protocol/src/index.ts
@@ -57,6 +57,9 @@ export {
   getDepositedEvent,
   convertBytes32ToAddress,
   convertAddressToBytes32,
+  computeNewAllocation,
+  computeNewAllocationWithGuarantee,
+  computeNewOutcome,
 } from './contract/multi-asset-holder';
 export {
   getChallengeRegisteredEvent,

--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -6,6 +6,7 @@ import {
   getChallengeRegisteredEvent,
   getChannelId,
   Transactions,
+  computeNewOutcome,
 } from '@statechannels/nitro-protocol';
 import {
   Address,
@@ -25,7 +26,6 @@ import PQueue from 'p-queue';
 import {Logger} from 'pino';
 import _ from 'lodash';
 const MAGIC_ADDRESS_INDICATING_ETH = constants.AddressZero;
-import {computeNewOutcome} from '@statechannels/nitro-protocol/src/contract/multi-asset-holder';
 
 import {Bytes32} from '../type-aliases';
 import {createLogger} from '../logger';


### PR DESCRIPTION
I think this will fix #3717.

I would like to have a way of testing or linting for this problem in future. Something like https://www.npmjs.com/package/eslint-plugin-monorepo although this didn't pick up this issue when I tried it.