### PR TITLE
refactor: remove unnecessary index k

### DIFF
--- a/packages/nitro-protocol/contracts/MultiAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/MultiAssetHolder.sol
@@ -402,7 +402,6 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
         totalPayouts = 0;
         allocatesOnlyZeros = true; // switched to false if there is an item remaining with amount > 0
         uint256 surplus = initialHoldings; // tracks funds available during calculation
-        uint256 k = 0; // indexes the `indices` array
         //  We rely on the assumption that the indices are strictly increasing.
         //  This allows us to iterate over the destinations in order once, continuing until we hit the first index, then the second etc.
         //  If the indices were to decrease, we would have to start from the beginning: doing a full search for each index.
@@ -425,16 +424,13 @@ contract MultiAssetHolder is IMultiAssetHolder, StatusManager {
                     uint256 affordsForDestination = min(allocation[i].amount, surplus);
                     // decrease surplus by the current amount regardless of hitting a specified index
                     surplus -= affordsForDestination;
-                    if ((indices.length == 0) || ((k < indices.length) && (indices[k] == i))) {
-                        // only if specified in supplied indices, or we if we are doing "all"
-                        // reduce the new allocationItem.amount
-                        newAllocation[i].amount -= affordsForDestination;
-                        // increase the relevant payout
-                        payouts[i] += affordsForDestination;
-                        totalPayouts += affordsForDestination;
-                        // move on to the next supplied index
-                        ++k;
-                    }
+                    // only if specified in supplied indices, or we if we are doing "all"
+                    // reduce the new allocationItem.amount
+                    newAllocation[i].amount -= affordsForDestination;
+                    // increase the relevant payout
+                    payouts[i] += affordsForDestination;
+                    totalPayouts += affordsForDestination;
+
                     break; // start again with the next guarantee destination
                 }
             }

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 3952404, // Singleton
+      NitroAdjudicator: 3935135, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -107,9 +107,9 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeJ: 101068,
       challengeX: 92745,
       transferAllAssetsL: 65462,
-      claimG: 81712,
+      claimG: 81645,
       transferAllAssetsX: 114930,
-      total: 641582,
+      total: 641515,
     },
   },
 };


### PR DESCRIPTION
note that previously, the expression
`(indices.length == 0) || ((k < indices.length) && (indices[k] == i))`
would always evaluate to `true`. This meant that `i == k` was always true.

This refactor removes the unnecessary index k.