### PR TITLE
Update wallet core and client-api-schema to work with exit format

### DIFF
--- a/packages/client-api-schema/src/__tests__/sample_messages/notifications/good.ts
+++ b/packages/client-api-schema/src/__tests__/sample_messages/notifications/good.ts
@@ -24,17 +24,22 @@ const channelResult: ChannelResult = {
       destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
     }
   ],
-  allocations: [
+  outcome: [
     {
       asset: '0x0000000000000000000000000000000000000000',
-      allocationItems: [
+      metadata: '0x',
+      allocations: [
         {
           destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
-          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
+          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+          allocationType: 0,
+          metadata: '0x'
         },
         {
           destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
-          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
+          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+          allocationType: 0,
+          metadata: '0x'
         }
       ]
     }

--- a/packages/client-api-schema/src/__tests__/sample_messages/requests/good.ts
+++ b/packages/client-api-schema/src/__tests__/sample_messages/requests/good.ts
@@ -50,17 +50,22 @@ const message = {
         isFinal: false,
         outcome: [
           {
-            allocationItems: [
+            allocations: [
               {
                 amount: '0x06f05b59d3b20000',
-                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
+                allocationType: 0,
+                metadata: '0x'
               },
               {
                 amount: '0x06f05b59d3b20000',
-                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+                destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
+                allocationType: 0,
+                metadata: '0x'
               }
             ],
-            asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'
+            asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57',
+            metadata: '0x'
           }
         ],
         turnNum: 0
@@ -111,17 +116,22 @@ const createChannel = {
         destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
       }
     ],
-    allocations: [
+    outcome: [
       {
         asset: '0x0000000000000000000000000000000000000000',
-        allocationItems: [
+        metadata: '0x',
+        allocations: [
           {
             destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
-            amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
+            amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+            allocationType: 0,
+            metadata: '0x'
           },
           {
             destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
-            amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
+            amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+            allocationType: 0,
+            metadata: '0x'
           }
         ]
       }
@@ -173,17 +183,22 @@ const pushMessage2 = {
           isFinal: false,
           outcome: [
             {
-              allocationItems: [
+              allocations: [
                 {
                   amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
-                  destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+                  destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
+                  allocationType: 0,
+                  metadata: '0x'
                 },
                 {
                   amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
-                  destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+                  destination: '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
+                  allocationType: 0,
+                  metadata: '0x'
                 }
               ],
-              asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'
+              asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57',
+              metadata: '0x'
             }
           ],
           turnNum: 1

--- a/packages/client-api-schema/src/__tests__/sample_messages/responses/good.ts
+++ b/packages/client-api-schema/src/__tests__/sample_messages/responses/good.ts
@@ -16,17 +16,22 @@ const channelResult: ChannelResult = {
       destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
     }
   ],
-  allocations: [
+  outcome: [
     {
       asset: '0x0000000000000000000000000000000000000000',
-      allocationItems: [
+      metadata: '0x',
+      allocations: [
         {
           destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
-          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
+          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+          allocationType: 0,
+          metadata: '0x'
         },
         {
           destination: '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7',
-          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
+          amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+          allocationType: 0,
+          metadata: '0x'
         }
       ]
     }

--- a/packages/client-api-schema/src/data-types.ts
+++ b/packages/client-api-schema/src/data-types.ts
@@ -52,7 +52,7 @@ export interface Participant {
 /**
  * Assigns some amount of an unspecified asset to a destination
  */
-export interface AllocationItem {
+export interface Allocation {
   /**
    * Address of EOA to receive channel proceeds.
    */
@@ -61,12 +61,11 @@ export interface AllocationItem {
    * How much funds will be transferred to the destination address.
    */
   amount: Uint256;
+  metadata: string;
+  allocationType: number;
 }
 
-/**
- * Array of destination-amount pairings for a given token
- */
-export interface Allocation {
+export interface SingleAssetOutcome {
   /**
    * The contract address of the asset
    */
@@ -74,14 +73,11 @@ export interface Allocation {
   /**
    * Array of destination-amount pairings
    */
-  allocationItems: AllocationItem[];
+  allocations: Allocation[];
+  metadata: string;
 }
 
-/**
- * Included for backwards compatibility
- */
-export type Allocations = Allocation[];
-
+export type Outcome = SingleAssetOutcome[];
 export interface ChannelBudget {
   channelId: Bytes32;
   amount: Uint256;
@@ -134,7 +130,7 @@ export type FundingStatus =
 
 export interface ChannelResult {
   participants: Participant[];
-  allocations: Allocation[];
+  outcome: SingleAssetOutcome[];
   appData: string;
   appDefinition: Address;
   channelId: ChannelId;

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -8,30 +8,11 @@
     },
     "Allocation": {
       "additionalProperties": false,
-      "description": "Array of destination-amount pairings for a given token",
-      "properties": {
-        "allocationItems": {
-          "description": "Array of destination-amount pairings",
-          "items": {
-            "$ref": "#/definitions/AllocationItem"
-          },
-          "type": "array"
-        },
-        "asset": {
-          "$ref": "#/definitions/Address",
-          "description": "The contract address of the asset"
-        }
-      },
-      "required": [
-        "asset",
-        "allocationItems"
-      ],
-      "type": "object"
-    },
-    "AllocationItem": {
-      "additionalProperties": false,
       "description": "Assigns some amount of an unspecified asset to a destination",
       "properties": {
+        "allocationType": {
+          "type": "number"
+        },
         "amount": {
           "$ref": "#/definitions/Uint256",
           "description": "How much funds will be transferred to the destination address."
@@ -39,11 +20,16 @@
         "destination": {
           "$ref": "#/definitions/Address",
           "description": "Address of EOA to receive channel proceeds."
+        },
+        "metadata": {
+          "type": "string"
         }
       },
       "required": [
         "destination",
-        "amount"
+        "amount",
+        "metadata",
+        "allocationType"
       ],
       "type": "object"
     },
@@ -154,12 +140,6 @@
           ],
           "type": "string"
         },
-        "allocations": {
-          "items": {
-            "$ref": "#/definitions/Allocation"
-          },
-          "type": "array"
-        },
         "appData": {
           "type": "string"
         },
@@ -171,6 +151,12 @@
         },
         "fundingStatus": {
           "$ref": "#/definitions/FundingStatus"
+        },
+        "outcome": {
+          "items": {
+            "$ref": "#/definitions/SingleAssetOutcome"
+          },
+          "type": "array"
         },
         "participants": {
           "items": {
@@ -187,7 +173,7 @@
       },
       "required": [
         "participants",
-        "allocations",
+        "outcome",
         "appData",
         "appDefinition",
         "channelId",
@@ -275,12 +261,6 @@
     "CreateChannelParams": {
       "additionalProperties": false,
       "properties": {
-        "allocations": {
-          "items": {
-            "$ref": "#/definitions/Allocation"
-          },
-          "type": "array"
-        },
         "appData": {
           "type": "string"
         },
@@ -296,6 +276,12 @@
         "fundingStrategy": {
           "$ref": "#/definitions/FundingStrategy"
         },
+        "outcome": {
+          "items": {
+            "$ref": "#/definitions/SingleAssetOutcome"
+          },
+          "type": "array"
+        },
         "participants": {
           "items": {
             "$ref": "#/definitions/Participant"
@@ -305,7 +291,7 @@
       },
       "required": [
         "participants",
-        "allocations",
+        "outcome",
         "appDefinition",
         "appData",
         "fundingStrategy",
@@ -392,7 +378,7 @@
       "$ref": "#/definitions/JsonRpcRequest%3C%22GetChannels%22%2Cstructure-1978982097-247-273-1978982097-217-274-1978982097-184-275-1978982097-0-344%3E"
     },
     "GetChannelsResponse": {
-      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src_data-types.ts-3336-3684-src_data-types.ts-0-4103%5B%5D%3E"
+      "$ref": "#/definitions/JsonRpcResponse%3Cdef-interface-src_data-types.ts-3287-3639-src_data-types.ts-0-4058%5B%5D%3E"
     },
     "GetStateError": {
       "$ref": "#/definitions/JsonRpcError%3C1200%2C%22Could%20not%20find%20channel%22%3E"
@@ -1684,7 +1670,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcResponse<def-interface-src_data-types.ts-3336-3684-src_data-types.ts-0-4103[]>": {
+    "JsonRpcResponse<def-interface-src_data-types.ts-3287-3639-src_data-types.ts-0-4058[]>": {
       "additionalProperties": false,
       "description": "Specifies response headers as per {@link https://www.jsonrpc.org/specification | JSON-RPC 2.0 Specification }",
       "properties": {
@@ -1925,6 +1911,31 @@
       },
       "required": [
         "success"
+      ],
+      "type": "object"
+    },
+    "SingleAssetOutcome": {
+      "additionalProperties": false,
+      "properties": {
+        "allocations": {
+          "description": "Array of destination-amount pairings",
+          "items": {
+            "$ref": "#/definitions/Allocation"
+          },
+          "type": "array"
+        },
+        "asset": {
+          "$ref": "#/definitions/Address",
+          "description": "The contract address of the asset"
+        },
+        "metadata": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "asset",
+        "allocations",
+        "metadata"
       ],
       "type": "object"
     },

--- a/packages/client-api-schema/src/methods/CreateChannel.ts
+++ b/packages/client-api-schema/src/methods/CreateChannel.ts
@@ -1,4 +1,4 @@
-import {Participant, Allocation, Address, ChannelResult} from '../data-types';
+import {Participant, Address, ChannelResult, SingleAssetOutcome} from '../data-types';
 import {JsonRpcRequest, JsonRpcResponse, JsonRpcError} from '../jsonrpc-header-types';
 import {ErrorCodes as AllErrors} from '../error-codes';
 
@@ -6,7 +6,7 @@ export type FundingStrategy = 'Direct' | 'Ledger' | 'Virtual' | 'Fake' | 'Unknow
 
 export interface CreateChannelParams {
   participants: Participant[];
-  allocations: Allocation[];
+  outcome: SingleAssetOutcome[];
   appDefinition: Address;
   appData: string;
   fundingStrategy: FundingStrategy;

--- a/packages/nitro-protocol/src/contract/outcome.ts
+++ b/packages/nitro-protocol/src/contract/outcome.ts
@@ -2,6 +2,8 @@ import {BytesLike, constants, utils} from 'ethers';
 import {defaultAbiCoder} from '@ethersproject/abi';
 import * as ExitFormat from '@statechannels/exit-format';
 
+export type AllocationType = ExitFormat.AllocationType;
+export type Allocation = ExitFormat.Allocation;
 export type AssetOutcome = ExitFormat.SingleAssetExit;
 export type Outcome = ExitFormat.Exit;
 export const encodeOutcome = ExitFormat.encodeExit;

--- a/packages/nitro-protocol/src/index.ts
+++ b/packages/nitro-protocol/src/index.ts
@@ -69,7 +69,7 @@ export {
   ForceMoveAppContractInterface,
   createValidTransitionTransaction,
 } from './contract/force-move-app';
-export {encodeOutcome, decodeOutcome, Outcome, AssetOutcome, hashOutcome} from './contract/outcome';
+export * from './contract/outcome';
 export {channelDataToStatus} from './contract/channel-storage';
 
 export {

--- a/packages/wallet-core/src/index.ts
+++ b/packages/wallet-core/src/index.ts
@@ -4,10 +4,10 @@ export * from './utils';
 export * from './bignumber';
 export * from './constants';
 
-export * from './serde/app-messages/deserialize';
-export * from './serde/app-messages/serialize';
-export * from './serde/wire-format/deserialize';
-export * from './serde/wire-format/serialize';
+export * as AppDeserialize from './serde/app-messages/deserialize';
+export * as AppSerialize from './serde/app-messages/serialize';
+export * as WireSerialize from './serde/wire-format/deserialize';
+export * as WireDeserialize from './serde/wire-format/serialize';
 
 export * from './protocols';
 

--- a/packages/wallet-core/src/protocols/direct-funder.ts
+++ b/packages/wallet-core/src/protocols/direct-funder.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
 
-import {checkThat, isSimpleAllocation} from '../utils';
 import {BN} from '../bignumber';
 import {calculateChannelId, hashState, signState} from '../state-utils';
 import {Address, SignatureEntry, SignedState, State, Uint256} from '../types';
@@ -334,9 +333,10 @@ type FundingMilestone = {
 
 export const utils = {
   fundingMilestone(state: State, destination: string): FundingMilestone {
-    const {allocationItems} = checkThat(state.outcome, isSimpleAllocation);
+    if (state.outcome.length !== 1) throw Error('too many SingleAssetOutcomes');
+    const {allocations} = state.outcome[0];
 
-    const myAllocationItem = _.find(allocationItems, ai => ai.destination === destination);
+    const myAllocationItem = _.find(allocations, ai => ai.destination === destination);
     if (!myAllocationItem) {
       // throw new ChannelError(ChannelError.reasons.destinationNotInAllocations, {
       //   destination: this.participants[this.myIndex].destination
@@ -344,12 +344,12 @@ export const utils = {
       throw new Error('unexpected outcome');
     }
 
-    const allocationsBefore = _.takeWhile(allocationItems, a => a.destination !== destination);
+    const allocationsBefore = _.takeWhile(allocations, a => a.destination !== destination);
     const targetBefore = allocationsBefore.map(a => a.amount).reduce(BN.add, BN.from(0));
 
     const targetAfter = BN.add(targetBefore, myAllocationItem.amount);
 
-    const targetTotal = allocationItems.map(a => a.amount).reduce(BN.add, BN.from(0));
+    const targetTotal = allocations.map(a => a.amount).reduce(BN.add, BN.from(0));
 
     return {targetBefore, targetAfter, targetTotal};
   }

--- a/packages/wallet-core/src/serde/app-messages/deserialize.ts
+++ b/packages/wallet-core/src/serde/app-messages/deserialize.ts
@@ -1,19 +1,19 @@
 import {
   Allocation as AppAllocation,
-  Allocations as AppAllocations,
-  AllocationItem as AppAllocationItem,
+  SingleAssetOutcome as AppSingleAssetOutcome,
   DomainBudget as AppDomainBudget,
+  Outcome as AppOutcome,
   ApproveBudgetAndFundParams as AppBudgetRequest
 } from '@statechannels/client-api-schema';
 import {constants} from 'ethers';
 
 import {
   Allocation,
-  AllocationItem,
-  SimpleAllocation,
   DomainBudget,
   AssetBudget,
-  makeAddress
+  makeAddress,
+  SingleAssetOutcome,
+  Outcome
 } from '../../types';
 import {BN} from '../../bignumber';
 import {makeDestination} from '../../utils';
@@ -58,31 +58,29 @@ export function deserializeDomainBudget(DomainBudget: AppDomainBudget): DomainBu
   };
 }
 
-export function deserializeAllocations(allocations: AppAllocations): Allocation {
-  switch (allocations.length) {
-    case 0:
-      throw new Error('Allocations is empty');
-    case 1:
-      return deserializeAllocation(allocations[0]);
-    default:
-      return {
-        type: 'MixedAllocation',
-        simpleAllocations: allocations.map(deserializeAllocation)
-      };
-  }
+export function deserializeAllocations(allocations: AppAllocation[]): Allocation[] {
+  return allocations.map(deserializeAllocation);
 }
 
-function deserializeAllocation(allocation: AppAllocation): SimpleAllocation {
+export function deserializeSingleAssetOutcome(
+  singleAssetOutcome: AppSingleAssetOutcome
+): SingleAssetOutcome {
   return {
-    type: 'SimpleAllocation',
-    allocationItems: allocation.allocationItems.map(deserializeAllocationItem),
-    asset: makeAddress(allocation.asset)
+    allocations: singleAssetOutcome.allocations.map(deserializeAllocation),
+    asset: makeAddress(singleAssetOutcome.asset),
+    metadata: singleAssetOutcome.metadata
   };
 }
 
-function deserializeAllocationItem(allocationItem: AppAllocationItem): AllocationItem {
+export function deserializeOutcome(outcome: AppOutcome): Outcome {
+  return outcome.map(deserializeSingleAssetOutcome);
+}
+
+function deserializeAllocation(allocation: AppAllocation): Allocation {
   return {
-    destination: makeDestination(allocationItem.destination),
-    amount: BN.from(allocationItem.amount)
+    destination: makeDestination(allocation.destination),
+    amount: BN.from(allocation.amount),
+    metadata: allocation.metadata,
+    allocationType: allocation.allocationType
   };
 }

--- a/packages/wallet-core/src/serde/app-messages/example.ts
+++ b/packages/wallet-core/src/serde/app-messages/example.ts
@@ -1,22 +1,28 @@
-import {Allocations} from '@statechannels/client-api-schema';
+import {Outcome as AppOutcome} from '@statechannels/client-api-schema';
 import {utils} from 'ethers';
+import {AllocationType} from '@statechannels/exit-format';
 
-import {SimpleAllocation, MixedAllocation, makeAddress} from '../../types';
+import {makeAddress, Outcome} from '../../types';
 import {makeDestination} from '../../utils';
 import {BN} from '../../bignumber';
 import {zeroAddress} from '../../config';
 
-export const externalEthAllocation: Allocations = [
+export const externalEthAllocation: AppOutcome = [
   {
     asset: zeroAddress,
-    allocationItems: [
+    metadata: '0x',
+    allocations: [
       {
         amount: utils.hexZeroPad('0x5', 32),
-        destination: '0x000000000000000000000000A5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5'
+        destination: '0x000000000000000000000000A5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5',
+        metadata: '0x',
+        allocationType: AllocationType.simple
       },
       {
         amount: utils.hexZeroPad('0x5', 32),
-        destination: '0x000000000000000000000000BAF5D86514365D487ea69B7D7c85913E5dF51648'
+        destination: '0x000000000000000000000000BAF5D86514365D487ea69B7D7c85913E5dF51648',
+        metadata: '0x',
+        allocationType: AllocationType.simple
       }
     ]
   }
@@ -25,37 +31,48 @@ export const externalEthAllocation: Allocations = [
 // TODO: Comparing bigNumbers in a test is fragile
 // since BigNumber.from('0x1') ~= BigNumber.from('0x01')
 // We should probably just a jest matcher instead
-export const internalEthAllocation: SimpleAllocation = {
-  asset: zeroAddress,
-  allocationItems: [
-    {
-      amount: BN.from(utils.hexZeroPad('0x5', 32)),
-      destination: makeDestination('0xA5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5')
-    },
-    {
-      amount: BN.from(utils.hexZeroPad('0x5', 32)),
-      destination: makeDestination('0xBAF5D86514365D487ea69B7D7c85913E5dF51648')
-    }
-  ],
-  type: 'SimpleAllocation'
-};
+export const internalEthAllocation: Outcome = [
+  {
+    asset: zeroAddress,
+    metadata: '0x',
+    allocations: [
+      {
+        amount: BN.from(utils.hexZeroPad('0x5', 32)),
+        destination: makeDestination('0xA5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5'),
+        allocationType: AllocationType.simple,
+        metadata: '0x'
+      },
+      {
+        amount: BN.from(utils.hexZeroPad('0x5', 32)),
+        destination: makeDestination('0xBAF5D86514365D487ea69B7D7c85913E5dF51648'),
+        allocationType: AllocationType.simple,
+        metadata: '0x'
+      }
+    ]
+  }
+];
 
-export const externalMixedAllocation: Allocations = [
+export const externalMixedAllocation: AppOutcome = [
   externalEthAllocation[0],
   {
     asset: '0x1000000000000000000000000000000000000001',
-    allocationItems: [
+    metadata: '0x',
+    allocations: [
       {
         amount: utils.hexZeroPad('0x1', 32),
         destination: makeDestination(
           '0x000000000000000000000000a5c9d076b3fc5910d67b073cbf75c4e13a5ac6e5'
-        )
+        ),
+        metadata: '0x',
+        allocationType: AllocationType.simple
       },
       {
         amount: utils.hexZeroPad('0x1', 32),
         destination: makeDestination(
           '0x000000000000000000000000baf5d86514365d487ea69b7d7c85913e5df51648'
-        )
+        ),
+        metadata: '0x',
+        allocationType: AllocationType.simple
       }
     ]
   }
@@ -64,23 +81,24 @@ export const externalMixedAllocation: Allocations = [
 // TODO: Comparing bigNumbers in a test is fragile
 // since BigNumber.from('0x1') ~= BigNumber.from('0x01')
 // We should probably just a jest matcher instead
-export const internalMixedAllocation: MixedAllocation = {
-  type: 'MixedAllocation',
-  simpleAllocations: [
-    internalEthAllocation,
-    {
-      type: 'SimpleAllocation',
-      asset: makeAddress('0x1000000000000000000000000000000000000001'),
-      allocationItems: [
-        {
-          amount: BN.from(utils.hexZeroPad('0x1', 32)),
-          destination: makeDestination('0xA5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5')
-        },
-        {
-          amount: BN.from(utils.hexZeroPad('0x1', 32)),
-          destination: makeDestination('0xBAF5D86514365D487ea69B7D7c85913E5dF51648')
-        }
-      ]
-    }
-  ]
-};
+export const internalMixedAllocation: Outcome = [
+  ...internalEthAllocation,
+  {
+    asset: makeAddress('0x1000000000000000000000000000000000000001'),
+    metadata: '0x',
+    allocations: [
+      {
+        amount: BN.from(utils.hexZeroPad('0x1', 32)),
+        destination: makeDestination('0xA5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5'),
+        allocationType: AllocationType.simple,
+        metadata: '0x'
+      },
+      {
+        amount: BN.from(utils.hexZeroPad('0x1', 32)),
+        destination: makeDestination('0xBAF5D86514365D487ea69B7D7c85913E5dF51648'),
+        allocationType: AllocationType.simple,
+        metadata: '0x'
+      }
+    ]
+  }
+];

--- a/packages/wallet-core/src/serde/app-messages/serde.test.ts
+++ b/packages/wallet-core/src/serde/app-messages/serde.test.ts
@@ -1,5 +1,5 @@
-import {serializeAllocation} from './serialize';
-import {deserializeAllocations} from './deserialize';
+import {serializeOutcome} from './serialize';
+import {deserializeOutcome} from './deserialize';
 import {
   externalEthAllocation,
   internalEthAllocation,
@@ -8,11 +8,11 @@ import {
 } from './example';
 
 it('works for a simple eth allocation', () => {
-  expect(deserializeAllocations(externalEthAllocation)).toEqual(internalEthAllocation);
-  expect(serializeAllocation(internalEthAllocation)).toEqual(externalEthAllocation);
+  expect(deserializeOutcome(externalEthAllocation)).toEqual(internalEthAllocation);
+  expect(serializeOutcome(internalEthAllocation)).toEqual(externalEthAllocation);
 });
 
 it('works for a mixed allocation', () => {
-  expect(deserializeAllocations(externalMixedAllocation)).toEqual(internalMixedAllocation);
-  expect(serializeAllocation(internalMixedAllocation)).toEqual(externalMixedAllocation);
+  expect(deserializeOutcome(externalMixedAllocation)).toEqual(internalMixedAllocation);
+  expect(serializeOutcome(internalMixedAllocation)).toEqual(externalMixedAllocation);
 });

--- a/packages/wallet-core/src/serde/app-messages/serialize.ts
+++ b/packages/wallet-core/src/serde/app-messages/serialize.ts
@@ -1,13 +1,14 @@
 import {
+  SingleAssetOutcome as AppSingleAssetOutcome,
   Allocation as AppAllocation,
-  Allocations as AppAllocations,
-  AllocationItem as AppAllocationItem,
   DomainBudget as AppDomainBudget,
-  TokenBudget
+  TokenBudget,
+  Outcome as AppOutcome
 } from '@statechannels/client-api-schema';
 import {constants} from 'ethers';
+import {AllocationType} from '@statechannels/exit-format';
 
-import {Allocation, AllocationItem, SimpleAllocation, DomainBudget, AssetBudget} from '../../types';
+import {Allocation, DomainBudget, AssetBudget, SingleAssetOutcome, Outcome} from '../../types';
 import {checkThat, exists, formatAmount} from '../../utils';
 import {BN} from '../../bignumber';
 
@@ -33,25 +34,29 @@ export function serializeDomainBudget(budget: DomainBudget): AppDomainBudget {
   };
 }
 
-export function serializeAllocation(allocation: Allocation): AppAllocations {
-  switch (allocation.type) {
-    case 'SimpleAllocation':
-      return [serializeSimpleAllocation(allocation)];
-    case 'MixedAllocation':
-      return allocation.simpleAllocations.map(serializeSimpleAllocation);
-  }
+export function serializeAllocations(allocations: Allocation[]): AppAllocation[] {
+  return allocations.map(serializeAllocation);
 }
 
-function serializeSimpleAllocation(allocation: SimpleAllocation): AppAllocation {
+function serializeAllocation(allocation: Allocation): AppAllocation {
   return {
-    allocationItems: allocation.allocationItems.map(serializeAllocationItem),
-    asset: allocation.asset
+    destination: allocation.destination,
+    amount: formatAmount(allocation.amount),
+    metadata: allocation.metadata ?? '0x',
+    allocationType: allocation.allocationType ?? AllocationType.simple
   };
 }
 
-function serializeAllocationItem(allocationItem: AllocationItem): AppAllocationItem {
+export function serializeSingleAssetOutcome(
+  singleAssetOutcome: SingleAssetOutcome
+): AppSingleAssetOutcome {
   return {
-    destination: allocationItem.destination,
-    amount: formatAmount(allocationItem.amount)
+    asset: singleAssetOutcome.asset,
+    metadata: singleAssetOutcome.metadata ?? '0x',
+    allocations: singleAssetOutcome.allocations.map(serializeAllocation)
   };
+}
+
+export function serializeOutcome(outcome: Outcome): AppOutcome {
+  return outcome.map(serializeSingleAssetOutcome);
 }

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -1,7 +1,8 @@
 import {Message as WireMessage, SignedState as WireState} from '@statechannels/wire-format';
+import {AllocationType} from '@statechannels/exit-format';
 
 import {BN} from '../../bignumber';
-import {makeAddress, Payload, SignedState} from '../../types';
+import {makeAddress, Payload, SignedState, Uint256} from '../../types';
 import {makeDestination} from '../../utils';
 import {calculateChannelId} from '../../state-utils';
 
@@ -30,17 +31,22 @@ export const wireStateFormat: WireState = {
   isFinal: false,
   outcome: [
     {
-      allocationItems: [
+      allocations: [
         {
           amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
-          destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7'
+          destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7',
+          metadata: '0x',
+          allocationType: AllocationType.simple
         },
         {
           amount: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
-          destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7'
+          destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7',
+          metadata: '0x',
+          allocationType: AllocationType.simple
         }
       ],
-      asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'
+      asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57',
+      metadata: '0x'
     }
   ],
   turnNum: 1,
@@ -55,8 +61,15 @@ const wireStateFormat2: WireState = {
   outcome: [
     {
       asset: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57',
-      destinations: ['0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7'],
-      targetChannelId: '0xb08bc94ebfbe1b23c419bec2d57993d33c41b112fbbca5d51f0f18194baadcf1'
+      metadata: '0x',
+      allocations: [
+        {
+          destination: '0xb08bc94ebfbe1b23c419bec2d57993d33c41b112fbbca5d51f0f18194baadcf1',
+          amount: '0x0000000000000000000000000000000000000000000000000000000000000055',
+          metadata: '0xdeadbeef',
+          allocationType: AllocationType.guarantee
+        }
+      ]
     }
   ],
   signatures: []
@@ -82,24 +95,30 @@ export const internalStateFormat: SignedState = {
   chainId: '0x2329',
   channelNonce: 123,
   isFinal: false,
-  outcome: {
-    type: 'SimpleAllocation',
-    asset: makeAddress('0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'),
-    allocationItems: [
-      {
-        amount: BN.from('0x00000000000000000000000000000000000000000000000006f05b59d3b20000'),
-        destination: makeDestination(
-          '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
-        )
-      },
-      {
-        amount: BN.from('0x00000000000000000000000000000000000000000000000006f05b59d3b20000'),
-        destination: makeDestination(
-          '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
-        )
-      }
-    ]
-  },
+  outcome: [
+    {
+      asset: makeAddress('0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'),
+      metadata: '0x',
+      allocations: [
+        {
+          amount: BN.from('0x00000000000000000000000000000000000000000000000006f05b59d3b20000'),
+          destination: makeDestination(
+            '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+          ),
+          metadata: '0x',
+          allocationType: AllocationType.simple
+        },
+        {
+          amount: BN.from('0x00000000000000000000000000000000000000000000000006f05b59d3b20000'),
+          destination: makeDestination(
+            '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
+          ),
+          metadata: '0x',
+          allocationType: AllocationType.simple
+        }
+      ]
+    }
+  ],
   turnNum: 1,
   signatures: [
     {
@@ -113,12 +132,20 @@ export const internalStateFormat: SignedState = {
 export const internalStateFormat2: SignedState = {
   ...internalStateFormat,
   channelNonce: internalStateFormat.channelNonce + 1,
-  outcome: {
-    asset: makeAddress('0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'),
-    type: 'SimpleGuarantee',
-    targetChannelId: calculateChannelId(internalStateFormat),
-    destinations: [makeDestination('0x63E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7')]
-  },
+  outcome: [
+    {
+      asset: makeAddress('0x4ad3F07BEFDC54511449A1f553E36A653c82eA57'),
+      metadata: '0x',
+      allocations: [
+        {
+          destination: makeDestination(calculateChannelId(internalStateFormat)),
+          amount: '0x0000000000000000000000000000000000000000000000000000000000000055' as Uint256,
+          metadata: '0xdeadbeef',
+          allocationType: AllocationType.guarantee
+        }
+      ]
+    }
+  ],
   signatures: []
 };
 

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -151,7 +151,7 @@ export const internalStateFormat2: SignedState = {
       allocations: [
         {
           destination: makeDestination(calculateChannelId(internalStateFormat)),
-          amount: '0x0000000000000000000000000000000000000000000000000000000000000055' as Uint256,
+          amount: BN.from('0x0000000000000000000000000000000000000000000000000000000000000055'),
           metadata: '0xdeadbeef',
           allocationType: AllocationType.guarantee
         }

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -8,6 +8,17 @@ import {calculateChannelId} from '../../state-utils';
 
 export const walletVersion = 'someWalletVersion';
 
+// NOTE ABOUT GENERATING THE SIGNATURES IN THIS FILE
+// A quick and dirty method is to use
+// console.log(
+//   signState(
+//     deserializeState(wireStateFormat),
+//     '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
+//   )
+// );
+// but you will need to disable the check (in nitro-protocol) that throws if the signature is incorrect
+// (i.e. recovers to a non participant)
+
 export const wireStateFormat: WireState = {
   participants: [
     {
@@ -51,9 +62,10 @@ export const wireStateFormat: WireState = {
   ],
   turnNum: 1,
   signatures: [
-    '0x59069c99dd52a7766e439ef9344e5cee7a51625ec366095cbd7bad66075a54e924ab48b08a683deff7e3642d8017178e55990b2073d169eec64a7fef60648a6a1b'
+    '0x6ad8005aa8cb0d6decae9d6e8e84df853f8d625a3a8728d8e4d2053e6333011632c586d40e34ff3104fa3be00f9172d89f0a5bb43587fd55eeefc7549765749d1c' // SEE NOTE ABOVE ABOUT GENERATING THIS
   ]
 };
+
 const wireStateFormat2: WireState = {
   ...wireStateFormat,
   channelNonce: 124,
@@ -123,7 +135,7 @@ export const internalStateFormat: SignedState = {
   signatures: [
     {
       signature:
-        '0x59069c99dd52a7766e439ef9344e5cee7a51625ec366095cbd7bad66075a54e924ab48b08a683deff7e3642d8017178e55990b2073d169eec64a7fef60648a6a1b',
+        '0x6ad8005aa8cb0d6decae9d6e8e84df853f8d625a3a8728d8e4d2053e6333011632c586d40e34ff3104fa3be00f9172d89f0a5bb43587fd55eeefc7549765749d1c',
       signer: makeAddress('0x2222e21c8019b14da16235319d34b5dd83e644a9')
     }
   ]

--- a/packages/wallet-core/src/state-utils.ts
+++ b/packages/wallet-core/src/state-utils.ts
@@ -171,7 +171,9 @@ function convertToNitroAllocations(allocations: Allocation[]): NitroAllocation[]
 function convertFromNitroAllocations(allocations: NitroAllocation[]): Allocation[] {
   return allocations.map(a => ({
     amount: BN.from(a.amount),
-    destination: makeDestination(a.destination)
+    destination: makeDestination(a.destination),
+    metadata: a.metadata as string, // TODO
+    allocationType: a.allocationType
   }));
 }
 

--- a/packages/wallet-core/src/state-utils.ts
+++ b/packages/wallet-core/src/state-utils.ts
@@ -1,8 +1,8 @@
 import {
+  Allocation as NitroAllocation,
   State as NitroState,
   SignedState as NitroSignedState,
   Outcome as NitroOutcome,
-  AllocationItem as NitroAllocationItem,
   signState as signNitroState,
   hashState as hashNitroState,
   getStateSignerAddress as getNitroSignerAddress,
@@ -10,20 +10,21 @@ import {
   convertAddressToBytes32
 } from '@statechannels/nitro-protocol';
 import * as _ from 'lodash';
-import {Wallet, utils} from 'ethers';
+import {Wallet, utils, BigNumber} from 'ethers';
+import {AllocationType} from '@statechannels/exit-format';
 
 import {
+  Allocation,
   State,
   ChannelConstants,
   Outcome,
-  AllocationItem,
   SignedState,
   Destination,
-  SimpleAllocation,
   SignatureEntry,
   makeAddress,
   Address,
-  Hashed
+  Hashed,
+  SingleAssetOutcome
 } from './types';
 import {BN} from './bignumber';
 
@@ -120,35 +121,25 @@ export function statesEqual(left: State, right: State): boolean {
   return hashState(left) === hashState(right);
 }
 
-function simpleAllocationsEqual(left: SimpleAllocation, right: SimpleAllocation) {
+function singleAssetOutcomesEqual(left: SingleAssetOutcome, right: SingleAssetOutcome) {
   return (
     left.asset === right.asset &&
-    left.allocationItems.length === right.allocationItems.length &&
+    left.allocations.length === right.allocations.length &&
     _.every(
-      left.allocationItems,
+      left.allocations,
       (value, index) =>
-        value.destination === right.allocationItems[index].destination &&
-        BN.eq(value.amount, right.allocationItems[index].amount)
-    )
+        value.destination === right.allocations[index].destination &&
+        BN.eq(value.amount, right.allocations[index].amount)
+    ) &&
+    left.metadata === right.metadata
   );
 }
 
 export function outcomesEqual(left: Outcome, right?: Outcome): boolean {
-  if (left.type === 'SimpleAllocation' && right?.type === 'SimpleAllocation') {
-    return simpleAllocationsEqual(left, right);
-  }
-  if (left.type === 'SimpleGuarantee' && right?.type === 'SimpleGuarantee') {
-    return _.isEqual(left, right);
-  }
-  if (left.type === 'MixedAllocation' && right?.type === 'MixedAllocation') {
-    return (
-      left.simpleAllocations.length === right.simpleAllocations.length &&
-      _.every(left.simpleAllocations, (_, index) =>
-        simpleAllocationsEqual(left.simpleAllocations[index], right.simpleAllocations[index])
-      )
-    );
-  }
-  return false;
+  return (
+    left.length === right?.length &&
+    _.every(left, (_, index) => singleAssetOutcomesEqual(left[index], right[index]))
+  );
 }
 
 export const firstState = (
@@ -167,80 +158,40 @@ export const firstState = (
   outcome
 });
 
-function convertToNitroAllocationItems(allocationItems: AllocationItem[]): NitroAllocationItem[] {
-  return allocationItems.map(a => ({
+function convertToNitroAllocations(allocations: Allocation[]): NitroAllocation[] {
+  return allocations.map(a => ({
+    allocationType: a.allocationType ?? AllocationType.simple,
+    metadata: a.metadata ?? '0x',
     amount: a.amount,
     destination:
       a.destination.length === 42 ? convertAddressToBytes32(a.destination) : a.destination
   }));
 }
 
-function convertFromNitroAllocationItems(allocationItems: NitroAllocationItem[]): AllocationItem[] {
-  return allocationItems.map(a => ({
+function convertFromNitroAllocations(allocations: NitroAllocation[]): Allocation[] {
+  return allocations.map(a => ({
     amount: BN.from(a.amount),
     destination: makeDestination(a.destination)
   }));
 }
 
 export function convertToNitroOutcome(outcome: Outcome): NitroOutcome {
-  switch (outcome.type) {
-    case 'SimpleAllocation':
-      return [
-        {
-          asset: outcome.asset,
-          allocationItems: convertToNitroAllocationItems(outcome.allocationItems)
-        }
-      ];
-    case 'SimpleGuarantee':
-      return [
-        {
-          asset: outcome.asset,
-          guarantee: {
-            targetChannelId: outcome.targetChannelId,
-            destinations: outcome.destinations
-          }
-        }
-      ];
-    case 'MixedAllocation':
-      // TODO: Update NitroOutcome to support multiple asset holders
-      console.warn('NOTE: MixedAllocation is using 0th-indexed allocation only');
-      return outcome.simpleAllocations.map(convertToNitroOutcome)[0];
-  }
+  return outcome.map(o => ({
+    asset: o.asset,
+    allocations: convertToNitroAllocations(o.allocations),
+    metadata: o.metadata ?? '0x'
+  }));
 }
 
 export function fromNitroOutcome(outcome: NitroOutcome): Outcome {
-  const [singleOutcomeItem] = outcome;
-
-  if (typeof singleOutcomeItem['allocationItems'] !== 'undefined') {
-    return {
-      type: 'SimpleAllocation',
-      asset: makeAddress(singleOutcomeItem.asset),
-      allocationItems: convertFromNitroAllocationItems(singleOutcomeItem['allocationItems'])
-    };
-  }
-
-  if (typeof singleOutcomeItem['guarantee'] !== 'undefined') {
-    return {
-      type: 'SimpleGuarantee',
-      asset: makeAddress(singleOutcomeItem.asset),
-      targetChannelId: singleOutcomeItem['guarantee'].targetChannelId,
-      destinations: singleOutcomeItem['guarantee'].destinations
-    };
-  }
-
-  return {
-    type: 'MixedAllocation',
-    // FIXME: Figure out what needs to be here
-    simpleAllocations: []
-    // simpleAllocations: outcome.map(fromNitroOutcome)
-  };
+  return outcome.map(o => ({
+    asset: makeAddress(o.asset),
+    allocations: convertFromNitroAllocations(o.allocations),
+    metadata: BigNumber.from(o.metadata).toString()
+  }));
 }
 
 export function nextState(state: State, outcome: Outcome): State {
-  if (state.outcome.type !== outcome.type) {
-    throw new Error('Attempting to change outcome type');
-  }
-
   return {...state, turnNum: state.turnNum + 1, outcome};
 }
 

--- a/packages/wallet-core/src/tests/direct-funder.test.ts
+++ b/packages/wallet-core/src/tests/direct-funder.test.ts
@@ -1,5 +1,6 @@
 import {ethers} from 'ethers';
 import * as _ from 'lodash';
+import {AllocationType} from '@statechannels/exit-format';
 
 import {DirectFunder} from '../protocols';
 import {unreachable} from '../utils';
@@ -44,10 +45,21 @@ const deposits = {
 const asset = zeroAddress; // must be even length
 const singleAssetOutcome: SingleAssetOutcome = {
   allocations: [
-    {destination: participantA.destination, amount: deposits.A},
-    {destination: participantB.destination, amount: deposits.B}
+    {
+      destination: participantA.destination,
+      amount: deposits.A,
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    },
+    {
+      destination: participantB.destination,
+      amount: deposits.B,
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    }
   ],
-  asset
+  asset,
+  metadata: '0x'
 };
 
 const openingState: State = {
@@ -134,8 +146,9 @@ describe('initialization', () => {
   test('when the outcome does not match the expectations', () => {
     expect(() => initialize({...openingState, outcome: 'any' as any}, 0)).toThrow();
 
-    const singleAssetOutcome = {
+    const singleAssetOutcome: SingleAssetOutcome = {
       asset: zeroAddress,
+      metadata: '0x',
       allocations: []
     };
     expect(() => initialize({...openingState, outcome: [singleAssetOutcome]}, 0)).toThrow(
@@ -164,9 +177,20 @@ describe('cranking', () => {
       outcome: [
         {
           asset,
+          metadata: '0x',
           allocations: [
-            {destination: participants.A.destination, amount: BN.from(0)},
-            {destination: participants.B.destination, amount: BN.from(0)}
+            {
+              destination: participants.A.destination,
+              amount: BN.from(0),
+              metadata: '0x',
+              allocationType: AllocationType.simple
+            },
+            {
+              destination: participants.B.destination,
+              amount: BN.from(0),
+              metadata: '0x',
+              allocationType: AllocationType.simple
+            }
           ]
         }
       ]

--- a/packages/wallet-core/src/tests/outcomes-equal.test.ts
+++ b/packages/wallet-core/src/tests/outcomes-equal.test.ts
@@ -1,4 +1,5 @@
 import {constants} from 'ethers';
+import {AllocationType} from '@statechannels/exit-format';
 
 import {makeDestination} from '../utils';
 import {outcomesEqual} from '../state-utils';
@@ -10,12 +11,28 @@ const HashZero = constants.HashZero;
 
 const singleAssetOutcome1: SingleAssetOutcome = {
   asset: AddressZero,
-  allocations: [{destination: makeDestination(HashZero), amount: BN.from('0x2')}]
+  metadata: '0x',
+  allocations: [
+    {
+      destination: makeDestination(HashZero),
+      amount: BN.from('0x2'),
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    }
+  ]
 };
 
 const singleAssetOutcome2: SingleAssetOutcome = {
   asset: AddressZero,
-  allocations: [{destination: makeDestination(HashZero), amount: BN.from('0x02')}]
+  metadata: '0x',
+  allocations: [
+    {
+      destination: makeDestination(HashZero),
+      amount: BN.from('0x02'),
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    }
+  ]
 };
 
 describe('outcomesEqual', () => {

--- a/packages/wallet-core/src/tests/outcomes-equal.test.ts
+++ b/packages/wallet-core/src/tests/outcomes-equal.test.ts
@@ -2,30 +2,28 @@ import {constants} from 'ethers';
 
 import {makeDestination} from '../utils';
 import {outcomesEqual} from '../state-utils';
-import {SimpleAllocation, makeAddress} from '../types';
+import {makeAddress, SingleAssetOutcome} from '../types';
 import {BN} from '../bignumber';
 
 const AddressZero = makeAddress(constants.AddressZero);
 const HashZero = constants.HashZero;
 
-const simpleAllocation1: SimpleAllocation = {
-  type: 'SimpleAllocation',
+const singleAssetOutcome1: SingleAssetOutcome = {
   asset: AddressZero,
-  allocationItems: [{destination: makeDestination(HashZero), amount: BN.from('0x2')}]
+  allocations: [{destination: makeDestination(HashZero), amount: BN.from('0x2')}]
 };
 
-const simpleAllocation2: SimpleAllocation = {
-  type: 'SimpleAllocation',
+const singleAssetOutcome2: SingleAssetOutcome = {
   asset: AddressZero,
-  allocationItems: [{destination: makeDestination(HashZero), amount: BN.from('0x02')}]
+  allocations: [{destination: makeDestination(HashZero), amount: BN.from('0x02')}]
 };
 
 describe('outcomesEqual', () => {
   it('returns equal for identical SimpleAllocations', async () => {
-    expect(outcomesEqual(simpleAllocation1, simpleAllocation1)).toEqual(true);
+    expect(outcomesEqual([singleAssetOutcome1], [singleAssetOutcome1])).toEqual(true);
   });
 
   it('returns equal for equivalent SimpleAllocations', async () => {
-    expect(outcomesEqual(simpleAllocation1, simpleAllocation2)).toEqual(true);
+    expect(outcomesEqual([singleAssetOutcome1], [singleAssetOutcome2])).toEqual(true);
   });
 });

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -42,14 +42,14 @@ export type Destination = string & {_isDestination: void};
 export interface Allocation {
   destination: Destination;
   amount: Uint256;
-  allocationType?: AllocationType;
-  metadata?: string;
+  allocationType: AllocationType;
+  metadata: string;
 }
 
 export interface SingleAssetOutcome {
   asset: Address;
   allocations: Allocation[];
-  metadata?: string;
+  metadata: string;
 }
 
 export type Outcome = SingleAssetOutcome[];

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -1,5 +1,6 @@
 import {FundingStrategy} from '@statechannels/client-api-schema';
 import {utils} from 'ethers';
+import {AllocationType} from '@statechannels/exit-format';
 
 export type Uint256 = string & {_isUint256: void};
 // These "integers" have "type-safe" addition:
@@ -37,33 +38,25 @@ export interface StateVariables {
 }
 export type StateVariablesWithHash = StateVariables & Hashed;
 export type Destination = string & {_isDestination: void};
-export interface AllocationItem {
+
+export interface Allocation {
   destination: Destination;
   amount: Uint256;
-}
-export interface SimpleAllocation {
-  type: 'SimpleAllocation';
-  asset: Address;
-  allocationItems: AllocationItem[];
-}
-export interface SimpleGuarantee {
-  type: 'SimpleGuarantee';
-  targetChannelId: string;
-  asset: Address;
-  destinations: string[];
-}
-export interface MixedAllocation {
-  type: 'MixedAllocation';
-  simpleAllocations: SimpleAllocation[];
+  allocationType?: AllocationType;
+  metadata?: string;
 }
 
-// Should we even have these two different types??
-export type Allocation = SimpleAllocation | MixedAllocation;
-export type Outcome = Allocation | SimpleGuarantee;
-
-export function isAllocation(outcome: Outcome): outcome is Allocation {
-  return outcome.type !== 'SimpleGuarantee';
+export interface SingleAssetOutcome {
+  asset: Address;
+  allocations: Allocation[];
+  metadata?: string;
 }
+
+export type Outcome = SingleAssetOutcome[];
+
+// export function isAllocation(outcome: Outcome): outcome is Allocation {
+//   return outcome.type !== 'SimpleGuarantee';
+// }
 
 export interface ChannelConstants {
   chainId: string;
@@ -110,12 +103,11 @@ export type CloseChannel = _Objective<
     /**
      * Collaboratively concluding a channel on-chain involves the following:
      * 1. Submit a conclusion proof to the NitroAdjudicator.
-     * 2. Push the outcome to all AssetHolders.
-     * 3. Transfer out of the channel for all asset holders.
+     * 2. Transfer out of the channel for all assets.
      *
-     * Steps 1 and 2 require one or two transactions that are submitted by one participant
-     * but affect (and block) both participants. txSubmitterOrder defines the order in which
-     * participants will try to submit the collaborative transactions.
+     * Step 1 requires a transactions that is submitted by one participant
+     * but affecst (and blocsk) both participants. txSubmitterOrder defines the order in which
+     * participants will try to submit the collaborative transaction.
      *
      * CAVEAT:
      * Let's say 2 participants are concluding a channel with:

--- a/packages/wallet-core/src/utils/allocate-to-target.test.ts
+++ b/packages/wallet-core/src/utils/allocate-to-target.test.ts
@@ -1,9 +1,12 @@
+import {AllocationType} from '@statechannels/exit-format';
+
 import {BN} from '../bignumber';
 import {Allocation} from '../types';
 import {MOCK_ASSET_HOLDER_ADDRESS} from '../constants';
 
-import {Errors, allocateToTarget, makeDestination} from '.';
 import {ethOutcome, tokenAllocation} from './outcome';
+
+import {Errors, allocateToTarget, makeDestination} from '.';
 
 const zero = BN.from(0);
 const one = BN.from(1);
@@ -20,62 +23,86 @@ const targetChannelId = makeDestination(
 type Allocations = Allocation[];
 describe('allocateToTarget with valid input', () => {
   const target1: Allocations = [
-    {destination: left, amount: one},
-    {destination: right, amount: one}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: one, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const ledger1: Allocations = [...target1];
   const expected1 = [{destination: targetChannelId, amount: two}];
 
   const target2: Allocations = [
-    {destination: left, amount: one},
-    {destination: right, amount: two}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: two, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const ledger2: Allocations = [
-    {destination: left, amount: three},
-    {destination: right, amount: three}
+    {destination: left, amount: three, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: three, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const expected2: Allocations = [
-    {destination: left, amount: two},
-    {destination: right, amount: one},
-    {destination: targetChannelId, amount: three}
+    {destination: left, amount: two, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {
+      destination: targetChannelId,
+      amount: three,
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    }
   ];
 
   const target3: Allocations = [
-    {destination: left, amount: one},
-    {destination: right, amount: two}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: two, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const ledger3: Allocations = [
-    {destination: right, amount: three},
-    {destination: left, amount: three}
+    {destination: right, amount: three, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: left, amount: three, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const expected3: Allocations = [
-    {destination: right, amount: one},
-    {destination: left, amount: two},
-    {destination: targetChannelId, amount: three}
+    {destination: right, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: left, amount: two, metadata: '0x', allocationType: AllocationType.simple},
+    {
+      destination: targetChannelId,
+      amount: three,
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    }
   ];
 
   const target4: Allocations = [
-    {destination: left, amount: one},
-    {destination: right, amount: two}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: two, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const ledger4: Allocations = [
-    {destination: left, amount: three},
-    {destination: middle, amount: three},
-    {destination: right, amount: three}
+    {destination: left, amount: three, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: middle, amount: three, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: three, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const expected4: Allocations = [
-    {destination: left, amount: two},
-    {destination: middle, amount: three},
-    {destination: right, amount: one},
-    {destination: targetChannelId, amount: three}
+    {destination: left, amount: two, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: middle, amount: three, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {
+      destination: targetChannelId,
+      amount: three,
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    }
   ];
 
   const target5: Allocations = [
-    {destination: left, amount: one},
-    {destination: right, amount: zero}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: zero, metadata: '0x', allocationType: AllocationType.simple}
   ];
-  const ledger5: Allocations = [{destination: left, amount: one}];
-  const expected5: Allocations = [{destination: targetChannelId, amount: one}];
+  const ledger5: Allocations = [
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple}
+  ];
+  const expected5: Allocations = [
+    {
+      destination: targetChannelId,
+      amount: one,
+      metadata: '0x',
+      allocationType: AllocationType.simple
+    }
+  ];
 
   it.each`
     description | deductions | ledgerAllocation | expectedAllocation
@@ -101,22 +128,22 @@ describe('allocateToTarget with valid input', () => {
 
 describe('allocateToTarget with invalid input', () => {
   const target1: Allocations = [
-    {destination: left, amount: one},
-    {destination: middle, amount: one}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: middle, amount: one, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const ledger1: Allocations = [
-    {destination: left, amount: one},
-    {destination: right, amount: one}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: one, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const error1 = Errors.DestinationMissing;
 
   const target2: Allocations = [
-    {destination: left, amount: three},
-    {destination: right, amount: three}
+    {destination: left, amount: three, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: three, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const ledger2: Allocations = [
-    {destination: left, amount: one},
-    {destination: right, amount: two}
+    {destination: left, amount: one, metadata: '0x', allocationType: AllocationType.simple},
+    {destination: right, amount: two, metadata: '0x', allocationType: AllocationType.simple}
   ];
   const error2 = Errors.InsufficientFunds;
 

--- a/packages/wallet-core/src/utils/allocate-to-target.test.ts
+++ b/packages/wallet-core/src/utils/allocate-to-target.test.ts
@@ -1,14 +1,9 @@
 import {BN} from '../bignumber';
-import {AllocationItem} from '../types';
+import {Allocation} from '../types';
 import {MOCK_ASSET_HOLDER_ADDRESS} from '../constants';
 
-import {
-  Errors,
-  allocateToTarget,
-  simpleEthAllocation,
-  simpleTokenAllocation,
-  makeDestination
-} from '.';
+import {Errors, allocateToTarget, makeDestination} from '.';
+import {ethOutcome, tokenAllocation} from './outcome';
 
 const zero = BN.from(0);
 const one = BN.from(1);
@@ -22,65 +17,65 @@ const targetChannelId = makeDestination(
   '0x1234123412341234123412341234123412341234123412341234123412341234'
 );
 
-type Allocation = AllocationItem[];
+type Allocations = Allocation[];
 describe('allocateToTarget with valid input', () => {
-  const target1: Allocation = [
+  const target1: Allocations = [
     {destination: left, amount: one},
     {destination: right, amount: one}
   ];
-  const ledger1: Allocation = [...target1];
+  const ledger1: Allocations = [...target1];
   const expected1 = [{destination: targetChannelId, amount: two}];
 
-  const target2: Allocation = [
+  const target2: Allocations = [
     {destination: left, amount: one},
     {destination: right, amount: two}
   ];
-  const ledger2: Allocation = [
+  const ledger2: Allocations = [
     {destination: left, amount: three},
     {destination: right, amount: three}
   ];
-  const expected2: Allocation = [
+  const expected2: Allocations = [
     {destination: left, amount: two},
     {destination: right, amount: one},
     {destination: targetChannelId, amount: three}
   ];
 
-  const target3: Allocation = [
+  const target3: Allocations = [
     {destination: left, amount: one},
     {destination: right, amount: two}
   ];
-  const ledger3: Allocation = [
+  const ledger3: Allocations = [
     {destination: right, amount: three},
     {destination: left, amount: three}
   ];
-  const expected3: Allocation = [
+  const expected3: Allocations = [
     {destination: right, amount: one},
     {destination: left, amount: two},
     {destination: targetChannelId, amount: three}
   ];
 
-  const target4: Allocation = [
+  const target4: Allocations = [
     {destination: left, amount: one},
     {destination: right, amount: two}
   ];
-  const ledger4: Allocation = [
+  const ledger4: Allocations = [
     {destination: left, amount: three},
     {destination: middle, amount: three},
     {destination: right, amount: three}
   ];
-  const expected4: Allocation = [
+  const expected4: Allocations = [
     {destination: left, amount: two},
     {destination: middle, amount: three},
     {destination: right, amount: one},
     {destination: targetChannelId, amount: three}
   ];
 
-  const target5: Allocation = [
+  const target5: Allocations = [
     {destination: left, amount: one},
     {destination: right, amount: zero}
   ];
-  const ledger5: Allocation = [{destination: left, amount: one}];
-  const expected5: Allocation = [{destination: targetChannelId, amount: one}];
+  const ledger5: Allocations = [{destination: left, amount: one}];
+  const expected5: Allocations = [{destination: targetChannelId, amount: one}];
 
   it.each`
     description | deductions | ledgerAllocation | expectedAllocation
@@ -91,35 +86,35 @@ describe('allocateToTarget with valid input', () => {
     ${'five'}   | ${target5} | ${ledger5}       | ${expected5}
   `('Test $description', ({deductions, ledgerAllocation, expectedAllocation}) => {
     expect(
-      allocateToTarget(simpleEthAllocation(ledgerAllocation), deductions, targetChannelId)
-    ).toMatchObject(simpleEthAllocation(expectedAllocation));
+      allocateToTarget(ethOutcome(ledgerAllocation), deductions, targetChannelId)
+    ).toMatchObject(ethOutcome(expectedAllocation));
 
     expect(
       allocateToTarget(
-        simpleTokenAllocation(MOCK_ASSET_HOLDER_ADDRESS, ledgerAllocation),
+        tokenAllocation(MOCK_ASSET_HOLDER_ADDRESS, ledgerAllocation),
         deductions,
         targetChannelId
       )
-    ).toMatchObject(simpleTokenAllocation(MOCK_ASSET_HOLDER_ADDRESS, expectedAllocation));
+    ).toMatchObject(tokenAllocation(MOCK_ASSET_HOLDER_ADDRESS, expectedAllocation));
   });
 });
 
 describe('allocateToTarget with invalid input', () => {
-  const target1: Allocation = [
+  const target1: Allocations = [
     {destination: left, amount: one},
     {destination: middle, amount: one}
   ];
-  const ledger1: Allocation = [
+  const ledger1: Allocations = [
     {destination: left, amount: one},
     {destination: right, amount: one}
   ];
   const error1 = Errors.DestinationMissing;
 
-  const target2: Allocation = [
+  const target2: Allocations = [
     {destination: left, amount: three},
     {destination: right, amount: three}
   ];
-  const ledger2: Allocation = [
+  const ledger2: Allocations = [
     {destination: left, amount: one},
     {destination: right, amount: two}
   ];
@@ -131,7 +126,7 @@ describe('allocateToTarget with invalid input', () => {
     ${'two'}    | ${target2} | ${ledger2}       | ${error2}
   `('Test $description', ({deductions, ledgerAllocation, error}) => {
     expect(() =>
-      allocateToTarget(simpleEthAllocation(ledgerAllocation), deductions, targetChannelId)
+      allocateToTarget(ethOutcome(ledgerAllocation), deductions, targetChannelId)
     ).toThrow(error);
   });
 });

--- a/packages/wallet-core/src/utils/outcome.ts
+++ b/packages/wallet-core/src/utils/outcome.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import {ethers} from 'ethers';
+import {AllocationType} from '@statechannels/exit-format';
 
 import {Allocation, Destination, makeAddress, SingleAssetOutcome, Address} from '../types';
 import {BN, Zero} from '../bignumber';
@@ -7,12 +8,14 @@ import {zeroAddress} from '../config';
 
 export const ethOutcome = (allocations: Allocation[]): SingleAssetOutcome => ({
   asset: zeroAddress,
-  allocations
+  allocations,
+  metadata: '0x'
 });
 
 export const tokenAllocation = (asset: Address, allocations: Allocation[]): SingleAssetOutcome => ({
   asset,
-  allocations
+  allocations,
+  metadata: '0x'
 });
 
 export enum Errors {
@@ -48,7 +51,12 @@ export function allocateToTarget(
       if (BN.lt(ledgerItem.amount, 0)) throw new Error(Errors.InsufficientFunds);
     });
 
-  currentAllocations.push({amount: total, destination: makeDestination(targetChannelId)});
+  currentAllocations.push({
+    amount: total,
+    destination: makeDestination(targetChannelId),
+    metadata: '0x',
+    allocationType: AllocationType.simple
+  });
   currentAllocations = currentAllocations.filter(i => BN.gt(i.amount, 0));
 
   currentOutcome.allocations = currentAllocations;


### PR DESCRIPTION
`yarn prepare` and `yarn test` should work in `wallet-core` but *not* in `browser-wallet` or `server-wallet`. I couldn't see any easy way to preserve the types exported by wallet core, so unfortunately this change is breaking and more work will be needed to convert those packages too.

We cannot easily maintain the current `SimpleGuarantee` type because it does not have an `amount` field. In the exit format, guarantee allocations require an `amount`. 

~Early feedback appreciated on the following design decision: the internal types in wallet core have optional fields. These fields are given default values when converting to (serializing) types for the wire or for the app. Although this seems kind of nasty, it leads to a smaller change set here and can be fixed later on.~ Turns out this wasn't too hard to fix now, in fact. 
