### PR TITLE
Small improvements to gas-benchmark tests

### DIFF
--- a/packages/nitro-protocol/gas-benchmarks/gas.ts
+++ b/packages/nitro-protocol/gas-benchmarks/gas.ts
@@ -28,15 +28,15 @@ type Path =
 export const gasRequiredTo: GasRequiredTo = {
   deployInfrastructureContracts: {
     vanillaNitro: {
-      NitroAdjudicator: 4228615, // Singleton
+      NitroAdjudicator: 4_228_615, // Singleton
     },
   },
   directlyFundAChannelWithETHFirst: {
-    vanillaNitro: 48014,
+    vanillaNitro: 48_014,
   },
   directlyFundAChannelWithETHSecond: {
     // meaning the second participant in the channel
-    vanillaNitro: 30926,
+    vanillaNitro: 30_926,
   },
   directlyFundAChannelWithERC20First: {
     // The depositor begins with zero tokens approved for the AssetHolder
@@ -44,30 +44,30 @@ export const gasRequiredTo: GasRequiredTo = {
     // The depositor retains a nonzero balance of tokens after depositing
     // The depositor retains some tokens approved for the AssetHolder after depositing
     vanillaNitro: {
-      approve: 46383,
+      approve: 46_383,
       // ^^^^^
       // In principle this only needs to be done once per account
       // (the cost may be amortized over several deposits into this AssetHolder)
-      deposit: 71392,
+      deposit: 71_392,
     },
   },
   directlyFundAChannelWithERC20Second: {
     // meaning the second participant in the channel
     vanillaNitro: {
-      approve: 46383,
+      approve: 46_383,
       // ^^^^^
       // In principle this only needs to be done once per account
       // (the cost may be amortized over several deposits into this AssetHolder)
-      deposit: 54304,
+      deposit: 54_304,
     },
   },
   ETHexit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 133112,
+    vanillaNitro: 133_112,
   },
   ERC20exit: {
     // We completely liquidate the channel (paying out both parties)
-    vanillaNitro: 123510,
+    vanillaNitro: 123_510,
   },
   ETHexitSad: {
     // Scenario: Counterparty Bob goes offline
@@ -75,9 +75,9 @@ export const gasRequiredTo: GasRequiredTo = {
     // challenge + timeout       ⬛ -> (X) -> 👩
     // transferAllAssets         ⬛ --------> 👩
     vanillaNitro: {
-      challenge: 94673,
-      transferAllAssets: 109517,
-      total: 204190,
+      challenge: 94_673,
+      transferAllAssets: 109_517,
+      total: 204_190,
     },
   },
   ETHexitSadLedgerFunded: {
@@ -87,11 +87,11 @@ export const gasRequiredTo: GasRequiredTo = {
       // challenge X, L and timeout  ⬛ -> (L) -> (X) -> 👩
       // transferAllAssetsL          ⬛ --------> (X) -> 👩
       // transferAllAssetsX          ⬛ ---------------> 👩
-      challengeX: 94673,
-      challengeL: 91703,
-      transferAllAssetsL: 58742,
-      transferAllAssetsX: 109517,
-      total: 354635,
+      challengeX: 94_673,
+      challengeL: 91_703,
+      transferAllAssetsL: 58_742,
+      transferAllAssetsX: 109_517,
+      total: 354_635,
     },
   },
   ETHexitSadVirtualFunded: {
@@ -101,12 +101,12 @@ export const gasRequiredTo: GasRequiredTo = {
       // challenge L,J,X + timeout   ⬛ -> (L) -> (J) -> (X) -> 👩
       // claimL                      ⬛ ---------------> (X) -> 👩
       // transferAllAssetsX          ⬛ ----------------------> 👩
-      challengeL: 94980,
-      challengeJ: 103014,
-      challengeX: 94673,
-      claimL: 95060,
-      transferAllAssetsX: 109517,
-      total: 497244,
+      challengeL: 94_980,
+      challengeJ: 103_014,
+      challengeX: 94_673,
+      claimL: 95_060,
+      transferAllAssetsX: 109_517,
+      total: 497_244,
     },
   },
 };

--- a/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
+++ b/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
@@ -78,11 +78,16 @@ expect.extend({
         pass: true,
       };
     } else {
+      const format = (x: number) => {
+        return x.toLocaleString().replace(/,/g, '_');
+      };
       const diff: BigNumber = (gasUsed as BigNumber).sub(benchmark);
       const diffStr: string = diff.gt(0) ? '+' + diff.toString() : diff.toString();
       return {
         message: () =>
-          `expected to consume ${benchmark} gas, but actually consumed ${(gasUsed as BigNumber).toNumber()} gas (${diffStr}). Consider updating the appropriate number in gas.ts!`,
+          `expected to consume ${format(benchmark)} gas, but actually consumed ${format(
+            (gasUsed as BigNumber).toNumber()
+          )} gas (${diffStr}). Consider updating the appropriate number in gas.ts!`,
         pass: false,
       };
     }

--- a/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
+++ b/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
@@ -85,8 +85,11 @@ expect.extend({
       const format = (x: number) => {
         return x.toLocaleString().replace(/,/g, '_');
       };
+      const green = (x: string) => `\x1b[32m${x}\x1b[0m`;
+      const red = (x: string) => `\x1b[31m${x}\x1b[0m`;
+
       const diff = gasUsed - benchmark;
-      const diffStr: string = diff > 0 ? '+' + format(diff) : format(diff);
+      const diffStr: string = diff > 0 ? red('+' + format(diff)) : green(format(diff));
 
       return {
         message: () =>

--- a/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
+++ b/packages/nitro-protocol/gas-benchmarks/vanillaSetup.ts
@@ -2,7 +2,7 @@ import {exec} from 'child_process';
 import {promises, existsSync, truncateSync} from 'fs';
 
 import {ContractFactory, Contract} from '@ethersproject/contracts';
-import {ethers, providers} from 'ethers';
+import {providers} from 'ethers';
 import waitOn from 'wait-on';
 import kill from 'tree-kill';
 import {BigNumber} from '@ethersproject/bignumber';
@@ -11,7 +11,6 @@ import nitroAdjudicatorArtifact from '../artifacts/contracts/NitroAdjudicator.so
 import tokenArtifact from '../artifacts/contracts/Token.sol/Token.json';
 import {NitroAdjudicator} from '../typechain/NitroAdjudicator';
 import {Token} from '../typechain/Token';
-import {X} from './fixtures';
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
@@ -90,12 +89,13 @@ expect.extend({
 
       const diff = gasUsed - benchmark;
       const diffStr: string = diff > 0 ? red('+' + format(diff)) : green(format(diff));
+      const diffPercent = `${Math.round((Math.abs(diff) / benchmark) * 100)}%`;
 
       return {
         message: () =>
           `expected to consume ${format(benchmark)} gas, but actually consumed ${format(
             gasUsed
-          )} gas (${diffStr}). Consider updating the appropriate number in gas.ts!`,
+          )} gas (${diffStr}, ${diffPercent}). Consider updating the appropriate number in gas.ts!`,
         pass: false,
       };
     }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/10780590/132030319-889d9e09-19fd-4d6f-b2c6-ab2d1ee0c469.png)


## Summary of Changes
This PR offers readability improvement on `gas.ts` and on test output, via:
- snake_cased inputs and outputs of large numbers (`34_254`)
- colour-coded test output for happpy (green) and sad (red) changes to gas consumption
- adding a percentage to the reported difference of gas consumption

## Shortcomings
the text colouring functions are gnarly low-level bash stuff which may not behave as expected in all environments, and whose workings are not obvious at a glance. Works on my machine!

## How Has This Been Tested?
against manual manipulations of the values in `gas.ts`

## Does this require multiple approvals?
No

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [x] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [x] I have assigned myself to this PR
- [x] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
