### PR TITLE
Fix serious bug in `claim` and enhance sanity checks in gas benchmarking suite. 

### DIFF
--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -368,7 +368,7 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
 
         for (uint256 j = 0; j < payouts.length; j++) {
             if (payouts[j] > 0) {
-                bytes32 destination = allocation[indices.length > 0 ? indices[j] : j].destination;
+                bytes32 destination = allocation[j].destination;
                 // storage updated BEFORE external contracts called (prevent reentrancy attacks)
                 if (_isExternalDestination(destination)) {
                     _transferAsset(asset, _bytes32ToAddress(destination), payouts[j]);
@@ -398,7 +398,7 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
     {
         // `indices == []` means "pay out to all"
         // Note: by initializing payouts to be an array of fixed length, its entries are initialized to be `0`
-        payouts = new uint256[](indices.length > 0 ? indices.length : allocation.length);
+        payouts = new uint256[](allocation.length);
         totalPayouts = 0;
         allocatesOnlyZeros = true; // switched to false if there is an item remaining with amount > 0
         uint256 surplus = initialHoldings; // tracks funds available during calculation
@@ -430,14 +430,14 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
                         // reduce the new allocationItem.amount
                         newAllocation[i].amount -= affordsForDestination;
                         // increase the relevant payout
-                        payouts[k] += affordsForDestination;
+                        payouts[i] += affordsForDestination;
                         totalPayouts += affordsForDestination;
+                        // move on to the next supplied index
+                        ++k;
                     }
                     break; // start again with the next guarantee destination
                 }
             }
-            // move on to the next supplied index
-            ++k;
         }
 
         for (uint256 i = 0; i < allocation.length; i++) {

--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -432,12 +432,12 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
                         // increase the relevant payout
                         payouts[k] += affordsForDestination;
                         totalPayouts += affordsForDestination;
-                        // move on to the next supplied index
-                        ++k;
                     }
                     break; // start again with the next guarantee destination
                 }
             }
+            // move on to the next supplied index
+            ++k;
         }
 
         for (uint256 i = 0; i < allocation.length; i++) {

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -1,4 +1,5 @@
 import {constants} from 'ethers';
+
 import {encodeOutcome} from '../src';
 import {MAGIC_ADDRESS_INDICATING_ETH} from '../src/transactions';
 
@@ -190,7 +191,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
     ).toEqual(gasRequiredTo.ETHexitSadLedgerFunded.vanillaNitro.total);
   });
 
