### PR TITLE
add an assertEthBalancesAndHoldings fn

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
+++ b/packages/nitro-protocol/gas-benchmarks/benchmark.test.ts
@@ -10,6 +10,10 @@ import {
   LforG,
   G,
   J,
+  assertEthBalancesAndHoldings,
+  amountForAlice,
+  amountForBob,
+  amountForAliceAndBob,
 } from './fixtures';
 import {gasRequiredTo} from './gas';
 import {nitroAdjudicator, token} from './vanillaSetup';
@@ -234,6 +238,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
     ]);
     // end wait
     // challenge L,G,J,X + timeout ⬛ -> (L) -> (G) -> (J) -> (X) -> 👩
+    await assertEthBalancesAndHoldings(
+      {Alice: 0, Bob: 0, Ingrid: 0},
+      {LforG: amountForAliceAndBob, G: 0, J: 0, X: 0}
+    );
     await expect(
       await nitroAdjudicator.transferAllAssets(
         LforG.channelId,
@@ -242,6 +250,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.transferAllAssetsL);
     // transferAllAssetsL  ⬛ --------> (G) -> (J) -> (X) -> 👩
+    await assertEthBalancesAndHoldings(
+      {Alice: 0, Bob: 0, Ingrid: 0},
+      {LforG: 0, G: amountForAliceAndBob, J: 0, X: 0}
+    );
     await expect(
       await nitroAdjudicator.claim(
         0,
@@ -253,6 +265,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
         [] // meaning "all"
       )
     ).toConsumeGas(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.claimG);
+    await assertEthBalancesAndHoldings(
+      {Alice: 0, Bob: 0, Ingrid: 0},
+      {LforG: 0, G: 0, J: 0, X: amountForAliceAndBob}
+    );
     // claimG                      ⬛ ----------------------> (X) -> 👩
     await expect(
       await nitroAdjudicator.transferAllAssets(
@@ -270,5 +286,10 @@ describe('Consumes the expected gas for sad-path exits', () => {
         (a, b) => a + b
       ) - gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.total
     ).toEqual(gasRequiredTo.ETHexitSadVirtualFunded.vanillaNitro.total);
+
+    await assertEthBalancesAndHoldings(
+      {Alice: amountForAlice, Bob: amountForBob, Ingrid: 0},
+      {LforG: 0, G: 0, J: 0, X: 0}
+    );
   });
 });

--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -1,6 +1,6 @@
 import {Signature} from '@ethersproject/bytes';
 import {Wallet} from '@ethersproject/wallet';
-import {ContractReceipt, ethers} from 'ethers';
+import {BigNumber, BigNumberish, constants, ContractReceipt, ethers} from 'ethers';
 
 import {
   Allocation,
@@ -32,6 +32,11 @@ export const Ingrid = new Wallet(
   '0x558789345da13a7ac1d6d6ac9275ba66836eb4a088efc1920db0f5d092d6ee71'
 );
 export const participants = [Alice.address, Bob.address];
+
+export const amountForAlice = BigNumber.from(5).toHexString();
+export const amountForBob = BigNumber.from(5).toHexString();
+export const amountForAliceAndBob = BigNumber.from(amountForAlice).add(amountForBob).toHexString();
+
 class TestChannel {
   constructor(
     channelNonce: number,
@@ -154,8 +159,8 @@ export const X = new TestChannel(
   2,
   [Alice, Bob],
   [
-    {destination: convertAddressToBytes32(Alice.address), amount: '0x5'},
-    {destination: convertAddressToBytes32(Bob.address), amount: '0x5'},
+    {destination: convertAddressToBytes32(Alice.address), amount: amountForAlice},
+    {destination: convertAddressToBytes32(Bob.address), amount: amountForBob},
   ]
 );
 
@@ -164,21 +169,25 @@ export const Y = new TestChannel(
   3,
   [Alice, Bob],
   [
-    {destination: convertAddressToBytes32(Alice.address), amount: '0x5'},
-    {destination: convertAddressToBytes32(Bob.address), amount: '0x5'},
+    {destination: convertAddressToBytes32(Alice.address), amount: amountForAlice},
+    {destination: convertAddressToBytes32(Bob.address), amount: amountForBob},
   ]
 );
 
 /** Ledger channel between Alice and Bob, providing funds to channel X */
-export const LforX = new TestChannel(4, [Alice, Bob], [{destination: X.channelId, amount: '0xa'}]);
+export const LforX = new TestChannel(
+  4,
+  [Alice, Bob],
+  [{destination: X.channelId, amount: amountForAliceAndBob}]
+);
 
 /** Joint channel between Alice, Bob, and Ingrid, funding application channel X */
 export const J = new TestChannel(
   5,
   [Alice, Bob, Ingrid],
   [
-    {destination: X.channelId, amount: '0xa'},
-    {destination: convertAddressToBytes32(Ingrid.address), amount: '0xa'},
+    {destination: X.channelId, amount: amountForAliceAndBob},
+    {destination: convertAddressToBytes32(Ingrid.address), amount: amountForAliceAndBob},
   ]
 );
 
@@ -191,7 +200,11 @@ export const G = new TestChannel(6, [Alice, Ingrid], {
     X.channelId,
   ],
 });
-export const LforG = new TestChannel(7, [Alice, Bob], [{destination: G.channelId, amount: '0xa'}]);
+export const LforG = new TestChannel(
+  7,
+  [Alice, Bob],
+  [{destination: G.channelId, amount: amountForAliceAndBob}]
+);
 
 // Utils
 export async function getFinalizesAtFromTransactionHash(hash: string): Promise<number> {
@@ -229,4 +242,51 @@ export async function challengeChannelAndExpectGas(
 
   const finalizesAt = await getFinalizesAtFromTransactionHash(challengeTx.hash);
   return {proof, finalizesAt};
+}
+
+interface ETHBalances {
+  Alice: BigNumberish;
+  Bob: BigNumberish;
+  Ingrid: BigNumberish;
+}
+
+interface ETHHoldings {
+  LforG: BigNumberish;
+  G: BigNumberish;
+  J: BigNumberish;
+  X: BigNumberish;
+}
+
+/**
+ * Asserts the ETH balance of the supplied ethereum account addresses and the ETH holdings in the statechannels asset holding contract for the supplied channelIds.
+ */
+export async function assertEthBalancesAndHoldings(
+  ethBalances: Partial<ETHBalances>,
+  ethHoldings: Partial<ETHHoldings>
+): Promise<void> {
+  const internalDestinations: {[Property in keyof ETHHoldings]: string} = {
+    LforG: LforG.channelId,
+    G: G.channelId,
+    J: J.channelId,
+    X: X.channelId,
+  };
+  const externalDestinations: {[Property in keyof ETHBalances]: string} = {
+    Alice: Alice.address,
+    Bob: Bob.address,
+    Ingrid: Ingrid.address,
+  };
+  await Promise.all([
+    ...Object.keys(ethHoldings).map(async key => {
+      expect(
+        (await nitroAdjudicator.holdings(constants.AddressZero, internalDestinations[key])).eq(
+          BigNumber.from(ethHoldings[key])
+        )
+      ).toBe(true);
+    }),
+    ...Object.keys(ethBalances).map(async key => {
+      expect(
+        (await provider.getBalance(externalDestinations[key])).eq(BigNumber.from(ethBalances[key]))
+      ).toBe(true);
+    }),
+  ]);
 }


### PR DESCRIPTION
 to gas benchmarks.

 Buy calling this function at judicious moments during the benchmarking script,
 we can be sure the script achieves the defined goal of moving money through a network of channels to Alice

