### PR TITLE
fix guarantee order in gas benchmark fixtures

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/fixtures.ts
+++ b/packages/nitro-protocol/gas-benchmarks/fixtures.ts
@@ -195,9 +195,9 @@ export const J = new TestChannel(
 export const G = new TestChannel(6, [Alice, Ingrid], {
   targetChannelId: J.channelId,
   destinations: [
+    X.channelId,
     convertAddressToBytes32(Alice.address),
     convertAddressToBytes32(Ingrid.address),
-    X.channelId,
   ],
 });
 export const LforG = new TestChannel(

--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -103,13 +103,13 @@ export const gasRequiredTo: GasRequiredTo = {
       // claimG                      ⬛ ----------------------> (X) -> 👩
       // transferAllAssetsX          ⬛ -----------------------------> 👩
       challengeL: 91691,
-      challengeG: 93950,
+      challengeG: 93974,
       challengeJ: 101068,
       challengeX: 92757,
       transferAllAssetsL: 65462,
-      claimG: 94510,
-      transferAllAssetsX: 44478,
-      total: 583916,
+      claimG: 81523,
+      transferAllAssetsX: 114930,
+      total: 641405,
     },
   },
 };


### PR DESCRIPTION
This is failing on master currently, because we merged 

1.  extra assertions about the movement of money during the benchmark script, which passed CI because the (then) 
    a) buggy claim implementation AND 
    b) the incorrect guarantee order
     interacted (accidentally) to make the money move as intended
2. a fix to the buggy claim implementation

In separate PRs. The second was not rebased or brought up to date with master before being merged. 

This PR fixes 1b to restore balance to the galaxy. 

The "correct" order for a guarantee in the virtual funding protocol must have the intermediary as the lowest priority, because they can recover their funds via a pair of guarantees. Alice and Bob have only the one guarantee to claim on, so must each have a higher priority than Ingrid (including when they are "inside" an application channel X). 