-  it.only(`when exiting a virtual funded (with ETH) channel`, async () => {
+  it(`when exiting a virtual funded (with ETH) channel`, async () => {
     // begin setup
     await (
       await nitroAdjudicator.deposit(MAGIC_ADDRESS_INDICATING_ETH, LforG.channelId, 0, 10, {

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -1,5 +1,3 @@
-import {constants} from 'ethers';
-
 import {encodeOutcome} from '../src';
 import {MAGIC_ADDRESS_INDICATING_ETH} from '../src/transactions';
 
@@ -12,12 +10,10 @@ import {
   LforG,
   G,
   J,
-  Alice,
-  Ingrid,
-  Bob,
+  assertETHSanityChecks,
 } from './fixtures';
 import {gasRequiredTo} from './gas';
-import {nitroAdjudicator, provider, token} from './vanillaSetup';
+import {nitroAdjudicator, token} from './vanillaSetup';
 
 /**
  * Ensures the supplied asset holder always has a nonzero token balance.
@@ -282,48 +278,3 @@ describe('Consumes the expected gas for sad-path exits', () => {
     await assertETHSanityChecks({Alice: 5, Bob: 5, Ingrid: 0}, {LforG: 0, G: 0, J: 0, X: 0});
   });
 });
-
-interface ETHBalances {
-  Alice: number;
-  Bob: number;
-  Ingrid: number;
-}
-
-interface ETHHoldings {
-  LforG: number;
-  G: number;
-  J: number;
-  X: number;
-}
-
-async function assertETHSanityChecks(
-  ethBalances: Partial<ETHBalances>,
-  ethHoldings: Partial<ETHHoldings>
-) {
-  const internalDestinations: {[Property in keyof ETHHoldings]: string} = {
-    // todo type this
-    LforG: LforG.channelId,
-    G: G.channelId,
-    J: J.channelId,
-    X: X.channelId,
-  };
-  const externalDestinations: {[Property in keyof ETHBalances]: string} = {
-    Alice: Alice.address,
-    Bob: Bob.address,
-    Ingrid: Ingrid.address,
-  };
-  await Promise.all([
-    ...Object.keys(ethHoldings).map(async key => {
-      expect(
-        (
-          await nitroAdjudicator.holdings(constants.AddressZero, internalDestinations[key])
-        ).toNumber()
-      ).toEqual(ethHoldings[key]);
-    }),
-    ...Object.keys(ethBalances).map(async key => {
-      expect((await provider.getBalance(externalDestinations[key])).toNumber()).toEqual(
-        ethBalances[key]
-      );
-    }),
-  ]);
-}

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -11,6 +11,8 @@ import {
   G,
   J,
   assertETHSanityChecks,
+  amountForAlice,
+  amountForBob,
 } from './fixtures';
 import {gasRequiredTo} from './gas';
 import {nitroAdjudicator, token} from './vanillaSetup';
@@ -235,7 +237,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
     ]);
     // end wait
     // challenge L,G,J,X + timeout ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
-    await assertETHSanityChecks({Alice: 0, Bob: 0, Ingrid: 0}, {LforG: 10, G: 0, J: 0, X: 0});
+    await assertETHSanityChecks(
+      {Alice: 0, Bob: 0, Ingrid: 0},
+      {LforG: amountForAlice + amountForBob, G: 0, J: 0, X: 0}
+    );
     await expect(
       await nitroAdjudicator.transferAllAssets(
         LforG.channelId,
@@ -244,7 +249,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.transferAllAssetsL);
     // transferAllAssetsL  ⬛ --------> (G) -> (J) -> (X) -> 👩
-    await assertETHSanityChecks({Alice: 0, Bob: 0, Ingrid: 0}, {LforG: 0, G: 10, J: 0, X: 0});
+    await assertETHSanityChecks(
+      {Alice: 0, Bob: 0, Ingrid: 0},
+      {LforG: 0, G: amountForAlice + amountForBob, J: 0, X: 0}
+    );
     await expect(
       await nitroAdjudicator.claim(
         0,
@@ -256,7 +264,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
         [] // meaning "all"
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.claimG);
-    await assertETHSanityChecks({Alice: 0, Bob: 0, Ingrid: 0}, {LforG: 0, G: 0, J: 0, X: 10});
+    await assertETHSanityChecks(
+      {Alice: 0, Bob: 0, Ingrid: 0},
+      {LforG: 0, G: 0, J: 0, X: amountForAlice + amountForBob}
+    );
     // claimG                      ⬛ ----------------------> (X) -> 👩
     await expect(
       await nitroAdjudicator.transferAllAssets(
@@ -275,6 +286,9 @@ describe('Consumes the expected gas for sad-path exits', () => {
       ) - gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.total
     ).toEqual(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.total);
 
-    await assertETHSanityChecks({Alice: 5, Bob: 5, Ingrid: 0}, {LforG: 0, G: 0, J: 0, X: 0});
+    await assertETHSanityChecks(
+      {Alice: amountForAlice, Bob: amountForBob, Ingrid: 0},
+      {LforG: 0, G: 0, J: 0, X: 0}
+    );
   });
 });

--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -13,6 +13,7 @@ import {
   assertETHSanityChecks,
   amountForAlice,
   amountForBob,
+  amountForAliceAndBob,
 } from './fixtures';
 import {gasRequiredTo} from './gas';
 import {nitroAdjudicator, token} from './vanillaSetup';
@@ -239,7 +240,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
     // challenge L,G,J,X + timeout ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
     await assertETHSanityChecks(
       {Alice: 0, Bob: 0, Ingrid: 0},
-      {LforG: amountForAlice + amountForBob, G: 0, J: 0, X: 0}
+      {LforG: amountForAliceAndBob, G: 0, J: 0, X: 0}
     );
     await expect(
       await nitroAdjudicator.transferAllAssets(
@@ -251,7 +252,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
     // transferAllAssetsL  ⬛ --------> (G) -> (J) -> (X) -> 👩
     await assertETHSanityChecks(
       {Alice: 0, Bob: 0, Ingrid: 0},
-      {LforG: 0, G: amountForAlice + amountForBob, J: 0, X: 0}
+      {LforG: 0, G: amountForAliceAndBob, J: 0, X: 0}
     );
     await expect(
       await nitroAdjudicator.claim(
@@ -266,7 +267,7 @@ describe('Consumes the expected gas for sad-path exits', () => {
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.claimG);
     await assertETHSanityChecks(
       {Alice: 0, Bob: 0, Ingrid: 0},
-      {LforG: 0, G: 0, J: 0, X: amountForAlice + amountForBob}
+      {LforG: 0, G: 0, J: 0, X: amountForAliceAndBob}
     );
     // claimG                      ⬛ ----------------------> (X) -> 👩
     await expect(

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -186,9 +186,9 @@ export const J = new TestChannel(
 export const G = new TestChannel(6, [Alice, Ingrid], {
   targetChannelId: J.channelId,
   destinations: [
+    X.channelId,
     convertAddressToBytes32(Alice.address),
     convertAddressToBytes32(Ingrid.address),
-    X.channelId,
   ],
 });
 export const LforG = new TestChannel(7, [Alice, Bob], [{destination: G.channelId, amount: '0xa'}]);

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -1,6 +1,6 @@
 import {Signature} from '@ethersproject/bytes';
 import {Wallet} from '@ethersproject/wallet';
-import {constants, ContractReceipt, ethers} from 'ethers';
+import {BigNumber, constants, ContractReceipt, ethers} from 'ethers';
 
 import {
   Allocation,
@@ -32,6 +32,9 @@ export const Ingrid = new Wallet(
   '0x558789345da13a7ac1d6d6ac9275ba66836eb4a088efc1920db0f5d092d6ee71'
 );
 export const participants = [Alice.address, Bob.address];
+
+export const amountForAlice = 6;
+export const amountForBob = 4;
 class TestChannel {
   constructor(
     channelNonce: number,
@@ -154,8 +157,14 @@ export const X = new TestChannel(
   2,
   [Alice, Bob],
   [
-    {destination: convertAddressToBytes32(Alice.address), amount: '0x5'},
-    {destination: convertAddressToBytes32(Bob.address), amount: '0x5'},
+    {
+      destination: convertAddressToBytes32(Alice.address),
+      amount: BigNumber.from(amountForAlice).toHexString(),
+    },
+    {
+      destination: convertAddressToBytes32(Bob.address),
+      amount: BigNumber.from(amountForBob).toHexString(),
+    },
   ]
 );
 
@@ -164,21 +173,34 @@ export const Y = new TestChannel(
   3,
   [Alice, Bob],
   [
-    {destination: convertAddressToBytes32(Alice.address), amount: '0x5'},
-    {destination: convertAddressToBytes32(Bob.address), amount: '0x5'},
+    {
+      destination: convertAddressToBytes32(Alice.address),
+      amount: BigNumber.from(amountForAlice).toHexString(),
+    },
+    {
+      destination: convertAddressToBytes32(Bob.address),
+      amount: BigNumber.from(amountForBob).toHexString(),
+    },
   ]
 );
 
 /** Ledger channel between Alice and Bob, providing funds to channel X */
-export const LforX = new TestChannel(4, [Alice, Bob], [{destination: X.channelId, amount: '0xa'}]);
+export const LforX = new TestChannel(
+  4,
+  [Alice, Bob],
+  [{destination: X.channelId, amount: BigNumber.from(amountForAlice + amountForBob).toHexString()}]
+);
 
 /** Joint channel between Alice, Bob, and Ingrid, funding application channel X */
 export const J = new TestChannel(
   5,
   [Alice, Bob, Ingrid],
   [
-    {destination: X.channelId, amount: '0xa'},
-    {destination: convertAddressToBytes32(Ingrid.address), amount: '0xa'},
+    {destination: X.channelId, amount: BigNumber.from(amountForAlice + amountForBob).toHexString()},
+    {
+      destination: convertAddressToBytes32(Ingrid.address),
+      amount: BigNumber.from(amountForAlice + amountForBob).toHexString(),
+    },
   ]
 );
 
@@ -191,7 +213,11 @@ export const G = new TestChannel(6, [Alice, Ingrid], {
     convertAddressToBytes32(Ingrid.address),
   ],
 });
-export const LforG = new TestChannel(7, [Alice, Bob], [{destination: G.channelId, amount: '0xa'}]);
+export const LforG = new TestChannel(
+  7,
+  [Alice, Bob],
+  [{destination: G.channelId, amount: BigNumber.from(amountForAlice + amountForBob).toHexString()}]
+);
 
 // Utils
 export async function getFinalizesAtFromTransactionHash(hash: string): Promise<number> {

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -263,16 +263,16 @@ export async function assertETHSanityChecks(
     Ingrid: Ingrid.address,
   };
   await Promise.all([
-    ...Object.keys(ethHoldings).map(async key => {
+    ...Object.keys(ethHoldings).map(async channelId => {
       expect(
         (
-          await nitroAdjudicator.holdings(constants.AddressZero, internalDestinations[key])
+          await nitroAdjudicator.holdings(constants.AddressZero, internalDestinations[channelId])
         ).toNumber()
-      ).toEqual(ethHoldings[key]);
+      ).toEqual(ethHoldings[channelId]);
     }),
-    ...Object.keys(ethBalances).map(async key => {
-      expect((await provider.getBalance(externalDestinations[key])).toNumber()).toEqual(
-        ethBalances[key]
+    ...Object.keys(ethBalances).map(async address => {
+      expect((await provider.getBalance(externalDestinations[address])).toNumber()).toEqual(
+        ethBalances[address]
       );
     }),
   ]);

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -103,13 +103,13 @@ export const gasRequiredTo: GasRequiredTo = {
       // claimG                      ⬛ ----------------------> (X) -> 👩
       // transferAllAssetsX          ⬛ -----------------------------> 👩
       challengeL: 91691,
-      challengeG: 93950,
+      challengeG: 93974,
       challengeJ: 101068,
       challengeX: 92757,
       transferAllAssetsL: 65462,
-      claimG: 94758,
-      transferAllAssetsX: 44478,
-      total: 584164,
+      claimG: 81783,
+      transferAllAssetsX: 114930,
+      total: 641665,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 3963428, // Singleton
+      NitroAdjudicator: 3952404, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -107,9 +107,9 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeJ: 101068,
       challengeX: 92757,
       transferAllAssetsL: 65462,
-      claimG: 81783,
+      claimG: 81712,
       transferAllAssetsX: 114930,
-      total: 641665,
+      total: 641594,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -107,9 +107,9 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeJ: 101068,
       challengeX: 92757,
       transferAllAssetsL: 65462,
-      claimG: 82369,
-      transferAllAssetsX: 114930,
-      total: 642227,
+      claimG: 94758,
+      transferAllAssetsX: 44478,
+      total: 584164,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -75,9 +75,9 @@ export const gasRequiredTo: GasRequiredTo = {
     // challenge + timeout       ⬛ -> (X) -> 👩
     // transferAllAssets         ⬛ --------> 👩
     vanillaNitro: {
-      challenge: 92757,
+      challenge: 92745,
       transferAllAssets: 114930,
-      total: 207687,
+      total: 207675,
     },
   },
   ETHexitSadLedgerFunded: {
@@ -87,11 +87,11 @@ export const gasRequiredTo: GasRequiredTo = {
       // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
       // transferAllAssetsL          ⬛ --------> (X) -> 👩
       // transferAllAssetsX          ⬛ ---------------> 👩
-      challengeX: 92757,
+      challengeX: 92745,
       challengeL: 91691,
       transferAllAssetsL: 65462,
       transferAllAssetsX: 114930,
-      total: 364840,
+      total: 364828,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -105,11 +105,11 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeL: 91691,
       challengeG: 93974,
       challengeJ: 101068,
-      challengeX: 92757,
+      challengeX: 92745,
       transferAllAssetsL: 65462,
       claimG: 81712,
       transferAllAssetsX: 114930,
-      total: 641594,
+      total: 641582,
     },
   },
 };

--- a/packages/nitro-protocol/src/contract/multi-asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/multi-asset-holder.ts
@@ -65,9 +65,7 @@ export function computeNewAllocationWithGuarantee(
   payouts: string[];
   totalPayouts: string;
 } {
-  const payouts: string[] = Array(indices.length > 0 ? indices.length : allocation.length).fill(
-    BigNumber.from(0).toHexString()
-  );
+  const payouts: string[] = Array(allocation.length).fill(BigNumber.from(0).toHexString());
   let totalPayouts = BigNumber.from(0);
   let allocatesOnlyZeros = true;
   let surplus = BigNumber.from(initialHoldings);
@@ -102,7 +100,7 @@ export function computeNewAllocationWithGuarantee(
             .sub(affordsForDestination)
             .toHexString();
           // increase the relevant payout
-          payouts[k] = affordsForDestination.toHexString();
+          payouts[i] = affordsForDestination.toHexString();
           totalPayouts = totalPayouts.add(affordsForDestination);
           ++k;
         }

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -41,26 +41,28 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter        | payouts         | reason
-    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
-    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
-    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
-    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
-    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
-    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
-    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{A: 5, B: 5}} | ${undefined}
-    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
-    ${'18. absent guarantee entry, indices=[]'}               | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
-    ${'19. absent guarantee entry, indices=[1]'}              | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
+    name                                                              | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter        | payouts         | reason
+    ${' 1. straight-through guarantee, 3 destinations'}               | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${' 2. swap guarantee,             2 destinations'}               | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${' 3. swap guarantee,             3 destinations'}               | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${' 4. straight-through guarantee, 2 destinations'}               | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${' 5. allocation not on chain'}                                  | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${' 6. guarantee not on chain'}                                   | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${' 7. swap guarantee, overfunded, 2 destinations'}               | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${' 8. underspecified guarantee, overfunded      '}               | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${' 9. (all) straight-through guarantee, 3 destinations'}         | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${'10. (all) swap guarantee,             2 destinations'}         | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${'11. (all) swap guarantee,             3 destinations'}         | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${'12. (all) straight-through guarantee, 2 destinations'}         | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${'13. (all) allocation not on chain'}                            | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${'14. (all) guarantee not on chain'}                             | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${'15. (all) swap guarantee, overfunded, 2 destinations'}         | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. (all) underspecified guarantee, overfunded      '}         | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${'17. guarantee and target assets do not match'}                 | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
+    ${'18. absent guarantee entry, indices=[], bad guarantee order'}  | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
+    ${'19. absent guarantee entry, indices=[1], bad guarantee order'} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
+    ${'20. absent guarantee entry, indices=[]'}                       | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
+    ${'21. absent guarantee entry, indices=[1]'}                      | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[0]}  | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
   `(
     '$name',
     async ({

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -23,6 +23,7 @@ const addresses = {
   // Channels
   t: undefined, // Target
   g: undefined, // Guarantor
+  x: undefined, // Application channel
   // Externals
   I: randomExternalDestination(),
   A: randomExternalDestination(),
@@ -40,24 +41,26 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
-    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
+    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter        | payouts         | reason
+    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
+    ${'18. absent guarantee entry, indices=[]'}               | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
+    ${'19. absent guarantee entry, indices=[1]'}              | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
   `(
     '$name',
     async ({
@@ -82,8 +85,10 @@ describe('claim', () => {
       // Compute channelIds
       const targetId = randomChannelId();
       const guarantorId = randomChannelId();
+      const applicationChannelId = randomChannelId();
       addresses.t = targetId;
       addresses.g = guarantorId;
+      addresses.x = applicationChannelId;
 
       // Transform input data (unpack addresses and BigNumber amounts)
       [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [


### PR DESCRIPTION
The `claim` function uses an array called `payouts` (internally) to build up payouts for each of the destinations in the target channel at the supplied `indices`. We are not currently updating this array correctly in general: particularly in the case where the `guarantee` has an entry that is absent from the target outcome. Essentially, a different party gets the funds that should go to their rightful owner.

The change here decouples indexing of `payouts` from indexing of `indices`. `payouts` will always contain an entry for every allocation in the target, but many of them may be zero. 

### Changes
I discovered this bug through our gas benchmarking suite, but only in a very roundabout way, by running it against the exit format branch which has a non-buggy claim implementation and looking carefully at the gas consumption. On the base branch here, the guarantee in the benchmark is incorrectly ordered, but the bug in `claim` meant that Alice still recovered her funds. So the two problems cancelled each other out, making the problems hard to spot.



This is a good approach because it increases our test "depth" and "breadth" and fixes a critical security bug.

The new test infra will be useful for future refactor of `claim` (including the aforementioned exit format version). 

## How Has This Been Tested? 

 I have added some sanity check assertions into the gas benchmarking suite that would have caught this. I have also added some appropriate test cases to our unit testing suite.

## :warning: Does this require multiple approvals? [Optional]
Please explain which reason, if any, why this requires more than one approval.
- [x] Is it security related?
- [ ] Is it a significant process change?
- [ ] Is it a significant change to architectural, design?

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
