### PR TITLE
fix claim.test.ts and remove payouts from computeNewAllocationWithGuarantee in order to fix critical bug

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,7 +28,7 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 3963428, // Singleton
+      NitroAdjudicator: 3942872, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
@@ -107,9 +107,9 @@ export const gasRequiredTo: GasRequiredTo = {
       challengeJ: 101068,
       challengeX: 92757,
       transferAllAssetsL: 65462,
-      claimG: 82369,
-      transferAllAssetsX: 114930,
-      total: 642227,
+      claimG: 94510,
+      transferAllAssetsX: 44478,
+      total: 583916,
     },
   },
 };

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -40,36 +40,55 @@ const addresses = {
 const reason5 = 'Channel not finalized';
 const reason6 = 'targetAsset != guaranteeAsset';
 
-// 1. claim G1 (step 1 of figure 23 of nitro paper)
-// 2. claim G2 (step 2 of figure 23 of nitro paper)
-// 3. claim G1 (step 1 of alternative in figure 23 of nitro paper)
-// 4. claim G2 (step 2 of alternative of figure 23 of nitro paper)
+const names = {
+  1: ' 1. straight-through guarantee, 3 destinations', // 1. claim G1 (step 1 of figure 23 of nitro paper)
+  2: ' 2. swap guarantee,             2 destinations', // 2. claim G2 (step 2 of figure 23 of nitro paper)
+  3: ' 3. swap guarantee,             3 destinations', // 3. claim G1 (step 1 of alternative in figure 23 of nitro paper)
+  4: ' 4. straight-through guarantee, 2 destinations', // 4. claim G2 (step 2 of alternative of figure 23 of nitro paper)
+  5: ' 5. allocation not on chain',
+  6: ' 6. guarantee not on chain',
+  7: ' 7. swap guarantee, overfunded, 2 destinations',
+  8: ' 8. underspecified guarantee, overfunded      ',
+  9: ' 9. (all) straight-through guarantee, 3 destinations',
+  10: '10. (all) swap guarantee,             2 destinations',
+  11: '11. (all) swap guarantee,             3 destinations',
+  12: '12. (all) straight-through guarantee, 2 destinations',
+  13: '13. (all) allocation not on chain',
+  14: '14. (all) guarantee not on chain',
+  15: '15. (all) swap guarantee, overfunded, 2 destinations',
+  16: '16. (all) underspecified guarantee, overfunded      ',
+  17: '17. guarantee and target assets do not match',
+  18: '18. guarantee includes destination missing in target outcome, indices=[], lowest priority is a channel',
+  19: '19. guarantee includes destination missing in target outcome, indices=[1], lowest priority is a channel',
+  20: '20. guarantee includes destination missing in target outcome, indices=[], lowest priority is an external destination', // this guarantee is typical of the virtual funding construction
+  21: '21. guarantee includes destination missing in target outcome, indices=[1], lowest priority is an external destination', // this guarantee is typical of the virtual funding construction
+};
 
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                              | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter        | payouts         | reason
-    ${' 1. straight-through guarantee, 3 destinations'}               | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${' 2. swap guarantee,             2 destinations'}               | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
-    ${' 3. swap guarantee,             3 destinations'}               | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${' 4. straight-through guarantee, 2 destinations'}               | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
-    ${' 5. allocation not on chain'}                                  | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${' 6. guarantee not on chain'}                                   | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${' 7. swap guarantee, overfunded, 2 destinations'}               | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
-    ${' 8. underspecified guarantee, overfunded      '}               | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
-    ${' 9. (all) straight-through guarantee, 3 destinations'}         | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${'10. (all) swap guarantee,             2 destinations'}         | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
-    ${'11. (all) swap guarantee,             3 destinations'}         | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
-    ${'12. (all) straight-through guarantee, 2 destinations'}         | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
-    ${'13. (all) allocation not on chain'}                            | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${'14. (all) guarantee not on chain'}                             | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
-    ${'15. (all) swap guarantee, overfunded, 2 destinations'}         | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '}         | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
-    ${'17. guarantee and target assets do not match'}                 | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
-    ${'18. absent guarantee entry, indices=[], bad guarantee order'}  | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
-    ${'19. absent guarantee entry, indices=[1], bad guarantee order'} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
-    ${'20. absent guarantee entry, indices=[]'}                       | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
-    ${'21. absent guarantee entry, indices=[1]'}                      | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[0]}  | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
+    name         | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter        | payouts         | reason
+    ${names[1]}  | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${names[2]}  | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${names[3]}  | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${names[4]}  | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${names[5]}  | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${names[6]}  | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${names[7]}  | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${names[8]}  | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${names[9]}  | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${names[10]} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${names[11]} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${names[12]} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${names[13]} | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${names[14]} | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${names[15]} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${names[16]} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${names[17]} | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
+    ${names[18]} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
+    ${names[19]} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
+    ${names[20]} | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
+    ${names[21]} | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[0]}  | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
   `(
     '$name',
     async ({

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -23,6 +23,7 @@ const addresses = {
   // Channels
   t: undefined, // Target
   g: undefined, // Guarantor
+  x: undefined, // Application
   // Externals
   I: randomExternalDestination(),
   A: randomExternalDestination(),
@@ -40,24 +41,28 @@ const reason6 = 'targetAsset != guaranteeAsset';
 // Amounts are valueString representations of wei
 describe('claim', () => {
   it.each`
