### PR TITLE
Chain Service reads process.env.NITRO_ADJUDICATOR_ADDRESS when constructed

### DIFF
--- a/packages/server-wallet/src/chain-service/chain-service.ts
+++ b/packages/server-wallet/src/chain-service/chain-service.ts
@@ -53,10 +53,6 @@ type AllocationUpdatedEvent = {
   ethersEvent: Event;
 } & AllocationUpdatedArg;
 
-/* eslint-disable no-process-env, */
-const nitroAdjudicatorAddress = makeAddress(
-  process.env.NITRO_ADJUDICATOR_ADDRESS || constants.AddressZero
-);
 export class ChainService implements ChainServiceInterface {
   private logger: Logger;
   private readonly ethWallet: NonceManager;
@@ -92,7 +88,10 @@ export class ChainService implements ChainServiceInterface {
       pollingInterval = pollingInterval ?? 50;
     }
     if (pollingInterval) this.provider.pollingInterval = pollingInterval;
-
+    /* eslint-disable no-process-env, */
+    const nitroAdjudicatorAddress = makeAddress(
+      process.env.NITRO_ADJUDICATOR_ADDRESS || constants.AddressZero
+    );
     this.nitroAdjudicator = new Contract(
       nitroAdjudicatorAddress,
       ContractArtifacts.NitroAdjudicatorArtifact.abi,


### PR DESCRIPTION
Read the `process.env.NITRO_ADJUDICATOR_ADDRESS` var when constructing the `chainService` instead of when the chain servic file is loaded.

This is to make testing more convenient. Previously you could inadvertently load the file before you had a chance to set `process.env.NITRO_ADJUDICATOR_ADDRESS` resulting in the `chain-service` using a `0x0000...`.

I ran into this with the stress test as the LoadNodes have references to the `ServerWallet` which has a reference to `ChainService`. This meant that `nitroAdjudicatorAddress` got set as soon as the LoadNode file was loaded before we had a chance to set the `process.env` vars.