### PR TITLE
refactor: remove payouts from _computeNewAllocationWithGuarantee

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 3952404, // Singleton
+      NitroAdjudicator: 3926103, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -107,9 +107,9 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeJ: 101068,
       challengeX: 92745,
       transferAllAssetsL: 65462,
-      claimG: 81712,
+      claimG: 81235,
       transferAllAssetsX: 114930,
-      total: 641582,
+      total: 641105,
     },
   },
 };


### PR DESCRIPTION
note that previously, information was duplicated, since
newAllocation[i].amount + payouts[i] == allocation[i].amount
always held true