### PR TITLE
Update wire-format to comply with exit-format

### DIFF
--- a/packages/wire-format/src/__tests__/good_sample_messages.ts
+++ b/packages/wire-format/src/__tests__/good_sample_messages.ts
@@ -27,17 +27,22 @@ export const goodMessage = {
         isFinal: false,
         outcome: [
           {
-            allocationItems: [
+            allocations: [
               {
                 amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
-                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
+                allocationType: 0,
+                metadata: '0x'
               },
               {
                 amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
-                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
+                allocationType: 0,
+                metadata: '0x'
               }
             ],
-            asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'
+            asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57',
+            metadata: '0x'
           }
         ],
         turnNum: 1,

--- a/packages/wire-format/src/generated-schema.json
+++ b/packages/wire-format/src/generated-schema.json
@@ -9,43 +9,26 @@
     "Allocation": {
       "additionalProperties": false,
       "properties": {
-        "allocationItems": {
-          "items": {
-            "$ref": "#/definitions/AllocationItem"
-          },
-          "type": "array"
+        "allocationType": {
+          "$ref": "#/definitions/Uint8"
         },
-        "asset": {
-          "$ref": "#/definitions/Address"
-        }
-      },
-      "required": [
-        "asset",
-        "allocationItems"
-      ],
-      "type": "object"
-    },
-    "AllocationItem": {
-      "additionalProperties": false,
-      "properties": {
         "amount": {
           "$ref": "#/definitions/Uint256"
         },
         "destination": {
           "$ref": "#/definitions/Bytes32"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Bytes"
         }
       },
       "required": [
         "destination",
-        "amount"
+        "amount",
+        "metadata",
+        "allocationType"
       ],
       "type": "object"
-    },
-    "Allocations": {
-      "items": {
-        "$ref": "#/definitions/Allocation"
-      },
-      "type": "array"
     },
     "Bytes": {
       "description": "Bytes",
@@ -232,35 +215,6 @@
       ],
       "type": "object"
     },
-    "Guarantee": {
-      "additionalProperties": false,
-      "properties": {
-        "asset": {
-          "$ref": "#/definitions/Address"
-        },
-        "destinations": {
-          "items": {
-            "$ref": "#/definitions/Bytes32"
-          },
-          "type": "array"
-        },
-        "targetChannelId": {
-          "$ref": "#/definitions/Bytes32"
-        }
-      },
-      "required": [
-        "asset",
-        "targetChannelId",
-        "destinations"
-      ],
-      "type": "object"
-    },
-    "Guarantees": {
-      "items": {
-        "$ref": "#/definitions/Guarantee"
-      },
-      "type": "array"
-    },
     "Message": {
       "additionalProperties": false,
       "properties": {
@@ -357,14 +311,10 @@
       "type": "object"
     },
     "Outcome": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Guarantees"
-        },
-        {
-          "$ref": "#/definitions/Allocations"
-        }
-      ]
+      "items": {
+        "$ref": "#/definitions/SingleAssetOutcome"
+      },
+      "type": "array"
     },
     "Participant": {
       "additionalProperties": false,
@@ -474,12 +424,38 @@
       ],
       "type": "object"
     },
+    "SingleAssetOutcome": {
+      "additionalProperties": false,
+      "properties": {
+        "allocations": {
+          "items": {
+            "$ref": "#/definitions/Allocation"
+          },
+          "type": "array"
+        },
+        "asset": {
+          "$ref": "#/definitions/Address"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Bytes"
+        }
+      },
+      "required": [
+        "asset",
+        "allocations",
+        "metadata"
+      ],
+      "type": "object"
+    },
     "Uint256": {
       "description": "Uint256",
       "pattern": "^0x([a-fA-F0-9]{64})$",
       "type": "string"
     },
     "Uint48": {
+      "type": "number"
+    },
+    "Uint8": {
       "type": "number"
     },
     "VirtuallyFund": {

--- a/packages/wire-format/src/types.ts
+++ b/packages/wire-format/src/types.ts
@@ -11,6 +11,7 @@ export type Address = string;
 export type Bytes32 = string;
 
 export type Uint48 = number;
+export type Uint8 = number;
 
 /**
  * Uint256
@@ -30,36 +31,20 @@ export interface Participant {
   destination: Address; // Address of EOA to receive channel proceeds (the account that'll get the funds).
 }
 
-export interface AllocationItem {
+export interface Allocation {
   destination: Bytes32; // Address of EOA or channelId to receive funds
   amount: Uint256; // How much funds will be transferred to the destination address.
+  metadata: Bytes;
+  allocationType: Uint8;
 }
 
-export interface Allocation {
+export interface SingleAssetOutcome {
   asset: Address; // The asset holder address.
-  allocationItems: AllocationItem[]; // A list of allocations (how much funds will each destination address get).
+  allocations: Allocation[]; // A list of allocations (how much funds will each destination address get).
+  metadata: Bytes;
 }
 
-export type Allocations = Allocation[]; // included for backwards compatibility
-
-export interface Guarantee {
-  asset: Address;
-  targetChannelId: Bytes32;
-  destinations: Bytes32[];
-}
-
-export type Guarantees = Guarantee[];
-
-export type Outcome = Guarantees | Allocations;
-
-export function isAllocations(outcome: Outcome): outcome is Allocations {
-  if (outcome.length === 0) {
-    return true;
-  } else {
-    const first = outcome[0];
-    return 'allocationItems' in first;
-  }
-}
+export type Outcome = SingleAssetOutcome[];
 
 export interface SignedState {
   chainId: string;


### PR DESCRIPTION
The wire format consists of typescript types, a json schema and validator functions for messages sent between nitro wallets. 

It is necessary to update the package if we want wallets to work with the exit format, since they need to pass messages (for signing by counterparties) that can eventually be submitted to chain.

The approach taken here is:
*  ensure the new `metadata` and `allocationType` fields are present and correct, as well as
*  renaming `allocationItems` to `allocations` (as per the exit format). 
* I have removed the `Guarantee` outcome type, since this is now just an allocation with certain metadata. 
* I have also removed the `Allocation(s)` type as this collides with new types coming out of exit format. It is also unnecessary given the removal of `Guarantee` type.
* regenerate the schema
* update the sample messages so the tests pass

I considered whether these changes were really necessary -- in other packages we can probably get away with reusing different types and writing adapter code. But here it seems to me that it really is necessary to have things compatible here, since we do runtime checks (on inter-wallet messages) against a schema generated from the types in _this_ package, and go on to use those messages to construct transactions that need to work against types defined in the exit-format package. 

I also considered whether we should be duplicating types here, or in fact just re-importing them from the exit format (seeing as they seem to need to be tightly coupled). I didn't reach a conclusion on that, and it felt like mission creep in any case. 

⚠️ reminder: CI is *not* expected or required to pass (yet)

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
