### PR TITLE
Simplify Load Generator arguments

### DIFF
--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -16,6 +16,9 @@ import {COUNTING_APP_DEFINITION} from '../../src/models/__test__/fixtures/app-by
 import {FundingInfo, RoleConfig, Step} from '../types';
 import {setupUnhandledErrorListeners} from '../utils';
 
+// We want to create all the ledger channels in the first 5 seconds.
+const MAX_CREATE_LEDGER_TIME = ms('5 seconds');
+
 setupUnhandledErrorListeners();
 
 createLoad();
@@ -157,9 +160,7 @@ function generateCreateLedgerSteps(
 ): Step[] {
   const steps: Step[] = [];
   _.times(amountOfLedgerChannels, () => {
-    // We create ledger channels in the first quarter of the duration
-    const maxLedgerTime = Math.floor(duration / 4);
-    const timestamp = generateRandomInteger(0, toMilliseconds(maxLedgerTime));
+    const timestamp = generateRandomInteger(0, MAX_CREATE_LEDGER_TIME);
     const startIndex = generateRandomInteger(0, Object.keys(roles).length - 1);
 
     const participants = generateParticipants(roles, startIndex);

--- a/packages/server-wallet/e2e-testing/scripts/load-generator.ts
+++ b/packages/server-wallet/e2e-testing/scripts/load-generator.ts
@@ -50,7 +50,7 @@ async function createLoad() {
     })
     .option('fundingStrategy', {
       alias: 'f',
-      describe: 'Whether channels are funded directly or by ledger channels.',
+      describe: 'Whether application channels are funded directly or by ledger channels.',
       choices: ['Ledger', 'Direct'],
       demandOption: true,
     })
@@ -58,8 +58,7 @@ async function createLoad() {
       alias: 'd',
       min: 10,
       default: 60,
-      describe: `The amount of time (in seconds) that the load should run for.
-      This dictactes the max timestamp a step can have.`,
+      describe: `The amount of time (in seconds) that the load should run for. Steps will be generated with a timestamp such that step.timestamp <= duration.`,
     })
     .option('createRate', {
       alias: 'cr',
@@ -75,12 +74,12 @@ async function createLoad() {
     .option('ledgerDelay', {
       default: 20,
       min: 0,
-      describe: `The minumum amount of time (in seconds) to wait for a ledger channel to be created before scheduling a createChannel job.`,
+      describe: `The minumum amount of time (in seconds) to wait before attempting to use a ledger channel. This is used to prevent using a ledger channel that has not finished being funded.`,
     })
     .option('closeDelay', {
       default: 5,
       min: 0,
-      describe: `The minumum amount of time (in seconds) to wait before closing a channel.`,
+      describe: `The minumum amount of time (in seconds) to wait before closing a channel. This is used to prevent closing a channel that has not finished being funded.`,
     })
     .option('closeRate', {
       default: 0,


### PR DESCRIPTION
Instead of using `ledgerRate` and `createLedgerDuration` arguments, the load-generator takes a `amountOfLedgerChannels`. 

CreateLedgerChannel steps will be scheduled in the first 5 seconds regardless of the duration. 

This makes the load-generator slightly more straightforward to use. I've also tried to clean up the argument descriptions so they're more understandable.