### PR TITLE
pin the dependencies of nitro-protocol to the npm version

### DIFF
--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/nitro-protocol",
   "description": "A protocol for state channel networks",
-  "version": "0.17.3",
+  "version": "0.17.3-exit-format",
   "author": "statechannels",
   "browser": "dist/nitro-protocol.min.js",
   "bugs": "https://github.com/statechannels/monorepo/issues",

--- a/packages/wallet-core/tsconfig.json
+++ b/packages/wallet-core/tsconfig.json
@@ -12,8 +12,8 @@
   },
   "include": ["./src"],
   "references": [
-    {"path": "../nitro-protocol"},
+    // {"path": "../nitro-protocol"}, // we don't need this as long as nitro is installed from npm
     {"path": "../devtools"},
-    {"path": "../wire-format"},
+    {"path": "../wire-format"}
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5986,6 +5986,17 @@
   resolved "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.2.tgz#a6a5e93ac8dca6884a99a532f133beba59b87b69"
   integrity sha512-8LySx3qrNXPgB5JiULfG10O3V7QTxI/TLzSw5hFQhXWSkVxZBAv4rZQ0sYgLEbc8g3L2lmnujj1hKul38Eu5NQ==
 
+"@statechannels/nitro-protocol@0.17.3":
+  version "0.17.3"
+  resolved "https://registry.npmjs.org/@statechannels/nitro-protocol/-/nitro-protocol-0.17.3.tgz#5394d5454a6ee20399afe0a859cf5537caac7973"
+  integrity sha512-E372J29OerSFR5RdSwJPPy24C4WXOg9ibTvZ8wueIh0Kii0rNrY/3YxJ9ZFClKpnpZWFo3e2ATMD2Q/Nomf9wA==
+  dependencies:
+    "@openzeppelin/contracts" "3.2.2-solc-0.7"
+    ethers "5.0.12"
+    lodash.isequal "^4.5.0"
+    lodash.pick "4.4.0"
+    lodash.shuffle "^4.2.0"
+
 "@statechannels/wasm-utils@0.1.6-asset":
   version "0.1.6-asset"
   resolved "https://registry.npmjs.org/@statechannels/wasm-utils/-/wasm-utils-0.1.6-asset.tgz#9e4342c94bd256990450cb03358740fb8fd34bf0"


### PR DESCRIPTION
This decouples nitro-protocol from the rest of the monorepo. It would allow us to merge #3696 and tackle updating the rest of the monorepo at a later moment. 