-    name                                                      | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter | payouts         | reason
-    ${' 1. straight-through guarantee, 3 destinations'}       | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 2. swap guarantee,             2 destinations'}       | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${' 3. swap guarantee,             3 destinations'}       | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${' 4. straight-through guarantee, 2 destinations'}       | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${' 5. allocation not on chain'}                          | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 6. guarantee not on chain'}                           | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${' 7. swap guarantee, overfunded, 2 destinations'}       | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 8. underspecified guarantee, overfunded      '}       | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{B: 5}}       | ${undefined}
-    ${' 9. (all) straight-through guarantee, 3 destinations'} | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'10. (all) swap guarantee,             2 destinations'} | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}} | ${{B: 5}}       | ${undefined}
-    ${'11. (all) swap guarantee,             3 destinations'} | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}} | ${{I: 5}}       | ${undefined}
-    ${'12. (all) straight-through guarantee, 2 destinations'} | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}} | ${{A: 5}}       | ${undefined}
-    ${'13. (all) allocation not on chain'}                    | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'14. (all) guarantee not on chain'}                     | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}} | ${{B: 5}}       | ${reason5}
-    ${'15. (all) swap guarantee, overfunded, 2 destinations'} | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '} | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}} | ${{A: 5, B: 5}} | ${undefined}
-    ${'17. guarantee and target assets do not match'}         | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}} | ${{A: 1}}       | ${reason6}
+    name                                                              | heldBefore | guaranteeDestinations | tOutcomeBefore        | indices | tOutcomeAfter         | heldAfter        | payouts         | reason
+    ${' 1. straight-through guarantee, 3 destinations'}               | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${' 2. swap guarantee,             2 destinations'}               | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${' 3. swap guarantee,             3 destinations'}               | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[0]}  | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${' 4. straight-through guarantee, 2 destinations'}               | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[0]}  | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${' 5. allocation not on chain'}                                  | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[0]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${' 6. guarantee not on chain'}                                   | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5}}             | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${' 7. swap guarantee, overfunded, 2 destinations'}               | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${' 8. underspecified guarantee, overfunded      '}               | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
+    ${' 9. (all) straight-through guarantee, 3 destinations'}         | ${{g: 5}}  | ${['I', 'A', 'B']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${'10. (all) swap guarantee,             2 destinations'}         | ${{g: 5}}  | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 0}}        | ${{B: 5}}       | ${undefined}
+    ${'11. (all) swap guarantee,             3 destinations'}         | ${{g: 5}}  | ${['I', 'B', 'A']}    | ${{I: 5, A: 5, B: 5}} | ${[]}   | ${{I: 0, A: 5, B: 5}} | ${{g: 0}}        | ${{I: 5}}       | ${undefined}
+    ${'12. (all) straight-through guarantee, 2 destinations'}         | ${{g: 5}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 5}}       | ${{g: 0}}        | ${{A: 5}}       | ${undefined}
+    ${'13. (all) allocation not on chain'}                            | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${'14. (all) guarantee not on chain'}                             | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
+    ${'15. (all) swap guarantee, overfunded, 2 destinations'}         | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. (all) underspecified guarantee, overfunded      '}         | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${'17. guarantee and target assets do not match'}                 | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
+    ${'18. absent guarantee entry, indices=[], bad guarantee order'}  | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
+    ${'19. absent guarantee entry, indices=[1], bad guarantee order'} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
+    ${'20. absent guarantee entry, indices=[]'}                       | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
+    ${'21. absent guarantee entry, indices=[1]'}                      | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[0]}  | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
   `(
     '$name',
     async ({
@@ -82,8 +87,10 @@ describe('claim', () => {
       // Compute channelIds
       const targetId = randomChannelId();
       const guarantorId = randomChannelId();
+      const applicationChannelId = randomChannelId();
       addresses.t = targetId;
       addresses.g = guarantorId;
+      addresses.x = applicationChannelId;
 
       // Transform input data (unpack addresses and BigNumber amounts)
       [heldBefore, tOutcomeBefore, tOutcomeAfter, heldAfter, payouts] = [

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -64,7 +64,7 @@ describe('claim', () => {
     ${'13. (all) allocation not on chain'}                            | ${{g: 5}}  | ${['B', 'A']}         | ${{}}                 | ${[]}   | ${{}}                 | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
     ${'14. (all) guarantee not on chain'}                             | ${{g: 5}}  | ${[]}                 | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 5}}       | ${{g: 0}}        | ${{B: 5}}       | ${reason5}
     ${'15. (all) swap guarantee, overfunded, 2 destinations'}         | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
-    ${'16. (all) underspecified guarantee, overfunded      '}         | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{A: 5, B: 5}} | ${undefined}
+    ${'16. (all) underspecified guarantee, overfunded      '}         | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{B: 5}}       | ${undefined}
     ${'17. guarantee and target assets do not match'}                 | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
     ${'18. absent guarantee entry, indices=[], bad guarantee order'}  | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
     ${'19. absent guarantee entry, indices=[1], bad guarantee order'} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -59,8 +59,8 @@ describe('claim', () => {
     ${'15. (all) swap guarantee, overfunded, 2 destinations'}         | ${{g: 12}} | ${['B', 'A']}         | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 0, B: 0}}       | ${{g: 2}}        | ${{A: 5, B: 5}} | ${undefined}
     ${'16. (all) underspecified guarantee, overfunded      '}         | ${{g: 12}} | ${['B']}              | ${{A: 5, B: 5}}       | ${[]}   | ${{A: 5, B: 0}}       | ${{g: 7}}        | ${{A: 5, B: 5}} | ${undefined}
     ${'17. guarantee and target assets do not match'}                 | ${{g: 1}}  | ${['A', 'B']}         | ${{A: 5, B: 5}}       | ${[1]}  | ${{A: 4, B: 5}}       | ${{g: 0}}        | ${{A: 1}}       | ${reason6}
-    ${'18. absent guarantee entry, indices=[], bad guarantee order'}  | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
-    ${'19. absent guarantee entry, indices=[1], bad guarantee order'} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0}}        | ${{I: 10}}      | ${undefined}
+    ${'18. absent guarantee entry, indices=[], bad guarantee order'}  | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 10, I: 0}}      | ${{g: 0, x: 0}}  | ${{I: 10}}      | ${undefined}
+    ${'19. absent guarantee entry, indices=[1], bad guarantee order'} | ${{g: 10}} | ${['A', 'I', 'x']}    | ${{x: 10, I: 10}}     | ${[1]}  | ${{x: 10, I: 0}}      | ${{g: 0, x: 0}}  | ${{I: 10}}      | ${undefined}
     ${'20. absent guarantee entry, indices=[]'}                       | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[]}   | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
     ${'21. absent guarantee entry, indices=[1]'}                      | ${{g: 10}} | ${['A', 'x', 'I']}    | ${{x: 10, I: 10}}     | ${[0]}  | ${{x: 0, I: 10}}      | ${{g: 0, x: 10}} | ${{}}           | ${undefined}
   `(

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/claim.test.ts
@@ -207,6 +207,7 @@ describe('claim', () => {
           ethBalancesBefore[address] = await provider.getBalance(address);
         })
       );
