### PR TITLE
fix typo in quick-start-contracts.md

### DIFF
--- a/packages/docs-website/docs/docs/server-app-devs/quick-start-contracts.md
+++ b/packages/docs-website/docs/docs/server-app-devs/quick-start-contracts.md
@@ -17,7 +17,7 @@ The `ForceMoveApp` interface calls for an application-specific `validTransition(
 
 ## Examples
 
-For example, one can implement a simple counting application, where the stae of the channel can only be updated by incrementing a counter variable:
+For example, one can implement a simple counting application, where the state of the channel can only be updated by incrementing a counter variable:
 
 In `/contracts/CountingApp.sol`:
 


### PR DESCRIPTION
# Description

Fix small typo in `quick-start-contracts.md`.

## Changes [Optional] 

Replaced `stae` by `state`.

---
## Checklist:

### Code quality
- [x] I have written clear commit messages
- [x] I have performed a self-review of my own code
- [x] This change does not have an unduly wide scope
- [x] I have separated logic changes from refactor changes (formatting, renames, etc.)
- [x] I have commented my code wherever necessary (can be 0)
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
### Project management
- [ ] I have applied the [appropriate labels](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#f959a79c3b4f41708b8506612a99ec14)
- [x] I have [linked to all relevant issues](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues) (can be 0)
- [x] I have [linked to all dependent issues](https://help.zenhub.com/support/solutions/articles/43000010349-create-github-issue-dependencies) (can be 0)
- [ ] I have assigned myself to this PR
- [ ] I have chosen the appropriate [pipeline](https://www.notion.so/statechannels/Team-working-agreements-3cbcd6e85a7e481db4fe572ddf50cbd6#a96b6b02704d46afbcff147cf5a85566) on zenhub for the linked issue
