### PR TITLE
Fix Funding Typo

### DIFF
--- a/packages/server-wallet/e2e-testing/wallet-load-node.ts
+++ b/packages/server-wallet/e2e-testing/wallet-load-node.ts
@@ -127,10 +127,11 @@ export class WalletLoadNode {
     const ourSteps = this.steps.filter(s => s.serverId === this.loadNodeConfig.serverId);
     const createdAmount = ourSteps.filter(s => s.type === 'CreateChannel').length;
     const ledgerAmount = ourSteps.filter(s => s.type === 'CreateLedgerChannel').length;
+    const isLedgerFunding = this.steps.some(s => s.type === 'CreateLedgerChannel');
     console.log(
       chalk.whiteBright(
         `This node will create ${createdAmount} channel(s) using ${
-          ledgerAmount > 0 ? 'ledger' : 'direct'
+          isLedgerFunding ? 'ledger' : 'direct'
         } funding`
       )
     );


### PR DESCRIPTION
Fixes #3722 
If the node wasn't assigned any create ledger steps it would log that direct funding was being used. We now check for the presence of a create ledger step for any serverId to avoid this.