### PR TITLE
Integrate exit format claim tests

### DIFF
--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -336,7 +336,7 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
         sourceOutcome = Outcome.decodeExit(sourceOutcomeBytes);
         targetOutcome = Outcome.decodeExit(targetOutcomeBytes);
         asset = sourceOutcome[sourceAssetIndex].asset;
-        require(targetOutcome[targetAssetIndex].asset == asset, 'asset mismatch');
+        require(targetOutcome[targetAssetIndex].asset == asset, 'targetAsset != guaranteeAsset');
         initialAssetHoldings = holdings[asset][sourceChannelId];
         bytes32 targetChannelId = sourceOutcome[sourceAssetIndex].allocations[claimArgs
             .indexOfTargetInSource]

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -231,6 +231,14 @@ describe('claim', () => {
           {
             event: 'AllocationUpdated',
             args: {
+              channelId: guarantorId,
+              assetIndex: BigNumber.from(0),
+              initialHoldings: heldBefore[addresses.g],
+            },
+          },
+          {
+            event: 'AllocationUpdated',
+            args: {
               channelId: targetId,
               assetIndex: BigNumber.from(0),
               initialHoldings: heldBefore[addresses.g],

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -42,31 +42,31 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
-    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
+    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | payoutIndices | tOutcomeAfter         | heldAfter | payouts         | reason
+    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}        | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}        | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}        | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}        | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}        | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}        | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}        | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}        | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}         | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}         | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}         | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}         | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}         | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}         | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}         | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}         | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}        | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
   `(
     '$name',
     async ({
       heldBefore,
       guaranteeDestinations,
       tOutcomeBefore,
-      indices,
+      payoutIndices: targetAllocationIndicesToPayout,
       tOutcomeAfter,
       heldAfter,
       payouts,
@@ -75,7 +75,7 @@ describe('claim', () => {
       heldBefore: AssetOutcomeShortHand;
       guaranteeDestinations;
       tOutcomeBefore: AssetOutcomeShortHand;
-      indices: number[];
+      payoutIndices: number[];
       tOutcomeAfter: AssetOutcomeShortHand;
       heldAfter: AssetOutcomeShortHand;
       payouts: AssetOutcomeShortHand;
@@ -83,9 +83,9 @@ describe('claim', () => {
     }) => {
       // Compute channelIds
       const targetId = randomChannelId();
-      const guarantorId = randomChannelId();
+      const sourceChannelId = randomChannelId();
       addresses.t = targetId;
-      addresses.g = guarantorId;
+      addresses.g = sourceChannelId;
 
       // Transform input data (unpack addresses and BigNumber amounts)
       [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [
@@ -115,21 +115,18 @@ describe('claim', () => {
       );
 
       // Compute an appropriate allocation.
-      const allocation: Allocation[] = [];
+      const allocations: Allocation[] = [];
       Object.keys(tOutcomeBefore).forEach(key =>
-        allocation.push({
+        allocations.push({
           destination: key,
           amount: tOutcomeBefore[key].toString(),
           metadata: '0x',
           allocationType: AllocationType.simple,
         })
       );
-      const outcomeHash = hashOutcome([
-        {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocation, metadata: '0x'},
-      ]);
-      const targetOutcomeBytes = encodeOutcome([
-        {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocation, metadata: '0x'},
-      ]);
+      const outcome: Outcome = [{asset: MAGIC_ADDRESS_INDICATING_ETH, allocations, metadata: '0x'}];
+      const outcomeHash = hashOutcome(outcome);
+      const targetOutcomeBytes = encodeOutcome(outcome);
 
       // Set adjudicator status
       const stateHash = constants.HashZero; // not realistic, but OK for purpose of this test
@@ -167,13 +164,13 @@ describe('claim', () => {
         },
       ];
 
-      const guarantorOutcomeBytes = encodeOutcome(guaranteeOutcome);
+      const sourceOutcomeBytes = encodeOutcome(guaranteeOutcome);
       const guarantorOutcomeHash = hashOutcome(guaranteeOutcome);
 
       // Set status for guarantor
       if (guaranteeDestinations.length > 0) {
         await (
-          await testNitroAdjudicator.setStatusFromChannelData(guarantorId, {
+          await testNitroAdjudicator.setStatusFromChannelData(sourceChannelId, {
             turnNumRecord,
             finalizesAt,
             stateHash,
@@ -183,15 +180,15 @@ describe('claim', () => {
       }
 
       const tx = testNitroAdjudicator.claim({
-        sourceChannelId: guarantorId,
+        sourceChannelId,
         sourceStateHash: stateHash,
-        sourceOutcomeBytes: guarantorOutcomeBytes,
+        sourceOutcomeBytes,
         sourceAssetIndex: 0, // TODO: introduce test cases with multiple-asset Source and Targets
         indexOfTargetInSource: 0,
         targetStateHash: stateHash,
         targetOutcomeBytes,
         targetAssetIndex: 0,
-        targetAllocationIndicesToPayout: indices,
+        targetAllocationIndicesToPayout,
       });
 
       // Call method in a slightly different way if expecting a revert
@@ -237,7 +234,7 @@ describe('claim', () => {
           {
             event: 'AllocationUpdated',
             args: {
-              channelId: guarantorId,
+              channelId: sourceChannelId,
               assetIndex: BigNumber.from(0),
               initialHoldings: heldBefore[addresses.g],
             },

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -42,24 +42,8 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
-    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
+    name                                                | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts   | reason
+    ${' 1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
   `(
     '$name',
     async ({

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -42,8 +42,24 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts   | reason
-    ${' 1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
+    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
+    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
   `(
     '$name',
     async ({

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -184,11 +184,13 @@ describe('claim', () => {
         const {events: eventsFromTx} = await (await tx).wait();
 
         // Check new holdings
-        Object.keys(heldAfter).forEach(async key =>
-          expect(await testNitroAdjudicator.holdings(MAGIC_ADDRESS_INDICATING_ETH, key)).toEqual(
-            heldAfter[key]
-          )
-        );
+        const heldAfterChecks = Object.keys(heldAfter).map(async g => {
+          return expect(
+            await testNitroAdjudicator.holdings(MAGIC_ADDRESS_INDICATING_ETH, g)
+          ).toEqual(heldAfter[g]);
+        });
+
+        await Promise.all(heldAfterChecks);
 
         // Check new outcomeHash
         const allocationAfter = [];

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -152,15 +152,6 @@ describe('claim', () => {
       ];
       console.log(`Creates Guarantee`);
 
-      const guarantee = {
-        destinations: guaranteeDestinations,
-        targetChannelId: targetId,
-      };
-
-      const guaranteeOutcome: Outcome =
-        reason === reason6
-          ? [{asset: '0xdac17f958d2ee523a2206206994597c13d831ec7', guarantee}] // USDT
-          : [{asset: MAGIC_ADDRESS_INDICATING_ETH, guarantee}];
       const guarantorOutcomeBytes = encodeOutcome(guaranteeOutcome);
       const guarantorOutcomeHash = hashOutcome(guaranteeOutcome);
 

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -166,7 +166,6 @@ describe('claim', () => {
               : MAGIC_ADDRESS_INDICATING_ETH,
         },
       ];
-      console.log(`Creates Guarantee`);
 
       const guarantorOutcomeBytes = encodeOutcome(guaranteeOutcome);
       const guarantorOutcomeHash = hashOutcome(guaranteeOutcome);

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -46,8 +46,24 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts   | reason
-    ${' 1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
+    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
+    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
+    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
   `(
     //${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
     // ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -29,10 +29,6 @@ const addresses = {
   I: randomExternalDestination(),
   A: randomExternalDestination(),
   B: randomExternalDestination(),
-  // I: '0x0000000000000000000000000000000000000001',
-  // A: '0x0000000000000000000000000000000000000002',
-  // B: '0x0000000000000000000000000000000000000003',
-  // c: '0xEC1Ce986ded5056B9DB178EFa21F1a33892Ae49F'
 };
 
 const reason5 = 'Channel not finalized';
@@ -65,23 +61,6 @@ describe('claim', () => {
     ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
     ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
   `(
-    //${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    // ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    // ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    // ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    // ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    // ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    // ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    // ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    // ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    // ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    // ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    // ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    // ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    // ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
-    // ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
-    // ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
-    //`(
     '$name',
     async ({
       heldBefore,
@@ -102,7 +81,6 @@ describe('claim', () => {
       payouts: AssetOutcomeShortHand;
       reason;
     }) => {
-      // console.log(`LOG: prints logs statements`);
       // Compute channelIds
       const targetId = randomChannelId();
       const guarantorId = randomChannelId();
@@ -118,8 +96,6 @@ describe('claim', () => {
         payouts,
       ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
       guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
-      console.log(`Guarantee Destinations:`);
-      console.log(guaranteeDestinations.toString());
 
       // Deposit into channels
 
@@ -137,7 +113,6 @@ describe('claim', () => {
           ).toBe(true);
         })
       );
-      console.log(`Deposits into channels`);
 
       // Compute an appropriate allocation.
       const allocation: Allocation[] = [];
@@ -149,18 +124,13 @@ describe('claim', () => {
           allocationType: AllocationType.simple,
         })
       );
-      console.log(`Comuptes Allocation`);
-      allocation.forEach(a => {
-        console.log(JSON.stringify(a));
-      });
       const outcomeHash = hashOutcome([
         {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocation, metadata: '0x'},
       ]);
-      console.log(`Hashes outcome`);
       const targetOutcomeBytes = encodeOutcome([
         {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocation, metadata: '0x'},
       ]);
-      console.log(`encodes Outcome`);
+
       // Set adjudicator status
       const stateHash = constants.HashZero; // not realistic, but OK for purpose of this test
       const finalizesAt = 42;
@@ -185,7 +155,7 @@ describe('claim', () => {
           allocations: [
             {
               allocationType: AllocationType.guarantee,
-              amount: heldBefore[addresses.g].toString(),
+              amount: '0x00',
               destination: targetId,
               metadata: encodedGuaranteeData,
             },
@@ -198,16 +168,17 @@ describe('claim', () => {
       ];
       console.log(`Creates Guarantee`);
 
-      console.log(`guaranteeOutcome:`);
-      guaranteeOutcome.forEach(g => {
-        console.log(JSON.stringify(g));
-      });
-      const guarantorOutcomeBytes = encodeOutcome(guaranteeOutcome);
-      console.log(`encoded guaranteeOutcome: ${guarantorOutcomeBytes}`);
+      const guarantee = {
+        destinations: guaranteeDestinations,
+        targetChannelId: targetId,
+      };
 
-      console.log(`Encodes Guarantee`);
+      const guaranteeOutcome: Outcome =
+        reason === reason6
+          ? [{asset: '0xdac17f958d2ee523a2206206994597c13d831ec7', guarantee}] // USDT
+          : [{asset: MAGIC_ADDRESS_INDICATING_ETH, guarantee}];
+      const guarantorOutcomeBytes = encodeOutcome(guaranteeOutcome);
       const guarantorOutcomeHash = hashOutcome(guaranteeOutcome);
-      console.log(`Hashes guarontorOutcome`);
 
       // Set status for guarantor
       if (guaranteeDestinations.length > 0) {
@@ -220,7 +191,6 @@ describe('claim', () => {
           })
         ).wait();
       }
-      console.log(`Sets status for guarantor`);
 
       const tx = await testNitroAdjudicator.claim({
         sourceChannelId: guarantorId,
@@ -240,11 +210,6 @@ describe('claim', () => {
       } else {
         // Extract logs
         const {events: eventsFromTx} = await (await tx).wait();
-        console.log(
-          `Events: ${eventsFromTx.map(e => {
-            return '\n' + JSON.stringify(e);
-          })}`
-        );
 
         // Check new holdings
         const heldAfterChecks = Object.keys(heldAfter).map(async g => {
@@ -252,7 +217,7 @@ describe('claim', () => {
             await testNitroAdjudicator.holdings(MAGIC_ADDRESS_INDICATING_ETH, g)
           ).toEqual(heldAfter[g]);
         });
-        // fails - eth balance not updated
+
         await Promise.all(heldAfterChecks);
 
         // Check new outcomeHash
@@ -265,11 +230,6 @@ describe('claim', () => {
             allocationType: AllocationType.simple,
           });
         });
-        console.log(
-          `Allocations After: ${allocationAfter.map(a => {
-            return '\n' + JSON.stringify(a);
-          })}`
-        );
         const outcomeAfter: Outcome = [
           {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocationAfter, metadata: '0x'},
         ];
@@ -280,19 +240,10 @@ describe('claim', () => {
           // if state property of this object is undefined
           outcome: outcomeAfter,
         });
-        //fails - eth balance not updated
         expect(await testNitroAdjudicator.statusOf(targetId)).toEqual(expectedStatusAfter);
 
         // Compile event expectations
         const expectedEvents = [
-          {
-            event: 'AllocationUpdated',
-            args: {
-              channelId: guarantorId,
-              assetIndex: BigNumber.from(0),
-              initialHoldings: heldBefore[addresses.g],
-            },
-          },
           {
             event: 'AllocationUpdated',
             args: {

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -139,7 +139,7 @@ describe('claim', () => {
           allocations: [
             {
               allocationType: AllocationType.guarantee,
-              amount: '0x00',
+              amount: heldBefore[addresses.g].toString(),
               destination: targetId,
               metadata: encodedGuaranteeData,
             },

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -176,7 +176,7 @@ describe('claim', () => {
         ).wait();
       }
 
-      const tx = await testNitroAdjudicator.claim({
+      const tx = testNitroAdjudicator.claim({
         sourceChannelId: guarantorId,
         sourceStateHash: stateHash,
         sourceOutcomeBytes: guarantorOutcomeBytes,

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -29,6 +29,10 @@ const addresses = {
   I: randomExternalDestination(),
   A: randomExternalDestination(),
   B: randomExternalDestination(),
+  // I: '0x0000000000000000000000000000000000000001',
+  // A: '0x0000000000000000000000000000000000000002',
+  // B: '0x0000000000000000000000000000000000000003',
+  // c: '0xEC1Ce986ded5056B9DB178EFa21F1a33892Ae49F'
 };
 
 const reason5 = 'Channel not finalized';
@@ -42,25 +46,26 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
-    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
+    name                                                | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts   | reason
+    ${' 1. straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}} | ${undefined}
   `(
+    //${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    // ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    // ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    // ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    // ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    // ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    // ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
+    // ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    // ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
+    // ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
+    // ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
+    // ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    // ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
+    // ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
+    // ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
+    // ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
+    //`(
     '$name',
     async ({
       heldBefore,
@@ -81,6 +86,7 @@ describe('claim', () => {
       payouts: AssetOutcomeShortHand;
       reason;
     }) => {
+      // console.log(`LOG: prints logs statements`);
       // Compute channelIds
       const targetId = randomChannelId();
       const guarantorId = randomChannelId();
@@ -96,6 +102,8 @@ describe('claim', () => {
         payouts,
       ].map(object => replaceAddressesAndBigNumberify(object, addresses) as AssetOutcomeShortHand);
       guaranteeDestinations = guaranteeDestinations.map(x => addresses[x]);
+      console.log(`Guarantee Destinations:`);
+      console.log(guaranteeDestinations.toString());
 
       // Deposit into channels
 
@@ -113,6 +121,7 @@ describe('claim', () => {
           ).toBe(true);
         })
       );
+      console.log(`Deposits into channels`);
 
       // Compute an appropriate allocation.
       const allocation: Allocation[] = [];
@@ -124,13 +133,18 @@ describe('claim', () => {
           allocationType: AllocationType.simple,
         })
       );
+      console.log(`Comuptes Allocation`);
+      allocation.forEach(a => {
+        console.log(JSON.stringify(a));
+      });
       const outcomeHash = hashOutcome([
         {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocation, metadata: '0x'},
       ]);
+      console.log(`Hashes outcome`);
       const targetOutcomeBytes = encodeOutcome([
         {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocation, metadata: '0x'},
       ]);
-
+      console.log(`encodes Outcome`);
       // Set adjudicator status
       const stateHash = constants.HashZero; // not realistic, but OK for purpose of this test
       const finalizesAt = 42;
@@ -155,7 +169,7 @@ describe('claim', () => {
           allocations: [
             {
               allocationType: AllocationType.guarantee,
-              amount: '0x00',
+              amount: heldBefore[addresses.g].toString(),
               destination: targetId,
               metadata: encodedGuaranteeData,
             },
@@ -168,17 +182,16 @@ describe('claim', () => {
       ];
       console.log(`Creates Guarantee`);
 
-      const guarantee = {
-        destinations: guaranteeDestinations,
-        targetChannelId: targetId,
-      };
-
-      const guaranteeOutcome: Outcome =
-        reason === reason6
-          ? [{asset: '0xdac17f958d2ee523a2206206994597c13d831ec7', guarantee}] // USDT
-          : [{asset: MAGIC_ADDRESS_INDICATING_ETH, guarantee}];
+      console.log(`guaranteeOutcome:`);
+      guaranteeOutcome.forEach(g => {
+        console.log(JSON.stringify(g));
+      });
       const guarantorOutcomeBytes = encodeOutcome(guaranteeOutcome);
+      console.log(`encoded guaranteeOutcome: ${guarantorOutcomeBytes}`);
+
+      console.log(`Encodes Guarantee`);
       const guarantorOutcomeHash = hashOutcome(guaranteeOutcome);
+      console.log(`Hashes guarontorOutcome`);
 
       // Set status for guarantor
       if (guaranteeDestinations.length > 0) {
@@ -191,6 +204,7 @@ describe('claim', () => {
           })
         ).wait();
       }
+      console.log(`Sets status for guarantor`);
 
       const tx = await testNitroAdjudicator.claim({
         sourceChannelId: guarantorId,
@@ -210,6 +224,11 @@ describe('claim', () => {
       } else {
         // Extract logs
         const {events: eventsFromTx} = await (await tx).wait();
+        console.log(
+          `Events: ${eventsFromTx.map(e => {
+            return '\n' + JSON.stringify(e);
+          })}`
+        );
 
         // Check new holdings
         const heldAfterChecks = Object.keys(heldAfter).map(async g => {
@@ -217,7 +236,7 @@ describe('claim', () => {
             await testNitroAdjudicator.holdings(MAGIC_ADDRESS_INDICATING_ETH, g)
           ).toEqual(heldAfter[g]);
         });
-
+        // fails - eth balance not updated
         await Promise.all(heldAfterChecks);
 
         // Check new outcomeHash
@@ -230,6 +249,11 @@ describe('claim', () => {
             allocationType: AllocationType.simple,
           });
         });
+        console.log(
+          `Allocations After: ${allocationAfter.map(a => {
+            return '\n' + JSON.stringify(a);
+          })}`
+        );
         const outcomeAfter: Outcome = [
           {asset: MAGIC_ADDRESS_INDICATING_ETH, allocations: allocationAfter, metadata: '0x'},
         ];
@@ -240,10 +264,19 @@ describe('claim', () => {
           // if state property of this object is undefined
           outcome: outcomeAfter,
         });
+        //fails - eth balance not updated
         expect(await testNitroAdjudicator.statusOf(targetId)).toEqual(expectedStatusAfter);
 
         // Compile event expectations
         const expectedEvents = [
+          {
+            event: 'AllocationUpdated',
+            args: {
+              channelId: guarantorId,
+              assetIndex: BigNumber.from(0),
+              initialHoldings: heldBefore[addresses.g],
+            },
+          },
           {
             event: 'AllocationUpdated',
             args: {


### PR DESCRIPTION
Marked draft because alterations to `computeNewOutcomeWithGuarantee.test.ts` (and `deposit.test.ts`?) are still incoming.