+
       const tx = testNitroAdjudicator.claim(
         0,
         guarantorId,
@@ -267,11 +268,9 @@ describe('claim', () => {
         await Promise.all(
           Object.keys(payouts).map(async destination => {
             const address = convertBytes32ToAddress(destination);
-            expect(
-              (await provider.getBalance(address)).eq(
-                ethBalancesBefore[address].add(payouts[destination])
-              )
-            ).toBe(true);
+            const balanceAfter = await provider.getBalance(address);
+            const expectedBalanceAfter = ethBalancesBefore[address].add(payouts[destination]);
+            expect(balanceAfter).toEqual(expectedBalanceAfter);
           })
         );
       }

--- a/packages/nitro-protocol/test/contracts/MultiAssetHolder/computeNewAllocationWithGuarantee.test.ts
+++ b/packages/nitro-protocol/test/contracts/MultiAssetHolder/computeNewAllocationWithGuarantee.test.ts
@@ -73,8 +73,5 @@ describe('MultiAssetHolder._computeNewAllocationWithGuarantee', () => {
       locallyComputedNewAllocation.allocatesOnlyZeros
     );
     expect(result.totalPayouts).toEqual(BigNumber.from(locallyComputedNewAllocation.totalPayouts));
-    expect(result.payouts).toMatchObject(
-      locallyComputedNewAllocation.payouts.map(p => BigNumber.from(p))
-    );
   });
 });


### PR DESCRIPTION
The `claim` function uses an array called `payouts` (internally) to build up payouts for each of the destinations in the target channel at the supplied `indices`. We are not currently updating this array correctly in general: particularly in the case where the `guarantee` has an entry that is absent from the target outcome. Essentially, a different party gets the funds that should go to their rightful owner.

Example: We are claiming a guarantee of `[A,I,x]` (funded with `10`) targeting an outcome of `{x:10,I:10}` with `indices=[]` signalling our wish to claim all of the target allocations. `I` should be paid 10 and `x` should not be paid anything. Instead, `x` is paid `10` and `I` is not paid anything. The problem with the current implementation is that inside `_computeNewAllocationWithGuarantee`, `k` remains at its initial value of `0`; so the payout calculated for `I` is stored in the slot for `x`. The outer function then pays the coins to `x`.

The fix I have opted for here is to remove `payouts` entirely. Seeing as it contains redundant information, we can simply recompute the payouts from the changes to `allocations` in the outer function. There is now implicitly a payout for every allocation item (even if some of those are zero).

If we like that pattern, we can use it inside `transfer`, too. 
 

### Changes
Strengthen and extend test coverage to catch this bug. 
Fix the bug. 


## :warning: Does this require multiple approvals? [Optional]
Please explain which reason, if any, why this requires more than one approval.
- [x] Is it security related?
- [ ] Is it a significant process change?
- [ ] Is it a significant change to architectural, design?

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue


Note to reviewer: recommend viewing with whitespace changes hidden: 

<img width="370" alt="Screenshot 2021-08-17 at 16 43 32" src="https://user-images.githubusercontent.com/1833419/129757817-659c9aa9-579c-4eb4-819a-7c90052d1a4b.png">
